### PR TITLE
Potential fix for code scanning alert no. 4: Client-side cross-site scripting

### DIFF
--- a/web/golf_ui/index.html
+++ b/web/golf_ui/index.html
@@ -171,7 +171,7 @@ div#actions button {
           username = state.username;
           register_holder.className = "gone";
           new_game_holder.className = "";
-          log.innerHTML = "USER: " + username;
+          log.textContent = "USER: " + username;
           return;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/muchq/MoonBase/security/code-scanning/4](https://github.com/muchq/MoonBase/security/code-scanning/4)

To fix the issue, we need to sanitize the `username` value before inserting it into the DOM. Instead of using `innerHTML`, which allows HTML content to be injected, we should use `textContent`, which safely escapes any HTML characters. This ensures that the `username` is treated as plain text, preventing any malicious scripts from being executed.

**Steps to fix:**
1. Replace the use of `innerHTML` with `textContent` on line 174.
2. Ensure that `username` is displayed as plain text, not as HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
