### PR TITLE
add GameStoreInterface to enable golf persistence

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,8 +6,9 @@ common --enable_bzlmod=true
 common --disk_cache=~/bzlcache
 common --repository_cache=~/.bzl_repo_cache
 
-common --cxxopt='-std=c++17'
-common --host_cxxopt='-std=c++17'
+common --cxxopt='-std=c++20'
+common --host_cxxopt='-std=c++20'
+# common --action_env=BAZEL_CXXOPTS="-std=c++20"
 
 build:debug -c dbg
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,7 +58,7 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
     name = "llvm_toolchain",
     llvm_versions = {
-        "": "15.0.7",
+        "": "15.0.6",
         "darwin-aarch64": "15.0.7",
         "darwin-x86_64": "15.0.7",
     },

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,13 +3,7 @@ module(
     version = "1.0",
 )
 
-bazel_dep(name = "toolchains_llvm", version = "1.0.0")
-git_override(
-    module_name = "toolchains_llvm",
-    commit = "01132cfdae7d7187a885cf79d5a3ac1ed8a02e5a",
-    remote = "https://github.com/bazel-contrib/toolchains_llvm",
-)
-
+bazel_dep(name = "toolchains_llvm", version = "1.1.2")
 bazel_dep(name = "rules_python", version = "0.34.0")
 bazel_dep(name = "protobuf", version = "27.2", repo_name = "com_google_protobuf")
 bazel_dep(name = "grpc", version = "1.65.0", repo_name = "com_github_grpc_grpc")
@@ -64,7 +58,7 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
     name = "llvm_toolchain",
     llvm_versions = {
-        "": "15.0.6",
+        "": "15.0.7",
         "darwin-aarch64": "15.0.7",
         "darwin-x86_64": "15.0.7",
     },

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -222,6 +222,8 @@
     "https://bcr.bazel.build/modules/stardoc/0.7.0/source.json": "e3c524bf2ef20992539ce2bc4a2243f4853130209ee831689983e28d05769099",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/source.json": "32bd87e5f4d7acc57c5b2ff7c325ae3061d5e242c0c4c214ae87e0f1c13e54cb",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.1.2/MODULE.bazel": "402101d6f73115ec49a3a765a3361c1dd90ba3959fa688ccdcd465c36dbbbc52",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.1.2/source.json": "27f3cf531bc654c719b50411cac94613b7676d63e60962243d485af63e13b9ff",
     "https://bcr.bazel.build/modules/upb/0.0.0-20211020-160625a/MODULE.bazel": "6cced416be2dc5b9c05efd5b997049ba795e5e4e6fafbe1624f4587767638928",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
@@ -15393,7 +15395,7 @@
     "@@toolchains_llvm~//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "y9h5L2NtWbogyWSOJgqnUaU50MTPWAW+waelXSirMVg=",
-        "usagesDigest": "Et7KqcNo+/M94tHe1ac9l9jkyxcNtdSSs7s5lm13L88=",
+        "usagesDigest": "FoDHi49UxsaXMAlpWHr8bEBSehkib+bj/6ykbs6eJhY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -15416,7 +15418,7 @@
               "link_flags": {},
               "link_libs": {},
               "llvm_versions": {
-                "": "15.0.6",
+                "": "15.0.7",
                 "darwin-aarch64": "15.0.7",
                 "darwin-x86_64": "15.0.7"
               },
@@ -15441,7 +15443,7 @@
               "llvm_mirror": "",
               "llvm_version": "",
               "llvm_versions": {
-                "": "15.0.6",
+                "": "15.0.7",
                 "darwin-aarch64": "15.0.7",
                 "darwin-x86_64": "15.0.7"
               },

