### PR TITLE
one_d4: fix migration to add new motif columns to existing tables

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -140,6 +140,19 @@ public class Migration {
     this.useH2 = useH2;
   }
 
+  private static final String ADD_CHECK_COLUMN =
+      "ALTER TABLE game_features ADD COLUMN IF NOT EXISTS has_check BOOLEAN DEFAULT FALSE";
+  private static final String ADD_CHECKMATE_COLUMN =
+      "ALTER TABLE game_features ADD COLUMN IF NOT EXISTS has_checkmate BOOLEAN DEFAULT FALSE";
+  private static final String ADD_PROMOTION_COLUMN =
+      "ALTER TABLE game_features ADD COLUMN IF NOT EXISTS has_promotion BOOLEAN DEFAULT FALSE";
+  private static final String ADD_PROMOTION_WITH_CHECK_COLUMN =
+      "ALTER TABLE game_features ADD COLUMN IF NOT EXISTS has_promotion_with_check BOOLEAN DEFAULT"
+          + " FALSE";
+  private static final String ADD_PROMOTION_WITH_CHECKMATE_COLUMN =
+      "ALTER TABLE game_features ADD COLUMN IF NOT EXISTS has_promotion_with_checkmate BOOLEAN"
+          + " DEFAULT FALSE";
+
   public void run() {
     try (Connection conn = dataSource.getConnection();
         Statement stmt = conn.createStatement()) {
@@ -153,6 +166,12 @@ public class Migration {
         stmt.execute(PG_GAME_FEATURES);
         stmt.execute(PG_INDEXED_PERIODS);
       }
+
+      stmt.execute(ADD_CHECK_COLUMN);
+      stmt.execute(ADD_CHECKMATE_COLUMN);
+      stmt.execute(ADD_PROMOTION_COLUMN);
+      stmt.execute(ADD_PROMOTION_WITH_CHECK_COLUMN);
+      stmt.execute(ADD_PROMOTION_WITH_CHECKMATE_COLUMN);
 
       LOG.info("Database migration completed successfully (H2={})", useH2);
     } catch (SQLException e) {


### PR DESCRIPTION
## Summary
- `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables, so the 5 new boolean columns from #1046 (`has_check`, `has_checkmate`, `has_promotion`, `has_promotion_with_check`, `has_promotion_with_checkmate`) were never applied to the live database
- Adds `ALTER TABLE game_features ADD COLUMN IF NOT EXISTS ...` statements that run unconditionally on every startup, safely backfilling the schema
- Fixes 500s: `Column "has_check" not found [42122-240]`

## Test plan
- [ ] All existing one_d4 tests pass (confirmed locally)
- [ ] Deploy and verify 500s are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)