### PR TITLE
dedupe test config :money_with_wings: 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,23 +1,15 @@
 startup --output_base=~/.bazelout
+common --color=yes
 
 build --cxxopt='-std=c++17'
 build --host_cxxopt='-std=c++17'
 build --disk_cache=~/bzlcache
 
-test --cxxopt='-std=c++17'
-test --host_cxxopt='-std=c++17'
-
-common --color=yes
 build --java_language_version=17
 build --java_runtime_version=17
 build --tool_java_language_version=17
 build --tool_java_runtime_version=remotejdk_17
 
-test --java_language_version=17
-test --java_runtime_version=17
-test --tool_java_language_version=17
-test --tool_java_runtime_version=remotejdk_17
-test --test_output=streamed
-test --test_verbose_timeout_warnings
-
 build --strategy=Scalac=worker
+
+test --test_verbose_timeout_warnings

--- a/cpp/golf_service/BUILD.bazel
+++ b/cpp/golf_service/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
 
 cc_test(
     name = "game_state_mapper_test",
+    size = "small",
     srcs = ["game_state_mapper_test.cc"],
     deps = [
         ":game_state_mapper",


### PR DESCRIPTION
This stops bazel from thinking the local cache can't be re-used between build and test (painful for building protoc)