--- a/cpp/cards/golf/BUILD.bazel
+++ b/cpp/cards/golf/BUILD.bazel
@@ -2,15 +2,51 @@ cc_library(
     name = "golf",
     srcs = [
         "game_manager.cc",
-        "game_state.cc",
-        "player.cc",
     ],
     hdrs = [
         "game_manager.h",
-        "game_state.h",
         "golf.h",
-        "player.h",
     ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":game_state",
+        ":game_store",
+        ":player",
+        "//cpp/cards",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "game_store",
+    srcs = ["game_store.cc"],
+    hdrs = ["game_store.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":game_state",
+        ":player",
+        "//cpp/cards",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "game_state",
+    srcs = ["game_state.cc"],
+    hdrs = ["game_state.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":player",
+        "//cpp/cards",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "player",
+    srcs = ["player.cc"],
+    hdrs = ["player.h"],
     visibility = ["//visibility:public"],
     deps = [
         "//cpp/cards",
@@ -23,7 +59,7 @@ cc_test(
     size = "small",
     srcs = ["player_test.cc"],
     deps = [
-        ":golf",
+        ":player",
         "@googletest//:gtest_main",
     ],
 )
@@ -33,7 +69,7 @@ cc_test(
     size = "small",
     srcs = ["game_state_test.cc"],
     deps = [
-        ":golf",
+        ":game_state",
         "@googletest//:gtest_main",
     ],
 )

--- a/cpp/cards/golf/game_manager.cc
+++ b/cpp/cards/golf/game_manager.cc
@@ -14,6 +14,7 @@ namespace golf {
 using namespace cards;
 
 using absl::InvalidArgumentError;
+using absl::Status;
 using absl::StatusOr;
 
 using std::deque;
@@ -23,21 +24,28 @@ using std::vector;
 static const std::string allowedChars =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-";
 
-StatusOr<string> GameManager::registerUser(const string& username) {
-  if (username.size() < 4 || username.size() > 15) {
+auto validate_user_id(const string& user_id) -> Status {
+  if (user_id.size() < 4 || user_id.size() > 15) {
     return InvalidArgumentError("username length must be between 4 and 15 chars");
   }
 
-  if (username.find_first_not_of(allowedChars) != string::npos) {
+  if (user_id.find_first_not_of(allowedChars) != string::npos) {
     return InvalidArgumentError("only alphanumeric, underscore, or dash allowed in username");
   }
+  return absl::OkStatus();
+}
 
-  if (usersOnline.find(username) != usersOnline.end()) {
-    return InvalidArgumentError("username taken");
+StatusOr<string> GameManager::registerUser(const string& user_id) {
+  auto validate_status = validate_user_id(user_id);
+  if (!validate_status.ok()) {
+    return validate_status;
   }
 
-  usersOnline.insert(username);
-  return username;
+  auto save_status = game_store_->AddUser(user_id);
+  if (save_status.ok()) {
+    return user_id;
+  }
+  return save_status;
 }
 
 deque<Card> GameManager::shuffleNewDeck() {
@@ -84,23 +92,21 @@ std::string GameManager::generateRandomAlphanumericString(std::size_t len) const
 std::optional<std::string> GameManager::generateUnusedRandomId() const {
   for (int i = 0; i < 10; i++) {
     auto attempt = generateRandomAlphanumericString(12);
-    if (gamesById.find(attempt) == gamesById.end()) {
+    auto existing_game = game_store_->ReadGame(attempt);
+    if (!existing_game.ok()) {
       return attempt;
     }
   }
   return {};
 }
 
-// TODO: generate random game id
-// TODO: support multiple decks
-StatusOr<GameStatePtr> GameManager::newGame(const string& username, int numberOfPlayers) {
-  if (usersOnline.find(username) == usersOnline.end()) {
-    return InvalidArgumentError("unregistered username");
+// TODO: support multiple decks for many players?
+StatusOr<GameStatePtr> GameManager::newGame(const string& user_id, int number_of_players) {
+  if (!game_store_->UserExists(user_id)) {
+    return InvalidArgumentError("unknown user");
   }
-  if (gameIdsByUser.find(username) != gameIdsByUser.end()) {
-    return InvalidArgumentError("already in game");
-  }
-  if (numberOfPlayers < 2 || numberOfPlayers > 5) {
+
+  if (number_of_players < 2 || number_of_players > 5) {
     return InvalidArgumentError("2 to 5 players");
   }
 
@@ -112,7 +118,7 @@ StatusOr<GameStatePtr> GameManager::newGame(const string& username, int numberOf
   deque<Card> mutableDrawPile = shuffleNewDeck();
 
   vector<Card> allDealt{};
-  for (int i = 0; i < numberOfPlayers * 4; i++) {
+  for (int i = 0; i < number_of_players * 4; i++) {
     allDealt.push_back(mutableDrawPile.back());
     mutableDrawPile.pop_back();
   }
@@ -120,14 +126,14 @@ StatusOr<GameStatePtr> GameManager::newGame(const string& username, int numberOf
   vector<Player> mutablePlayers;
 
   // two up, two down
-  int halfway = numberOfPlayers * 2;
-  for (int i = 0; i < numberOfPlayers; i++) {
+  int halfway = number_of_players * 2;
+  for (int i = 0; i < number_of_players; i++) {
     auto& tl = allDealt.at(2 * i);
     auto& tr = allDealt.at(2 * i + 1);
     auto& bl = allDealt.at(2 * i + halfway);
     auto& br = allDealt.at(2 * i + halfway + 1);
     if (i == 0) {
-      mutablePlayers.emplace_back(username, tl, tr, bl, br);
+      mutablePlayers.emplace_back(user_id, tl, tr, bl, br);
     } else {
       mutablePlayers.emplace_back(tl, tr, bl, br);
     }
@@ -141,29 +147,22 @@ StatusOr<GameStatePtr> GameManager::newGame(const string& username, int numberOf
   const deque<Card> drawPile = std::move(mutableDrawPile);
   const deque<Card> discardPile = std::move(mutableDiscardPile);
 
-  auto emplaceWorked = gamesById.emplace(
-      gameId,
-      std::make_shared<GameState>(GameState{drawPile, discardPile, players, false, 0, -1, gameId}));
-  if (!emplaceWorked.second) {
-    return InvalidArgumentError("could not generate unused game id");
-  }
-
-  usersByGame.insert(std::make_pair(gameId, std::unordered_set<string>{username}));
-  gameIdsByUser[username] = gameId;
-  return gamesById.at(gameId);
+  auto game_state =
+      std::make_shared<GameState>(GameState{drawPile, discardPile, players, false, 0, -1, gameId});
+  return game_store_->NewGame(game_state);
 }
 
-StatusOr<GameStatePtr> GameManager::joinGame(const string& gameId, const string& username) {
-  if (usersOnline.find(username) == usersOnline.end()) {
+StatusOr<GameStatePtr> GameManager::joinGame(const string& game_id, const string& user_id) {
+  if (!game_store_->UserExists(user_id)) {
     return InvalidArgumentError("unregistered username");
   }
 
-  auto gameIter = gamesById.find(gameId);
-  if (gameIter == gamesById.end()) {
+  auto game_read_status = game_store_->ReadGame(game_id);
+  if (!game_read_status.ok()) {
     return InvalidArgumentError("unknown game id");
   }
 
-  auto oldGameState = gameIter->second;
+  auto oldGameState = *game_read_status;
 
   if (oldGameState->allPlayersPresent()) {
     return InvalidArgumentError("no spots available");
@@ -177,28 +176,21 @@ StatusOr<GameStatePtr> GameManager::joinGame(const string& gameId, const string&
       updatedPlayers.push_back(p);
     } else {
       // safe because we know player is not already claimed
-      updatedPlayers.emplace_back(*p.claimHand(username));
+      updatedPlayers.emplace_back(*p.claimHand(user_id));
       playerAdded = true;
     }
   }
 
-  gamesById.erase(gameId);
-  gamesById.emplace(gameId, std::make_shared<GameState>(oldGameState->withPlayers(updatedPlayers)));
-  usersByGame.at(gameId).insert(username);
-  gameIdsByUser[username] = gameId;
-
-  return gamesById.at(gameId);
+  auto updated_game = std::make_shared<GameState>(oldGameState->withPlayers(updatedPlayers));
+  return game_store_->UpdateGame(updated_game);
 }
 
-StatusOr<GameStatePtr> GameManager::getGameStateForUser(const string& username) const {
-  if (usersOnline.find(username) == usersOnline.end()) {
-    return InvalidArgumentError("unregistered username");
-  }
-  if (gameIdsByUser.find(username) == gameIdsByUser.end()) {
-    return InvalidArgumentError("user not in game");
+StatusOr<GameStatePtr> GameManager::getGameStateForUser(const string& user_id) const {
+  if (!game_store_->UserExists(user_id)) {
+    return InvalidArgumentError("unknown user");
   }
 
-  return gamesById.at(gameIdsByUser.at(username));
+  return game_store_->ReadGameByUserId(user_id);
 }
 
 StatusOr<GameStatePtr> GameManager::updateGameState(StatusOr<GameState> updateResult,
@@ -207,10 +199,8 @@ StatusOr<GameStatePtr> GameManager::updateGameState(StatusOr<GameState> updateRe
     return InvalidArgumentError(updateResult.status().message());
   }
 
-  gamesById.erase(gameId);
-  gamesById.emplace(gameId, std::make_shared<GameState>(*updateResult));
-
-  return gamesById.at(gameId);
+  auto game_state = std::make_shared<GameState>(*updateResult);
+  return game_store_->UpdateGame(game_state);
 }
 
 StatusOr<GameStatePtr> GameManager::peekAtDrawPile(const string& username) {
@@ -272,5 +262,46 @@ StatusOr<GameStatePtr> GameManager::knock(const string& username) {
 
   return updateGameState(game->knock(playerIndex), game->getGameId());
 }
+
+  std::unordered_set<string> GameManager::getUsersOnline() const {
+    auto read_users_status = game_store_->GetUsers();
+    if (!read_users_status.ok()) {
+      return {}; // TODO: bubble status to caller
+    }
+    return *read_users_status;
+  }
+
+
+  std::unordered_set<GameStatePtr> GameManager::getGames() const {
+    return game_store_->ReadAllGames();
+  }
+
+  std::unordered_map<string, string> GameManager::getGameIdsByUserId() const {
+    auto games_result = game_store_->ReadAllGames();
+    std::unordered_map<string, string> game_ids_by_user{};
+    for (auto g : games_result) {
+      auto game_id = g->getGameId();
+      for (auto p : g->getPlayers()) {
+        if (p.isPresent() && p.getName().has_value()) {
+          game_ids_by_user[p.getName().value()] = game_id;
+        }
+      }
+    }
+    return game_ids_by_user;
+  }
+
+  std::unordered_set<string> GameManager::getUsersByGameId(const string& game_id) const {
+    auto game_maybe = game_store_->ReadGame(game_id);
+    if (!game_maybe.ok()) {
+      return {};
+    }
+    std::unordered_set<string> users{};
+    for (auto p : (*game_maybe)->getPlayers()) {
+      if (p.isPresent() && p.getName().has_value()) {
+        users.insert(p.getName().value());
+      }
+    }
+    return users;
+  }
 
 }  // namespace golf

--- a/cpp/cards/golf/game_manager.cc
+++ b/cpp/cards/golf/game_manager.cc
@@ -263,45 +263,44 @@ StatusOr<GameStatePtr> GameManager::knock(const string& username) {
   return updateGameState(game->knock(playerIndex), game->getGameId());
 }
 
-  std::unordered_set<string> GameManager::getUsersOnline() const {
-    auto read_users_status = game_store_->GetUsers();
-    if (!read_users_status.ok()) {
-      return {}; // TODO: bubble status to caller
-    }
-    return *read_users_status;
+std::unordered_set<string> GameManager::getUsersOnline() const {
+  auto read_users_status = game_store_->GetUsers();
+  if (!read_users_status.ok()) {
+    return {};  // TODO: bubble status to caller
   }
+  return *read_users_status;
+}
 
+std::unordered_set<GameStatePtr> GameManager::getGames() const {
+  return game_store_->ReadAllGames();
+}
 
-  std::unordered_set<GameStatePtr> GameManager::getGames() const {
-    return game_store_->ReadAllGames();
-  }
-
-  std::unordered_map<string, string> GameManager::getGameIdsByUserId() const {
-    auto games_result = game_store_->ReadAllGames();
-    std::unordered_map<string, string> game_ids_by_user{};
-    for (auto g : games_result) {
-      auto game_id = g->getGameId();
-      for (auto p : g->getPlayers()) {
-        if (p.isPresent() && p.getName().has_value()) {
-          game_ids_by_user[p.getName().value()] = game_id;
-        }
-      }
-    }
-    return game_ids_by_user;
-  }
-
-  std::unordered_set<string> GameManager::getUsersByGameId(const string& game_id) const {
-    auto game_maybe = game_store_->ReadGame(game_id);
-    if (!game_maybe.ok()) {
-      return {};
-    }
-    std::unordered_set<string> users{};
-    for (auto p : (*game_maybe)->getPlayers()) {
+std::unordered_map<string, string> GameManager::getGameIdsByUserId() const {
+  auto games_result = game_store_->ReadAllGames();
+  std::unordered_map<string, string> game_ids_by_user{};
+  for (auto g : games_result) {
+    auto game_id = g->getGameId();
+    for (auto p : g->getPlayers()) {
       if (p.isPresent() && p.getName().has_value()) {
-        users.insert(p.getName().value());
+        game_ids_by_user[p.getName().value()] = game_id;
       }
     }
-    return users;
   }
+  return game_ids_by_user;
+}
+
+std::unordered_set<string> GameManager::getUsersByGameId(const string& game_id) const {
+  auto game_maybe = game_store_->ReadGame(game_id);
+  if (!game_maybe.ok()) {
+    return {};
+  }
+  std::unordered_set<string> users{};
+  for (auto p : (*game_maybe)->getPlayers()) {
+    if (p.isPresent() && p.getName().has_value()) {
+      users.insert(p.getName().value());
+    }
+  }
+  return users;
+}
 
 }  // namespace golf

--- a/cpp/cards/golf/game_manager_test.cc
+++ b/cpp/cards/golf/game_manager_test.cc
@@ -4,24 +4,26 @@
 
 #include <vector>
 
-#include "cpp/cards/card.h"
+#include "cpp/cards/golf/game_store.h"
 
 using namespace cards;
 using namespace golf;
 
 TEST(GameManager, Constructor) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
 
   std::unordered_set<std::string> expectedUsers;
   EXPECT_EQ(gm.getUsersOnline(), expectedUsers);
 
   EXPECT_TRUE(gm.getGameIdsByUserId().empty());
 
-  EXPECT_TRUE(gm.getGamesById().empty());
+  EXPECT_TRUE(gm.getGames().empty());
 }
 
 TEST(GameManager, RegisterUser) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
   auto id = gm.registerUser("Andy");
 
   EXPECT_TRUE(id.ok());
@@ -29,7 +31,8 @@ TEST(GameManager, RegisterUser) {
 }
 
 TEST(GameManager, RegisterUserValidates) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
   auto res1 = gm.registerUser("");
   EXPECT_FALSE(res1.ok());
   EXPECT_EQ(res1.status().message(), "username length must be between 4 and 15 chars");
@@ -44,17 +47,19 @@ TEST(GameManager, RegisterUserValidates) {
 }
 
 TEST(GameManager, RegisterUserNameTaken) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
   auto res1 = gm.registerUser("foosername");
   EXPECT_TRUE(res1.ok());
 
   auto res2 = gm.registerUser("foosername");
   EXPECT_FALSE(res2.ok());
-  EXPECT_EQ(res2.status().message(), "username taken");
+  EXPECT_EQ(res2.status().message(), "already exists");
 }
 
 TEST(GameManager, NewGame) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
   auto res1 = gm.registerUser("user1");
   EXPECT_TRUE(res1.ok());
 
@@ -72,7 +77,8 @@ TEST(GameManager, NewGame) {
 }
 
 TEST(GameManager, NewGameWithWrongPlayerCount) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
   auto res1 = gm.registerUser("user1");
   EXPECT_TRUE(res1.ok());
 
@@ -86,14 +92,16 @@ TEST(GameManager, NewGameWithWrongPlayerCount) {
 }
 
 TEST(GameManager, NewGameWithUnknownUser) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
   auto res = gm.newGame("user1", 2);
   EXPECT_FALSE(res.ok());
-  EXPECT_EQ(res.status().message(), "unregistered username");
+  EXPECT_EQ(res.status().message(), "unknown user");
 }
 
 TEST(GameManager, JoinGame) {
-  GameManager gm;
+  auto store = std::make_shared<InMemoryGameStore>();
+  GameManager gm{store};
   auto res1 = gm.registerUser("user1");
   EXPECT_TRUE(res1.ok());
 

--- a/cpp/cards/golf/game_store.cc
+++ b/cpp/cards/golf/game_store.cc
@@ -1,0 +1,115 @@
+#include "cpp/cards/golf/game_store.h"
+
+#include <mutex>
+#include <ranges>
+#include <string>
+#include <unordered_set>
+
+#include "absl/status/statusor.h"
+
+namespace golf {
+using absl::Status;
+using absl::StatusOr;
+using std::string;
+
+std::mutex users_mutex{};
+std::mutex game_state_mutex{};
+
+Status InMemoryGameStore::AddUser(const string& user_id) {
+  std::scoped_lock lock{users_mutex};
+  if (users_online.contains(user_id)) {
+    return absl::AlreadyExistsError("already exists");
+  }
+
+  users_online.insert(user_id);
+  return absl::OkStatus();
+}
+
+bool InMemoryGameStore::UserExists(const string& user_id) {
+  std::scoped_lock lock{users_mutex};
+  return users_online.contains(user_id);
+}
+
+Status InMemoryGameStore::RemoveUser(const string& user_id) {
+  std::scoped_lock lock{users_mutex};
+  users_online.erase(user_id);
+  return absl::OkStatus();
+}
+
+StatusOr<std::unordered_set<string>> InMemoryGameStore::GetUsers() const {
+  std::scoped_lock lock{users_mutex};
+  return users_online;
+}
+
+StatusOr<GameStatePtr> InMemoryGameStore::NewGame(const GameStatePtr game_state) {
+  std::scoped_lock lock{game_state_mutex};
+  auto game_id = game_state->getGameId();
+  auto user_id_maybe = game_state->getPlayer(0).getName();
+  if (user_id_maybe->empty()) {
+    return absl::InternalError(
+        "game_state cannot be created without a player. This should have been validated upstream.");
+  }
+  auto user_id = user_id_maybe.value();
+
+  if (game_ids_by_user_id.contains(user_id)) {
+    return absl::InvalidArgumentError("already in game");
+  }
+
+  auto emplaceWorked = games_by_id.emplace(game_state->getGameId(), game_state);
+  if (!emplaceWorked.second) {
+    return absl::InvalidArgumentError("could not generate unused game id");
+  }
+
+  game_ids_by_user_id[user_id] = game_id;
+  return games_by_id.at(game_id);
+}
+
+StatusOr<GameStatePtr> InMemoryGameStore::ReadGame(const string& game_id) const {
+  std::scoped_lock lock{game_state_mutex};
+  if (games_by_id.contains(game_id)) {
+    return games_by_id.at(game_id);
+  }
+  return absl::NotFoundError("game not found");
+}
+
+StatusOr<GameStatePtr> InMemoryGameStore::ReadGameByUserId(const string& user_id) const {
+  std::scoped_lock lock{game_state_mutex};
+  if (game_ids_by_user_id.contains(user_id)) {
+    return games_by_id.at(game_ids_by_user_id.at(user_id));
+  }
+  return absl::NotFoundError("game not found");
+}
+
+StatusOr<GameStatePtr> InMemoryGameStore::UpdateGame(const GameStatePtr game_state) {
+  std::scoped_lock lock{game_state_mutex};
+  auto game_id = game_state->getGameId();
+  if (!games_by_id.contains(game_id)) {
+    return absl::InvalidArgumentError("game does not exist");
+  }
+  if (games_by_id.at(game_id)->isOver()) {
+    return absl::InvalidArgumentError("game is over");
+  }
+
+  for (auto p : game_state->getPlayers()) {
+    if (p.isPresent() && p.getName().has_value()) {
+      game_ids_by_user_id[p.getName().value()] = game_id;
+    }
+  }
+
+  games_by_id[game_id] = game_state;
+  return game_state;
+}
+
+std::unordered_set<GameStatePtr> InMemoryGameStore::ReadAllGames() const {
+  std::scoped_lock lock{game_state_mutex};
+  // TODO: switch to ranges once llvm publishes a release build for darwin-x86_64 for a recent version
+  // auto kv = std::ranges::views::values(games_by_id);
+  // return {kv.begin(), kv.end()};
+
+  std::unordered_set<GameStatePtr> games{};
+  for (auto [_, game] : games_by_id) {
+    games.insert(game);
+  }
+  return games;
+}
+}  // namespace golf

--- a/cpp/cards/golf/game_store.cc
+++ b/cpp/cards/golf/game_store.cc
@@ -102,9 +102,8 @@ StatusOr<GameStatePtr> InMemoryGameStore::UpdateGame(const GameStatePtr game_sta
 
 std::unordered_set<GameStatePtr> InMemoryGameStore::ReadAllGames() const {
   std::scoped_lock lock{game_state_mutex};
-  // TODO: switch to ranges once llvm publishes a release build for darwin-x86_64 for a recent version
-  // auto kv = std::ranges::views::values(games_by_id);
-  // return {kv.begin(), kv.end()};
+  // TODO: switch to ranges once llvm publishes a release build for darwin-x86_64 for a recent
+  // version auto kv = std::ranges::views::values(games_by_id); return {kv.begin(), kv.end()};
 
   std::unordered_set<GameStatePtr> games{};
   for (auto [_, game] : games_by_id) {

--- a/cpp/cards/golf/game_store.h
+++ b/cpp/cards/golf/game_store.h
@@ -1,0 +1,53 @@
+#ifndef CPP_CARDS_GOLF_GAME_STORE_H
+#define CPP_CARDS_GOLF_GAME_STORE_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "cpp/cards/golf/game_state.h"
+
+namespace golf {
+
+typedef std::shared_ptr<const GameState> GameStatePtr;
+using absl::Status;
+using absl::StatusOr;
+using std::string;
+
+class GameStoreInterface {
+ public:
+  virtual ~GameStoreInterface() {}
+  virtual Status AddUser(const string& user_id) = 0;
+  virtual bool UserExists(const string& user_id) = 0;
+  virtual Status RemoveUser(const string& user_id) = 0;
+  virtual StatusOr<std::unordered_set<string>> GetUsers() const = 0;
+  virtual StatusOr<GameStatePtr> NewGame(const GameStatePtr game_state) = 0;
+  virtual StatusOr<GameStatePtr> ReadGame(const string& game_id) const = 0;
+  virtual StatusOr<GameStatePtr> ReadGameByUserId(const string& user_id) const = 0;
+  virtual std::unordered_set<GameStatePtr> ReadAllGames() const = 0;
+  virtual StatusOr<GameStatePtr> UpdateGame(const GameStatePtr game_state) = 0;
+};
+
+class InMemoryGameStore final : public GameStoreInterface {
+ public:
+  Status AddUser(const string& user_id) override;
+  bool UserExists(const string& user_id) override;
+  Status RemoveUser(const string& user_id) override;
+  StatusOr<std::unordered_set<string>> GetUsers() const override;
+  StatusOr<GameStatePtr> NewGame(const GameStatePtr game_state) override;
+  StatusOr<GameStatePtr> ReadGame(const string& game_id) const override;
+  StatusOr<GameStatePtr> ReadGameByUserId(const string& user_id) const override;
+  std::unordered_set<GameStatePtr> ReadAllGames() const override;
+  StatusOr<GameStatePtr> UpdateGame(const GameStatePtr game_state) override;
+
+ private:
+  std::unordered_set<string> users_online;
+  std::unordered_map<string, string> game_ids_by_user_id;
+  std::unordered_map<string, GameStatePtr> games_by_id;
+};
+}  // namespace golf
+
+#endif

--- a/cpp/cards/golf/golf.h
+++ b/cpp/cards/golf/golf.h
@@ -3,6 +3,7 @@
 
 #include "cpp/cards/golf/game_manager.h"
 #include "cpp/cards/golf/game_state.h"
+#include "cpp/cards/golf/game_store.h"
 #include "cpp/cards/golf/player.h"
 
 #endif

--- a/cpp/escapist_client/escapist_client.h
+++ b/cpp/escapist_client/escapist_client.h
@@ -1,6 +1,7 @@
 #ifndef CPP_ESCAPIST_CLIENT_H
 #define CPP_ESCAPIST_CLIENT_H
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -34,7 +35,7 @@ struct DocEgg {
 
 class EscapistClient {
  public:
-  explicit EscapistClient(shared_ptr<Escapist::StubInterface> stub) : stub_(std::move(stub)) {}
+  explicit EscapistClient(shared_ptr<Escapist::StubInterface> stub, string db) : stub_(std::move(stub)), db_(db) {}
 
   StatusOr<DocIdAndVersion> InsertDoc(const string& collection, const DocEgg& input_doc_egg);
 
@@ -47,6 +48,7 @@ class EscapistClient {
   StatusOr<Doc> FindDocByTags(const string& collection, const unordered_map<string, string>& tags);
 
  private:
+  std::unique_ptr<grpc::ClientContext> MakeClientContext();
   static void PopulateDocEgg(DocumentEgg* doc, const DocEgg& docEgg);
   static StatusOr<DocIdAndVersion> HandleIdAndVersionResponse(const grpc::Status& rpc_status,
                                                               const string& id,
@@ -54,6 +56,7 @@ class EscapistClient {
   static StatusOr<Doc> HandleDocResponse(const grpc::Status& rpc_status, const Document& doc);
 
   shared_ptr<Escapist::StubInterface> stub_;
+  string db_;
 };
 
 }  // namespace escapist

--- a/cpp/escapist_client/escapist_client.h
+++ b/cpp/escapist_client/escapist_client.h
@@ -35,7 +35,8 @@ struct DocEgg {
 
 class EscapistClient {
  public:
-  explicit EscapistClient(shared_ptr<Escapist::StubInterface> stub, string db) : stub_(std::move(stub)), db_(db) {}
+  explicit EscapistClient(shared_ptr<Escapist::StubInterface> stub, string db)
+      : stub_(std::move(stub)), db_(db) {}
 
   StatusOr<DocIdAndVersion> InsertDoc(const string& collection, const DocEgg& input_doc_egg);
 

--- a/cpp/escapist_client/escapist_client_test.cc
+++ b/cpp/escapist_client/escapist_client_test.cc
@@ -32,7 +32,7 @@ TEST(EscapistClient, InsertDocRpcSuccess) {
   ON_CALL(*stub, InsertDoc(_, _, _))
       .WillByDefault(DoAll(SetArgPointee<2>(resp), Return(grpc::Status::OK)));
 
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
 
   // Act
@@ -48,7 +48,7 @@ TEST(EscapistClient, InsertDocRpcFailure) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
   ON_CALL(*stub, InsertDoc(_, _, _)).WillByDefault(Return(grpc::Status::CANCELLED));
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
 
   // Act
@@ -62,7 +62,7 @@ TEST(EscapistClient, InsertDocRpcFailure) {
 TEST(EscapistClient, InsertDocClientValidatesCollection) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
 
   // Act
@@ -76,7 +76,7 @@ TEST(EscapistClient, InsertDocClientValidatesCollection) {
 TEST(EscapistClient, InsertDocClientValidatesBytes) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("", {});
 
   // Act
@@ -97,7 +97,7 @@ TEST(EscapistClient, UpdateDocRpcSuccess) {
   ON_CALL(*stub, UpdateDoc(_, _, _))
       .WillByDefault(DoAll(SetArgPointee<2>(resp), Return(grpc::Status::OK)));
 
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
   DocIdAndVersion input_id;
   input_id.id = "foo";
@@ -116,7 +116,7 @@ TEST(EscapistClient, UpdateDocRpcFailure) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
   ON_CALL(*stub, UpdateDoc(_, _, _)).WillByDefault(Return(grpc::Status::CANCELLED));
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
   DocIdAndVersion input_ids = MakeInputIds("foo", "001");
 
@@ -131,7 +131,7 @@ TEST(EscapistClient, UpdateDocRpcFailure) {
 TEST(EscapistClient, UpdateDocClientValidatesCollection) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
   DocIdAndVersion input_ids = MakeInputIds("foo", "001");
 
@@ -146,7 +146,7 @@ TEST(EscapistClient, UpdateDocClientValidatesCollection) {
 TEST(EscapistClient, UpdateDocClientValidatesId) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
   DocIdAndVersion input_ids = MakeInputIds("", "001");
 
@@ -161,7 +161,7 @@ TEST(EscapistClient, UpdateDocClientValidatesId) {
 TEST(EscapistClient, UpdateDocClientValidatesVersion) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("cool bytes", {});
   DocIdAndVersion input_ids = MakeInputIds("foo", "");
 
@@ -176,7 +176,7 @@ TEST(EscapistClient, UpdateDocClientValidatesVersion) {
 TEST(EscapistClient, UpdateDocClientValidatesBytes) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   DocEgg input_doc_egg = MakeDocEgg("", {});
   DocIdAndVersion input_ids = MakeInputIds("foo", "001");
 
@@ -200,7 +200,7 @@ TEST(EscapistClient, FindDocByIdRpcSuccess) {
   ON_CALL(*stub, FindDocById(_, _, _))
       .WillByDefault(DoAll(SetArgPointee<2>(resp), Return(grpc::Status::OK)));
 
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
 
   // Act
   auto status = client.FindDocById("foo_col", "foo");
@@ -217,7 +217,7 @@ TEST(EscapistClient, FindDocByIdRpcFailure) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
   ON_CALL(*stub, FindDocById(_, _, _)).WillByDefault(Return(grpc::Status::CANCELLED));
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
 
   // Act
   auto status = client.FindDocById("foo_col", "foo");
@@ -230,7 +230,7 @@ TEST(EscapistClient, FindDocByIdRpcFailure) {
 TEST(EscapistClient, FindDocByIdClientValidatesCollection) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
 
   // Act
   auto status = client.FindDocById("", "foo");
@@ -243,7 +243,7 @@ TEST(EscapistClient, FindDocByIdClientValidatesCollection) {
 TEST(EscapistClient, FindDocByIdClientValidatesId) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
 
   // Act
   auto status = client.FindDocById("foo_col", "");
@@ -267,7 +267,7 @@ TEST(EscapistClient, FindDocByTagsRpcSuccess) {
   ON_CALL(*stub, FindDoc(_, _, _))
       .WillByDefault(DoAll(SetArgPointee<2>(resp), Return(grpc::Status::OK)));
 
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   unordered_map<string, string> input_tags;
   input_tags["player_1"] = "Tippy";
 
@@ -287,7 +287,7 @@ TEST(EscapistClient, FindDocByTagsRpcFailure) {
   auto stub = std::make_shared<MockEscapistStub>();
   ON_CALL(*stub, FindDoc(_, _, _)).WillByDefault(Return(grpc::Status::CANCELLED));
 
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   unordered_map<string, string> input_tags;
   input_tags["player_1"] = "Tippy";
 
@@ -302,7 +302,7 @@ TEST(EscapistClient, FindDocByTagsRpcFailure) {
 TEST(EscapistClient, FindDocByTagsClientValidatesCollection) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   unordered_map<string, string> input_tags;
   input_tags["player_1"] = "Tippy";
 
@@ -317,7 +317,7 @@ TEST(EscapistClient, FindDocByTagsClientValidatesCollection) {
 TEST(EscapistClient, FindDocByTagsClientValidatesTags) {
   // Arrange
   auto stub = std::make_shared<MockEscapistStub>();
-  EscapistClient client(stub);
+  EscapistClient client(stub, "test");
   unordered_map<string, string> input_tags;
 
   // Act

--- a/cpp/escapist_client/escapist_demo.cc
+++ b/cpp/escapist_client/escapist_demo.cc
@@ -30,7 +30,7 @@ int main() {
 
   auto channel = grpc::CreateChannel("localhost:50051", grpc::InsecureChannelCredentials());
   auto stub = std::make_shared<Escapist::Stub>(Escapist::Stub(channel));
-  EscapistClient client(stub);
+  EscapistClient client(stub, "demo");
 
   DocEgg doc_egg{"hello this is nice", {{"player_1", "Tippy"}}};
 

--- a/cpp/example_service/example_service_test.cc
+++ b/cpp/example_service/example_service_test.cc
@@ -23,9 +23,12 @@ TEST(SERVICE_TEST, BasicAssertions) {
   builder.RegisterService(&service);
   std::unique_ptr<Server> server(builder.BuildAndStart());
 
+  auto channel = server->InProcessChannel({});
   auto stub = Greeter::NewStub(server->InProcessChannel({}));
 
   ClientContext context;
+  context.AddMetadata("app-name", "test-app");
+
   HelloRequest req;
   HelloReply res;
   req.set_name("Test Name");

--- a/cpp/golf_service/handlers.h
+++ b/cpp/golf_service/handlers.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "absl/status/statusor.h"
-#include "cpp/cards/golf/golf.h"
 #include "mongoose.h"
 #include "protos/golf_ws/golf_ws.pb.h"
 

--- a/protos/golf/golf.proto
+++ b/protos/golf/golf.proto
@@ -1,0 +1,122 @@
+syntax = "proto3";
+
+package golf;
+
+service Golf {
+  rpc RegisterPlayer (RegisterUserRequest) returns (RegisterUserResponse) {}
+  rpc NewGame (NewGameRequest) returns (NewGameResponse) {}
+  rpc JoinGame (JoinGameRequest) returns (JoinGameResponse) {}
+  rpc Peek (PeekRequest) returns (PeekResponse) {}
+  rpc DiscardDraw (DiscardDrawRequest) returns (DiscardDrawResponse) {}
+  rpc SwapForDraw (SwapForDrawRequest) returns (SwapForDrawResponse) {}
+  rpc SwapForDiscard (SwapForDiscardRequest) returns (SwapForDiscardResponse) {}
+  rpc Knock (KnockRequest) returns (KnockResponse) {}
+}
+
+message RegisterUserRequest {
+  string user_id = 1;
+}
+
+message RegisterUserResponse {
+}
+
+message NewGameRequest {
+  string user_id = 1;
+  int32 number_of_players = 2;
+}
+
+message NewGameResponse {
+  GameState game_state = 1;
+}
+
+message JoinGameRequest {
+  string user_id = 1;
+  string game_id = 2;
+}
+
+message JoinGameResponse {
+  GameState game_state = 1;
+}
+
+message PeekRequest {
+  string user_id = 1;
+}
+
+message PeekResponse {
+  GameState game_state = 1;
+}
+
+message DiscardDrawRequest {
+  string user_id = 1;
+}
+
+message DiscardDrawResponse {
+  GameState game_state = 1;
+}
+
+enum Position {
+  TOP_LEFT = 0;
+  TOP_RIGHT = 1;
+  BOTTOM_LEFT = 2;
+  BOTTOM_RIGHT = 3;
+}
+
+message SwapForDrawRequest {
+  string user_id = 1;
+  Position position = 2;
+}
+
+message SwapForDrawResponse {
+  GameState game_state = 1;
+}
+
+message SwapForDiscardRequest {
+  string user_id = 1;
+  Position position = 2;
+}
+
+message SwapForDiscardResponse {
+  GameState game_state = 1;
+}
+
+message KnockRequest {
+  string user_id = 1;
+}
+
+message KnockResponse {
+  GameState game_state = 1;
+}
+
+message VisibleHand {
+  string bottom_left = 1;
+  string bottom_right = 2;
+}
+
+message GameState {
+  bool all_here = 1;
+  int32 discard_size = 2;
+  int32 draw_size = 3;
+  string game_id = 4;
+  bool game_started = 5;
+  bool game_over = 6;
+  optional string knocker = 7;
+  optional VisibleHand hand = 8;
+  int32 number_of_players = 9;
+  repeated string players = 10;
+  repeated int32 scores = 11;
+  optional string top_discard = 12;
+  optional string top_draw = 13;
+  bool your_turn = 14;
+}
+
+message ErrorResponse {
+  string message = 1;
+}
+
+message ResponseWrapper {
+  optional int32 id = 1;
+  oneof kind {
+    GameState game_state = 2;
+    ErrorResponse error = 3;
+  }
+}


### PR DESCRIPTION
 - GameStoreInterface currently has InMemoryGameStore implementation for use in tests
 - escapist backed GameStore coming in future change
 - update to c++20
 - remove local state from golf::GameManager
 - add db name to client metadata in escapist c++ client
 - clean up game_manager.h
 - add new golf rpc proto (incomplete)

TODO:
 - add escapist backed GameStore
 - escapist server should read clientContext metadata for db name (ideally via Authentication header?)
 - InMemoryGameStore unit tests so we don't have to test via GameManager