### PR TITLE
Bump microgpt CLI to 0.1.1

### DIFF
--- a/domains/ai/apps/microgpt_cli/Cargo.toml
+++ b/domains/ai/apps/microgpt_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microgpt_cli"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true

--- a/domains/ai/apps/microgpt_cli/src/main.rs
+++ b/domains/ai/apps/microgpt_cli/src/main.rs
@@ -17,7 +17,7 @@ use microgpt::{
 #[command(
     name = "microgpt",
     about = "microgpt — a minimal GPT trainer and generator",
-    version = "0.1.0",
+    version = "0.1.1",
     long_about = "A from-scratch GPT implementation in Rust with its own autograd engine.\n\
                   Trains character-level language models and generates samples.\n\
                   Ported from karpathy's microgpt.py — the complete algorithm,\n\


### PR DESCRIPTION
## Summary
- Bump microgpt CLI version from 0.1.0 to 0.1.1 in Cargo.toml and clap command attribute
- Testing the new release workflow

## Test plan
- [ ] Verify `microgpt --version` prints 0.1.1
- [ ] Confirm release workflow triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)