### PR TITLE
c++23 support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 startup --output_base=~/.bazelout
 common --color=yes
 
-build --crosstool_top=//bazel:g++13-suite
+build --crosstool_top=//bazel:gcc13-suite
 build --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 
 build --cxxopt='-std=c++17'

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 startup --output_base=~/.bazelout
 common --color=yes
 
+build --crosstool_top=//toolchain:g++13-suite
+build --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+
 build --cxxopt='-std=c++17'
 build --host_cxxopt='-std=c++17'
 build --disk_cache=~/bzlcache

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 startup --output_base=~/.bazelout
 common --color=yes
 
-build --crosstool_top=//toolchain:g++13-suite
+build --crosstool_top=//bazel:g++13-suite
 build --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
 
 build --cxxopt='-std=c++17'

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,12 +1,13 @@
-load(":cc_toolchain_config.bzl", "cc_toolchain_config_darwin")
+load(":cc_toolchain_config.bzl", "cc_toolchain_config_darwin", "cc_toolchain_config_k8")
 
 
 package(default_visibility = ["//visibility:public"])
 
 cc_toolchain_suite(
-    name = "g++13-suite",
+    name = "gcc13-suite",
     toolchains = {
         "darwin": ":darwin_toolchain",
+        "k8": "k8_toolchain",
     },
 )
 
@@ -25,4 +26,18 @@ cc_toolchain(
     supports_param_files = 0,
 )
 
+cc_toolchain(
+    name = "k8_toolchain",
+    toolchain_identifier = "k8-toolchain",
+    toolchain_config = ":cc_config_k8",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+)
+
 cc_toolchain_config_darwin(name = "cc_config_darwin")
+cc_toolchain_config_k8(name = "cc_config_k8")

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,28 @@
+load(":cc_toolchain_config.bzl", "cc_toolchain_config_darwin")
+
+
+package(default_visibility = ["//visibility:public"])
+
+cc_toolchain_suite(
+    name = "g++13-suite",
+    toolchains = {
+        "darwin": ":darwin_toolchain",
+    },
+)
+
+filegroup(name = "empty")
+
+cc_toolchain(
+    name = "darwin_toolchain",
+    toolchain_identifier = "darwin-toolchain",
+    toolchain_config = ":cc_config_darwin",
+    all_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+)
+
+cc_toolchain_config_darwin(name = "cc_config_darwin")

--- a/bazel/cc_toolchain_config.bzl
+++ b/bazel/cc_toolchain_config.bzl
@@ -1,9 +1,7 @@
 "cc build helpers"
-
 load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
 
