### PR TITLE
Use logging library for one_d4 and mcpserver; fix Sentry appender

### DIFF
--- a/domains/games/apis/mcpserver/BUILD.bazel
+++ b/domains/games/apis/mcpserver/BUILD.bazel
@@ -63,12 +63,13 @@ java_binary(
     ],
     resource_strip_prefix = "domains/platform/resources",
     resources = [
-        "//domains/platform/resources:logback_config",
         "//domains/platform/resources:micronaut_config",
     ],
     visibility = ["//visibility:public"],
     runtime_deps = [
+        "//domains/platform/libs/logging",
         artifact("ch.qos.logback:logback-classic"),
+        artifact("io.sentry:sentry-logback"),
     ],
     deps = [
         ":dtos",
@@ -77,6 +78,7 @@ java_binary(
         "//domains/platform/libs/http_client:core",
         "//domains/platform/libs/http_client:jdk11",
         "//domains/platform/libs/json",
+        "//domains/platform/libs/logging",
         artifact("com.fasterxml.jackson.core:jackson-annotations"),
         artifact("com.fasterxml.jackson.core:jackson-databind"),
         artifact("io.micronaut:micronaut-context"),

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -216,12 +216,13 @@ java_binary(
     ],
     resource_strip_prefix = "domains/platform/resources",
     resources = [
-        "//domains/platform/resources:logback_config",
         "//domains/platform/resources:micronaut_config",
     ],
     visibility = ["//visibility:public"],
     runtime_deps = [
+        "//domains/platform/libs/logging",
         artifact("ch.qos.logback:logback-classic"),
+        artifact("io.sentry:sentry-logback"),
         artifact("org.postgresql:postgresql"),
     ],
     deps = [
@@ -238,6 +239,7 @@ java_binary(
         "//domains/platform/libs/http_client:core",
         "//domains/platform/libs/http_client:jdk11",
         "//domains/platform/libs/json",
+        "//domains/platform/libs/logging",
         artifact("com.fasterxml.jackson.core:jackson-databind"),
         artifact("com.zaxxer:HikariCP"),
         artifact("io.micronaut.jaxrs:micronaut-jaxrs-server"),

--- a/domains/platform/libs/logging/BUILD.bazel
+++ b/domains/platform/libs/logging/BUILD.bazel
@@ -4,6 +4,7 @@ java_library(
     name = "logging",
     resource_strip_prefix = "domains/platform/resources",
     resources = ["//domains/platform/resources:logback_config"],
+    visibility = ["//visibility:public"],
     runtime_deps = [
         artifact("ch.qos.logback:logback-classic"),
         artifact("io.sentry:sentry-logback"),

--- a/domains/platform/resources/logback.xml
+++ b/domains/platform/resources/logback.xml
@@ -8,8 +8,10 @@
     </filter>
   </appender>
 
-  <appender name="Sentry" class="com.getsentry.raven.logback.SentryAppender">
-    <dsn>${SENTRY_DSN}</dsn>
+  <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+    <options>
+      <dsn>${SENTRY_DSN}</dsn>
+    </options>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>ERROR</level>
     </filter>


### PR DESCRIPTION
## Changes
- **logback.xml**: Switch to modern Sentry SDK (`io.sentry.logback.SentryAppender`) with `<options><dsn>` (fixes ClassNotFoundException for old raven appender).
- **one_d4, mcpserver**: Get logback config from `//domains/platform/libs/logging` instead of embedding `logback_config`; add `sentry-logback` to `runtime_deps` (Bazel does not propagate a library’s `runtime_deps`).
- **logging library**: Add `visibility = ["//visibility:public"]` so one_d4/mcpserver can depend on it.