### PR TITLE
[posterize] add edge detection endpoint + improve local dev

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,6 @@
 startup --output_base=~/.bazelout
 startup --digest_function=BLAKE3
+startup --max_idle_secs=86400
 
 common --color=yes
 

--- a/deploy/consolidated/Caddyfile
+++ b/deploy/consolidated/Caddyfile
@@ -14,6 +14,11 @@ api.muchq.com {
 		path /v1/imagine/blur
 	}
 
+	@post_posterize_edges {
+		method POST
+		path /v1/imagine/edges
+	}
+
 	@get_timeseries {
 		method GET
 		path /v1/timeseries/*
@@ -22,6 +27,14 @@ api.muchq.com {
 	@get_metrics {
 		method GET
 		path /v1/metrics/*
+	}
+
+	@ws_thoughts {
+		path /v1/games/thoughts-ws
+	}
+
+	@ws_golf {
+		path /v1/games/golf-ws
 	}
 
 	@options {
@@ -45,12 +58,14 @@ api.muchq.com {
 		respond 204
 	}
 
-	reverse_proxy games_ws_backend:8080
+	reverse_proxy @ws_thoughts games_ws_backend:8080
+	reverse_proxy @ws_golf games_ws_backend:8080
 	reverse_proxy @post_portrait portrait:8081
 	reverse_proxy @get_timeseries prom_proxy:8082
 	reverse_proxy @get_metrics prom_proxy:8082
 	reverse_proxy @post_mithril mithril:8083
 	reverse_proxy @post_posterize_blur posterize:8084
+	reverse_proxy @post_posterize_edges posterize:8084
 
 	log {
 		output file /var/log/caddy/access.log {

--- a/deploy/consolidated/Caddyfile.local
+++ b/deploy/consolidated/Caddyfile.local
@@ -1,0 +1,71 @@
+:2015 {
+	@post_portrait {
+		method POST
+		path /v1/trace
+	}
+
+	@post_mithril {
+		method POST
+		path /v1/wordchain
+	}
+
+	@post_posterize_blur {
+		method POST
+		path /v1/imagine/blur
+	}
+
+	@post_posterize_edges {
+		method POST
+		path /v1/imagine/edges
+	}
+
+	@get_timeseries {
+		method GET
+		path /v1/timeseries/*
+	}
+
+	@get_metrics {
+		method GET
+		path /v1/metrics/*
+	}
+
+	@ws_thoughts {
+		path /v1/games/thoughts-ws
+	}
+
+	@ws_golf {
+		path /v1/games/golf-ws
+	}
+
+	@options {
+		method OPTIONS
+	}
+
+	header {
+		Access-Control-Allow-Origin "*"
+		Access-Control-Allow-Methods "GET, POST, OPTIONS"
+		Access-Control-Allow-Headers "Content-Type, Authorization"
+		Access-Control-Max-Age "86400"
+	}
+
+	handle @options {
+		header {
+			Access-Control-Allow-Origin "*"
+			Access-Control-Allow-Methods "GET, POST, OPTIONS"
+			Access-Control-Allow-Headers "Content-Type, Authorization"
+			Access-Control-Max-Age "86400"
+		}
+		respond 204
+	}
+
+	reverse_proxy @ws_thoughts localhost:8080
+	reverse_proxy @ws_golf localhost:8080
+	reverse_proxy @post_portrait localhost:8081
+	reverse_proxy @post_mithril localhost:8083
+	reverse_proxy @post_posterize_blur localhost:8084
+	reverse_proxy @post_posterize_edges localhost:8084
+
+	log {
+		output stdout
+	}
+}

--- a/deploy/consolidated/LOCAL.md
+++ b/deploy/consolidated/LOCAL.md
@@ -1,0 +1,42 @@
+# Local Development Setup
+
+## Overview
+Run services directly on your machine and use Caddy to proxy requests with CORS for localhost.
+
+## Quick Start
+
+Use the provided script to run all services and Caddy in one command:
+
+```bash
+./deploy/consolidated/local.sh
+```
+
+This will start:
+- games_ws_backend on port 8080
+- portrait on port 8081
+- mithril on port 8083
+- posterize on port 8084
+- Caddy proxy on port 2015
+
+Then run the local UI:
+```bash
+cd /path/to/muchq.github.io
+npm run local-server
+```
+
+## Manual Setup
+
+Alternatively, run services individually:
+
+```bash
+# Terminal 1: run posterize
+PORT=8084 bazel run //rust/posterize
+
+# Terminal 2: run portrait
+PORT=8081 bazel run //cpp/portrait
+
+# ... other services as desired
+
+# Terminal N: run Caddy
+caddy run --config deploy/consolidated/Caddyfile.local
+```

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -5,14 +5,14 @@ This directory contains the consolidated deployment configuration for multiple s
 ## Services Deployed
 
 - **api.muchq.com** - API backend services
-  - `games_ws_backend` (port 8080)
-  - `portrait` (port 8081)
-  - `prom_proxy` (port 8082)
-  - `mithril` (port 8083)
-  - `posterize` (port 8084)
+  - [`games_ws_backend`](../../go/games_ws_backend) (port 8080)
+  - [`portrait`](../../cpp/portrait) (port 8081)
+  - [`prom_proxy`](../../go/prom_proxy) (port 8082)
+  - [`mithril`](../../rust/mithril) (port 8083)
+  - [`posterize`](../../rust/posterize) (port 8084)
 
 - **r3dr.net** - URL shortener service
-  - `r3dr` (port 8085)
+  - [`r3dr`](../../go/r3dr) (port 8085)
   - Static assets served from `/var/www/r3dr`
 
 - **Observability Stack**
@@ -47,7 +47,7 @@ This script will:
 4. Copy the database config file to `/etc/r3dr/db_config`
 
 **Requirements:**
-- SSH access to the host configured (e.g., `ssh ubuntu@api.muchq.com`)
+- SSH access to the host configured (e.g., `ssh ubuntu@consolidated.cmptr.info`)
 - Database config file for r3dr service
 
 After initialization, you may need to reboot the instance.
@@ -80,4 +80,4 @@ Services require configuration files in their respective `/etc` directories on t
 
 ## Network
 
-All services run on the `muchq_network` Docker bridge network, allowing them to communicate with each other using service names.
+All services run on the `muchq_network` Docker bridge network.

--- a/deploy/consolidated/local.sh
+++ b/deploy/consolidated/local.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+trap 'kill $(jobs -p) 2>/dev/null; exit' SIGINT SIGTERM EXIT
+
+PORT=8080 DEV_MODE=1 bazel run //go/games_ws_backend 2>&1 | sed 's/^/[games_ws_backend] /' &
+PORT=8081 bazel run //cpp/portrait 2>&1 | sed 's/^/[portrait] /' &
+PORT=8083 bazel run //rust/mithril 2>&1 | sed 's/^/[mithril] /' &
+PORT=8084 bazel run //rust/posterize 2>&1 | sed 's/^/[posterize] /' &
+caddy run --config deploy/consolidated/Caddyfile.local 2>&1 | sed 's/^/[caddy] /' &
+
+echo "$(tput setaf 3)Caddy listening on port 2015...\n$(tput sgr0)"
+
+wait

--- a/deploy/consolidated/local_deploy.sh
+++ b/deploy/consolidated/local_deploy.sh
@@ -16,8 +16,8 @@ mkdir -p local_docker
 
 # Copy deployment files
 echo "Copying deployment files..."
-cp deploy/api.muchq.com/compose.yaml local_docker/
-cp deploy/api.muchq.com/Caddyfile local_docker/
+cp deploy/consolidated/compose.yaml local_docker/
+cp deploy/consolidated/Caddyfile local_docker/
 
 # Copy observability compose file from root
 echo "Copying observability compose file..."

--- a/go/games_ws_backend/README.md
+++ b/go/games_ws_backend/README.md
@@ -4,7 +4,7 @@ A real-time multiplayer, multitenant WebSocket game server
 
 ## Overview
 This server handles real-time player interactions for
-- [Thoughts](../thoughts), a pretty chill 3D vibe you can play [here](https://muchq.com/thoughts)
+- **[Thoughts](../thoughts)**, a pretty chill 3D vibe you can play [here](https://muchq.com/thoughts)
 - **[Golf](golf/)**, a 4-card golf game with room-based multi-game architecture
 - Some other games someday
 
@@ -17,17 +17,18 @@ This server handles real-time player interactions for
 
 ### Build
 ```bash
-bazel build //go/backend_ws_server
+bazel build //go/games_ws_backend
 ```
 
 ### Development Mode
 ```bash
-DEV_MODE=1 bazel-bin/go/games_ws_backend/games_ws_backend_/games_ws_backend
+DEV_MODE=1 bazel run //go/games_ws_backend
 ```
 
 ### Deploy
+This is now deployed as part of the consolidated deploy in
 ```bash
-go/games_ws_backend/deploy/deploy.sh
+deploy/consolidated/deploy.sh
 ```
 
 ### Configuration
@@ -42,7 +43,7 @@ go/games_ws_backend/deploy/deploy.sh
 
 ## Game Implementations
 
-### Golf (`/golf-ws`)
+### Golf (`/v1/games/golf-ws`)
 4-card golf game with advanced room-based multi-game architecture:
 - **Multiple concurrent games** within the same room
 - **Room-based player management** with persistent statistics

--- a/go/games_ws_backend/main.go
+++ b/go/games_ws_backend/main.go
@@ -39,14 +39,14 @@ func main() {
 	// Serve thoughts backend
 	thoughtsHub := thoughts.NewThoughtsHub()
 	go thoughtsHub.Run()
-	http.HandleFunc("/thoughts-ws", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/v1/games/thoughts-ws", func(w http.ResponseWriter, r *http.Request) {
 		hub.ServeWs(thoughtsHub, w, r)
 	})
 
 	// Serve golf backend
 	golfHub := golf.NewGolfHub(&players.WhimsicalIDGenerator{})
 	go golfHub.Run()
-	http.HandleFunc("/golf-ws", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/v1/games/golf-ws", func(w http.ResponseWriter, r *http.Request) {
 		hub.ServeWs(golfHub, w, r)
 	})
 

--- a/rust/imagine/src/lib.rs
+++ b/rust/imagine/src/lib.rs
@@ -2,6 +2,6 @@ mod processing;
 mod radius;
 mod storage;
 
-pub use processing::{fast_blur, gray_gaussian_blur, gray_scale};
+pub use processing::{fast_blur, gray_gaussian_blur, gray_scale, sobel};
 pub use radius::Radius;
 pub use storage::{read_png, write_gray_png, write_png};

--- a/rust/imagine/src/main.rs
+++ b/rust/imagine/src/main.rs
@@ -1,4 +1,4 @@
-use imagine::{Radius, gray_gaussian_blur, gray_scale, read_png, write_gray_png};
+use imagine::{Radius, gray_gaussian_blur, gray_scale, read_png, write_gray_png, sobel};
 use std::env;
 
 fn main() {
@@ -15,4 +15,9 @@ fn main() {
     let gray_blur = gray_gaussian_blur(&dyn_img, Radius::Five, 5);
     write_gray_png(&gray_blur, "gray_blur.png");
     println!("wrote output to: gray_blur.png");
+
+    let edges = sobel(&gray_blur);
+    write_gray_png(&edges, "edges.png");
+    println!("wrote output to: edges.png");
+
 }

--- a/rust/imagine/src/radius.rs
+++ b/rust/imagine/src/radius.rs
@@ -5,7 +5,7 @@ pub enum Radius {
 }
 
 impl Radius {
-    pub fn gaussian_kernel(&self) -> &'static [u8] {
+    pub fn gaussian_kernel(&self) -> &'static [i32] {
         match self {
             Radius::Three => &[1, 3, 1, 3, 9, 3, 1, 3, 1],
             Radius::Five => &[

--- a/rust/posterize/BUILD.bazel
+++ b/rust/posterize/BUILD.bazel
@@ -5,7 +5,10 @@ load("//bazel/rules:oci.bzl", "linux_amd64_oci_binary")
 rust_binary(
     name = "posterize",
     srcs = [
+        "src/images.rs",
         "src/main.rs",
+        "src/service.rs",
+        "src/types.rs",
     ],
     crate_name = "posterize",
     deps = [

--- a/rust/posterize/README.md
+++ b/rust/posterize/README.md
@@ -1,3 +1,13 @@
 # Posterize
 
 Image post-processing api
+
+## Routes
+
+### POST /v1/imagine/blur
+
+blur a png
+
+### POST /v1/imagine/edges
+
+detect edges on a png

--- a/rust/posterize/src/images.rs
+++ b/rust/posterize/src/images.rs
@@ -1,0 +1,77 @@
+use crate::types::ErrorResponse;
+use axum::Json;
+use axum::http::StatusCode;
+use base64::Engine;
+use base64::engine::general_purpose;
+use image::{DynamicImage, ImageFormat};
+use std::io::Cursor;
+use std::time::Duration;
+use tracing::{event, Level};
+
+fn error_response(status_code: StatusCode, message: String) -> (StatusCode, Json<ErrorResponse>) {
+    (status_code, Json(ErrorResponse { error: message }))
+}
+
+fn server_error() -> (StatusCode, Json<ErrorResponse>) {
+    error_response(StatusCode::INTERNAL_SERVER_ERROR, "Server Error".to_string())
+}
+
+pub fn read_png_from_b64_string(
+    b64_png: &String,
+) -> Result<DynamicImage, (StatusCode, Json<ErrorResponse>)> {
+    general_purpose::STANDARD
+        .decode(b64_png)
+        .map_err(|_| {
+            error_response(
+                StatusCode::BAD_REQUEST,
+                "Invalid base64 encoding".to_string(),
+            )
+        })
+        .and_then(|image_bytes| {
+            image::load_from_memory(&image_bytes).map_err(|e| {
+                error_response(
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid image format: {}", e),
+                )
+            })
+        })
+}
+
+pub fn write_png_to_b64_string(
+    png: &DynamicImage,
+) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+    let mut png_bytes = Vec::new();
+    let mut cursor = Cursor::new(&mut png_bytes);
+
+    png.write_to(&mut cursor, ImageFormat::Png)
+        .map(|()| {
+            return png_bytes;
+        })
+        .map_err(|e| {
+            event!(Level::INFO, "Failed to encode PNG: {}", e);
+            server_error()
+        })
+        .map(|bytes| {
+            return general_purpose::STANDARD.encode(bytes);
+        })
+}
+
+pub async fn process_image(
+    input_png: DynamicImage,
+    f: impl Fn(&DynamicImage) -> DynamicImage + Send + 'static,
+) -> Result<DynamicImage, (StatusCode, Json<ErrorResponse>)> {
+    tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::task::spawn_blocking(move || f(&input_png)),
+    )
+    .await
+    .map_err(|_| {
+        error_response(
+            StatusCode::REQUEST_TIMEOUT,
+            "Image processing timed out after 10 seconds".to_string(),
+        )
+    })?
+    .map_err(|_| {
+        server_error()
+    })
+}

--- a/rust/posterize/src/main.rs
+++ b/rust/posterize/src/main.rs
@@ -1,145 +1,11 @@
-use axum::extract::Json as ExtractJson;
-use axum::http::StatusCode;
-use axum::response::Json;
+mod images;
+mod service;
+mod types;
+
+use crate::service::{blur_post, edges_post};
 use axum::routing::post;
-use base64::{Engine as _, engine::general_purpose};
-use image::ImageFormat;
-use imagine::{fast_blur, gray_gaussian_blur, Radius};
-use serde::{Deserialize, Deserializer, Serialize};
 use server_pal::{listen_addr_pal, router_builder};
-use std::io::Cursor;
-use std::time::Duration;
 use tracing::{Level, event};
-
-fn validate_png<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let b64_png = String::deserialize(deserializer)?;
-
-    if b64_png.is_empty() {
-        return Err(serde::de::Error::custom("png cannot be empty"));
-    }
-
-    if b64_png.len() > 5_000_000 {
-        return Err(serde::de::Error::custom("b64 png must be at most 5MiB"));
-    }
-    Ok(b64_png)
-}
-
-fn validate_sigma<'de, D>(deserializer: D) -> Result<Option<f32>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let sigma_maybe = Option::<f32>::deserialize(deserializer)?;
-
-    if let Some(sigma) = sigma_maybe {
-        if sigma <= 0.0 {
-            return Err(serde::de::Error::custom("sigma must be positive"));
-        }
-    }
-
-    Ok(sigma_maybe)
-}
-
-#[derive(Deserialize)]
-struct BlurRequest {
-    #[serde(deserialize_with = "validate_png")]
-    b64_png: String,
-    #[serde(deserialize_with = "validate_sigma")]
-    sigma: Option<f32>,
-    gray: bool
-}
-
-#[derive(Serialize)]
-struct BlurResponse {
-    width: u32,
-    height: u32,
-    format: String,
-    image_data: String,
-    size_bytes: usize,
-}
-
-#[derive(Serialize, Debug)]
-struct ErrorResponse {
-    error: String,
-}
-
-async fn blur_post(
-    ExtractJson(request): ExtractJson<BlurRequest>,
-) -> Result<Json<BlurResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let image_bytes = general_purpose::STANDARD
-        .decode(&request.b64_png)
-        .map_err(|_| {
-            (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: "Invalid base64 encoding".to_string(),
-                }),
-            )
-        })?;
-
-    let input_png = image::load_from_memory(&image_bytes).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: format!("Invalid image format: {}", e),
-            }),
-        )
-    })?;
-
-    let blurred = tokio::time::timeout(
-        Duration::from_secs(10),
-        tokio::task::spawn_blocking(move || {
-            if request.gray {
-                image::DynamicImage::ImageLuma8(gray_gaussian_blur(&input_png, Radius::Five, 3))
-            } else {
-                image::DynamicImage::ImageRgba8(fast_blur(&input_png, request.sigma.unwrap_or(5.0)))
-            }
-        })
-    )
-        .await
-        .map_err(|_| {
-            (
-                StatusCode::REQUEST_TIMEOUT,
-                Json(ErrorResponse {
-                    error: "Image processing timed out after 10 seconds".to_string(),
-                }),
-            )
-        })?
-        .map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "Image processing failed".to_string(),
-                }),
-            )
-        })?;
-
-    let mut png_bytes = Vec::new();
-    let mut cursor = Cursor::new(&mut png_bytes);
-
-    blurred
-        .write_to(&mut cursor, ImageFormat::Png)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: format!("Failed to encode PNG: {}", e),
-                }),
-            )
-        })?;
-
-    let blurred_b64 = general_purpose::STANDARD.encode(&png_bytes);
-    let response = BlurResponse {
-        width: blurred.width(),
-        height: blurred.height(),
-        format: "PNG".to_string(),
-        size_bytes: blurred_b64.len(),
-        image_data: blurred_b64,
-    };
-    Ok(Json(response))
-}
 
 #[tokio::main]
 async fn main() {
@@ -149,6 +15,7 @@ async fn main() {
 
     let app = router_builder()
         .route("/v1/imagine/blur", post(blur_post))
+        .route("/v1/imagine/edges", post(edges_post))
         .build();
 
     let listener = tokio::net::TcpListener::bind(listen_address.clone())

--- a/rust/posterize/src/service.rs
+++ b/rust/posterize/src/service.rs
@@ -1,0 +1,54 @@
+use crate::images::{process_image, read_png_from_b64_string, write_png_to_b64_string};
+use crate::types::{BlurRequest, BlurResponse, EdgesRequest, EdgesResponse, ErrorResponse};
+use axum::Json;
+use axum::extract::Json as ExtractJson;
+use axum::http::StatusCode;
+use imagine::{Radius, fast_blur, gray_gaussian_blur, sobel};
+
+pub async fn blur_post(
+    ExtractJson(request): ExtractJson<BlurRequest>,
+) -> Result<Json<BlurResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let input_png = read_png_from_b64_string(&request.b64_png)?;
+
+    let gray = request.gray;
+    let sigma = request.sigma.unwrap_or(5.0);
+    let blurred = process_image(input_png, move |p| {
+        if gray {
+            image::DynamicImage::ImageLuma8(gray_gaussian_blur(&p, Radius::Five, 3))
+        } else {
+            image::DynamicImage::ImageRgba8(fast_blur(&p, sigma))
+        }
+    })
+    .await?;
+
+    let blurred_b64 = write_png_to_b64_string(&blurred)?;
+    let response = BlurResponse {
+        width: blurred.width(),
+        height: blurred.height(),
+        format: "PNG".to_string(),
+        size_bytes: blurred_b64.len(),
+        image_data: blurred_b64,
+    };
+    Ok(Json(response))
+}
+
+pub async fn edges_post(
+    ExtractJson(request): ExtractJson<EdgesRequest>,
+) -> Result<Json<EdgesResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let input_png = read_png_from_b64_string(&request.b64_png)?;
+
+    let edges_img = process_image(input_png, move |p| {
+        image::DynamicImage::ImageLuma8(sobel(&p.to_luma8()))
+    })
+    .await?;
+
+    let edges_b64 = write_png_to_b64_string(&edges_img)?;
+    let response = EdgesResponse {
+        width: edges_img.width(),
+        height: edges_img.height(),
+        format: "PNG".to_string(),
+        size_bytes: edges_b64.len(),
+        image_data: edges_b64,
+    };
+    Ok(Json(response))
+}

--- a/rust/posterize/src/types.rs
+++ b/rust/posterize/src/types.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+fn validate_png<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let b64_png = String::deserialize(deserializer)?;
+
+    if b64_png.is_empty() {
+        return Err(serde::de::Error::custom("png cannot be empty"));
+    }
+
+    if b64_png.len() > 5_000_000 {
+        return Err(serde::de::Error::custom("b64 png must be at most 5MiB"));
+    }
+    Ok(b64_png)
+}
+
+fn validate_sigma<'de, D>(deserializer: D) -> Result<Option<f32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let sigma_maybe = Option::<f32>::deserialize(deserializer)?;
+
+    if let Some(sigma) = sigma_maybe {
+        if sigma <= 0.0 {
+            return Err(serde::de::Error::custom("sigma must be positive"));
+        }
+    }
+
+    Ok(sigma_maybe)
+}
+
+#[derive(Deserialize)]
+pub struct BlurRequest {
+    #[serde(deserialize_with = "validate_png")]
+    pub(crate) b64_png: String,
+    #[serde(deserialize_with = "validate_sigma")]
+    pub(crate) sigma: Option<f32>,
+    pub(crate) gray: bool,
+}
+
+#[derive(Serialize)]
+pub struct BlurResponse {
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) format: String,
+    pub(crate) image_data: String,
+    pub(crate) size_bytes: usize,
+}
+
+#[derive(Deserialize)]
+pub struct EdgesRequest {
+    #[serde(deserialize_with = "validate_png")]
+    pub(crate) b64_png: String,
+}
+
+#[derive(Serialize)]
+pub struct EdgesResponse {
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) format: String,
+    pub(crate) image_data: String,
+    pub(crate) size_bytes: usize,
+}
+
+#[derive(Serialize, Debug)]
+pub struct ErrorResponse {
+    pub(crate) error: String,
+}


### PR DESCRIPTION
  - Add Sobel edge detection algorithm to imagine library
  - Expose new /v1/imagine/edges endpoint in posterize service
  - Refactor posterize into modular structure (images, service, types)
  - Update Caddy configs to route edge detection and WebSocket endpoints
  - Add local development tooling (Caddyfile.local, local.sh, LOCAL.md)
  - Improve deployment documentation with service links
  - Update games_ws_backend to use versioned WebSocket paths
  - Add fallback handler and increase Bazel idle timeout
  - Fix gaussian blur kernel types (u8 -> i32) for signed convolution