### PR TITLE
Auto-release changed container services

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -51,11 +51,73 @@ jobs:
         run: |
           bazel query 'kind(oci_push, //...)' | xargs -n1 bazel run
 
-      - name: Tag images with commit SHA (for rollback)
+      - name: Tag images with short SHA
         run: |
-          repos=$(bazel query 'kind(oci_push, //...)' --output=build | sed -n 's/.*repository = "\(ghcr\.io\/muchq\/[^"]*\)".*/\1/p')
+          SHORT_SHA="${GITHUB_SHA::7}"
+          repos=$(bazel query 'kind(oci_push, //...)' --output=build \
+            | sed -n 's/.*repository = "\(ghcr\.io\/muchq\/[^"]*\)".*/\1/p')
           for repo in $repos; do
             docker pull "$repo:latest"
-            docker tag "$repo:latest" "$repo:${{ github.sha }}"
-            docker push "$repo:${{ github.sha }}"
+            docker tag "$repo:latest" "$repo:$SHORT_SHA"
+            docker push "$repo:$SHORT_SHA"
+          done
+
+      - name: Create releases for changed services
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+
+          repos=$(bazel query 'kind(oci_push, //...)' --output=build \
+            | sed -n 's/.*repository = "\(ghcr\.io\/muchq\/[^"]*\)".*/\1/p')
+
+          for repo in $repos; do
+            SERVICE="${repo##*/}"
+            echo "Checking $SERVICE..."
+
+            # Get digest of the image we just pushed
+            NEW_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$repo:latest" \
+              | sed 's/.*@//')
+
+            # Get digest from the most recent GH release for this service
+            PREV_TAG=$(gh release list --limit 100 --json tagName,name \
+              -q ".[] | select(.tagName | startswith(\"${SERVICE}-\")) | .tagName" \
+              | head -1)
+
+            if [ -n "$PREV_TAG" ]; then
+              PREV_DIGEST=$(gh release view "$PREV_TAG" --json body -q '.body' \
+                | grep -oP '(?<=Digest:\*\* `)[^`]+' || echo "")
+            else
+              PREV_DIGEST=""
+            fi
+
+            if [ "$NEW_DIGEST" = "$PREV_DIGEST" ]; then
+              echo "  $SERVICE: unchanged, skipping"
+              continue
+            fi
+
+            TAG="${SERVICE}-${SHORT_SHA}"
+            echo "  $SERVICE: changed, creating release $TAG"
+
+            # Build release body
+            BODY=$(cat <<EOF
+          **Image:** \`${repo}:${SHORT_SHA}\`
+          **Digest:** \`${NEW_DIGEST}\`
+          **Commit:** ${{ github.sha }}
+          EOF
+            )
+
+            # Use --notes-start-tag for auto-generated changelog since last release
+            if [ -n "$PREV_TAG" ]; then
+              gh release create "$TAG" \
+                --title "${SERVICE} ${SHORT_SHA}" \
+                --notes-start-tag "$PREV_TAG" \
+                --notes "$BODY"
+            else
+              gh release create "$TAG" \
+                --title "${SERVICE} ${SHORT_SHA}" \
+                --notes "$BODY"
+            fi
+
+            echo "  Created release: $TAG"
           done


### PR DESCRIPTION
## Summary
- Switch image SHA tags from full SHA to short SHA (7 chars) for cleaner version references
- Add a new workflow step that compares each image's digest against the digest stored in its most recent GitHub Release
- Only create a `{service}-{short-sha}` GitHub Release when a service's container image actually changed

## How it works
1. After pushing `:latest` and `:short-sha` tags, the workflow inspects each image's digest
2. It fetches the digest from the most recent GitHub Release for that service (stored in the release body)
3. If the digests differ (or no previous release exists), it creates a new release with the image reference, digest, and commit info
4. If unchanged, the service is skipped — no noise in the releases page

## Test plan
- [ ] Push a change affecting only one service → only that service gets a release
- [ ] Push a shared library change → multiple releases created
- [ ] Push a no-op change (formatting) → no new releases
- [ ] Verify image pullable via `docker pull ghcr.io/muchq/{service}:{short-sha}`