### PR TITLE
one_d4: add reanalysis unit/e2e tests and pin detector game position tests

### DIFF
--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -353,6 +353,7 @@ java_test_suite(
     name = "api_validation_tests",
     size = "small",
     srcs = [
+        "src/test/java/com/muchq/games/one_d4/api/AdminControllerTest.java",
         "src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java",
         "src/test/java/com/muchq/games/one_d4/api/IndexRequestValidatorTest.java",
         "src/test/java/com/muchq/games/one_d4/api/QueryControllerTest.java",
@@ -362,6 +363,7 @@ java_test_suite(
         ":api",
         ":db",
         ":dto",
+        ":engine",
         ":model",
         ":queue",
         "//domains/games/libs/chessql:compiler",
@@ -409,6 +411,7 @@ java_test_suite(
     srcs = [
         "src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java",
         "src/test/java/com/muchq/games/one_d4/e2e/MotifE2ETest.java",
+        "src/test/java/com/muchq/games/one_d4/e2e/ReanalysisE2ETest.java",
     ],
     deps = [
         ":api",
@@ -416,6 +419,7 @@ java_test_suite(
         ":dto",
         ":e2e_support",
         ":engine",
+        ":model",
         ":motifs",
         ":queue",
         ":worker",

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AdminControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AdminControllerTest.java
@@ -1,0 +1,237 @@
+package com.muchq.games.one_d4.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.muchq.games.one_d4.api.dto.GameFeature;
+import com.muchq.games.one_d4.api.dto.OccurrenceRow;
+import com.muchq.games.one_d4.api.dto.ReanalysisResponse;
+import com.muchq.games.one_d4.db.GameFeatureStore;
+import com.muchq.games.one_d4.engine.FeatureExtractor;
+import com.muchq.games.one_d4.engine.GameReplayer;
+import com.muchq.games.one_d4.engine.PgnParser;
+import com.muchq.games.one_d4.engine.model.GameFeatures;
+import com.muchq.games.one_d4.engine.model.Motif;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.Test;
+
+public class AdminControllerTest {
+
+  // === Tests ===
+
+  @Test
+  public void reanalyze_emptyStore_returnsZeroCounts() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    ReanalysisResponse response = controller.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(0);
+    assertThat(response.gamesFailed()).isEqualTo(0);
+  }
+
+  @Test
+  public void reanalyze_singleValidGame_returnsOneProcessed() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    store.addGame("https://chess.com/game/1", "valid pgn");
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    ReanalysisResponse response = controller.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(1);
+    assertThat(response.gamesFailed()).isEqualTo(0);
+  }
+
+  @Test
+  public void reanalyze_nullPgn_countsAsFailed_extractorNeverCalled() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    store.addGame("https://chess.com/game/1", null);
+    FakeFeatureExtractor extractor = noOpExtractor();
+    AdminController controller = new AdminController(store, extractor);
+
+    ReanalysisResponse response = controller.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(0);
+    assertThat(response.gamesFailed()).isEqualTo(1);
+    assertThat(extractor.callCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void reanalyze_blankPgn_countsAsFailed() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    store.addGame("https://chess.com/game/1", "   ");
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    ReanalysisResponse response = controller.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(0);
+    assertThat(response.gamesFailed()).isEqualTo(1);
+  }
+
+  @Test
+  public void reanalyze_updateMotifsThrows_countsAsFailed() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    store.addGame("https://chess.com/game/1", "valid pgn");
+    store.throwOnUpdateMotifs = true;
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    ReanalysisResponse response = controller.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(0);
+    assertThat(response.gamesFailed()).isEqualTo(1);
+  }
+
+  @Test
+  public void reanalyze_exceptionOnOneGame_othersStillProcessed() {
+    // Null PGN game is sandwiched between two valid games.
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    store.addGame("https://chess.com/game/1", "valid pgn 1");
+    store.addGame("https://chess.com/game/2", null);
+    store.addGame("https://chess.com/game/3", "valid pgn 3");
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    ReanalysisResponse response = controller.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(2);
+    assertThat(response.gamesFailed()).isEqualTo(1);
+    // Game 3 is processed even though game 2 failed.
+    assertThat(store.updateMotifsCount("https://chess.com/game/3")).isEqualTo(1);
+  }
+
+  @Test
+  public void reanalyze_validGame_callsUpdateDeleteInsert() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    String url = "https://chess.com/game/1";
+    store.addGame(url, "valid pgn");
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    controller.reanalyze();
+
+    assertThat(store.updateMotifsCount(url)).isEqualTo(1);
+    assertThat(store.deleteOccurrencesCount(url)).isEqualTo(1);
+    assertThat(store.insertOccurrencesCount(url)).isEqualTo(1);
+  }
+
+  @Test
+  public void reanalyze_nullPgn_doesNotCallUpdateOrDelete() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    String url = "https://chess.com/game/1";
+    store.addGame(url, null);
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    controller.reanalyze();
+
+    assertThat(store.updateMotifsCount(url)).isEqualTo(0);
+    assertThat(store.deleteOccurrencesCount(url)).isEqualTo(0);
+    assertThat(store.insertOccurrencesCount(url)).isEqualTo(0);
+  }
+
+  @Test
+  public void reanalyze_multipleGames_correctAggregateCounts() {
+    FakeGameFeatureStore store = new FakeGameFeatureStore();
+    for (int i = 0; i < 5; i++) {
+      store.addGame("https://chess.com/game/" + i, "pgn " + i);
+    }
+    AdminController controller = new AdminController(store, noOpExtractor());
+
+    ReanalysisResponse response = controller.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(5);
+    assertThat(response.gamesFailed()).isEqualTo(0);
+  }
+
+  // === Helpers ===
+
+  private static FakeFeatureExtractor noOpExtractor() {
+    return new FakeFeatureExtractor();
+  }
+
+  private static class FakeFeatureExtractor extends FeatureExtractor {
+    private int callCount = 0;
+
+    FakeFeatureExtractor() {
+      super(new PgnParser(), new GameReplayer(), List.of());
+    }
+
+    @Override
+    public GameFeatures extract(String pgn) {
+      callCount++;
+      return new GameFeatures(Set.of(), 0, Map.of());
+    }
+
+    int callCount() {
+      return callCount;
+    }
+  }
+
+  private static class FakeGameFeatureStore implements GameFeatureStore {
+    private final List<GameForReanalysis> games = new ArrayList<>();
+    private final Map<String, Integer> updateMotifsCount = new HashMap<>();
+    private final Map<String, Integer> deleteCount = new HashMap<>();
+    private final Map<String, Integer> insertCount = new HashMap<>();
+    boolean throwOnUpdateMotifs = false;
+
+    void addGame(String url, String pgn) {
+      games.add(new GameForReanalysis(UUID.randomUUID(), url, pgn));
+    }
+
+    int updateMotifsCount(String url) {
+      return updateMotifsCount.getOrDefault(url, 0);
+    }
+
+    int deleteOccurrencesCount(String url) {
+      return deleteCount.getOrDefault(url, 0);
+    }
+
+    int insertOccurrencesCount(String url) {
+      return insertCount.getOrDefault(url, 0);
+    }
+
+    @Override
+    public List<GameForReanalysis> fetchForReanalysis(int limit, int offset) {
+      int start = Math.min(offset, games.size());
+      int end = Math.min(offset + limit, games.size());
+      return new ArrayList<>(games.subList(start, end));
+    }
+
+    @Override
+    public void updateMotifs(String gameUrl, GameFeatures features) {
+      if (throwOnUpdateMotifs) throw new RuntimeException("store error");
+      updateMotifsCount.merge(gameUrl, 1, Integer::sum);
+    }
+
+    @Override
+    public void deleteOccurrencesByGameUrl(String gameUrl) {
+      deleteCount.merge(gameUrl, 1, Integer::sum);
+    }
+
+    @Override
+    public void insertOccurrences(
+        String gameUrl, Map<Motif, List<GameFeatures.MotifOccurrence>> occurrences) {
+      insertCount.merge(gameUrl, 1, Integer::sum);
+    }
+
+    @Override
+    public void insert(GameFeature feature) {}
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
+    }
+
+    @Override
+    public List<GameFeature> query(Object compiledQuery, int limit, int offset) {
+      return List.of();
+    }
+
+    @Override
+    public Map<String, Map<String, List<OccurrenceRow>>> queryOccurrences(List<String> gameUrls) {
+      return Map.of();
+    }
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/ReanalysisE2ETest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/ReanalysisE2ETest.java
@@ -1,0 +1,321 @@
+package com.muchq.games.one_d4.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.muchq.games.chess_com_client.Accuracies;
+import com.muchq.games.chess_com_client.PlayedGame;
+import com.muchq.games.chess_com_client.PlayerResult;
+import com.muchq.games.chessql.compiler.CompiledQuery;
+import com.muchq.games.chessql.compiler.SqlCompiler;
+import com.muchq.games.chessql.parser.Parser;
+import com.muchq.games.one_d4.api.AdminController;
+import com.muchq.games.one_d4.api.IndexController;
+import com.muchq.games.one_d4.api.IndexRequestValidator;
+import com.muchq.games.one_d4.api.dto.GameFeature;
+import com.muchq.games.one_d4.api.dto.IndexRequest;
+import com.muchq.games.one_d4.api.dto.OccurrenceRow;
+import com.muchq.games.one_d4.api.dto.ReanalysisResponse;
+import com.muchq.games.one_d4.db.DataSourceFactory;
+import com.muchq.games.one_d4.db.GameFeatureDao;
+import com.muchq.games.one_d4.db.GameFeatureStore;
+import com.muchq.games.one_d4.db.IndexedPeriodDao;
+import com.muchq.games.one_d4.db.IndexedPeriodStore;
+import com.muchq.games.one_d4.db.IndexingRequestDao;
+import com.muchq.games.one_d4.db.IndexingRequestStore;
+import com.muchq.games.one_d4.db.Migration;
+import com.muchq.games.one_d4.engine.FeatureExtractor;
+import com.muchq.games.one_d4.engine.GameReplayer;
+import com.muchq.games.one_d4.engine.PgnParser;
+import com.muchq.games.one_d4.engine.model.GameFeatures;
+import com.muchq.games.one_d4.engine.model.Motif;
+import com.muchq.games.one_d4.motifs.AttackDetector;
+import com.muchq.games.one_d4.motifs.BackRankMateDetector;
+import com.muchq.games.one_d4.motifs.CheckDetector;
+import com.muchq.games.one_d4.motifs.CheckmateDetector;
+import com.muchq.games.one_d4.motifs.CrossPinDetector;
+import com.muchq.games.one_d4.motifs.DiscoveredCheckDetector;
+import com.muchq.games.one_d4.motifs.DoubleCheckDetector;
+import com.muchq.games.one_d4.motifs.InterferenceDetector;
+import com.muchq.games.one_d4.motifs.MotifDetector;
+import com.muchq.games.one_d4.motifs.OverloadedPieceDetector;
+import com.muchq.games.one_d4.motifs.PinDetector;
+import com.muchq.games.one_d4.motifs.PromotionDetector;
+import com.muchq.games.one_d4.motifs.PromotionWithCheckDetector;
+import com.muchq.games.one_d4.motifs.PromotionWithCheckmateDetector;
+import com.muchq.games.one_d4.motifs.SacrificeDetector;
+import com.muchq.games.one_d4.motifs.SkewerDetector;
+import com.muchq.games.one_d4.motifs.SmotheredMateDetector;
+import com.muchq.games.one_d4.motifs.ZugzwangDetector;
+import com.muchq.games.one_d4.queue.InMemoryIndexQueue;
+import com.muchq.games.one_d4.queue.IndexMessage;
+import com.muchq.games.one_d4.queue.IndexQueue;
+import com.muchq.games.one_d4.worker.IndexWorker;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end tests for the POST /admin/reanalyze endpoint. Each test indexes one or more games,
+ * then calls AdminController.reanalyze() and verifies that motif columns and occurrences are
+ * correctly refreshed.
+ */
+public class ReanalysisE2ETest {
+
+  private static final String PLAYER = "reanalysis_e2e_player";
+  private static final String PLATFORM = "CHESS_COM";
+  private static final YearMonth MONTH = YearMonth.of(2024, 7);
+
+  // King's Gambit game used across motif tests — has PIN, CHECK, PROMOTION, etc.
+  private static final String KINGS_GAMBIT_URL = "https://chess.com/game/kings-gambit-reanalysis";
+  private static final String KINGS_GAMBIT_PGN =
+      """
+      [Event "Live Chess"]
+      [Site "Chess.com"]
+      [White "_prior"]
+      [Black "zapblast"]
+      [Result "1-0"]
+      [ECO "C30"]
+
+      1. e4 e5 2. f4 d6 3. Nf3 Nc6 4. Bb5 Bd7 5. Nc3 f6 6. f5 Be7 7. Nh4 h5 \
+      8. Ng6 Rh6 9. Nd5 Nd4 10. Bxd7+ Qxd7 11. d3 Rh7 12. h4 c6 13. Ngxe7 Nxe7 \
+      14. Nxe7 Kxe7 15. Be3 c5 16. g4 hxg4 17. Qxg4 Qa4 18. Bxd4 cxd4 19. Qg6 Rah8 \
+      20. a3 Qxc2 21. O-O Rxh4 22. Qxg7+ Ke8 23. Qg6+ Kf8 24. Qxf6+ Ke8 25. Qe6+ Kd8 \
+      26. Qxd6+ Kc8 27. Qe6+ Kb8 28. Qxe5+ Ka8 29. Rf2 Rh1+ 30. Kg2 R8h2+ 31. Qxh2 Rxh2+ \
+      32. Kxh2 Qxf2+ 33. Kh1 Qxb2 34. Rg1 a6 35. f6 Qf2 36. e5 Qf3+ 37. Kh2 Qf4+ \
+      38. Rg3 Qxe5 39. f7 Qh5+ 40. Kg2 Qxf7 41. Rf3 Qa2+ 42. Kg3 Qxa3 43. Kf4 Qf8+ \
+      44. Ke4 Qe8+ 45. Kxd4 Qd7+ 46. Ke5 a5 47. d4 a4 48. d5 Qg7+ 49. Ke6 Qg4+ \
+      50. Rf5 a3 51. d6 Kb8 52. d7 Qg7 53. d8=Q+ Ka7 54. Ra5# 1-0
+      """;
+
+  private IndexController controller;
+  private IndexQueue queue;
+  private IndexWorker worker;
+  private GameFeatureStore gameFeatureStore;
+  private AdminController adminController;
+  private FakeChessClient fakeChessClient;
+  private IndexingRequestStore requestStore;
+  private IndexedPeriodStore periodStore;
+  private FeatureExtractor featureExtractor;
+
+  @Before
+  public void setUp() {
+    String jdbcUrl =
+        "jdbc:h2:mem:reanalysis_e2e_" + System.currentTimeMillis() + ";DB_CLOSE_DELAY=-1";
+    DataSource dataSource = DataSourceFactory.create(jdbcUrl, "sa", "");
+    Migration migration = new Migration(dataSource, true);
+    migration.run();
+
+    requestStore = new IndexingRequestDao(dataSource);
+    periodStore = new IndexedPeriodDao(dataSource, true);
+    gameFeatureStore = new GameFeatureDao(dataSource, true);
+
+    queue = new InMemoryIndexQueue();
+    fakeChessClient = new FakeChessClient();
+
+    List<MotifDetector> detectors =
+        List.of(
+            new PinDetector(),
+            new CrossPinDetector(),
+            new SkewerDetector(),
+            new AttackDetector(),
+            new DiscoveredCheckDetector(),
+            new CheckDetector(),
+            new CheckmateDetector(),
+            new PromotionDetector(),
+            new PromotionWithCheckDetector(),
+            new PromotionWithCheckmateDetector(),
+            new BackRankMateDetector(),
+            new SmotheredMateDetector(),
+            new SacrificeDetector(),
+            new ZugzwangDetector(),
+            new DoubleCheckDetector(),
+            new InterferenceDetector(),
+            new OverloadedPieceDetector());
+    featureExtractor = new FeatureExtractor(new PgnParser(), new GameReplayer(), detectors);
+
+    worker =
+        new IndexWorker(
+            fakeChessClient, featureExtractor, requestStore, gameFeatureStore, periodStore);
+    controller = new IndexController(requestStore, queue, new IndexRequestValidator());
+    adminController = new AdminController(gameFeatureStore, featureExtractor);
+  }
+
+  // === Basic reanalysis ===
+
+  @Test
+  public void reanalyze_noGames_returnsZeroCounts() {
+    ReanalysisResponse response = adminController.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(0);
+    assertThat(response.gamesFailed()).isEqualTo(0);
+  }
+
+  @Test
+  public void reanalyze_kingsGambitGame_processesSingleGame() {
+    indexGame(KINGS_GAMBIT_URL, KINGS_GAMBIT_PGN);
+
+    ReanalysisResponse response = adminController.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(1);
+    assertThat(response.gamesFailed()).isEqualTo(0);
+  }
+
+  @Test
+  public void reanalyze_kingsGambitGame_motifColumnsPreserved() {
+    // Index the game so motif columns are set.
+    indexGame(KINGS_GAMBIT_URL, KINGS_GAMBIT_PGN);
+    assertMotifDetected(KINGS_GAMBIT_URL, "pin");
+    assertMotifDetected(KINGS_GAMBIT_URL, "check");
+    assertMotifDetected(KINGS_GAMBIT_URL, "promotion");
+
+    // Reanalysis should be idempotent — motif columns stay set.
+    ReanalysisResponse response = adminController.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(1);
+    assertMotifDetected(KINGS_GAMBIT_URL, "pin");
+    assertMotifDetected(KINGS_GAMBIT_URL, "check");
+    assertMotifDetected(KINGS_GAMBIT_URL, "promotion");
+  }
+
+  // === Occurrence replacement ===
+
+  @Test
+  public void reanalyze_replacesOccurrences_staleOccurrenceIsRemoved() {
+    indexGame(KINGS_GAMBIT_URL, KINGS_GAMBIT_PGN);
+
+    // Insert a fake extra pin occurrence to simulate stale data.
+    GameFeatures.MotifOccurrence fakeOcc =
+        new GameFeatures.MotifOccurrence(
+            999, 500, "white", "Fake stale pin", null, "Qa1", "kb8", false, false, "ABSOLUTE");
+    gameFeatureStore.insertOccurrences(KINGS_GAMBIT_URL, Map.of(Motif.PIN, List.of(fakeOcc)));
+
+    // Before reanalysis: the fake occurrence at ply 999 is in the DB.
+    List<OccurrenceRow> pinsBefore = getOccurrences(KINGS_GAMBIT_URL, "pin");
+    assertThat(pinsBefore).anyMatch(o -> o.moveNumber() == 500);
+
+    // Reanalyze: deletes all occurrences then re-inserts from detectors.
+    adminController.reanalyze();
+
+    // After reanalysis: fake occurrence is gone; real pins still present.
+    List<OccurrenceRow> pinsAfter = getOccurrences(KINGS_GAMBIT_URL, "pin");
+    assertThat(pinsAfter).noneMatch(o -> o.moveNumber() == 500);
+    assertThat(pinsAfter).isNotEmpty();
+  }
+
+  @Test
+  public void reanalyze_withNoDetectors_clearsMotifColumnsAndOccurrences() {
+    // Index the game with all detectors → pin detected.
+    indexGame(KINGS_GAMBIT_URL, KINGS_GAMBIT_PGN);
+    assertMotifDetected(KINGS_GAMBIT_URL, "pin");
+
+    // Build an AdminController with NO detectors — re-analysis will find nothing.
+    FeatureExtractor emptyExtractor =
+        new FeatureExtractor(new PgnParser(), new GameReplayer(), List.of());
+    AdminController emptyAdminController = new AdminController(gameFeatureStore, emptyExtractor);
+
+    ReanalysisResponse response = emptyAdminController.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(1);
+
+    // Motif columns should now be false (no detectors → no motifs found).
+    CompiledQuery pinQuery = new SqlCompiler().compile(Parser.parse("motif(pin)"));
+    List<GameFeature> pinned = gameFeatureStore.query(pinQuery, 10, 0);
+    assertThat(pinned).isEmpty();
+
+    // Occurrences should be empty.
+    List<OccurrenceRow> occs = getOccurrences(KINGS_GAMBIT_URL, "pin");
+    assertThat(occs).isEmpty();
+  }
+
+  @Test
+  public void reanalyze_multipleGames_allProcessed() {
+    // Index both games in a single request so they land in the same batch.
+    String url2 = "https://chess.com/game/opera-reanalysis";
+    String operaPgn =
+        """
+        [Event "Opera Game"]
+        [White "Morphy"]
+        [Black "Duke Karl"]
+        [Result "1-0"]
+
+        1. e4 e5 2. Nf3 d6 3. d4 Bg4 4. dxe5 Bxf3 5. Qxf3 dxe5 6. Bc4 Nf6 \
+        7. Qb3 Qe7 8. Nc3 c6 9. Bg5 b5 10. Nxb5 cxb5 11. Bxb5+ Nbd7 12. O-O-O Rd8 \
+        13. Rxd7 Rxd7 14. Rd1 Qe6 15. Bxd7+ Nxd7 16. Qb8+ Nxb8 17. Rd8# 1-0
+        """;
+
+    indexGames(List.of(playedGame(KINGS_GAMBIT_URL, KINGS_GAMBIT_PGN), playedGame(url2, operaPgn)));
+
+    ReanalysisResponse response = adminController.reanalyze();
+
+    assertThat(response.gamesProcessed()).isEqualTo(2);
+    assertThat(response.gamesFailed()).isEqualTo(0);
+    assertMotifDetected(KINGS_GAMBIT_URL, "pin");
+    assertMotifDetected(url2, "back_rank_mate");
+  }
+
+  // ===== Helpers =====
+
+  private String indexGame(String url, String pgn) {
+    fakeChessClient.setGames(PLAYER, MONTH, List.of(playedGame(url, pgn)));
+    IndexRequest request = new IndexRequest(PLAYER, PLATFORM, "2024-07", "2024-07");
+    controller.createIndex(request);
+    processQueueUntilIdle();
+    return url;
+  }
+
+  /** Indexes multiple games in a single indexing request (same player+month batch). */
+  private void indexGames(List<PlayedGame> games) {
+    fakeChessClient.setGames(PLAYER, MONTH, games);
+    IndexRequest request = new IndexRequest(PLAYER, PLATFORM, "2024-07", "2024-07");
+    controller.createIndex(request);
+    processQueueUntilIdle();
+  }
+
+  private void assertMotifDetected(String expectedUrl, String motifName) {
+    CompiledQuery compiled = new SqlCompiler().compile(Parser.parse("motif(" + motifName + ")"));
+    List<GameFeature> results = gameFeatureStore.query(compiled, 10, 0);
+    assertThat(results).anyMatch(r -> r.gameUrl().equals(expectedUrl));
+  }
+
+  private List<OccurrenceRow> getOccurrences(String gameUrl, String motifName) {
+    Map<String, Map<String, List<OccurrenceRow>>> all =
+        gameFeatureStore.queryOccurrences(List.of(gameUrl));
+    return all.getOrDefault(gameUrl, Map.of()).getOrDefault(motifName, List.of());
+  }
+
+  private static PlayedGame playedGame(String url, String pgn) {
+    return new PlayedGame(
+        url,
+        pgn,
+        Instant.EPOCH,
+        true,
+        new Accuracies(90.0, 85.0),
+        "",
+        "uuid-" + url.hashCode(),
+        "",
+        "",
+        "blitz",
+        "chess",
+        new PlayerResult(1500, "win", "https://chess.com/w", "White", "uuid-w"),
+        new PlayerResult(1500, "loss", "https://chess.com/b", "Black", "uuid-b"),
+        "C30");
+  }
+
+  private void processQueueUntilIdle() {
+    int maxIterations = 100;
+    for (int i = 0; i < maxIterations; i++) {
+      Optional<IndexMessage> message = queue.poll(Duration.ofMillis(50));
+      if (message.isEmpty()) {
+        return;
+      }
+      worker.process(message.get());
+    }
+    throw new AssertionError("Queue did not drain within " + maxIterations + " iterations");
+  }
+}


### PR DESCRIPTION
## Summary

- **AdminControllerTest** (new): 9 unit tests covering the `POST /admin/reanalyze` batching loop — null/blank PGN counted as failed, exceptions on individual games don't abort others, store methods (`updateMotifs`, `deleteOccurrencesByGameUrl`, `insertOccurrences`) called in the right order
- **GameFeatureDaoTest** (11 new): `fetchForReanalysis` pagination/ordering + `updateMotifs` including the three derived columns (`has_discovered_attack`, `has_checkmate`, `has_discovered_mate`) derived from ATTACK occurrences' `isDiscovered`/`isMate` flags
- **ReanalysisE2ETest** (new): 6 full-pipeline E2E tests — idempotency, stale-occurrence replacement, no-detector teardown (columns cleared), multi-game batch
- **PinDetectorTest** (3 new): King's Gambit move-4 FEN (`4.Bb5`) with exact attacker/target assertions; regression guard confirming exactly one pin detected in that position (no false positives)
- **BUILD**: `AdminControllerTest` added to `api_validation_tests` (+ `:engine` dep); `ReanalysisE2ETest` added to `e2e_tests` (+ `:model` dep)

## Test plan

- [x] `bazel test //domains/games/apis/one_d4:api_validation_tests` — 29 pass
- [x] `bazel test //domains/games/apis/one_d4:db_tests` — pass
- [x] `bazel test //domains/games/apis/one_d4:motifs_tests` — pass
- [x] `bazel test //domains/games/apis/one_d4:e2e_tests` — pass