### PR TITLE
Potential fix for code scanning alert no. 3: Client-side cross-site scripting

### DIFF
--- a/web/golf_ui/index.html
+++ b/web/golf_ui/index.html
@@ -160,7 +160,7 @@ div#actions button {
         }
         if (data.startsWith("error|")) {
           var errValue = data.split("error|")[1];
-          log.innerHTML = 'ERROR: ' + errValue;
+          log.textContent = 'ERROR: ' + errValue;
           return;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/muchq/MoonBase/security/code-scanning/3](https://github.com/muchq/MoonBase/security/code-scanning/3)

To fix this issue, we need to ensure that any untrusted data (`errValue`) is properly sanitized or encoded before being inserted into the DOM. The best approach is to use `textContent` instead of `innerHTML` when inserting plain text, as `textContent` automatically escapes any HTML or JavaScript content, preventing XSS attacks. This change will preserve the intended functionality while eliminating the vulnerability.

The fix involves replacing `log.innerHTML = 'ERROR: ' + errValue;` with `log.textContent = 'ERROR: ' + errValue;` on line 163.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
