### PR TITLE
Enable branch builds on free GitHub Actions runners

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -40,10 +40,8 @@ jobs:
           disk-cache: ${{ github.workflow }}
           repository-cache: true
           bazelrc: |
-            build --local_ram_resources=4096
-            build --local_cpu_resources=2
-            test --local_ram_resources=4096
-            test --local_cpu_resources=2
+            build --local_resources=cpu=2
+            build --local_resources=memory=4096
       - name: bazel-format-check
         run: |
           bazel run //:format.check


### PR DESCRIPTION
Replaces 'ubuntu-latest-4-cores' with 'ubuntu-latest' in branch.yml and adds Bazel resource limits (4GB RAM, 2 CPUs) to prevent OOM errors on standard runners. This removes the dependency on paid runners for branch builds.

---
*PR created automatically by Jules for task [8215646250712213223](https://jules.google.com/task/8215646250712213223) started by @aaylward*