### PR TITLE
Use @Context for RetentionWorker eager initialization

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/RetentionWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/RetentionWorker.java
@@ -2,15 +2,15 @@ package com.muchq.games.one_d4.worker;
 
 import com.muchq.games.one_d4.db.GameFeatureStore;
 import com.muchq.games.one_d4.db.IndexedPeriodStore;
+import io.micronaut.context.annotation.Context;
 import io.micronaut.scheduling.annotation.Scheduled;
 import jakarta.inject.Inject;
-import jakarta.inject.Singleton;
 import java.time.Duration;
 import java.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Singleton
+@Context
 public class RetentionWorker {
   private static final Logger LOG = LoggerFactory.getLogger(RetentionWorker.class);
   private static final Duration RETENTION_PERIOD = Duration.ofDays(7);


### PR DESCRIPTION
## Summary
- `@Singleton` is lazy in Micronaut — RetentionWorker was never instantiated because nothing injects it
- Switch to `@Context` to force eager creation at startup so the `@Scheduled` method registers with the scheduler

## Test plan
- [x] All 25 one_d4 tests pass
- [ ] Deploy and verify "Running game retention policy (7 days)" appears in logs ~1 minute after startup