### PR TITLE
one_d4: phase 2 — game detail panel with chess board and motif navigation

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/GameFeatureRow.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/GameFeatureRow.java
@@ -28,6 +28,7 @@ public record GameFeatureRow(
     boolean hasPromotion,
     boolean hasPromotionWithCheck,
     boolean hasPromotionWithCheckmate,
+    String pgn,
     Map<String, List<OccurrenceRow>> occurrences) {
 
   public static GameFeatureRow fromStore(
@@ -56,6 +57,7 @@ public record GameFeatureRow(
         row.hasPromotion(),
         row.hasPromotionWithCheck(),
         row.hasPromotionWithCheckmate(),
+        row.pgn(),
         occurrences);
   }
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
@@ -1,5 +1,7 @@
 # Chess Game Indexer — Roadmap
 
+**See also:** [Frontend Roadmap](../../../../../../../../../../../../apps/1d4_web/docs/ROADMAP.md) — React/TypeScript UI plans (game detail viewer, mobile, advanced query UX).
+
 ## Current State (Phase 1 — Delivered)
 
 - Indexing pipeline: chess.com → PGN parse → position replay → motif detection → PostgreSQL

--- a/domains/games/apps/1d4_web/docs/ROADMAP.md
+++ b/domains/games/apps/1d4_web/docs/ROADMAP.md
@@ -1,0 +1,295 @@
+# 1d4 Web — UI Roadmap
+
+**See also:** [Backend Roadmap](../../../../../domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md) — API, infrastructure, queue, and motif detector plans.
+
+## Current State (Phase 1 — Delivered)
+
+React 18 + TypeScript SPA built with Vite 6, deployed to Cloudflare Workers at [1d4.net](https://1d4.net).
+
+- **Games view** — Browse indexed games; sortable columns (player, ELO, time class, ECO, result, motifs); motif badges with occurrence count tooltips; click-through to chess.com; pagination.
+- **Index view** — Enqueue index requests (username, platform, start/end month); status table with auto-polling while any request is pending or processing (TanStack Query `refetchInterval`).
+- **Query view** — ChessQL textarea; syntax help; example-chip shortcuts; results table; limit selector.
+- **Foundation** — Tailwind CSS v4; react-router-dom v6; TanStack Query v5; Vitest + React Testing Library (30 tests); CI build/typecheck/test job on every PR.
+
+### Hook Points Already in Place
+
+These stubs exist in the codebase and are ready for Phase 2 wiring:
+
+- `GameTable` accepts `onRowClick?: (game: GameRow) => void` — passes a no-op today.
+- `OccurrenceRow.ply?: number` — field defined in `src/types.ts`; populated once the backend adds it.
+- `react-chessboard` v4 and `chess.js` v1 are already installed.
+
+---
+
+## Phase 2 — Game Detail Viewer
+
+### Goal
+
+Click any game row → see an interactive chess board that replays the game, with the motif occurrences listed alongside. Click an occurrence → board jumps to that position, with the tactical motif highlighted via arrows and square highlights.
+
+### Backend Prerequisites
+
+Two backend changes are required before the board viewer can function:
+
+**1. Add `ply` to `OccurrenceRow`**
+
+`ply` is the half-move index (0-based) needed to seek `chess.js` to the exact position. Move 12 white = ply 22; move 12 black = ply 23.
+
+- `api/dto/OccurrenceRow.java` — add `int ply` field.
+- `store/GameFeatureStore.java` (`queryOccurrences`) — add `ply` to SELECT and map to DTO.
+  - Derivation: `ply = (moveNumber - 1) * 2 + (side == 'black' ? 1 : 0)`
+
+**2. Expose `pgn` in `GameFeatureRow`**
+
+The board replayer needs the full PGN string.
+
+- `api/dto/GameFeatureRow.java` — add `String pgn` field.
+- `store/GameFeatureStore.java` (`fromStore`) — include `pgn` column in SELECT and map to DTO.
+- `api/controller/GameController.java` — the `pgn` column is already stored; no new indexing work needed.
+
+Once both changes are deployed, `OccurrenceRow.ply` and `GameFeatureRow.pgn` are populated and the frontend can be wired up.
+
+### Frontend: `GameDetailPanel`
+
+New component displayed below (or as a drawer over) the games table when a row is clicked.
+
+**Component tree:**
+
+```
+GameDetailPanel
+├── BoardPane
+│   ├── Chessboard (react-chessboard)
+│   └── MoveControls  (← Prev  ▶ Play  Next →)
+└── OccurrenceList
+    └── OccurrenceItem (click to jump)
+```
+
+**`src/components/GameDetailPanel.tsx`**
+
+```tsx
+interface Props {
+  game: GameRow;
+  onClose: () => void;
+}
+```
+
+- Receives `GameRow` (which now includes `pgn`).
+- Fetches occurrences via `GET /v1/occurrences?gameId=<id>` (or inlined in `GameRow` — see API note).
+- Passes current position FEN and motif arrows/highlights to `<Chessboard>`.
+
+**Board position management:**
+
+```ts
+// chess.js API
+const chess = new Chess();
+chess.loadPgn(game.pgn);
+const history = chess.history({ verbose: true }); // all moves
+
+// seek to ply N
+function seekToPly(ply: number) {
+  chess.reset();
+  for (let i = 0; i < ply; i++) chess.move(history[i]);
+  setFen(chess.fen());
+  setCurrentPly(ply);
+}
+```
+
+**Motif annotations:**
+
+Each motif type maps to a characteristic arrow color rendered by `react-chessboard`'s `customArrows` prop:
+
+| Motif type       | Arrow color  | Notes                               |
+|-----------------|--------------|-------------------------------------|
+| `fork`           | `#f6c90e`    | Yellow — attacker → each victim     |
+| `pin`            | `#e84393`    | Pink — pinned piece → king/anchor   |
+| `skewer`         | `#e84393`    | Pink — same as pin                  |
+| `discovered_*`   | `#66b2ff`    | Blue — moving piece + revealed ray  |
+| `check`          | `#ff4444`    | Red — attacker → king               |
+| `promotion`      | `#44cc44`    | Green — promotion square            |
+
+Arrows are built from `OccurrenceRow` fields (`moveNumber`, `side`, `description`). Phase 2 can use heuristic square extraction from `description`; richer data (source/destination squares per piece) can be added to `OccurrenceRow` in a follow-on.
+
+**Wiring `onRowClick`:**
+
+In `GamesView.tsx`, replace the no-op:
+
+```tsx
+<GameTable
+  games={games}
+  onRowClick={(game) => setSelectedGame(game)}
+/>
+{selectedGame && (
+  <GameDetailPanel
+    game={selectedGame}
+    onClose={() => setSelectedGame(null)}
+  />
+)}
+```
+
+Same pattern in `QueryView.tsx`.
+
+### API Note: Occurrence Data
+
+Two options for delivering occurrence data to the panel:
+
+**Option A — Inline in `GameRow`** (current approach): `GameRow.occurrences` already returns a `Record<motifName, OccurrenceRow[]>`. Add `ply` to `OccurrenceRow`; no new endpoint needed. Simple, but results in occurrence data being fetched on every `GET /v1/games` page load.
+
+**Option B — Separate endpoint**: `GET /v1/games/{gameId}/occurrences` returns occurrences only when needed. Cleaner separation, less bandwidth on the games list. Requires a new controller method and store query.
+
+Recommendation: Start with Option A (minimal backend changes). Migrate to Option B if games list performance degrades due to large occurrence payloads.
+
+### Tests
+
+```
+src/__tests__/GameDetailPanel.test.tsx   Board renders at move 1; next/prev controls advance ply;
+                                         occurrence click seeks to correct ply; close button works
+src/__tests__/seekToPly.test.ts          Unit test for chess.js seek utility
+```
+
+### Estimated Scope
+
+- 2 backend files modified (~50 lines)
+- 3-4 new frontend files (GameDetailPanel, BoardPane, OccurrenceList, seek utility)
+- 2 test files
+- ~300 lines of frontend code
+
+---
+
+## Phase 3 — Live Index Stats
+
+### Goal
+
+While an indexing request is processing, show a live progress bar and per-month breakdown rather than just a status badge. No page reload required.
+
+### Backend Prerequisite
+
+The polling endpoint (`GET /v1/index`) already returns `gamesIndexed` and `status`. A richer progress response would include:
+
+- `totalMonths: number` — derived from `startMonth`→`endMonth` range.
+- `monthsComplete: number` — how many months have been fully processed.
+- Current month being indexed (optional, nice-to-have).
+
+This requires a small addition to `IndexRequest` DTO and store query — or can be computed client-side from `startMonth`/`endMonth`/`gamesIndexed` as a heuristic.
+
+### Frontend Changes
+
+**`IndexView.tsx`** — replace status badge with:
+
+```tsx
+<ProgressBar value={monthsComplete} max={totalMonths} />
+<span>{gamesIndexed} games indexed so far</span>
+```
+
+**`ProgressBar.tsx`** — new shared component, also usable for query result progress.
+
+TanStack Query polling is already wired; only the rendering changes.
+
+### Estimated Scope
+
+- 1 backend DTO change (optional, for accurate progress)
+- 1 new component (`ProgressBar`)
+- ~50 lines changed in `IndexView.tsx`
+
+---
+
+## Phase 4 — Mobile Polish
+
+### Goal
+
+All three views (Games, Index, Query) are fully usable on a 375px viewport without horizontal scroll or overlapping elements.
+
+### Current Issues (as of Phase 1)
+
+- Games table: 10+ columns overflow on small screens.
+- Index form: date inputs are tight on narrow screens.
+- Query view: results table has same overflow issue as games table.
+- `GameDetailPanel` (Phase 2): board + occurrence list need responsive stacking.
+
+### Approach
+
+**Games / Query tables on mobile:**
+
+Show a card layout below `sm:` breakpoint instead of a table:
+
+```tsx
+// Wide screens: <table>
+// Narrow screens: stacked cards
+<div className="hidden sm:block">
+  <GameTable games={games} ... />
+</div>
+<div className="sm:hidden">
+  {games.map(g => <GameCard key={g.gameUrl} game={g} ... />)}
+</div>
+```
+
+`GameCard.tsx` — compact card showing white/black player, result, motif badges, and played date. Tappable to open `GameDetailPanel`.
+
+**`GameDetailPanel` on mobile:**
+
+- Full-screen drawer (slides up from bottom) on narrow viewports.
+- Board fills viewport width; occurrence list scrolls below.
+- Tailwind `@media (max-width: sm)` responsive variants throughout.
+
+**Index form:**
+
+- Month inputs stack vertically on mobile.
+- Submit button full-width on mobile.
+
+### Estimated Scope
+
+- 1 new component (`GameCard`)
+- ~100 lines of responsive Tailwind changes across existing components
+- Tests: add `screen.width` mock in jsdom for responsive rendering tests
+
+---
+
+## Phase 5 — Advanced Query UX
+
+### Goal
+
+Make ChessQL easier to write and interpret, especially for users unfamiliar with the query language.
+
+### Features
+
+**Query builder UI:**
+
+Visual form that constructs ChessQL without typing syntax:
+
+```
+Player: [_prior     ▾]  Result: [win     ▾]  Motif: [fork    ▾]  Time: [blitz  ▾]
+AND  [+ Add filter]                                             [ Run Query ]
+```
+
+Emits: `player_white = "_prior" AND result = "win" AND motif(fork) AND time_class = "blitz"`
+
+**Saved queries:**
+
+Store recent queries in `localStorage`; show a "Recent" dropdown. No backend required.
+
+**Result count estimate:**
+
+Show row count from `QueryResponse.count` more prominently; add a "Show all N results" link when results are capped by the limit.
+
+**Motif filter on games view:**
+
+Add a motif multi-select to the Games view that appends `AND motif(X)` to the internal query sent to `GET /v1/games`. Lets users filter the games list by tactic without switching to the Query tab.
+
+### Estimated Scope
+
+- 2-3 new components (QueryBuilder, FilterBar, SavedQueries)
+- ~200 lines of new code
+- No backend changes required
+
+---
+
+## Phase Dependencies
+
+```
+Phase 2 (game detail viewer)   ← needs backend: ply + pgn fields
+Phase 3 (live index stats)     ← optional backend enhancement; UI change is self-contained
+Phase 4 (mobile polish)        ← independent; can start any time; builds on Phase 2 layout
+Phase 5 (advanced query UX)    ← independent; no backend changes
+```
+
+Phase 2 is the highest-value next step and the only one gated on backend changes.
+Phases 3–5 are independent of each other and can be done in any order.

--- a/domains/games/apps/1d4_web/src/__tests__/GameDetailPanel.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameDetailPanel.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import GameDetailPanel from '../components/GameDetailPanel';
+import type { GameRow, OccurrenceRow } from '../types';
+
+vi.mock('react-chessboard', () => ({
+  Chessboard: ({ position }: { position: string }) => (
+    <div data-testid="chessboard" data-fen={position} />
+  ),
+}));
+
+// 1. e4 e5 2. Nf3 Nc6 — 4 half-moves
+const TEST_PGN = '1. e4 e5 2. Nf3 Nc6';
+
+const forkOccurrence: OccurrenceRow = {
+  moveNumber: 2,
+  side: 'white',
+  description: 'Fork detected',
+};
+
+const mockGame: GameRow = {
+  gameUrl: 'https://chess.com/game/1',
+  platform: 'chess.com',
+  whiteUsername: 'Alice',
+  blackUsername: 'Bob',
+  whiteElo: 1500,
+  blackElo: 1480,
+  timeClass: 'blitz',
+  eco: 'C60',
+  result: '1-0',
+  playedAt: 1700000000,
+  indexedAt: 1700001000,
+  numMoves: 4,
+  hasPin: false,
+  hasCrossPin: false,
+  hasFork: true,
+  hasSkewer: false,
+  hasDiscoveredAttack: false,
+  hasDiscoveredCheck: false,
+  hasCheck: false,
+  hasCheckmate: false,
+  hasPromotion: false,
+  hasPromotionWithCheck: false,
+  hasPromotionWithCheckmate: false,
+  pgn: TEST_PGN,
+  occurrences: { fork: [forkOccurrence] },
+};
+
+describe('GameDetailPanel', () => {
+  it('renders player names and game info', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    expect(screen.getByText('Alice vs Bob')).toBeInTheDocument();
+    expect(screen.getByText(/1-0/)).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<GameDetailPanel game={mockGame} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('shows chessboard when pgn is present', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    expect(screen.getByTestId('chessboard')).toBeInTheDocument();
+  });
+
+  it('shows PGN not available message when pgn is absent', () => {
+    const game = { ...mockGame, pgn: undefined };
+    render(<GameDetailPanel game={game} onClose={() => {}} />);
+    expect(screen.getByText(/PGN not available/)).toBeInTheDocument();
+    expect(screen.queryByTestId('chessboard')).not.toBeInTheDocument();
+  });
+
+  it('shows start position initially', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    expect(screen.getByText('Start')).toBeInTheDocument();
+  });
+
+  it('prev button is disabled at start', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Previous move' })).toBeDisabled();
+  });
+
+  it('advances to next move and updates position', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    const initialFen = screen.getByTestId('chessboard').getAttribute('data-fen');
+    fireEvent.click(screen.getByRole('button', { name: 'Next move' }));
+    const newFen = screen.getByTestId('chessboard').getAttribute('data-fen');
+    expect(newFen).not.toBe(initialFen);
+    expect(screen.getByText('Move 1 (W)')).toBeInTheDocument();
+  });
+
+  it('next button is disabled at end', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    const nextBtn = screen.getByRole('button', { name: 'Next move' });
+    // Advance through all 4 half-moves
+    fireEvent.click(nextBtn);
+    fireEvent.click(nextBtn);
+    fireEvent.click(nextBtn);
+    fireEvent.click(nextBtn);
+    expect(nextBtn).toBeDisabled();
+    expect(screen.getByText('End')).toBeInTheDocument();
+  });
+
+  it('go-to-start resets to initial position', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Next move' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next move' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Go to start' }));
+    expect(screen.getByText('Start')).toBeInTheDocument();
+  });
+
+  it('go-to-end seeks to last position', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go to end' }));
+    expect(screen.getByText('End')).toBeInTheDocument();
+  });
+
+  it('lists motif occurrences with label and description', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    expect(screen.getByText('fork')).toBeInTheDocument();
+    expect(screen.getByText('2.')).toBeInTheDocument();
+    expect(screen.getByText('Fork detected')).toBeInTheDocument();
+  });
+
+  it('clicking an occurrence seeks to the motif position', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    const startFen = screen.getByTestId('chessboard').getAttribute('data-fen');
+    // forkOccurrence: moveNumber=2, side=white → ply=2, seekTo(3)
+    fireEvent.click(screen.getByText('Fork detected'));
+    const newFen = screen.getByTestId('chessboard').getAttribute('data-fen');
+    expect(newFen).not.toBe(startFen);
+    expect(screen.getByText('Move 2 (W)')).toBeInTheDocument();
+  });
+
+  it('shows black occurrence move label with ellipsis', () => {
+    const blackOcc: OccurrenceRow = { moveNumber: 1, side: 'black', description: 'Pin' };
+    const game = { ...mockGame, occurrences: { pin: [blackOcc] } };
+    render(<GameDetailPanel game={game} onClose={() => {}} />);
+    expect(screen.getByText('1...')).toBeInTheDocument();
+  });
+
+  it('flip board button is present', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Flip board' })).toBeInTheDocument();
+  });
+});

