### PR TITLE
Fix Codex skill installation structure and bump version to 0.0.9-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "impact_mcp"
-version = "0.0.8-alpha"
+version = "0.0.9-alpha"
 dependencies = [
  "chrono",
  "clap",

--- a/domains/ai/apps/impact_mcp/Cargo.toml
+++ b/domains/ai/apps/impact_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impact_mcp"
-version = "0.0.8-alpha"
+version = "0.0.9-alpha"
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true

--- a/domains/ai/apps/impact_mcp/src/cli.rs
+++ b/domains/ai/apps/impact_mcp/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "impact-mcp",
     about = "impact-mcp — amplify your impact and make it visible",
-    version = "0.0.8-alpha",
+    version = "0.0.9-alpha",
     long_about = "A local-first AI agent that helps engineers capture evidence of impact, \
                    understand role expectations, close gaps, and communicate contributions \
                    clearly — for better project results and growth in your career."


### PR DESCRIPTION
Updated `install_codex_skills` to create a directory for each skill and write the content to `SKILL.md`, similar to the Claude skill installation. Updated tests to verify this structure. Bumped version in `Cargo.toml` and `cli.rs`.

---
*PR created automatically by Jules for task [3046788833388313332](https://jules.google.com/task/3046788833388313332) started by @aaylward*