### PR TITLE
update escapist README to include db-name metadata

### DIFF
--- a/cpp/example_service/main.cc
+++ b/cpp/example_service/main.cc
@@ -24,6 +24,6 @@ void RunServer(uint16_t port) {
 }
 
 int main() {
-  RunServer(8089);
+  RunServer(8088);
   return 0;
 }

--- a/rust/escapist/README.md
+++ b/rust/escapist/README.md
@@ -4,7 +4,8 @@ This seemed easier than figuring out how to build the mongocxx driver with Bazel
 
 ### No Reflection
 ```shell
-grpcurl -proto protos/escapist/queries.proto \
+grpcurl -proto protos/escapist/escapist.proto \
+    -rpc-header "db-name: demo"\
     -d '{"id": "foo123", "collection": "golf"}'\
     -plaintext localhost:50051 \
     escapist.Escapist/FindDocById


### PR DESCRIPTION
 - also make cc grpc example service port match README