### PR TITLE
read db-name in escapist

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -4446,8 +4446,8 @@
     },
     "@@rules_rust~//rust/private:extensions.bzl%i": {
       "general": {
-        "bzlTransitiveDigest": "xOtpGS0fbawPxOGm4LQUOxNmzCpYsKsavjYJfV/tBX8=",
-        "usagesDigest": "8rxNHg4HjTBAPEiIdmi1v8o2l8IMjsu1iuZOGuvYmFQ=",
+        "bzlTransitiveDigest": "9SGldd38PHYuYHvXHTTca4jSoCf/EHOU+L1ztik3FBU=",
+        "usagesDigest": "G2MQN/io1m6/q/SiBTjnPO5LDNPn2CBtP77/wXWGbB8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -7147,6 +7147,19 @@
               ],
               "strip_prefix": "num-complex-0.1.43",
               "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.num-complex-0.1.43.bazel"
+            }
+          },
+          "cui__once_cell-1.19.0": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
+              "type": "tar.gz",
+              "urls": [
+                "https://static.crates.io/crates/once_cell/1.19.0/download"
+              ],
+              "strip_prefix": "once_cell-1.19.0",
+              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.19.0.bazel"
             }
           },
           "rules_rust_prost__pin-project-1.1.0": {
@@ -12512,19 +12525,6 @@
               "build_file": "@@rules_rust~//wasm_bindgen/3rdparty/crates:BUILD.semver-1.0.17.bazel"
             }
           },
-          "cui__once_cell-1.18.0": {
-            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
-            "ruleClassName": "http_archive",
-            "attributes": {
-              "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
-              "type": "tar.gz",
-              "urls": [
-                "https://static.crates.io/crates/once_cell/1.18.0/download"
-              ],
-              "strip_prefix": "once_cell-1.18.0",
-              "build_file": "@@rules_rust~//crate_universe/3rdparty/crates:BUILD.once_cell-1.18.0.bazel"
-            }
-          },
           "rules_rust_wasm_bindgen__wasmparser-0.80.2": {
             "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
             "ruleClassName": "http_archive",
@@ -14745,6 +14745,7 @@
             "cui__indoc-2.0.4",
             "cui__itertools-0.12.0",
             "cui__normpath-1.1.1",
+            "cui__once_cell-1.19.0",
             "cui__pathdiff-0.2.1",
             "cui__regex-1.10.2",
             "cui__semver-1.0.20",
@@ -14909,6 +14910,11 @@
             "rules_rust~",
             "cui__normpath-1.1.1",
             "rules_rust~~i~cui__normpath-1.1.1"
+          ],
+          [
+            "rules_rust~",
+            "cui__once_cell-1.19.0",
+            "rules_rust~~i~cui__once_cell-1.19.0"
           ],
           [
             "rules_rust~",

--- a/rust/escapist/src/main.rs
+++ b/rust/escapist/src/main.rs
@@ -12,7 +12,7 @@ use escapist_proto::escapist::escapist_server::EscapistServer;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let uri = std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".into());
     let client = Client::with_uri_str(uri).await.expect("failed to connect");
-    let service = EscapistService { client: client };
+    let service = EscapistService { client };
 
     let addr = "[::1]:50051".parse()?;
     let server = Server::builder()


### PR DESCRIPTION
This updates escapist server to read client context metadata to allow clients to set their db name. At some point, some authn + authorization check should be added to make sure a caller is allowed to read/modify the requested db. This is the other half of https://github.com/muchq/MoonBase/pull/239/files#diff-f663c91b226b1b0ce0b75b8548117e68961ad72a0389bb89c3cd932be2cd6bd7 