### PR TITLE
Run autotag workflow only after publish succeeds

### DIFF
--- a/.github/workflows/auto-tag-impact-mcp.yml
+++ b/.github/workflows/auto-tag-impact-mcp.yml
@@ -1,11 +1,12 @@
 name: Auto-tag impact-mcp version
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Test + Publish"]
+    types:
+      - completed
     branches:
       - main
-    paths:
-      - 'domains/ai/apps/impact_mcp/Cargo.toml'
 
 permissions:
   contents: write
@@ -13,6 +14,7 @@ permissions:
 jobs:
   check-and-tag:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Change the auto-tag-impact-mcp workflow trigger from `push` to
`workflow_run` so it waits for the "Test + Publish" workflow to
complete successfully before running. This prevents tagging a
version that failed to build or publish.

https://claude.ai/code/session_018ekhBYroD7WhGMMVcWvrNe