### PR TITLE
Add GET /v1/server-info endpoint, UI maintenance banner, and daily restart script

### DIFF
--- a/deploy/consolidated/daily-restart.sh
+++ b/deploy/consolidated/daily-restart.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# daily-restart.sh – pull latest images and restart the consolidated stack.
+#
+# Install as a cron job to run daily at midnight server time:
+#   sudo crontab -e
+#   0 0 * * * /path/to/daily-restart.sh >> /var/log/daily-restart.log 2>&1
+#
+# The script must be run from the directory containing compose.yaml, or
+# set COMPOSE_DIR below to the absolute path of that directory.
+
+set -euo pipefail
+
+COMPOSE_DIR="${COMPOSE_DIR:-$(dirname "$(realpath "$0")")}"
+COMPOSE_FILES=(-f "$COMPOSE_DIR/compose.yaml" -f "$COMPOSE_DIR/docker-compose.observability.yml")
+LOG_PREFIX="[daily-restart $(date -u '+%Y-%m-%dT%H:%M:%SZ')]"
+
+cd "$COMPOSE_DIR"
+
+echo "$LOG_PREFIX Starting daily image pull and restart"
+
+# Load environment variables if present
+if [ -f "$COMPOSE_DIR/.env" ]; then
+  # shellcheck disable=SC2046
+  export $(grep -v '^#' "$COMPOSE_DIR/.env" | xargs)
+fi
+
+echo "$LOG_PREFIX Pulling latest images..."
+sudo docker compose "${COMPOSE_FILES[@]}" pull
+
+echo "$LOG_PREFIX Restarting services..."
+sudo docker compose "${COMPOSE_FILES[@]}" up -d --remove-orphans
+
+echo "$LOG_PREFIX Reloading Caddy configuration..."
+sudo docker compose "${COMPOSE_FILES[@]}" exec caddy caddy reload --config /etc/caddy/Caddyfile || true
+
+echo "$LOG_PREFIX Done"

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -119,9 +119,11 @@ java_library(
         "src/main/java/com/muchq/games/one_d4/api/dto/GameFeatureRow.java",
         "src/main/java/com/muchq/games/one_d4/api/dto/IndexRequest.java",
         "src/main/java/com/muchq/games/one_d4/api/dto/IndexResponse.java",
+        "src/main/java/com/muchq/games/one_d4/api/dto/MaintenanceWindow.java",
         "src/main/java/com/muchq/games/one_d4/api/dto/OccurrenceRow.java",
         "src/main/java/com/muchq/games/one_d4/api/dto/QueryRequest.java",
         "src/main/java/com/muchq/games/one_d4/api/dto/QueryResponse.java",
+        "src/main/java/com/muchq/games/one_d4/api/dto/ServerInfo.java",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -138,6 +140,7 @@ java_library(
         "src/main/java/com/muchq/games/one_d4/api/IndexRequestValidator.java",
         "src/main/java/com/muchq/games/one_d4/api/QueryController.java",
         "src/main/java/com/muchq/games/one_d4/api/QueryRequestValidator.java",
+        "src/main/java/com/muchq/games/one_d4/api/ServerInfoController.java",
     ],
     plugins = [
         "//bazel/rules:micronaut_type_element_visitor_processor",
@@ -335,6 +338,7 @@ java_test_suite(
         "src/test/java/com/muchq/games/one_d4/api/IndexRequestValidatorTest.java",
         "src/test/java/com/muchq/games/one_d4/api/QueryControllerTest.java",
         "src/test/java/com/muchq/games/one_d4/api/QueryRequestValidatorTest.java",
+        "src/test/java/com/muchq/games/one_d4/api/ServerInfoControllerTest.java",
     ],
     deps = [
         ":api",

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/ServerInfoController.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/ServerInfoController.java
@@ -1,0 +1,50 @@
+package com.muchq.games.one_d4.api;
+
+import com.muchq.games.one_d4.api.dto.MaintenanceWindow;
+import com.muchq.games.one_d4.api.dto.ServerInfo;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Singleton
+@Path("/v1/server-info")
+public class ServerInfoController {
+  static final Duration MAINTENANCE_WINDOW_THRESHOLD = Duration.ofHours(1);
+  static final String MAINTENANCE_MESSAGE =
+      "Scheduled server restart tonight at midnight UTC. Expect brief downtime.";
+
+  private final Clock clock;
+
+  public ServerInfoController() {
+    this(Clock.systemUTC());
+  }
+
+  ServerInfoController(Clock clock) {
+    this.clock = clock;
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public ServerInfo getServerInfo() {
+    ZonedDateTime now = ZonedDateTime.now(clock);
+    ZonedDateTime midnight =
+        LocalDate.now(clock).plusDays(1).atStartOfDay(ZoneOffset.UTC);
+    Duration timeUntilMidnight = Duration.between(now.toInstant(), midnight.toInstant());
+
+    if (timeUntilMidnight.compareTo(MAINTENANCE_WINDOW_THRESHOLD) <= 0) {
+      MaintenanceWindow window =
+          new MaintenanceWindow(MAINTENANCE_MESSAGE, midnight.toInstant().toString());
+      return new ServerInfo(List.of(window));
+    }
+
+    return new ServerInfo(List.of());
+  }
+}

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/MaintenanceWindow.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/MaintenanceWindow.java
@@ -1,0 +1,3 @@
+package com.muchq.games.one_d4.api.dto;
+
+public record MaintenanceWindow(String message, String scheduledAt) {}

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/ServerInfo.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/dto/ServerInfo.java
@@ -1,0 +1,5 @@
+package com.muchq.games.one_d4.api.dto;
+
+import java.util.List;
+
+public record ServerInfo(List<MaintenanceWindow> maintenanceWindows) {}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/ServerInfoControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/ServerInfoControllerTest.java
@@ -1,0 +1,102 @@
+package com.muchq.games.one_d4.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.muchq.games.one_d4.api.dto.ServerInfo;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.Test;
+
+public class ServerInfoControllerTest {
+
+  /** Returns a fixed clock set to the given UTC time string. */
+  private static Clock clockAt(String instantStr) {
+    return Clock.fixed(Instant.parse(instantStr), ZoneOffset.UTC);
+  }
+
+  @Test
+  public void getServerInfo_returnsEmptyWhenMoreThanOneHourBeforeMidnight() {
+    // 22:59:59 UTC – just over 1 hour before midnight, outside the window
+    Clock clock = clockAt("2024-06-15T22:59:59Z");
+    ServerInfoController controller = new ServerInfoController(clock);
+
+    ServerInfo info = controller.getServerInfo();
+
+    assertThat(info.maintenanceWindows()).isEmpty();
+  }
+
+  @Test
+  public void getServerInfo_returnsWindowWhenWithinOneHourOfMidnight() {
+    // 23:30:00 UTC – 30 minutes before midnight
+    Clock clock = clockAt("2024-06-15T23:30:00Z");
+    ServerInfoController controller = new ServerInfoController(clock);
+
+    ServerInfo info = controller.getServerInfo();
+
+    assertThat(info.maintenanceWindows()).hasSize(1);
+    assertThat(info.maintenanceWindows().get(0).message())
+        .contains("midnight UTC");
+    assertThat(info.maintenanceWindows().get(0).scheduledAt())
+        .isEqualTo("2024-06-16T00:00:00Z");
+  }
+
+  @Test
+  public void getServerInfo_returnsWindowAtExactlyOneHourBeforeMidnight() {
+    // 23:00:00 UTC – exactly 1 hour before midnight (inclusive boundary)
+    Clock clock = clockAt("2024-06-15T23:00:00Z");
+    ServerInfoController controller = new ServerInfoController(clock);
+
+    ServerInfo info = controller.getServerInfo();
+
+    assertThat(info.maintenanceWindows()).hasSize(1);
+  }
+
+  @Test
+  public void getServerInfo_returnsWindowOneMinuteBeforeMidnight() {
+    // 23:59:00 UTC – 1 minute before midnight
+    Clock clock = clockAt("2024-06-15T23:59:00Z");
+    ServerInfoController controller = new ServerInfoController(clock);
+
+    ServerInfo info = controller.getServerInfo();
+
+    assertThat(info.maintenanceWindows()).hasSize(1);
+    assertThat(info.maintenanceWindows().get(0).scheduledAt())
+        .isEqualTo("2024-06-16T00:00:00Z");
+  }
+
+  @Test
+  public void getServerInfo_returnsEmptyAtNoon() {
+    // 12:00:00 UTC – midday, far from midnight
+    Clock clock = clockAt("2024-06-15T12:00:00Z");
+    ServerInfoController controller = new ServerInfoController(clock);
+
+    ServerInfo info = controller.getServerInfo();
+
+    assertThat(info.maintenanceWindows()).isEmpty();
+  }
+
+  @Test
+  public void getServerInfo_scheduledAtPointsToNextMidnight() {
+    Clock clock = clockAt("2024-06-15T23:45:00Z");
+    ServerInfoController controller = new ServerInfoController(clock);
+
+    ServerInfo info = controller.getServerInfo();
+
+    assertThat(info.maintenanceWindows()).hasSize(1);
+    // Must point to next day's midnight
+    assertThat(info.maintenanceWindows().get(0).scheduledAt())
+        .startsWith("2024-06-16");
+  }
+
+  @Test
+  public void getServerInfo_returnsEmptyJustAfterMidnight() {
+    // 00:01:00 UTC – just past midnight, over 23 hours until next midnight
+    Clock clock = clockAt("2024-06-15T00:01:00Z");
+    ServerInfoController controller = new ServerInfoController(clock);
+
+    ServerInfo info = controller.getServerInfo();
+
+    assertThat(info.maintenanceWindows()).isEmpty();
+  }
+}

--- a/domains/games/apps/1d4_web/src/App.tsx
+++ b/domains/games/apps/1d4_web/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Header from './components/Header';
+import ServerInfoBanner from './components/ServerInfoBanner';
 import GamesView from './views/GamesView';
 import IndexView from './views/IndexView';
 import QueryView from './views/QueryView';
@@ -17,6 +18,7 @@ export default function App() {
           <Route path="*" element={<Navigate to="/games" replace />} />
         </Routes>
       </main>
+      <ServerInfoBanner />
     </>
   );
 }

--- a/domains/games/apps/1d4_web/src/__tests__/ServerInfoBanner.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/ServerInfoBanner.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ServerInfoBanner from '../components/ServerInfoBanner';
+import * as api from '../api';
+
+vi.mock('../api');
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('ServerInfoBanner', () => {
+  beforeEach(() => {
+    vi.mocked(api.getServerInfo).mockResolvedValue({ maintenanceWindows: [] });
+  });
+
+  it('renders nothing when maintenanceWindows is empty', async () => {
+    vi.mocked(api.getServerInfo).mockResolvedValue({ maintenanceWindows: [] });
+
+    render(<ServerInfoBanner />, { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(api.getServerInfo).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('renders banner when maintenanceWindows has entries', async () => {
+    vi.mocked(api.getServerInfo).mockResolvedValue({
+      maintenanceWindows: [
+        {
+          message: 'Scheduled server restart tonight at midnight UTC.',
+          scheduledAt: '2024-06-16T00:00:00Z',
+        },
+      ],
+    });
+
+    render(<ServerInfoBanner />, { wrapper: makeWrapper() });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Scheduled server restart tonight at midnight UTC.')
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders all maintenance window messages', async () => {
+    vi.mocked(api.getServerInfo).mockResolvedValue({
+      maintenanceWindows: [
+        { message: 'Window one', scheduledAt: '2024-06-16T00:00:00Z' },
+        { message: 'Window two', scheduledAt: '2024-06-16T00:00:00Z' },
+      ],
+    });
+
+    render(<ServerInfoBanner />, { wrapper: makeWrapper() });
+
+    await waitFor(() =>
+      expect(screen.getByText('Window one')).toBeInTheDocument()
+    );
+    expect(screen.getByText('Window two')).toBeInTheDocument();
+  });
+
+  it('dismisses banner when dismiss button is clicked', async () => {
+    vi.mocked(api.getServerInfo).mockResolvedValue({
+      maintenanceWindows: [
+        {
+          message: 'Restart tonight',
+          scheduledAt: '2024-06-16T00:00:00Z',
+        },
+      ],
+    });
+
+    render(<ServerInfoBanner />, { wrapper: makeWrapper() });
+
+    await waitFor(() =>
+      expect(screen.getByText('Restart tonight')).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss notification' }));
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('does not render before data is fetched', () => {
+    vi.mocked(api.getServerInfo).mockImplementation(
+      () => new Promise(() => {}) // never resolves
+    );
+
+    render(<ServerInfoBanner />, { wrapper: makeWrapper() });
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/domains/games/apps/1d4_web/src/__tests__/api.test.ts
+++ b/domains/games/apps/1d4_web/src/__tests__/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createIndex, listIndexRequests, query } from '../api';
+import { createIndex, listIndexRequests, query, getServerInfo } from '../api';
 
 describe('api', () => {
   afterEach(() => {
@@ -58,6 +58,28 @@ describe('api', () => {
         'https://api.1d4.net/v1/query',
         expect.objectContaining({ method: 'POST' })
       );
+    });
+  });
+
+  describe('getServerInfo', () => {
+    it('sends GET to /v1/server-info', async () => {
+      const mock = mockFetch({ maintenanceWindows: [] });
+      await getServerInfo();
+      expect(mock).toHaveBeenCalledWith(
+        'https://api.1d4.net/v1/server-info',
+        expect.any(Object)
+      );
+      const call = mock.mock.calls[0][1] as RequestInit;
+      expect(call.method).toBeUndefined(); // GET by default
+    });
+
+    it('returns maintenanceWindows from response', async () => {
+      const windows = [
+        { message: 'Restart at midnight', scheduledAt: '2024-06-16T00:00:00Z' },
+      ];
+      mockFetch({ maintenanceWindows: windows });
+      const result = await getServerInfo();
+      expect(result.maintenanceWindows).toEqual(windows);
     });
   });
 

--- a/domains/games/apps/1d4_web/src/api.ts
+++ b/domains/games/apps/1d4_web/src/api.ts
@@ -1,7 +1,7 @@
-import type { GameRow, IndexRequest, OccurrenceRow, QueryResponse } from './types';
+import type { GameRow, IndexRequest, OccurrenceRow, QueryResponse, ServerInfo } from './types';
 
 // re-export so consumers can import from one place
-export type { GameRow, IndexRequest, OccurrenceRow, QueryResponse };
+export type { GameRow, IndexRequest, OccurrenceRow, QueryResponse, ServerInfo };
 
 const API_BASE = 'https://api.1d4.net';
 
@@ -57,4 +57,8 @@ export async function query(body: {
   offset: number;
 }): Promise<QueryResponse> {
   return request('/v1/query', { method: 'POST', body: JSON.stringify(body) });
+}
+
+export async function getServerInfo(): Promise<ServerInfo> {
+  return request('/v1/server-info');
 }

--- a/domains/games/apps/1d4_web/src/components/ServerInfoBanner.tsx
+++ b/domains/games/apps/1d4_web/src/components/ServerInfoBanner.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getServerInfo } from '../api';
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export default function ServerInfoBanner() {
+  const [dismissed, setDismissed] = useState(false);
+
+  const { data } = useQuery({
+    queryKey: ['server-info'],
+    queryFn: getServerInfo,
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const windows = data?.maintenanceWindows ?? [];
+
+  if (dismissed || windows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="server-info-banner" role="status" aria-live="polite">
+      <div className="server-info-banner__content">
+        <span className="server-info-banner__icon">⚠</span>
+        <div className="server-info-banner__messages">
+          {windows.map((w, i) => (
+            <p key={i} className="server-info-banner__message">
+              {w.message}
+            </p>
+          ))}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="server-info-banner__dismiss"
+        aria-label="Dismiss notification"
+        onClick={() => setDismissed(true)}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/domains/games/apps/1d4_web/src/index.css
+++ b/domains/games/apps/1d4_web/src/index.css
@@ -315,3 +315,60 @@ td a.external:hover {
   padding: 1.5rem 0;
   text-align: center;
 }
+
+/* Server info corner banner */
+.server-info-banner {
+  position: fixed;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  z-index: 9999;
+  max-width: 340px;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--warning);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.server-info-banner__content {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.server-info-banner__icon {
+  color: var(--warning);
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 0.1em;
+}
+
+.server-info-banner__messages {
+  flex: 1;
+}
+
+.server-info-banner__message {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--text);
+  line-height: 1.4;
+}
+
+.server-info-banner__dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.server-info-banner__dismiss:hover {
+  color: var(--text);
+}

--- a/domains/games/apps/1d4_web/src/types.ts
+++ b/domains/games/apps/1d4_web/src/types.ts
@@ -47,3 +47,12 @@ export interface QueryResponse {
   games: GameRow[];
   count: number;
 }
+
+export interface MaintenanceWindow {
+  message: string;
+  scheduledAt: string;
+}
+
+export interface ServerInfo {
+  maintenanceWindows: MaintenanceWindow[];
+}


### PR DESCRIPTION
Backend (one_d4):
- Add GET /v1/server-info endpoint (ServerInfoController) that returns a
  maintenance window note when the server is within 1 hour of midnight UTC.
  Outside that window, returns an empty maintenanceWindows list.
- Add MaintenanceWindow and ServerInfo DTOs.
- Add ServerInfoControllerTest with boundary cases for the 1-hour threshold.
- Register new sources in BUILD.bazel (dto and api libraries, api_validation_tests).

Frontend (1d4_web):
- Add MaintenanceWindow and ServerInfo types.
- Add getServerInfo() API function.
- Add ServerInfoBanner component: polls /v1/server-info on page load and every
  5 minutes via React Query; shows a fixed corner notification with a dismiss
  button when maintenanceWindows is non-empty.
- Mount ServerInfoBanner in App.tsx.
- Add corner-banner CSS to index.css.
- Add ServerInfoBanner component tests and getServerInfo API tests.

Deploy:
- Add daily-restart.sh script that docker compose pulls latest images and
  restarts the consolidated stack. Intended to be installed as a root cron
  job scheduled at midnight server time (0 0 * * *).

https://claude.ai/code/session_01APniydhda23t5uxT3YZzUS