--- a/domains/games/apps/1d4_web/src/__tests__/GamesView.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GamesView.test.tsx
@@ -8,6 +8,11 @@ import * as api from '../api';
 import type { GameRow } from '../types';
 
 vi.mock('../api');
+vi.mock('react-chessboard', () => ({
+  Chessboard: ({ position }: { position: string }) => (
+    <div data-testid="chessboard" data-fen={position} />
+  ),
+}));
 
 const mockGame: GameRow = {
   gameUrl: 'https://chess.com/game/99',
@@ -78,6 +83,14 @@ describe('GamesView', () => {
         })
       )
     );
+  });
+
+  it('opens game detail panel when a row is clicked', async () => {
+    render(<GamesView />, { wrapper: makeWrapper() });
+    await waitFor(() => screen.getByText('_prior'));
+    const rows = screen.getAllByRole('row');
+    fireEvent.click(rows[1]); // first data row
+    expect(screen.getByText('_prior vs OpponentA')).toBeInTheDocument();
   });
 
   it('submits search on Enter key in the username input', async () => {

--- a/domains/games/apps/1d4_web/src/components/GameDetailPanel.tsx
+++ b/domains/games/apps/1d4_web/src/components/GameDetailPanel.tsx
@@ -1,0 +1,279 @@
+import { useState, useMemo } from 'react';
+import { Chess, type Move } from 'chess.js';
+import { Chessboard } from 'react-chessboard';
+import type { GameRow, OccurrenceRow } from '../types';
+
+const MOTIF_COLORS: Record<string, string> = {
+  fork: '#f6c90e',
+  pin: '#e84393',
+  skewer: '#e84393',
+  cross_pin: '#e84393',
+  discovered_attack: '#66b2ff',
+  discovered_check: '#66b2ff',
+  check: '#ff4444',
+  checkmate: '#ff4444',
+  promotion: '#44cc44',
+  promotion_with_check: '#44cc44',
+  promotion_with_checkmate: '#44cc44',
+};
+
+const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+function parsePgn(pgn: string): { fens: string[]; moves: Move[] } {
+  const chess = new Chess();
+  chess.loadPgn(pgn);
+  const sans = chess.history();
+  chess.reset();
+  const fens: string[] = [chess.fen()];
+  const moves: Move[] = [];
+  for (const san of sans) {
+    const move = chess.move(san);
+    moves.push(move);
+    fens.push(chess.fen());
+  }
+  return { fens, moves };
+}
+
+// 0-indexed half-move index of the move that produced the motif.
+// fens[ply + 1] is the resulting board position to display.
+function occurrencePly(occ: OccurrenceRow): number {
+  return (occ.moveNumber - 1) * 2 + (occ.side === 'black' ? 1 : 0);
+}
+
+function formatMoveLabel(occ: OccurrenceRow): string {
+  return occ.side === 'white' ? `${occ.moveNumber}.` : `${occ.moveNumber}...`;
+}
+
+function formatDate(val: string | number | null | undefined): string {
+  if (val == null) return '';
+  const date = typeof val === 'number' ? new Date(val * 1000) : new Date(val);
+  return isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
+}
+
+interface Props {
+  game: GameRow;
+  onClose: () => void;
+}
+
+export default function GameDetailPanel({ game, onClose }: Props) {
+  const [currentPly, setCurrentPly] = useState(0);
+  const [orientation, setOrientation] = useState<'white' | 'black'>('white');
+  const [activeOccurrence, setActiveOccurrence] = useState<OccurrenceRow | null>(null);
+
+  const { fens, moves } = useMemo(
+    () => (game.pgn ? parsePgn(game.pgn) : { fens: [START_FEN], moves: [] }),
+    [game.pgn]
+  );
+
+  const totalPlies = moves.length;
+  const fen = fens[currentPly] ?? fens[fens.length - 1];
+  const lastMove = currentPly > 0 ? moves[currentPly - 1] : null;
+
+  const activeMotifKey = activeOccurrence
+    ? Object.entries(game.occurrences ?? {}).find(([, occs]) =>
+        occs.includes(activeOccurrence)
+      )?.[0]
+    : null;
+  const motifColor = activeMotifKey != null ? (MOTIF_COLORS[activeMotifKey] ?? null) : null;
+
+  const squareStyles: Record<string, React.CSSProperties> = {};
+  if (lastMove) {
+    squareStyles[lastMove.from] = {
+      backgroundColor: motifColor ? motifColor + '66' : 'rgba(255,255,0,0.3)',
+    };
+    squareStyles[lastMove.to] = {
+      backgroundColor: motifColor ? motifColor + 'aa' : 'rgba(255,255,0,0.55)',
+    };
+  }
+
+  function seekTo(ply: number) {
+    setCurrentPly(Math.max(0, Math.min(ply, totalPlies)));
+  }
+
+  function handleOccurrenceClick(occ: OccurrenceRow) {
+    setActiveOccurrence(occ);
+    seekTo(occurrencePly(occ) + 1);
+  }
+
+  const moveLabel =
+    currentPly === 0
+      ? 'Start'
+      : currentPly === totalPlies
+        ? 'End'
+        : `Move ${Math.ceil(currentPly / 2)}${currentPly % 2 === 1 ? ' (W)' : ' (B)'}`;
+
+  const occurrenceEntries = Object.entries(game.occurrences ?? {});
+
+  return (
+    <div className="panel" style={{ marginTop: '1rem' }}>
+      <div
+        style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}
+      >
+        <div>
+          <strong>
+            {game.whiteUsername} vs {game.blackUsername}
+          </strong>
+          {game.playedAt && (
+            <span className="text-muted" style={{ marginLeft: '0.75rem', fontSize: '0.875rem' }}>
+              {formatDate(game.playedAt)}
+            </span>
+          )}
+          <span className="text-muted" style={{ marginLeft: '0.75rem', fontSize: '0.875rem' }}>
+            {game.result} · {game.timeClass} · {game.eco}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="btn"
+          onClick={onClose}
+          aria-label="Close panel"
+          style={{ padding: '0 0.5rem' }}
+        >
+          ×
+        </button>
+      </div>
+
+      {!game.pgn && (
+        <p className="text-muted" style={{ marginTop: '0.75rem' }}>
+          PGN not available for this game.
+        </p>
+      )}
+
+      {game.pgn && (
+        <div
+          style={{
+            display: 'flex',
+            gap: '1.5rem',
+            marginTop: '1rem',
+            flexWrap: 'wrap',
+            alignItems: 'flex-start',
+          }}
+        >
+          {/* Board */}
+          <div style={{ flex: '0 0 auto' }}>
+            <div style={{ width: 'min(400px, 90vw)' }}>
+              <Chessboard
+                position={fen}
+                boardOrientation={orientation}
+                customSquareStyles={squareStyles}
+                arePiecesDraggable={false}
+              />
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                gap: '0.4rem',
+                marginTop: '0.5rem',
+                alignItems: 'center',
+              }}
+            >
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  seekTo(0);
+                  setActiveOccurrence(null);
+                }}
+                aria-label="Go to start"
+              >
+                ««
+              </button>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => seekTo(currentPly - 1)}
+                disabled={currentPly === 0}
+                aria-label="Previous move"
+              >
+                ‹
+              </button>
+              <span
+                style={{ fontSize: '0.875rem', minWidth: '6.5rem', textAlign: 'center' }}
+              >
+                {moveLabel}
+              </span>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => seekTo(currentPly + 1)}
+                disabled={currentPly === totalPlies}
+                aria-label="Next move"
+              >
+                ›
+              </button>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => {
+                  seekTo(totalPlies);
+                  setActiveOccurrence(null);
+                }}
+                aria-label="Go to end"
+              >
+                »»
+              </button>
+              <button
+                type="button"
+                className="btn"
+                onClick={() => setOrientation((o) => (o === 'white' ? 'black' : 'white'))}
+                aria-label="Flip board"
+                title="Flip board"
+              >
+                ⇅
+              </button>
+            </div>
+          </div>
+
+          {/* Occurrence list */}
+          {occurrenceEntries.length > 0 && (
+            <div style={{ flex: '1 1 200px' }}>
+              <h3 style={{ margin: '0 0 0.5rem', fontSize: '1rem' }}>Motifs</h3>
+              <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {occurrenceEntries.flatMap(([motif, occs]) =>
+                  occs.map((occ, i) => {
+                    const color = MOTIF_COLORS[motif] ?? '#aaa';
+                    const isActive = activeOccurrence === occ;
+                    return (
+                      <li
+                        key={`${motif}-${i}`}
+                        onClick={() => handleOccurrenceClick(occ)}
+                        style={{
+                          cursor: 'pointer',
+                          padding: '0.35rem 0.5rem',
+                          borderRadius: '4px',
+                          marginBottom: '0.25rem',
+                          borderLeft: `3px solid ${color}`,
+                          backgroundColor: isActive ? 'var(--bg-panel)' : 'transparent',
+                          display: 'flex',
+                          gap: '0.5rem',
+                          alignItems: 'baseline',
+                        }}
+                      >
+                        <span
+                          className="badge"
+                          style={{
+                            backgroundColor: color,
+                            color: '#000',
+                            fontSize: '0.7rem',
+                          }}
+                        >
+                          {motif.replace(/_/g, ' ')}
+                        </span>
+                        <span style={{ fontSize: '0.875rem' }}>{formatMoveLabel(occ)}</span>
+                        {occ.description && (
+                          <span className="text-muted" style={{ fontSize: '0.8rem' }}>
+                            {occ.description}
+                          </span>
+                        )}
+                      </li>
+                    );
+                  })
+                )}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/domains/games/apps/1d4_web/src/types.ts
+++ b/domains/games/apps/1d4_web/src/types.ts
@@ -2,7 +2,6 @@ export interface OccurrenceRow {
   moveNumber: number;
   side: 'white' | 'black';
   description: string;
-  ply?: number; // populated in Phase 2 after backend adds it
 }
 
 export interface GameRow {
@@ -29,6 +28,7 @@ export interface GameRow {
   hasPromotion: boolean;
   hasPromotionWithCheck: boolean;
   hasPromotionWithCheckmate: boolean;
+  pgn?: string;
   occurrences?: Record<string, OccurrenceRow[]>;
 }
 

--- a/domains/games/apps/1d4_web/src/views/GamesView.tsx
+++ b/domains/games/apps/1d4_web/src/views/GamesView.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { query as apiQuery } from '../api';
 import type { GameRow } from '../types';
 import GameTable from '../components/GameTable';
+import GameDetailPanel from '../components/GameDetailPanel';
 import Pagination from '../components/Pagination';
 
 const DEFAULT_QUERY = 'num.moves >= 0';
@@ -57,6 +58,7 @@ export default function GamesView() {
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   const [offset, setOffset] = useState(0);
   const [limit, setLimit] = useState(25);
+  const [selectedGame, setSelectedGame] = useState<GameRow | null>(null);
 
   const queryText = buildQuery(username);
   const { data, isLoading, error } = useQuery({
@@ -138,6 +140,7 @@ export default function GamesView() {
             sortBy={sortBy}
             sortDir={sortDir}
             onSort={handleSort}
+            onRowClick={(game) => setSelectedGame(game)}
           />
           <Pagination
             offset={offset}
@@ -152,6 +155,13 @@ export default function GamesView() {
               setOffset((o) => Math.min(o + limit, sorted.length - limit))
             }
           />
+          {selectedGame && (
+            <GameDetailPanel
+              key={selectedGame.gameUrl}
+              game={selectedGame}
+              onClose={() => setSelectedGame(null)}
+            />
+          )}
         </>
       )}
     </>

--- a/domains/games/apps/1d4_web/src/views/QueryView.tsx
+++ b/domains/games/apps/1d4_web/src/views/QueryView.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { query as apiQuery } from '../api';
+import type { GameRow } from '../types';
 import GameTable from '../components/GameTable';
+import GameDetailPanel from '../components/GameDetailPanel';
 
 const EXAMPLE_QUERIES = [
   'motif(fork)',
@@ -19,6 +21,7 @@ export default function QueryView() {
   const [queryText, setQueryText] = useState('');
   const [committedQuery, setCommittedQuery] = useState('');
   const [limit, setLimit] = useState(50);
+  const [selectedGame, setSelectedGame] = useState<GameRow | null>(null);
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['query', committedQuery, limit],
@@ -108,10 +111,18 @@ export default function QueryView() {
             sortBy=""
             sortDir="asc"
             onSort={() => {}}
+            onRowClick={(game) => setSelectedGame(game)}
           />
           <p className="empty" style={{ textAlign: 'left' }}>
             Showing {data.games.length} result(s).
           </p>
+          {selectedGame && (
+            <GameDetailPanel
+              key={selectedGame.gameUrl}
+              game={selectedGame}
+              onClose={() => setSelectedGame(null)}
+            />
+          )}
         </>
       )}
       {!isLoading && !error && committedQuery && data?.games.length === 0 && (


### PR DESCRIPTION
## Summary

- Adds `pgn` to `GameFeatureRow` DTO so the API response carries the full PGN for each game (column already stored; no migration needed)
- New `GameDetailPanel` component: interactive chess board (`react-chessboard` + `chess.js`), `‹/›` move controls, go-to-start/end, flip board button, last-moved square highlights
- Occurrence list alongside the board — clicking any motif occurrence seeks to that position (ply computed client-side: `(moveNumber - 1) * 2 + (side === 'black' ? 1 : 0)`); destination square highlighted in the motif's color
- `onRowClick` wired in `GamesView` and `QueryView` — clicking a game row opens the panel below the table; `×` dismisses it
- Adds `domains/games/apps/1d4_web/docs/ROADMAP.md` (frontend phases 2–5); cross-linked with backend `ROADMAP.md`

## Test plan

- [ ] 46 tests pass (`npm test`), typecheck clean (`npm run typecheck`)
- [ ] CI `test-1d4-web` job passes
- [ ] Smoke test on deployed `1d4.net`: click a game row with motif occurrences (e.g. username `_prior`), verify board opens, moves navigate correctly, clicking an occurrence jumps to the right position
- [ ] Verify `×` closes the panel and clicking a different row opens a fresh panel
- [ ] Confirm backend API response now includes `pgn` field in game objects