### PR TITLE
Fix CI: Split release step to use gh CLI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,24 +62,49 @@ jobs:
             docker push "$repo:$SHORT_SHA"
           done
 
+      - name: Prepare release metadata
+        run: |
+          SHORT_SHA="$(echo "$GITHUB_SHA" | cut -c1-7)"
+          mkdir -p release-metadata
+          echo "$SHORT_SHA" > release-metadata/short_sha
+          repos=$(bazel query 'kind(oci_push, //...)' --output=build \
+            | sed -n 's/.*repository = "\(ghcr\.io\/muchq\/[^"]*\)".*/\1/p')
+          for repo in $repos; do
+            SERVICE="${repo##*/}"
+            NEW_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$repo:latest" \
+              | sed 's/.*@//')
+            echo "$repo $SERVICE $NEW_DIGEST" >> release-metadata/services.txt
+          done
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-metadata
+          path: release-metadata/
+
+  create-releases:
+    needs: test-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: release-metadata
+
       - name: Create releases for changed services
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          SHORT_SHA="$(echo "$GITHUB_SHA" | cut -c1-7)"
+          SHORT_SHA=$(cat release-metadata/short_sha)
+          COMMIT_SHA="${{ github.sha }}"
 
-          repos=$(bazel query 'kind(oci_push, //...)' --output=build \
-            | sed -n 's/.*repository = "\(ghcr\.io\/muchq\/[^"]*\)".*/\1/p')
+          while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            repo="${line%% *}"
+            rest="${line#* }"
+            SERVICE="${rest%% *}"
+            NEW_DIGEST="${rest#* }"
 
-          for repo in $repos; do
-            SERVICE="${repo##*/}"
             echo "Checking $SERVICE..."
 
-            # Get digest of the image we just pushed
-            NEW_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$repo:latest" \
-              | sed 's/.*@//')
-
-            # Get digest from the most recent GH release for this service
             PREV_TAG=$(gh release list --limit 100 --json tagName,name \
               -q ".[] | select(.tagName | startswith(\"${SERVICE}-\")) | .tagName" \
               | head -1)
@@ -99,15 +124,10 @@ jobs:
             TAG="${SERVICE}-${SHORT_SHA}"
             echo "  $SERVICE: changed, creating release $TAG"
 
-            # Build release body
-            BODY=$(cat <<EOF
-          **Image:** \`${repo}:${SHORT_SHA}\`
+            BODY="**Image:** \`${repo}:${SHORT_SHA}\`
           **Digest:** \`${NEW_DIGEST}\`
-          **Commit:** ${{ github.sha }}
-          EOF
-            )
+          **Commit:** ${COMMIT_SHA}"
 
-            # Use --notes-start-tag for auto-generated changelog since last release
             if [ -n "$PREV_TAG" ]; then
               gh release create "$TAG" \
                 --title "${SERVICE} ${SHORT_SHA}" \
@@ -120,4 +140,4 @@ jobs:
             fi
 
             echo "  Created release: $TAG"
-          done
+          done < release-metadata/services.txt


### PR DESCRIPTION
## Problem
CI was failing with `gh: not found` because the GitHub CLI is not available inside the `ci-base` container where all steps execute.

## Solution
Split the release step into a separate job that runs directly on the runner (no container) where `gh` is available:

- **test-and-publish job**: Runs in container, prepares release metadata (SHORT_SHA, service names, digests) and uploads as artifact
- **create-releases job**: Runs on runner (no container), downloads artifact, uses `gh` to create releases

This maintains the same functionality while ensuring `gh` is available when needed.