### PR TITLE
[portrait][meerkat] timing data + improve portrait json format

### DIFF
--- a/cpp/meerkat/meerkat.h
+++ b/cpp/meerkat/meerkat.h
@@ -1,6 +1,7 @@
 #ifndef CPP_MEERKAT_MEERKAT_H
 #define CPP_MEERKAT_MEERKAT_H
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <set>
@@ -21,6 +22,7 @@ struct HttpRequest {
   std::string body;
   std::unordered_map<std::string, std::string> headers;
   std::unordered_map<std::string, std::string> query_params;
+  std::chrono::steady_clock::time_point start_time;
 };
 
 struct HttpResponse {

--- a/cpp/portrait/BUILD.bazel
+++ b/cpp/portrait/BUILD.bazel
@@ -48,6 +48,8 @@ cc_binary(
         "@com_google_absl//absl/log:globals",
         "@com_google_absl//absl/log:initialize",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/cpp/portrait/Main.cc
+++ b/cpp/portrait/Main.cc
@@ -49,7 +49,8 @@ int main() {
   server.post("/v1/trace", [&tracer_service](const HttpRequest& req) -> HttpResponse {
     absl::StatusOr<TraceRequest> trace_or_status = parseTraceRequest(req.body);
     if (!trace_or_status.ok()) {
-      return responses::bad_request(absl::StrCat("Invalid JSON: ", trace_or_status.status().message()));
+      return responses::bad_request(
+          absl::StrCat("Invalid JSON: ", trace_or_status.status().message()));
     }
     auto [scene, perspective, output] = trace_or_status.value();
     auto image = tracer_service.trace(scene, perspective, output);

--- a/cpp/portrait/Main.cc
+++ b/cpp/portrait/Main.cc
@@ -1,7 +1,9 @@
-#include "../meerkat/meerkat.h"
 #include "absl/log/globals.h"
 #include "absl/log/initialize.h"
 #include "absl/log/log.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "cpp/image_core/image_core.h"
 #include "cpp/meerkat/meerkat.h"
 #include "cpp/portrait/types.h"
 #include "tracer_service.h"
@@ -9,11 +11,30 @@
 using namespace meerkat;
 using namespace portrait;
 
+using image_core::Image;
+using image_core::RGB_Double;
+
 uint16_t readPort(const uint16_t default_port) {
   if (const char* env_p = std::getenv("PORT")) {
     return static_cast<uint16_t>(std::atoi(env_p));
   }
   return default_port;
+}
+
+absl::StatusOr<TraceRequest> parseTraceRequest(const std::string& body) {
+  try {
+    json request_json = json::parse(body);
+    auto trace_request = request_json.template get<TraceRequest>();
+
+    auto trace_request_status = validateTraceRequest(trace_request);
+    if (!trace_request_status.ok()) {
+      return trace_request_status;
+    }
+
+    return trace_request;
+  } catch (const json::exception& e) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, std::string(e.what()));
+  }
 }
 
 int main() {
@@ -25,21 +46,14 @@ int main() {
   TracerService tracer_service;
 
   // Create a new user
-  server.post("/v1/trace", [](const HttpRequest& req) -> HttpResponse {
-    try {
-      json request_json = json::parse(req.body);
-      auto trace_request = request_json.template get<TraceRequest>();
-
-      auto trace_request_status = validateTraceRequest(trace_request);
-      if (!trace_request_status.ok()) {
-        return responses::bad_request(trace_request_status.message().data());
-      }
-
-      return responses::ok("yes");
-
-    } catch (const json::exception& e) {
-      return responses::bad_request("Invalid JSON: " + std::string(e.what()));
+  server.post("/v1/trace", [&tracer_service](const HttpRequest& req) -> HttpResponse {
+    absl::StatusOr<TraceRequest> trace_or_status = parseTraceRequest(req.body);
+    if (!trace_or_status.ok()) {
+      return responses::bad_request(absl::StrCat("Invalid JSON: ", trace_or_status.status().message()));
     }
+    auto [scene, perspective, output] = trace_or_status.value();
+    auto image = tracer_service.trace(scene, perspective, output);
+    return responses::ok(json{{"status", "ok"}});
   });
 
   server.enable_health_checks();

--- a/cpp/portrait/tracer_service.cc
+++ b/cpp/portrait/tracer_service.cc
@@ -57,7 +57,10 @@ vector<tracy::Light> TracerService::tracify(const vector<Light>& lights) {
   return tracyLights;
 }
 
-tracy::Vec3 TracerService::tracify(const Vec3& v) { return tracy::Vec3(v.x, v.y, v.z); }
+tracy::Vec3 TracerService::tracify(const Vec3& v) {
+  auto [x, y, z] = v;
+  return tracy::Vec3(x, y, z);
+}
 
 tracy::LightType TracerService::tracify(const LightType& lightType) {
   return static_cast<tracy::LightType>(lightType);

--- a/cpp/portrait/types.cc
+++ b/cpp/portrait/types.cc
@@ -14,10 +14,46 @@ absl::Status validatePerspective(Perspective &perspective) {
   return validateVec3(perspective.cameraFocus);
 }
 
+absl::Status validateScene(const Scene &scene) {
+  if (scene.spheres.empty()) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "empty scene");
+  }
+  if (scene.spheres.size() > 10) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "max spheres is 10");
+  }
+  return absl::OkStatus();
+}
+
+absl::Status validateOutput(const Output &output) {
+  if (output.width < 20) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "min width is 20 pixels");
+  }
+  if (output.height < 20) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "min height is 20 pixels");
+  }
+  if (output.width > 1200) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "max width is 1200 pixels");
+  }
+  if (output.height > 1200) {
+    return absl::Status(absl::StatusCode::kInvalidArgument, "max height is 1200 pixels");
+  }
+  return absl::OkStatus();
+}
+
 absl::Status validateTraceRequest(TraceRequest &traceRequest) {
   auto perspectiveStatus = validatePerspective(traceRequest.perspective);
   if (!perspectiveStatus.ok()) {
     return perspectiveStatus;
+  }
+
+  auto sceneStatus = validateScene(traceRequest.scene);
+  if (!sceneStatus.ok()) {
+    return sceneStatus;
+  }
+
+  auto outputStatus = validateOutput(traceRequest.output);
+  if (!outputStatus.ok()) {
+    return outputStatus;
   }
   return absl::OkStatus();
 }

