### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/web/golf_ui/index.html
+++ b/web/golf_ui/index.html
@@ -155,7 +155,7 @@ div#actions button {
       ws.onmessage = function(ev) {
         var data = ev.data;
         if (typeof data != "string") {
-          log.innerHTML = 'WAT: ' + ev.data;
+          log.textContent = 'WAT: ' + ev.data;
           return;
         }
         if (data.startsWith("error|")) {


### PR DESCRIPTION
Potential fix for [https://github.com/muchq/MoonBase/security/code-scanning/2](https://github.com/muchq/MoonBase/security/code-scanning/2)

To fix the issue, we need to sanitize or encode the `ev.data` value before inserting it into the DOM. The best approach is to use a method that escapes special HTML characters, such as `<`, `>`, `&`, and `"`, to prevent the browser from interpreting the input as HTML or JavaScript.

- Replace the direct assignment to `innerHTML` with a safer alternative that escapes the content. For example, use `textContent` instead of `innerHTML` to ensure the data is treated as plain text.
- Modify line 158 to use `log.textContent` instead of `log.innerHTML`.

This change ensures that any potentially malicious content in `ev.data` is displayed as plain text rather than being executed as code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
