### PR TITLE
[microgpt] fix metal training again

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -51,6 +51,29 @@ jobs:
         run: |
           ./scripts/diff-build origin/main
 
+  # Metal GPU training requires macOS; run microgpt tests on Apple Silicon when relevant files change.
+  test-microgpt-metal:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for microgpt changes
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD -- domains/ai/libs/microgpt/ domains/ai/apps/microgpt_cli/)
+          if [ -n "$CHANGED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run microgpt Metal tests
+        if: steps.filter.outputs.changed == 'true'
+        working-directory: domains/ai/libs/microgpt
+        run: cargo test --features metal -- test_metal
+
   # iOS targets can't build on Ubuntu; run Swift tests on macOS when relevant files change.
   test-ios:
     runs-on: macos-26

--- a/domains/ai/apps/microgpt_cli/Cargo.toml
+++ b/domains/ai/apps/microgpt_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microgpt_cli"
-version = "0.2.2"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true

--- a/domains/ai/apps/microgpt_cli/src/main.rs
+++ b/domains/ai/apps/microgpt_cli/src/main.rs
@@ -17,7 +17,7 @@ use microgpt::{
 #[command(
     name = "microgpt",
     about = "microgpt — a minimal GPT trainer and generator",
-    version = "0.2.2",
+    version = "0.3.0",
     long_about = "A minimal GPT implementation in Rust using candle for tensor ops.\n\
                   Trains character-level language models and generates samples.\n\
                   Ported from karpathy's microgpt.py — the complete algorithm,\n\


### PR DESCRIPTION
## Summary

- Fix two Metal GPU training crashes in microgpt's candle tensor backend
- Add CI gate to prevent Metal regressions on future PRs
- Bump CLI to 0.3.0

## Changes

**Fix f64 scalar on Metal** (`tensor_model.rs`): `Tensor::new(1e-5, ...)` creates an F64 tensor (Rust defaults `1e-5` to `f64`). Metal doesn't support F64→F32 dtype conversion. Fixed by using `1e-5f32`.

**Fix non-contiguous matmul on Metal** (`tensor_model.rs`): After `permute((1, 0, 2))` on Q/K/V tensors, the strides are neither row-major nor column-major. Metal's GEMM kernel (via MLX) rejects these with `MatMulNonContiguous`. Fixed by adding `.contiguous()` after each permute.

**Metal CI job** (`branch.yml`, `e2e.rs`): Added `test_metal_training` end-to-end test gated with `#[cfg(target_os = "macos")]` that runs 3 training steps on Metal device. New `test-microgpt-metal` CI job on `macos-26` runs when microgpt files change.

## Test plan

- [x] `cargo test --features metal -- test_metal` passes locally on Apple Silicon
- [x] All existing CPU e2e tests still pass
- [x] CI `test-microgpt-metal` job passes on macOS runner