### PR TITLE
[golf] return error on double room or game join

### DIFF
--- a/go/games_ws_backend/golf/game.go
+++ b/go/games_ws_backend/golf/game.go
@@ -101,6 +101,11 @@ func (g *Game) AddPlayer(clientID string, playerID string, playerName string) (*
 		return nil, fmt.Errorf("game is full")
 	}
 
+	// Check if player is already in the game
+	if _, exists := g.playersByClient[clientID]; exists {
+		return nil, fmt.Errorf("player already in game")
+	}
+
 	player := &Player{
 		ID:            playerID,
 		Name:          playerName,

--- a/go/games_ws_backend/golf/golf_hub.go
+++ b/go/games_ws_backend/golf/golf_hub.go
@@ -256,24 +256,10 @@ func (h *GolfHub) handleJoinRoom(client *hub.Client, roomID string) {
 		// Check if client is already in a room
 		ctx := h.clientContexts[client]
 		if ctx != nil && ctx.RoomID != "" {
-			// If already in the same room, do nothing
+			// If already in the same room, return error
 			if ctx.RoomID == roomID {
-				room = h.rooms[roomID]
-
-				// Find the player in the room
-				clientID := getClientID(client)
-				for _, p := range room.Players {
-					if p.ClientID == clientID {
-						player = p
-						break
-					}
-				}
-
-				if player == nil {
-					// This would be some kind of problem
-					h.sendError(client, "Player not found in room")
-					return
-				}
+				h.sendError(client, "player already in room")
+				return
 			} else {
 				h.sendError(client, "Already in a different room")
 				return


### PR DESCRIPTION
Previously, double room join did nothing, which is fine-ish, but double game join actually added the player twice, which is non-fine. Now we return an error in both cases.