### PR TITLE
fix(one_d4): derive FORK at query time; fix sequence() and ORDER BY for derived motifs

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/engine/FeatureExtractor.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/engine/FeatureExtractor.java
@@ -55,10 +55,6 @@ public class FeatureExtractor {
       }
     }
 
-    // Post-process: derive FORK occurrences from ATTACK occurrences.
-    // A fork is when the same attacker at the same ply attacks 2+ targets.
-    deriveForkFromAttack(allOccurrences, foundMotifs);
-
     return new GameFeatures(foundMotifs, numMoves, allOccurrences);
   }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
@@ -136,10 +136,11 @@ public class GameFeatureDaoTest {
   }
 
   @Test
-  public void insertOccurrences_isDiscovered_and_isMate_roundTrip() {
+  public void attack_notExposedInQueryOccurrences() {
+    // ATTACK is an internal backend primitive and must not appear in queryOccurrences results.
+    // It is stored (for ChessQL derived-motif queries) but filtered before returning to callers.
     String gameUrl = "https://chess.com/game/attack-1";
-    GameFeature game = createGame(gameUrl);
-    dao.insert(game);
+    dao.insert(createGame(gameUrl));
 
     GameFeatures.MotifOccurrence discovered =
         new GameFeatures.MotifOccurrence(
@@ -147,42 +148,73 @@ public class GameFeatureDaoTest {
     GameFeatures.MotifOccurrence mate =
         new GameFeatures.MotifOccurrence(
             7, 4, "white", "Attack at move 4", "Ra1a5", "Ra5", "ka8", false, true, null);
-    Map<Motif, List<GameFeatures.MotifOccurrence>> occurrences =
-        Map.of(Motif.ATTACK, List.of(discovered, mate));
-    dao.insertOccurrences(gameUrl, occurrences);
+    dao.insertOccurrences(gameUrl, Map.of(Motif.ATTACK, List.of(discovered, mate)));
 
     Map<String, Map<String, List<OccurrenceRow>>> result = dao.queryOccurrences(List.of(gameUrl));
-    assertThat(result).containsKey(gameUrl);
-    List<OccurrenceRow> rows = result.get(gameUrl).get("attack");
-    assertThat(rows).hasSize(2);
-    assertThat(rows.get(0))
-        .isEqualTo(
-            new OccurrenceRow(
-                gameUrl,
-                "attack",
-                3,
-                "white",
-                "Discovered attack at move 3",
-                "Kg1g2",
-                "Ra1",
-                "rh1",
-                true,
-                false,
-                null));
-    assertThat(rows.get(1))
-        .isEqualTo(
-            new OccurrenceRow(
-                gameUrl,
-                "attack",
-                4,
-                "white",
-                "Attack at move 4",
-                "Ra1a5",
-                "Ra5",
-                "ka8",
-                false,
-                true,
-                null));
+    Map<String, List<OccurrenceRow>> byMotif = result.getOrDefault(gameUrl, Map.of());
+    assertThat(byMotif).doesNotContainKey("attack");
+  }
+
+  @Test
+  public void fork_derivedFromAttackRowsInQueryOccurrences() {
+    // Two ATTACK rows at the same (moveNumber, side, attacker) with different targets = fork.
+    String gameUrl = "https://chess.com/game/fork-1";
+    dao.insert(createGame(gameUrl));
+
+    // Ng6 at move 8 attacks both rh6 and ke8 — this is a fork
+    GameFeatures.MotifOccurrence attack1 =
+        GameFeatures.MotifOccurrence.attack(
+            15, 8, "white", "Attack at move 8", "Ng5g6", "Ng6", "rh6", false, false);
+    GameFeatures.MotifOccurrence attack2 =
+        GameFeatures.MotifOccurrence.attack(
+            15, 8, "white", "Attack at move 8", "Ng5g6", "Ng6", "ke8", false, false);
+    dao.insertOccurrences(gameUrl, Map.of(Motif.ATTACK, List.of(attack1, attack2)));
+
+    Map<String, Map<String, List<OccurrenceRow>>> result = dao.queryOccurrences(List.of(gameUrl));
+    Map<String, List<OccurrenceRow>> byMotif = result.get(gameUrl);
+    assertThat(byMotif).doesNotContainKey("attack");
+    assertThat(byMotif).containsKey("fork");
+    List<OccurrenceRow> forkOccs = byMotif.get("fork");
+    assertThat(forkOccs).hasSize(2);
+    assertThat(forkOccs).allMatch(o -> o.moveNumber() == 8);
+    assertThat(forkOccs).allMatch(o -> "white".equals(o.side()));
+    assertThat(forkOccs).allMatch(o -> "Ng6".equals(o.attacker()));
+    assertThat(forkOccs).extracting(OccurrenceRow::target).containsExactlyInAnyOrder("rh6", "ke8");
+  }
+
+  @Test
+  public void fork_notDerivedWhenSingleTarget() {
+    // One ATTACK row per attacker — not a fork.
+    String gameUrl = "https://chess.com/game/no-fork-1";
+    dao.insert(createGame(gameUrl));
+
+    GameFeatures.MotifOccurrence attack =
+        GameFeatures.MotifOccurrence.attack(
+            15, 8, "white", "Attack at move 8", "Ng5g6", "Ng6", "ke8", false, false);
+    dao.insertOccurrences(gameUrl, Map.of(Motif.ATTACK, List.of(attack)));
+
+    Map<String, Map<String, List<OccurrenceRow>>> result = dao.queryOccurrences(List.of(gameUrl));
+    Map<String, List<OccurrenceRow>> byMotif = result.getOrDefault(gameUrl, Map.of());
+    assertThat(byMotif).doesNotContainKey("fork");
+    assertThat(byMotif).doesNotContainKey("attack");
+  }
+
+  @Test
+  public void fork_notDerivedFromDiscoveredAttacks() {
+    // Discovered attacks (isDiscovered=true) must not count toward fork grouping.
+    String gameUrl = "https://chess.com/game/no-fork-discovered";
+    dao.insert(createGame(gameUrl));
+
+    GameFeatures.MotifOccurrence disc1 =
+        GameFeatures.MotifOccurrence.attack(
+            15, 8, "white", "Discovered", "Pf5", "Bg2", "rh6", true, false);
+    GameFeatures.MotifOccurrence disc2 =
+        GameFeatures.MotifOccurrence.attack(
+            15, 8, "white", "Discovered", "Pf5", "Bg2", "ke8", true, false);
+    dao.insertOccurrences(gameUrl, Map.of(Motif.ATTACK, List.of(disc1, disc2)));
+
+    Map<String, Map<String, List<OccurrenceRow>>> result = dao.queryOccurrences(List.of(gameUrl));
+    assertThat(result.getOrDefault(gameUrl, Map.of())).doesNotContainKey("fork");
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/MotifE2ETest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/MotifE2ETest.java
@@ -191,9 +191,10 @@ public class MotifE2ETest {
   // === ATTACK ===
 
   @Test
-  public void attack_motifDetected() {
+  public void attack_notExposedInOccurrences() {
+    // ATTACK is an internal backend primitive and must not appear in the user-facing occurrences.
     String url = indexGame(KINGS_GAMBIT_URL, KINGS_GAMBIT_PGN);
-    assertThat(getOccurrences(url, "attack")).isNotEmpty();
+    assertThat(getOccurrences(url, "attack")).isEmpty();
   }
 
   // === DISCOVERED_ATTACK ===
@@ -204,9 +205,8 @@ public class MotifE2ETest {
     // King's Gambit has discovered attacks at moves 9, 11, 16, 30, 44.
     String url = indexGame(KINGS_GAMBIT_URL, KINGS_GAMBIT_PGN);
     assertMotifDetected(url, "discovered_attack");
-    // Attack occurrences with isDiscovered=true should be present
-    List<OccurrenceRow> attackOccs = getOccurrences(url, "attack");
-    assertThat(attackOccs.stream().anyMatch(OccurrenceRow::isDiscovered)).isTrue();
+    // ATTACK is internal and must not appear in user-facing occurrences
+    assertThat(getOccurrences(url, "attack")).isEmpty();
   }
 
   // === FORK ===

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/motifs/FullMotifDetectorTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/motifs/FullMotifDetectorTest.java
@@ -85,10 +85,10 @@ public class FullMotifDetectorTest {
   public void extractFeatures_detectsExactMotifSet() {
     GameFeatures features = extractor.extract(PGN);
 
+    // FORK is no longer materialized at index time — it is derived at query/response time.
     assertThat(features.motifs())
         .containsExactlyInAnyOrder(
             Motif.PIN,
-            Motif.FORK,
             Motif.SKEWER,
             Motif.ATTACK,
             Motif.CHECK,
@@ -210,28 +210,13 @@ public class FullMotifDetectorTest {
   }
 
   @Test
-  public void extractFeatures_fork_occurrences() {
+  public void extractFeatures_fork_notMaterializedAtIndexTime() {
+    // FORK is derived at query/response time from ATTACK rows; extract() must not produce FORK.
+    // The underlying ATTACK rows that would constitute forks ARE present.
     GameFeatures features = extractor.extract(PGN);
-    // FORK is derived from ATTACK: each fork produces one occurrence per target.
-    // 8.Ng6 forks Rh6+Ke8 → 2 occurrences; queen forks on 22/24/28; 49...Qg4+
-    List<GameFeatures.MotifOccurrence> forkOccs = features.occurrences().get(Motif.FORK);
-    assertThat(forkOccs).isNotEmpty();
-
-    // All fork occurrences have attacker/target populated and pinType null
-    assertThat(forkOccs).allMatch(o -> o.attacker() != null);
-    assertThat(forkOccs).allMatch(o -> o.target() != null);
-    assertThat(forkOccs).allMatch(o -> o.pinType() == null);
-
-    // Fork move numbers present (each fork position appears with ≥2 occurrences for the same
-    // attacker)
-    List<Integer> moveNumbers =
-        forkOccs.stream().map(GameFeatures.MotifOccurrence::moveNumber).toList();
-    assertThat(moveNumbers).contains(8, 22, 24, 28, 49);
-
-    // Sanity: move 8 fork by white (Ng6 attacks Rh6 and Ke8)
-    assertThat(forkOccs).anyMatch(o -> o.moveNumber() == 8 && "white".equals(o.side()));
-    // Sanity: move 49 fork by black
-    assertThat(forkOccs).anyMatch(o -> o.moveNumber() == 49 && "black".equals(o.side()));
+    assertThat(features.occurrences()).doesNotContainKey(Motif.FORK);
+    assertThat(features.hasMotif(Motif.FORK)).isFalse();
+    assertThat(features.hasMotif(Motif.ATTACK)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **ATTACK motifs no longer appear in the API response** — they're stored as an internal primitive but stripped before returning to callers, with FORK derived from them in Java
- **FORK is no longer materialized at index time** — `FeatureExtractor.deriveForkFromAttack()` call removed; FORK rows are now derived on-the-fly from ATTACK rows at query/response time
- **`sequence()` now works correctly for all motifs including derived ones** — `SqlCompiler` now generates per-motif `(game_url, ply)` subquery fragments joined on consecutive plies, so `sequence(fork THEN checkmate)` generates valid SQL regardless of how motifs are stored
- **`ORDER BY motif_count(fork)` fixed** — uses a derived ATTACK-based count subquery instead of looking for non-existent stored FORK rows

## Key abstraction: `motifToPlySubquery()`

Every motif returns a uniform `SELECT game_url, ply FROM ...` shape. Stored motifs query `motif_occurrences` directly; derived motifs aggregate ATTACK rows. The sequence compiler joins these shapes without needing to know which is which — users write `sequence(fork THEN checkmate)` and it just works.

## Follow-up issues

- #1083 — consistency audit for `discovered_attack`/`checkmate`/`double_check` dual-detection
- #1084 — data cleanup: `DELETE FROM motif_occurrences WHERE motif = 'FORK'` (stale rows from old write path; guarded by `AND motif != 'FORK'` filter in the meantime)