### PR TITLE
Remove unused cargo dependencies and fix tonic build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,8 +720,6 @@ name = "doc_db"
 version = "0.1.0"
 dependencies = [
  "doc_db_proto",
- "dotenv",
- "futures",
  "mongodb",
  "serde",
  "tokio",
@@ -734,18 +732,10 @@ name = "doc_db_proto"
 version = "0.1.0"
 dependencies = [
  "prost",
- "prost-types",
- "protoc-gen-prost",
- "protoc-gen-tonic",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dyn-clone"
@@ -792,7 +782,6 @@ name = "example_grpc_proto"
 version = "0.1.0"
 dependencies = [
  "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -837,6 +826,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -996,6 +991,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1369,7 +1373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1612,7 +1616,6 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "serde",
- "serde_json",
  "server_pal",
  "tokio",
  "tracing",
@@ -1849,11 +1852,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
 ]
 
@@ -1998,19 +2002,22 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
  "itertools",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
+ "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
+ "syn",
  "tempfile",
 ]
 
@@ -2037,35 +2044,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "protoc-gen-prost"
-version = "0.5.0"
+name = "pulldown-cmark"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4018e7b5e3a213d241d79a0ef43a442a17dc23dcdd5b81b0c42b2549197897fd"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "once_cell",
- "prost",
- "prost-build",
- "prost-types",
- "regex",
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
-name = "protoc-gen-tonic"
-version = "0.5.0"
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa40faad46fb55e5c4a3257461c43f6ed0f87b320d11d98b4ea397f6f45896be"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
- "heck",
- "prettyplease",
- "proc-macro2",
- "prost",
- "prost-build",
- "prost-types",
- "protoc-gen-prost",
- "quote",
- "regex",
- "syn",
- "tonic-build",
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -2169,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2906,13 +2901,29 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
 dependencies = [
  "bytes",
  "prost",
  "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,11 @@ base64 = "0.22.1"
 base64ct = { version = "1.8.3", features = ["alloc"] }
 clap = { version = "4.5.54", features = ["cargo"] }
 doc_db_proto = { path = "domains/platform/protos/doc_db" }
-dotenv = "0.15.0"
-futures = "0.3.31"
 image = { version = "0.25.9", default-features = false, features = ["png", "jpeg"] }
 imagine = { path = "domains/graphics/libs/imagine_rust" }
 log = "0.4.29"
 mongodb = "3.5.0"
 prost = { version = "0.14.3" }
-prost-types = { version = "0.14.3", default-features = false }
-protoc-gen-tonic = "0.5.0"
-protoc-gen-prost = "0.5.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 server_pal = { path = "domains/platform/libs/server_pal" }
@@ -42,17 +37,15 @@ sha2 = "0.11.0-rc.3"
 simplelog = { version = "0.12.2", features = ["paris"] }
 tokio = { version = "1.49.0", default-features = false, features = ["macros", "net", "rt-multi-thread", "signal"] }
 tonic = { version = "0.14.2", features = ["transport"] }
-tonic-build = "0.14.2"
 tonic-prost = "0.14.2"
+tonic-prost-build = "0.14.2"
 tower-http = { version = "0.6.8", features = ["full"] }
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 uuid = { version = "1.19.0", features = ["v4", "fast-rng", "serde"]}
 chrono = { version = "0.4.41", features = ["serde"] }
 dirs = "6.0.0"
-genai = "0.3.5"
 rmcp = { version = "0.13.0", features = ["client", "server", "macros", "transport-child-process", "transport-io"] }
 schemars = "1.0"
-rustyline = "15.0.0"
 serde_yaml_ng = "0.10"
 wordchains = { path = "domains/games/libs/wordchains" }

--- a/domains/games/apis/mithril/Cargo.toml
+++ b/domains/games/apis/mithril/Cargo.toml
@@ -8,7 +8,6 @@ readme.workspace = true
 [dependencies]
 axum = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
 server_pal = {workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }

--- a/domains/platform/apis/doc_db/Cargo.toml
+++ b/domains/platform/apis/doc_db/Cargo.toml
@@ -10,9 +10,7 @@ name = "doc_db"
 path = "src/main.rs"
 
 [dependencies]
-dotenv = { workspace = true }
 doc_db_proto = { workspace = true }
-futures = { workspace = true }
 mongodb = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }

--- a/domains/platform/protos/doc_db/Cargo.toml
+++ b/domains/platform/protos/doc_db/Cargo.toml
@@ -13,10 +13,7 @@ path = "lib.rs"
 [dependencies]
 tonic = { workspace = true }
 prost = { workspace = true }
-prost-types = { workspace = true }
-tonic-build = { workspace = true }
-protoc-gen-prost = { workspace = true }
-protoc-gen-tonic = { workspace = true }
+tonic-prost = { workspace = true }
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }

--- a/domains/platform/protos/doc_db/build.rs
+++ b/domains/platform/protos/doc_db/build.rs
@@ -1,4 +1,4 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("doc_db.proto")?;
+    tonic_prost_build::compile_protos("doc_db.proto")?;
     Ok(())
 }

--- a/domains/platform/protos/example_grpc/Cargo.toml
+++ b/domains/platform/protos/example_grpc/Cargo.toml
@@ -12,4 +12,3 @@ path = "lib.rs"
 
 [dependencies]
 tonic = { workspace = true }
-tonic-prost = { workspace = true }


### PR DESCRIPTION
This PR removes several unused Rust dependencies from the workspace and fixes the build for `doc_db_proto` which was broken due to `tonic` 0.14 changes (requiring migration to `tonic-prost-build`).

Changes:
- Removed unused deps: `dotenv`, `futures`, `genai`, `rustyline`, `prost-types`, `protoc-gen-*`.
- Migrated `doc_db_proto` to use `tonic-prost-build` for compilation.
- Removed `tonic-build` from workspace as it is no longer used (`tonic-prost-build` is used instead).

---
*PR created automatically by Jules for task [11382522897087785504](https://jules.google.com/task/11382522897087785504) started by @aaylward*