-
-def _impl(ctx):
+def _darwin_impl(ctx):
     tool_paths = [
         tool_path(
             name = "gcc",
@@ -42,7 +40,7 @@ def _impl(ctx):
 
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
-        cxx_builtin_include_directories = [ # NEW
+        cxx_builtin_include_directories = [
           "/usr/local/Cellar/gcc/13.1.0/include/",
           "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include/",
           "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include-fixed/",
@@ -57,11 +55,68 @@ def _impl(ctx):
         compiler = "g++-13",
         abi_version = "unknown",
         abi_libc_version = "unknown",
-        tool_paths = tool_paths, # NEW
+        tool_paths = tool_paths,
+    )
+
+def _k8_impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "/usr/bin/gcc-13",
+        ),
+        tool_path(
+            name = "ld",
+            path = "/usr/bin/ld",
+        ),
+        tool_path(
+            name = "ar",
+            path = "/usr/bin/gcc-ar-13",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/usr/bin/cpp-13",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/bin/false",
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        cxx_builtin_include_directories = [
+        ],
+        toolchain_identifier = "local",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "k8",
+        target_libc = "unknown",
+        compiler = "cpp-13",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
     )
 
 cc_toolchain_config_darwin = rule(
-    implementation = _impl,
+    implementation = _darwin_impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)
+
+cc_toolchain_config_k8 = rule(
+    implementation = _k8_impl,
     attrs = {},
     provides = [CcToolchainConfigInfo],
 )

--- a/bazel/cc_toolchain_config.bzl
+++ b/bazel/cc_toolchain_config.bzl
@@ -1,4 +1,5 @@
 "cc build helpers"
+
 load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
 
 def _darwin_impl(ctx):
@@ -13,7 +14,6 @@ def _darwin_impl(ctx):
         ),
         tool_path(
             name = "ar",
-            #path = "/usr/bin/ar",
             path = "/usr/local/bin/gcc-ar-13",
         ),
         tool_path(
@@ -41,11 +41,11 @@ def _darwin_impl(ctx):
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         cxx_builtin_include_directories = [
-          "/usr/local/Cellar/gcc/13.1.0/include/",
-          "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include/",
-          "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include-fixed/",
-          "/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/",
-          "/usr/include",
+            "/usr/local/Cellar/gcc/13.1.0/include/",
+            "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include/",
+            "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include-fixed/",
+            "/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/",
+            "/usr/include",
         ],
         toolchain_identifier = "local",
         host_system_name = "local",
@@ -62,7 +62,7 @@ def _k8_impl(ctx):
     tool_paths = [
         tool_path(
             name = "gcc",
-            path = "/usr/bin/gcc-13",
+            path = "/usr/bin/g++-13",
         ),
         tool_path(
             name = "ld",
@@ -74,7 +74,7 @@ def _k8_impl(ctx):
         ),
         tool_path(
             name = "cpp",
-            path = "/usr/bin/cpp-13",
+            path = "/usr/bin/g++-13",
         ),
         tool_path(
             name = "gcov",
@@ -97,13 +97,15 @@ def _k8_impl(ctx):
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         cxx_builtin_include_directories = [
+            "/usr/lib/gcc/x86_64-linux-gnu/13/include/",
+            "/usr/include",
         ],
         toolchain_identifier = "local",
         host_system_name = "local",
         target_system_name = "local",
         target_cpu = "k8",
         target_libc = "unknown",
-        compiler = "cpp-13",
+        compiler = "g++-13",
         abi_version = "unknown",
         abi_libc_version = "unknown",
         tool_paths = tool_paths,

--- a/bazel/cc_toolchain_config.bzl
+++ b/bazel/cc_toolchain_config.bzl
@@ -3,7 +3,7 @@
 load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
 
 
-def _darwin_impl(ctx):
+def _impl(ctx):
     tool_paths = [
         tool_path(
             name = "gcc",
@@ -54,14 +54,14 @@ def _darwin_impl(ctx):
         target_system_name = "local",
         target_cpu = "darwin",
         target_libc = "unknown",
-        compiler = "g++13",
+        compiler = "g++-13",
         abi_version = "unknown",
         abi_libc_version = "unknown",
         tool_paths = tool_paths, # NEW
     )
 
 cc_toolchain_config_darwin = rule(
-    implementation = _darwin_impl,
+    implementation = _impl,
     attrs = {},
     provides = [CcToolchainConfigInfo],
 )

--- a/bazel/cc_toolchain_config.bzl
+++ b/bazel/cc_toolchain_config.bzl
@@ -1,6 +1,20 @@
 "cc build helpers"
 
-load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+    "tool_path",
+)
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
 
 def _darwin_impl(ctx):
     tool_paths = [
@@ -38,8 +52,28 @@ def _darwin_impl(ctx):
         ),
     ]
 
+    features = [
+        feature(
+            name = "default_linker_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-lstdc++",
+                            ],
+                        ),
+                  ]),
+                ),
+            ],
+        ),
+    ]
+
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
+        features = features,
         cxx_builtin_include_directories = [
             "/usr/local/Cellar/gcc/13.1.0/include/",
             "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include/",
@@ -94,8 +128,28 @@ def _k8_impl(ctx):
         ),
     ]
 
