### PR TITLE
fixes #53 update scala to 3.3.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version = 3.7.4
 
 runner.dialect = scala3
-align.preset = more    // For pretty alignment.
-maxColumn = 100 // For my wide 30" display.
+align.preset = more
+maxColumn = 100

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,7 +102,7 @@ bind(
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "3.2.1")
+scala_config(scala_version = "3.3.0")
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
@@ -138,6 +138,6 @@ rules_rust_dependencies()
 rust_register_toolchains(
     edition = "2021",
     versions = [
-        "1.70.0"
+        "1.70.0",
     ],
 )

--- a/bazel/http_archives.bzl
+++ b/bazel/http_archives.bzl
@@ -64,6 +64,8 @@ def register_http_archive_dependencies():
 
     http_archive(
         name = "io_bazel_rules_scala",
+        patch_args = ["-p1"],
+        patches = ["//bazel/patches:rules_scala_33.patch"],
         sha256 = "5144514f81e63a3337e56d86b2924a22a1d5d9f273e482c2f2fb09639f6388fa",
         strip_prefix = "rules_scala-%s" % RULES_SCALA_VERSION,
         type = "zip",

--- a/bazel/http_archives.bzl
+++ b/bazel/http_archives.bzl
@@ -60,11 +60,11 @@ def register_http_archive_dependencies():
         ],
     )
 
-    RULES_SCALA_VERSION = "d6b81c893348c55875ba93475966858bc2478cfa"
+    RULES_SCALA_VERSION = "12d60d203591d92572c812f345b45babff688230"
 
     http_archive(
         name = "io_bazel_rules_scala",
-        sha256 = "4205be4f075c460158f5b931edac653406d12b6fd49bcdb5670dd6a5007e79b4",
+        sha256 = "5144514f81e63a3337e56d86b2924a22a1d5d9f273e482c2f2fb09639f6388fa",
         strip_prefix = "rules_scala-%s" % RULES_SCALA_VERSION,
         type = "zip",
         url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % RULES_SCALA_VERSION,

--- a/bazel/patches/rules_scala_33.patch
+++ b/bazel/patches/rules_scala_33.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/repositories/scala_3_3.bzl b/third_party/repositories/scala_3_3.bzl
+index 24f61cb..470c71f 100644
+--- a/third_party/repositories/scala_3_3.bzl
++++ b/third_party/repositories/scala_3_3.bzl
+@@ -39,7 +39,7 @@ artifacts = {
+     },
+     "io_bazel_rules_scala_scalatest_compatible": {
+         "artifact": "org.scalatest:scalatest-compatible:jar:3.2.16",
+-        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
++        "sha256": "9283e684d401d821a4cbb2646f9611cbbcd7828d2499483d13a4b507775a4cd7",
+     },
+     "io_bazel_rules_scala_scalatest_core": {
+         "artifact": "org.scalatest:scalatest-core_3:3.2.16",


### PR DESCRIPTION
scala 3.3 support was added in https://github.com/bazelbuild/rules_scala/pull/1501