### PR TITLE
[build][bazel-diff] exclude //:requirements_test

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -512,6 +512,24 @@
         ]
       }
     },
+    "@@apple_rules_lint+//lint:extensions.bzl%linter": {
+      "general": {
+        "bzlTransitiveDigest": "GRMyLraxrIqwpYRdzOfjZMmByG37F1TiOwo1vnf4KJ4=",
+        "usagesDigest": "jTOwxDX06coCna6ZG2TdoE5lX5fW4b+uJpv1bucdx+Q=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "apple_linters": {
+            "repoRuleId": "@@apple_rules_lint+//lint/private:register_linters.bzl%register_linters",
+            "attributes": {
+              "linters": {}
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@apple_support+//crosstool:setup.bzl%apple_cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "JJV/C5bhYKZip41t/GGZvqIMmmrcwr0Ydybkn97uXxQ=",

--- a/scripts/diff-build
+++ b/scripts/diff-build
@@ -72,7 +72,10 @@ echo "Computing impacted targets..."
 impacted_targets=()
 if [ -f "$impacted_targets_path" ]; then
   while IFS= read -r line; do
-    impacted_targets+=("$line")
+    # Skip deprecated requirements_test target (use requirements.test instead)
+    if [[ "$line" != "//:requirements_test" ]]; then
+      impacted_targets+=("$line")
+    fi
   done < "$impacted_targets_path"
 fi
 


### PR DESCRIPTION
It's deprecated for removal and breaks branch builds. The correct test target is now `//:requirements.test`