### PR TITLE
one_d4: tests for new index response fields, Caddy 404, docs

### DIFF
--- a/deploy/consolidated/Caddyfile
+++ b/deploy/consolidated/Caddyfile
@@ -260,6 +260,10 @@ api.1d4.net {
 	reverse_proxy @post_query one_d4:8080
 	reverse_proxy @get_health one_d4:8080
 
+	handle {
+		respond 404
+	}
+
 	log {
 		output file /var/log/caddy/access.log {
 			roll_size 1gb

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/IndexController.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/IndexController.java
@@ -54,7 +54,15 @@ public class IndexController {
     if (existing.isPresent()) {
       IndexingRequestStore.IndexingRequest row = existing.get();
       LOG.info("Returning existing index request {} (status={})", row.id(), row.status());
-      return new IndexResponse(row.id(), row.status(), row.gamesIndexed(), row.errorMessage());
+      return new IndexResponse(
+          row.id(),
+          row.player(),
+          row.platform(),
+          row.startMonth(),
+          row.endMonth(),
+          row.status(),
+          row.gamesIndexed(),
+          row.errorMessage());
     }
 
     UUID id =
@@ -65,7 +73,15 @@ public class IndexController {
         new IndexMessage(
             id, request.player(), request.platform(), request.startMonth(), request.endMonth()));
 
-    return new IndexResponse(id, "PENDING", 0, null);
+    return new IndexResponse(
+        id,
+        request.player(),
+        request.platform(),
+        request.startMonth(),
+        request.endMonth(),
+        "PENDING",
+        0,
+        null);
   }
 
   @GET
@@ -77,7 +93,15 @@ public class IndexController {
         .findById(id)
         .map(
             row ->
-                new IndexResponse(row.id(), row.status(), row.gamesIndexed(), row.errorMessage()))
+                new IndexResponse(
+                    row.id(),
+                    row.player(),
+                    row.platform(),
+                    row.startMonth(),
+                    row.endMonth(),
+                    row.status(),
+                    row.gamesIndexed(),
+                    row.errorMessage()))
         .orElseThrow(() -> new NoSuchElementException("Indexing request not found: " + id));
   }
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/IndexResponse.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/IndexResponse.java
@@ -4,4 +4,11 @@ import java.util.UUID;
 import org.jspecify.annotations.Nullable;
 
 public record IndexResponse(
-    UUID id, String status, int gamesIndexed, @Nullable String errorMessage) {}
+    UUID id,
+    String player,
+    String platform,
+    String startMonth,
+    String endMonth,
+    String status,
+    int gamesIndexed,
+    @Nullable String errorMessage) {}

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -37,6 +37,10 @@ Start indexing games for a player over a month range.
 ```json
 {
   "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "player": "hikaru",
+  "platform": "CHESS_COM",
+  "startMonth": "2024-03",
+  "endMonth": "2024-03",
   "status": "PENDING",
   "gamesIndexed": 0,
   "errorMessage": null
@@ -61,6 +65,10 @@ Poll the status of an indexing request.
 ```json
 {
   "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "player": "hikaru",
+  "platform": "CHESS_COM",
+  "startMonth": "2024-03",
+  "endMonth": "2024-03",
   "status": "COMPLETED",
   "gamesIndexed": 147,
   "errorMessage": null

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
@@ -57,7 +57,7 @@ com.muchq.indexer/
 
   api/dto/
     IndexRequest.java               Inbound: player, platform, month range
-    IndexResponse.java              Outbound: id, status, gamesIndexed, error
+    IndexResponse.java              Outbound: id, player, platform, startMonth, endMonth, status, gamesIndexed, errorMessage
     QueryRequest.java               Inbound: ChessQL query string, limit, offset
     QueryResponse.java              Outbound: list of GameFeatureRow, count
     GameFeatureRow.java             Projection of game_features for API consumers

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
@@ -105,6 +105,10 @@ public class IndexE2ETest {
     IndexResponse after = controller.getIndex(created.id());
     assertThat(after.status()).isEqualTo("COMPLETED");
     assertThat(after.gamesIndexed()).isEqualTo(2);
+    assertThat(after.player()).isEqualTo(PLAYER);
+    assertThat(after.platform()).isEqualTo(PLATFORM);
+    assertThat(after.startMonth()).isEqualTo("2024-03");
+    assertThat(after.endMonth()).isEqualTo("2024-03");
     assertThat(fakeChessClient.getFetchCalls())
         .containsExactly(new FakeChessClient.FetchCall(PLAYER, month));
   }


### PR DESCRIPTION
- IndexControllerTest: getIndex_returnsRequestWithPlayerAndDateRange; fake findById
- IndexE2ETest: assert player, platform, startMonth, endMonth on GET after completion
- Caddy: 404 for unmatched paths at api.1d4.net
- README/API/DESIGN updates for index response fields

Co-authored-by: Cursor <cursoragent@cursor.com>
