### PR TITLE
1d4 API v1 prefix, progress count, index form, Caddy routes

### DIFF
--- a/deploy/consolidated/Caddyfile
+++ b/deploy/consolidated/Caddyfile
@@ -39,6 +39,26 @@ api.muchq.com {
 		path /metrics/v1/scalar/*
 	}
 
+	@get_1d4_health {
+		method GET
+		path /1d4/v1/health
+	}
+
+	@post_1d4_index {
+		method POST
+		path /1d4/v1/index
+	}
+
+	@get_1d4_index {
+		method GET
+		path /1d4/v1/index/*
+	}
+
+	@post_1d4_query {
+		method POST
+		path /1d4/v1/query
+	}
+
 	@ws_thoughts {
 		path /games/v1/thoughts-ws
 	}
@@ -78,6 +98,23 @@ api.muchq.com {
 	reverse_proxy @post_posterize_edges posterize:8084
 	reverse_proxy @post_generate microgpt-serve:8087
 	reverse_proxy @post_chat microgpt-serve:8087
+
+	handle @get_1d4_health {
+		rewrite * /health
+		reverse_proxy one_d4:8080
+	}
+	handle @post_1d4_index {
+		rewrite * /v1/index
+		reverse_proxy one_d4:8080
+	}
+	handle @get_1d4_index {
+		uri strip_prefix /1d4
+		reverse_proxy one_d4:8080
+	}
+	handle @post_1d4_query {
+		rewrite * /v1/query
+		reverse_proxy one_d4:8080
+	}
 
 	log {
 		output file /var/log/caddy/access.log {
@@ -179,17 +216,17 @@ gpt.muchq.com {
 api.1d4.net {
 	@post_index {
 		method POST
-		path /index
+		path /v1/index
 	}
 
 	@get_index {
 		method GET
-		path /index/*
+		path /v1/index/*
 	}
 
 	@post_query {
 		method POST
-		path /query
+		path /v1/query
 	}
 
 	@get_health {

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -17,11 +17,11 @@ curl -X GET http://localhost:8080/health
 Starts a background task to index games for a specific player on a platform within a given time range.
 
 ```bash
-curl -X POST http://localhost:8080/index \
+curl -X POST http://localhost:8080/v1/index \
   -H "Content-Type: application/json" \
   -d '{
     "player": "magnuscarlsen",
-    "platform": "chess.com",
+    "platform": "CHESS_COM",
     "startMonth": "2023-01",
     "endMonth": "2023-12"
   }'
@@ -32,10 +32,10 @@ curl -X POST http://localhost:8080/index \
 Retrieves the status of a previously submitted indexing request.
 
 ```bash
-curl -X GET http://localhost:8080/index/{id}
+curl -X GET http://localhost:8080/v1/index/{id}
 ```
 
-Replace `{id}` with the UUID returned from the `POST /index` request.
+Replace `{id}` with the UUID returned from the `POST /v1/index` request.
 
 ### Query Games
 
@@ -43,7 +43,7 @@ Query indexed game features using the ChessQL expression language. ChessQL is an
 
 **Example: Query by rating**
 ```bash
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H "Content-Type: application/json" \
   -d '{
     "query": "white_elo > 2500 OR black_elo > 2500",
@@ -54,7 +54,7 @@ curl -X POST http://localhost:8080/query \
 
 **Example: Query by motifs**
 ```bash
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H "Content-Type: application/json" \
   -d '{
     "query": "motif(fork) AND white_elo >= 2400",
@@ -64,7 +64,7 @@ curl -X POST http://localhost:8080/query \
 
 **Example: Query by opening (ECO)**
 ```bash
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H "Content-Type: application/json" \
   -d '{
     "query": "eco = \"B90\" AND platform IN [\"chess.com\", \"lichess\"]",

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/IndexController.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/IndexController.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Singleton
-@Path("/index")
+@Path("/v1/index")
 public class IndexController {
   private static final Logger LOG = LoggerFactory.getLogger(IndexController.class);
 
@@ -41,7 +41,7 @@ public class IndexController {
     validator.validate(request);
 
     LOG.info(
-        "POST /index player={} platform={} months={}-{}",
+        "POST /v1/index player={} platform={} months={}-{}",
         request.player(),
         request.platform(),
         request.startMonth(),
@@ -62,7 +62,7 @@ public class IndexController {
   @Path("/{id}")
   @Produces(MediaType.APPLICATION_JSON)
   public IndexResponse getIndex(@PathParam("id") UUID id) {
-    LOG.info("GET /index/{}", id);
+    LOG.info("GET /v1/index/{}", id);
     return requestDao
         .findById(id)
         .map(

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/QueryController.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/QueryController.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Singleton
-@Path("/query")
+@Path("/v1/query")
 public class QueryController {
   private static final Logger LOG = LoggerFactory.getLogger(QueryController.class);
 
@@ -44,7 +44,7 @@ public class QueryController {
     validator.validate(request);
 
     LOG.info(
-        "POST /query query={} limit={} offset={}",
+        "POST /v1/query query={} limit={} offset={}",
         request.query(),
         request.limit(),
         request.offset());

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -10,7 +10,7 @@ Configurable via `PORT` environment variable.
 
 ---
 
-## POST /index
+## POST /v1/index
 
 Start indexing games for a player over a month range.
 
@@ -52,7 +52,7 @@ PENDING → PROCESSING → COMPLETED
 
 ---
 
-## GET /index/{id}
+## GET /v1/index/{id}
 
 Poll the status of an indexing request.
 
@@ -73,7 +73,7 @@ Returned when the ID does not match any indexing request.
 
 ---
 
-## POST /query
+## POST /v1/query
 
 Search indexed games using ChessQL.
 
@@ -147,29 +147,29 @@ Search indexed games using ChessQL.
 INDEXER_DB_URL="jdbc:h2:mem:indexer;DB_CLOSE_DELAY=-1" bazel run //domains/games/apis/one_d4:indexer
 
 # 1. Start indexing
-curl -X POST http://localhost:8080/index \
+curl -X POST http://localhost:8080/v1/index \
   -H "Content-Type: application/json" \
   -d '{"player":"hikaru","platform":"CHESS_COM","startMonth":"2026-01","endMonth":"2026-01"}'
 
 # Response: {"id":"abc-123","status":"PENDING","gamesIndexed":0}
 
 # 2. Poll until completed
-curl http://localhost:8080/index/abc-123
+curl http://localhost:8080/v1/index/abc-123
 
 # Response: {"id":"abc-123","status":"COMPLETED","gamesIndexed":828}
 
 # 3. Query indexed games
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H "Content-Type: application/json" \
   -d '{"query":"white.elo > 2700 AND motif(fork)","limit":10,"offset":0}'
 
 # 4. Query games with multiple motifs
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H "Content-Type: application/json" \
   -d '{"query":"motif(pin) AND motif(skewer)","limit":10,"offset":0}'
 
 # 5. Query by ECO opening code
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H "Content-Type: application/json" \
   -d '{"query":"eco = \"B90\"","limit":10,"offset":0}'
 ```

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
@@ -52,8 +52,8 @@ com.muchq.indexer/
   IndexerModule.java                @Factory — wires all beans
 
   api/
-    IndexController.java            POST /index, GET /index/{id}
-    QueryController.java            POST /query
+    IndexController.java            POST /v1/index, GET /v1/index/{id}
+    QueryController.java            POST /v1/query
 
   api/dto/
     IndexRequest.java               Inbound: player, platform, month range
@@ -107,7 +107,7 @@ com.muchq.indexer/
 
 ### Indexing
 
-1. Client sends `POST /index` with player, platform, month range
+1. Client sends `POST /v1/index` with player, platform, month range
 2. `IndexController` creates a row in `indexing_requests` (status=PENDING), enqueues an `IndexMessage`
 3. `IndexWorkerLifecycle` daemon thread polls the queue
 4. `IndexWorker.process()`:
@@ -120,7 +120,7 @@ com.muchq.indexer/
 
 ### Querying
 
-1. Client sends `POST /query` with a ChessQL string, limit, offset
+1. Client sends `POST /v1/query` with a ChessQL string, limit, offset
 2. `QueryController` parses ChessQL → AST → compiles to parameterized SQL
 3. `GameFeatureDao.query()` executes the SQL against `game_features`
 4. Results mapped to API DTOs and returned

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/IN_PROCESS_MODE.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/IN_PROCESS_MODE.md
@@ -7,20 +7,20 @@
 INDEXER_DB_URL="jdbc:h2:mem:indexer;DB_CLOSE_DELAY=-1" bazel run //domains/games/apis/one_d4:indexer
 
 # Index a player's games
-curl -X POST http://localhost:8080/index \
+curl -X POST http://localhost:8080/v1/index \
   -H 'Content-Type: application/json' \
   -d '{"player":"hikaru","platform":"CHESS_COM","startMonth":"2026-01","endMonth":"2026-01"}'
 
 # Check indexing status (replace {id} with the returned ID)
-curl http://localhost:8080/index/{id}
+curl http://localhost:8080/v1/index/{id}
 
 # Query indexed games using ChessQL
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H 'Content-Type: application/json' \
   -d '{"query":"white.elo > 2500","limit":10,"offset":0}'
 
 # Query with motif detection
-curl -X POST http://localhost:8080/query \
+curl -X POST http://localhost:8080/v1/query \
   -H 'Content-Type: application/json' \
   -d '{"query":"motif(fork) AND motif(pin)","limit":10,"offset":0}'
 ```
@@ -46,8 +46,8 @@ To use PostgreSQL instead, set the `INDEXER_DB_URL` environment variable to a Po
 │                                               │
 │  ┌───────────┐   ┌──────────────────────┐    │
 │  │ HTTP API  │   │  InMemoryIndexQueue   │    │
-│  │ /index    ├──►│  (LinkedBlockingQueue) │    │
-│  │ /query    │   └──────────┬───────────┘    │
+│  │ /v1/index ├──►│  (LinkedBlockingQueue) │    │
+│  │ /v1/query │   └──────────┬───────────┘    │
 │  └─────┬─────┘              │                │
 │        │              ┌─────▼──────┐         │
 │        │              │IndexWorker │         │
@@ -221,7 +221,7 @@ The system auto-detects H2 vs PostgreSQL from the JDBC URL and uses the appropri
 
 ### What Works
 
-- All API endpoints (`POST /index`, `GET /index/{id}`, `POST /query`)
+- All API endpoints (`POST /v1/index`, `GET /v1/index/{id}`, `POST /v1/query`)
 - Full ChessQL query support
 - Full motif detection pipeline
 - chess.com API fetching (still makes real HTTP calls)

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/MCP_INTEGRATION.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/MCP_INTEGRATION.md
@@ -48,8 +48,8 @@ MCP tools call the indexer's REST API over HTTP. The indexer runs as a separate 
 ```
 ┌────────────────────┐       HTTP        ┌──────────────────┐
 │    mcpserver       │ ────────────────► │    indexer        │
-│  IndexGamesTool ───┤  POST /index      │  IndexController  │
-│  QueryGamesTool ───┤  POST /query      │  QueryController  │
+│  IndexGamesTool ───┤  POST /v1/index  │  IndexController  │
+│  QueryGamesTool ───┤  POST /v1/query  │  QueryController  │
 └────────────────────┘                   └──────────────────┘
 ```
 
@@ -356,16 +356,16 @@ public class IndexerHttpClient {
     private final String baseUrl; // e.g. http://localhost:8080
 
     public IndexResult index(String player, String platform, String startMonth, String endMonth) {
-        // POST http://localhost:8080/index
+        // POST http://localhost:8080/v1/index
         // Body: {"player":"...","platform":"...","startMonth":"...","endMonth":"..."}
     }
 
     public IndexResult getStatus(UUID requestId) {
-        // GET http://localhost:8080/index/{id}
+        // GET http://localhost:8080/v1/index/{id}
     }
 
     public QueryResult query(String chessql, int limit) {
-        // POST http://localhost:8080/query
+        // POST http://localhost:8080/v1/query
         // Body: {"query":"...","limit":N,"offset":0}
     }
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
@@ -254,11 +254,11 @@ public class ApiKeyFilter implements HttpServerFilter {
 ### Authorization
 
 Phase 1: Single-tier (any valid key has full access).
-Phase 2: Role-based — `admin` keys can access /admin/*, `user` keys can access /index and /query.
+Phase 2: Role-based — `admin` keys can access /admin/*, `user` keys can access /v1/index and /v1/query.
 
 ### Rate Limiting
 
-Per-key rate limiting on the /query endpoint:
+Per-key rate limiting on the /v1/query endpoint:
 - 100 queries/minute per API key
 - 429 response with `Retry-After` header
 - In-memory counter with sliding window (Guava `Cache<String, AtomicInteger>`)

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -69,11 +69,13 @@ public class IndexWorker {
           try {
             indexGame(message, game);
             totalIndexed++;
+            if (totalIndexed % 10 == 0) {
+              requestStore.updateStatus(message.requestId(), "PROCESSING", null, totalIndexed);
+            }
           } catch (Exception e) {
             LOG.warn("Failed to index game {}", game.url(), e);
           }
         }
-
         requestStore.updateStatus(message.requestId(), "PROCESSING", null, totalIndexed);
       }
 

--- a/domains/games/apps/1d4_web/README.md
+++ b/domains/games/apps/1d4_web/README.md
@@ -5,7 +5,7 @@ Lightweight web frontend for the [one_d4](https://github.com/muchq/MoonBase/tree
 ## Features
 
 - **Games** — Browse indexed games with sortable columns (player, ELO, time class, ECO, result, motifs), motif badges, and click-through to chess.com. Pagination.
-- **Index** — Enqueue index requests (username, platform chess.com, start/end month). Submit calls `POST https://api.1d4.net/index`. View recent request status with auto-poll via `GET https://api.1d4.net/index/{id}`.
+- **Index** — Enqueue index requests (username, platform chess.com, start/end month). Submit calls `POST https://api.1d4.net/v1/index`. View recent request status with auto-poll via `GET https://api.1d4.net/v1/index/{id}`.
 - **Query** — ChessQL query input with syntax help and example chips; results table and limit selector.
 
 ## Run locally

--- a/domains/games/apps/1d4_web/src/api.js
+++ b/domains/games/apps/1d4_web/src/api.js
@@ -27,33 +27,33 @@ async function request(path, options = {}) {
 }
 
 /**
- * POST /index — enqueue an index request.
+ * POST /v1/index — enqueue an index request.
  * @param {{ player: string, platform: string, startMonth: string, endMonth: string }} body
  * @returns {Promise<{ id: string, status: string, gamesIndexed: number, errorMessage: string|null }>}
  */
 export async function createIndex(body) {
-  return request('/index', {
+  return request('/v1/index', {
     method: 'POST',
     body: JSON.stringify(body),
   });
 }
 
 /**
- * GET /index/{id} — get status of an indexing request.
+ * GET /v1/index/{id} — get status of an indexing request.
  * @param {string} id — UUID
  * @returns {Promise<{ id: string, status: string, gamesIndexed: number, errorMessage: string|null }>}
  */
 export async function getIndexStatus(id) {
-  return request(`/index/${id}`);
+  return request(`/v1/index/${id}`);
 }
 
 /**
- * POST /query — run ChessQL query.
+ * POST /v1/query — run ChessQL query.
  * @param {{ query: string, limit: number, offset: number }} body
  * @returns {Promise<{ games: import('./components/table.js').GameRow[], count: number }>}
  */
 export async function query(body) {
-  return request('/query', {
+  return request('/v1/query', {
     method: 'POST',
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
- one_d4: prefix index/query with `/v1` (IndexController, QueryController)
- one_d4: update `gamesIndexed` during processing (every 10 games + per month)
- one_d4: docs and 1d4_web api.js/README updated to v1 paths
- 1d4_web: index form month normalization, validation, API error display
- Caddy: api.1d4.net paths to `/v1/index`, `/v1/query`; add `api.muchq.com/1d4/v1/*` route

Made with [Cursor](https://cursor.com)