+    features = [
+        feature(
+            name = "default_linker_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions,
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-lstdc++",
+                            ],
+                        ),
+                  ]),
+                ),
+            ],
+        ),
+    ]
+
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
+        features = features,
         cxx_builtin_include_directories = [
             "/usr/lib/gcc/x86_64-linux-gnu/13/include/",
             "/usr/include",

--- a/bazel/cc_toolchain_config.bzl
+++ b/bazel/cc_toolchain_config.bzl
@@ -1,0 +1,67 @@
+"cc build helpers"
+
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "tool_path")
+
+
+def _darwin_impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "gcc",
+            path = "/usr/local/bin/gcc-13",
+        ),
+        tool_path(
+            name = "ld",
+            path = "/usr/bin/ld",
+        ),
+        tool_path(
+            name = "ar",
+            #path = "/usr/bin/ar",
+            path = "/usr/local/bin/gcc-ar-13",
+        ),
+        tool_path(
+            name = "cpp",
+            path = "/usr/local/bin/g++-13",
+        ),
+        tool_path(
+            name = "gcov",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "nm",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "objdump",
+            path = "/bin/false",
+        ),
+        tool_path(
+            name = "strip",
+            path = "/bin/false",
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        cxx_builtin_include_directories = [ # NEW
+          "/usr/local/Cellar/gcc/13.1.0/include/",
+          "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include/",
+          "/usr/local/Cellar/gcc/13.1.0/lib/gcc/current/gcc/x86_64-apple-darwin22/13/include-fixed/",
+          "/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/",
+          "/usr/include",
+        ],
+        toolchain_identifier = "local",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "darwin",
+        target_libc = "unknown",
+        compiler = "g++13",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths, # NEW
+    )
+
+cc_toolchain_config_darwin = rule(
+    implementation = _darwin_impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/cpp/golf_service/BUILD.bazel
+++ b/cpp/golf_service/BUILD.bazel
@@ -49,6 +49,7 @@ cc_binary(
     srcs = [
         "Main.cc",
     ],
+    copts = ["-std=c++23"],
     deps = [
         ":router",
         "@mongoose_cc//:mongoose",

--- a/scripts/setup/setup-linux
+++ b/scripts/setup/setup-linux
@@ -13,4 +13,4 @@ INSTALL_LOCATION=/usr/local/bin/scalafmt-native
 curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \
   bash -s -- $VERSION $INSTALL_LOCATION
 
-apt install gcc-13
+apt install gcc-13 g++-13

--- a/scripts/setup/setup-linux
+++ b/scripts/setup/setup-linux
@@ -8,11 +8,9 @@ echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] h
 
 add-apt-repository ppa:ubuntu-toolchain-r/ppa
 
-apt update && apt install bazel clang-format
+apt update && apt install bazel clang-format gcc-13 g++-13
 
 VERSION=3.7.4
 INSTALL_LOCATION=/usr/local/bin/scalafmt-native
 curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \
   bash -s -- $VERSION $INSTALL_LOCATION
-
-apt install gcc-13 g++-13

--- a/scripts/setup/setup-linux
+++ b/scripts/setup/setup-linux
@@ -12,3 +12,5 @@ VERSION=3.7.4
 INSTALL_LOCATION=/usr/local/bin/scalafmt-native
 curl https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh | \
   bash -s -- $VERSION $INSTALL_LOCATION
+
+apt install gcc-13

--- a/scripts/setup/setup-linux
+++ b/scripts/setup/setup-linux
@@ -6,7 +6,7 @@ mv bazel-archive-keyring.gpg /usr/share/keyrings
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | \
   tee /etc/apt/sources.list.d/bazel.list
 
-add-apt-repository ppa:ubuntu-toolchain-r/ppa
+add-apt-repository ppa:ubuntu-toolchain-r/ppa -y
 
 apt update && apt install bazel clang-format gcc-13 g++-13
 

--- a/scripts/setup/setup-linux
+++ b/scripts/setup/setup-linux
@@ -6,6 +6,8 @@ mv bazel-archive-keyring.gpg /usr/share/keyrings
 echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | \
   tee /etc/apt/sources.list.d/bazel.list
 
+add-apt-repository ppa:ubuntu-toolchain-r/ppa
+
 apt update && apt install bazel clang-format
 
 VERSION=3.7.4


### PR DESCRIPTION
Apple Clang doesn't support c++23, but even non-apple clang doesn't support [c++23 range fold](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2322r5.html) yet :( 

https://clang.llvm.org/cxx_status.html#cxx23
https://libcxx.llvm.org/Status/Ranges.html 

It's supported in gcc-13, but gld apparently doesn't work on mac, and for some reason cc_library targets are passing the `-D` flag to `ar`, which also doesn't work on mac.