### PR TITLE
1d4_web: path-based routing, username search, README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ a polyglot playground for experiments in application architecture, API design, l
 |-----------------|-----|----------------------------|
 | **muchq**       | [muchq.com](https://muchq.com) | Project landing page       |
 | **r3dr**        | [r3dr.net](https://r3dr.net) | Another URL shortener      |
+| **1d4**         | [1d4.net](https://1d4.net) | Chess game indexer web UI  |
 | **1d4.net MCP** | [mcp.1d4.net](https://mcp.1d4.net) | MCP server for chess tools |
 | **microgpt**    | [tty1.uk](https://tty1.uk)     | Minimal GPT implementation |
 

--- a/domains/games/README.md
+++ b/domains/games/README.md
@@ -2,6 +2,10 @@
 
 Game engines, services, and libraries.
 
+## Deployed
+
+- [**1d4**](https://1d4.net) — Chess game indexer web UI ([1d4_web](apps/1d4_web)); browse games, enqueue indexing, run ChessQL queries.
+
 ## APIs
 
 - [**Golf Service**](apis/golf_service): C++ backend for a golf-themed game.
@@ -15,7 +19,7 @@ Game engines, services, and libraries.
 
 - [**FlippyMem**](apps/flippymem): A simple memory game (web-based).
 - [**Chess Demo**](apps/chess_demo): Demonstration application for chess-related functionality.
-- [**1d4 Web**](apps/1d4_web): Lightweight web UI for the one_d4 chess game indexer — browse indexed games, enqueue index requests, run ChessQL queries. Vanilla HTML/JS/CSS; deploys to Cloudflare Workers at 1d4.net.
+- [**1d4 Web**](apps/1d4_web): Lightweight web UI for the one_d4 chess game indexer — browse indexed games (with username search), enqueue index requests, run ChessQL queries. Vanilla HTML/JS/CSS; deployed at [1d4.net](https://1d4.net).
 - [**Wordchains**](apps/wordchains): Interactive solver for Lewis Carroll's "Doublets" (Word Ladder) game. Supports graph generation, shortest path finding, and exploring all paths between words.
 - [**Wordchains iOS**](apps/wordchains_ios): SwiftUI iOS app for the Word Chains puzzle game. Quick Play, Daily Challenge, and Time Attack modes. Reuses the same word graph and algorithms as the CLI.
 

--- a/domains/games/apps/1d4_web/src/index.html
+++ b/domains/games/apps/1d4_web/src/index.html
@@ -8,12 +8,12 @@
 </head>
 <body>
   <header class="header">
-    <h1><a href="#games">1d4</a></h1>
+    <h1><a href="/">1d4</a></h1>
     <p class="tagline">Chess game indexer</p>
     <nav class="nav">
-      <a href="#games" class="nav-link">Games</a>
-      <a href="#index" class="nav-link">Index</a>
-      <a href="#query" class="nav-link">Query</a>
+      <a href="/games" class="nav-link">Games</a>
+      <a href="/index" class="nav-link">Index</a>
+      <a href="/query" class="nav-link">Query</a>
     </nav>
   </header>
   <main id="app" class="main"></main>

--- a/domains/games/apps/1d4_web/src/views/index.js
+++ b/domains/games/apps/1d4_web/src/views/index.js
@@ -109,7 +109,7 @@ export function renderIndex(container) {
           render();
           const msg = document.createElement('div');
           msg.className = 'message success';
-          msg.innerHTML = `Request created. ID: <strong>${res.id}</strong> — <a href="#index" class="external">View status below</a>.`;
+          msg.innerHTML = `Request created. ID: <strong>${res.id}</strong> — <a href="/index" class="external">View status below</a>.`;
           container.insertBefore(msg, container.firstChild);
         })
         .catch((err) => {
@@ -146,7 +146,7 @@ export function renderIndex(container) {
         const tr = document.createElement('tr');
         const statusClass = (row.status || '').toLowerCase().replace(' ', '-');
         tr.innerHTML = `
-          <td><a href="#index" class="external">${id}</a></td>
+          <td><a href="/index" class="external">${id}</a></td>
           <td class="status-${statusClass}">${row.status || '—'}</td>
           <td>${row.gamesIndexed ?? 0}</td>
           <td>${row.errorMessage || '—'}</td>

--- a/domains/games/apps/1d4_web/src/views/query.js
+++ b/domains/games/apps/1d4_web/src/views/query.js
@@ -97,9 +97,9 @@ export function renderQuery(container) {
     const help = document.createElement('div');
     help.className = 'syntax-help';
     help.innerHTML = `
-      <strong>ChessQL</strong> — Fields: <code>white.elo</code>, <code>black.elo</code>, <code>eco</code>, <code>result</code>, <code>time.class</code>, <code>num.moves</code>, <code>platform</code>, <code>game.url</code>, <code>played.at</code>.
-      Motifs: <code>motif(pin)</code>, <code>motif(fork)</code>, <code>motif(skewer)</code>, <code>motif(cross_pin)</code>, <code>motif(discovered_attack)</code>.
-      Combine with <code>AND</code>, <code>OR</code>, <code>NOT</code>. Strings in double quotes, e.g. <code>eco = "B90"</code>.
+      <strong>ChessQL</strong> — Fields: <code>white.elo</code>, <code>black.elo</code>, <code>white.username</code>, <code>black.username</code>, <code>time.class</code>, <code>num.moves</code>, <code>eco</code>, <code>result</code>, <code>platform</code>, <code>game.url</code>, <code>played.at</code>.
+      Motifs: <code>motif(pin)</code>, <code>motif(cross_pin)</code>, <code>motif(fork)</code>, <code>motif(skewer)</code>, <code>motif(discovered_attack)</code>.
+      Combine with <code>AND</code>, <code>OR</code>, <code>NOT</code>. Strings in double quotes, e.g. <code>eco = "B90"</code>. Do not use SELECT or *.
     `;
     container.appendChild(help);
 


### PR DESCRIPTION
- Path-based routing: replace `#games` / `#index` / `#query` with `/games`, `/index`, `/query` (History API)
- Username search on Games tab: filter by player as white or black (ChessQL exact match)
- Query view: align syntax help with one_d4 README (fields, motifs, "Do not use SELECT or *")
- Main README: add 1d4 to Deployed Projects table
- domains/games README: add Deployed section, link 1d4_web to 1d4.net

Made with [Cursor](https://cursor.com)