--- a/cpp/portrait/types.h
+++ b/cpp/portrait/types.h
@@ -2,6 +2,7 @@
 #define CPP_PORTRAIT_TYPES_H
 
 #include <nlohmann/json.hpp>
+#include <tuple>
 
 #include "absl/status/status.h"
 #include "cpp/tracy/tracy.h"
@@ -9,15 +10,8 @@
 namespace portrait {
 using namespace nlohmann::literals;
 
-struct Vec3 {
-  double x, y, z;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Vec3, x, y, z)
-
-struct Color {
-  unsigned char r, g, b;
-};
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Color, r, g, b)
+using Vec3 = std::tuple<double, double, double>;
+using Color = std::tuple<unsigned char, unsigned char, unsigned char>;
 
 struct Sphere {
   Vec3 center;


### PR DESCRIPTION
new request shape:
```
{
  "scene": {
    "spheres": [
      {
        "center": [0.0, 0.0, 0.0],
        "radius": 100.0,
        "color": [255, 0, 0],
        "specular": 500.0,
        "reflective": 0.2
      }
    ]
  },
  "perspective": {
    "cameraPosition": [0.0, 0.0, -5.0],
    "cameraFocus": [0.0, 0.0, 0.0]
  },
  "output": {
    "width": 760,
    "height": 700
  }
}
```

new logging format:
```
➜  MoonBase git:(portrait) ✗ bazel-bin/cpp/portrait/portrait
I0826 21:07:06.799520 7173750 Main.cc:43] Starting Portrait Server...
I0826 21:07:06.800349 7173750 Main.cc:68] Portrait Server running on http://0.0.0.0:8080
I0826 21:07:06.800364 7173750 Main.cc:69] Serving:
I0826 21:07:06.800370 7173750 Main.cc:70]   GET  http://localhost:8080/health
I0826 21:07:06.800376 7173750 Main.cc:71]   POST http://localhost:8080/v1/trace
I0826 21:07:06.800380 7173750 Main.cc:72] Press Ctrl+C to stop the server
I0826 21:07:10.112356 7173750 meerkat.cc:516] [POST /v1/trace]: trace_id=1850994446808296452 status=400 res.body.bytes=82 duration_ms=0
I0826 21:08:25.172972 7173750 meerkat.cc:516] [POST /v1/trace]: trace_id=5230196248105997256 status=200 res.body.bytes=15 duration_ms=380
I0826 21:08:47.053544 7173750 meerkat.cc:516] [POST /v1/trace]: trace_id=3490498562481841563 status=200 res.body.bytes=15 duration_ms=385
I0826 21:08:50.369362 7173750 meerkat.cc:516] [POST /v1/trace]: trace_id=4773466821257611182 status=200 res.body.bytes=15 duration_ms=391
```