### PR TITLE
Update impact-mcp skill installation and version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "impact_mcp"
-version = "0.0.7-alpha"
+version = "0.0.8-alpha"
 dependencies = [
  "chrono",
  "clap",

--- a/domains/ai/apps/impact_mcp/Cargo.toml
+++ b/domains/ai/apps/impact_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impact_mcp"
-version = "0.0.7-alpha"
+version = "0.0.8-alpha"
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true

--- a/domains/ai/apps/impact_mcp/src/cli.rs
+++ b/domains/ai/apps/impact_mcp/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "impact-mcp",
     about = "impact-mcp — amplify your impact and make it visible",
-    version = "0.0.7-alpha",
+    version = "0.0.8-alpha",
     long_about = "A local-first AI agent that helps engineers capture evidence of impact, \
                    understand role expectations, close gaps, and communicate contributions \
                    clearly — for better project results and growth in your career."


### PR DESCRIPTION
This change updates `impact-mcp` to version 0.0.8-alpha. It modifies the installation of Claude skills to use a nested directory structure (`.../<skill-name>/SKILL.md`) as required. It also updates the setup command to configure the MCP server using the `claude mcp add` CLI command instead of manually editing the settings file.


---
*PR created automatically by Jules for task [12180556454901869579](https://jules.google.com/task/12180556454901869579) started by @aaylward*