### PR TITLE
Make logging lib deps transitive for one_d4 and mcpserver

### DIFF
--- a/domains/games/apis/mcpserver/BUILD.bazel
+++ b/domains/games/apis/mcpserver/BUILD.bazel
@@ -68,8 +68,6 @@ java_binary(
     visibility = ["//visibility:public"],
     runtime_deps = [
         "//domains/platform/libs/logging",
-        artifact("ch.qos.logback:logback-classic"),
-        artifact("io.sentry:sentry-logback"),
     ],
     deps = [
         ":dtos",

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -221,8 +221,6 @@ java_binary(
     visibility = ["//visibility:public"],
     runtime_deps = [
         "//domains/platform/libs/logging",
-        artifact("ch.qos.logback:logback-classic"),
-        artifact("io.sentry:sentry-logback"),
         artifact("org.postgresql:postgresql"),
     ],
     deps = [
@@ -413,7 +411,7 @@ java_test_suite(
         "src/test/java/com/muchq/games/one_d4/api/ContentTypeHandlingTest.java",
     ],
     runtime_deps = [
-        artifact("ch.qos.logback:logback-classic"),
+        "//domains/platform/libs/logging",
         artifact("org.postgresql:postgresql"),
     ],
     deps = [

--- a/domains/platform/libs/logging/BUILD.bazel
+++ b/domains/platform/libs/logging/BUILD.bazel
@@ -2,10 +2,11 @@ load("//bazel/rules:java.bzl", "artifact", "java_library")
 
 java_library(
     name = "logging",
+    srcs = ["Dummy.java"],
     resource_strip_prefix = "domains/platform/resources",
     resources = ["//domains/platform/resources:logback_config"],
     visibility = ["//visibility:public"],
-    runtime_deps = [
+    deps = [
         artifact("ch.qos.logback:logback-classic"),
         artifact("io.sentry:sentry-logback"),
         artifact("org.slf4j:slf4j-api"),

--- a/domains/platform/libs/logging/Dummy.java
+++ b/domains/platform/libs/logging/Dummy.java
@@ -1,0 +1,3 @@
+package dummy;
+
+class Dummy {}


### PR DESCRIPTION
## Summary
- **logging library**: Add a trivial `Dummy.java` and move logback/sentry/slf4j from `runtime_deps` to `deps` so that dependents get them transitively.
- **one_d4, mcpserver**: Remove explicit `ch.qos.logback:logback-classic` and `io.sentry:sentry-logback` from `runtime_deps` (they come from `//domains/platform/libs/logging`).
- **one_d4 http_integration_tests**: Use `//domains/platform/libs/logging` in `runtime_deps` instead of `logback-classic` only.