### PR TITLE
docs(one_d4): replace Substrait plan with DataFusion SQL dual-compiler approach

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
@@ -56,17 +56,16 @@ Underscore-separated names also work directly: `white_elo >= 2500` is equivalent
 ## Motifs
 
 The `motif()` function checks for tactical pattern presence. Queries compile to `EXISTS` subqueries
-against the `motif_occurrences` table. Most motifs are stored directly as rows in that table;
-a few are derived from `ATTACK` rows using flag or grouping conditions.
+against the `motif_occurrences` table. 11 motifs are stored directly as rows in that table;
+5 are derived from `ATTACK` rows using flag or grouping conditions at query time.
 
-**Directly stored motifs** (one row per occurrence):
+**Directly stored motifs** (one row per occurrence, 11 total):
 
 | ChessQL                       | motif_occurrences filter        |
 |-------------------------------|---------------------------------|
 | `motif(pin)`                  | `motif = 'PIN'`                 |
 | `motif(cross_pin)`            | `motif = 'CROSS_PIN'`           |
 | `motif(skewer)`               | `motif = 'SKEWER'`              |
-| `motif(attack)`               | `motif = 'ATTACK'`              |
 | `motif(check)`                | `motif = 'CHECK'`               |
 | `motif(promotion)`            | `motif = 'PROMOTION'`           |
 | `motif(promotion_with_check)` | `motif = 'PROMOTION_WITH_CHECK'`|
@@ -76,7 +75,7 @@ a few are derived from `ATTACK` rows using flag or grouping conditions.
 | `motif(zugzwang)`             | `motif = 'ZUGZWANG'`            |
 | `motif(overloaded_piece)`     | `motif = 'OVERLOADED_PIECE'`    |
 
-**Derived motifs** (computed from `ATTACK` rows):
+**Derived motifs** (computed from `ATTACK` rows at query time, 5 total):
 
 | ChessQL                 | Derivation condition |
 |-------------------------|----------------------|

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DATAFUSION_PARQUET.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DATAFUSION_PARQUET.md
@@ -11,30 +11,37 @@ bypassing SQL entirely. A metadata table tracks which storage backend
 holds each game's data, enabling the query router to dispatch to the
 right backend.
 
-**Query IR: Substrait.** ChessQL compiles to [Substrait](https://substrait.io/)
-relational algebra plans (protobuf) instead of SQL strings. A `QueryRouter`
-dispatches Substrait plans to either PostgreSQL (via `substrait-java`
-SQL conversion) or DataFusion (via `datafusion-substrait` plan consumer),
-based on a feature flag, storage metadata, or cost-based routing. This
-gives us backend portability without maintaining dialect-specific SQL
-compilers.
+**Dual-backend compilation.** The existing `SqlCompiler` handles
+PostgreSQL queries unchanged. A new `DataFusionSqlCompiler` compiles
+ChessQL to DataFusion SQL for the `motif_query` service. Both compilers
+share the same ChessQL AST; dialect differences are isolated in each
+compiler. Contract tests seed both backends with the same data and assert
+result equivalence for all query patterns.
+
+This design favors reliability over abstraction: two well-tested SQL
+compilers with contract-test safety nets are simpler and more robust than
+a Substrait IR layer whose toolchain has known gaps for the correlated
+EXISTS + GROUP BY/HAVING patterns that ATTACK-derived motifs require.
+See [Future Enhancement: Substrait](#future-enhancement-substrait) for
+when to revisit.
 
 ## Why DataFusion + Parquet
 
 | Concern | PostgreSQL / H2 | DataFusion + Parquet |
 |---------|-----------------|---------------------|
-| Motif search (boolean filters) | B-tree index per flag, row-oriented scan | Columnar min/max pruning, vectorized filter pushdown |
-| Aggregate queries (motif counts) | COUNT + GROUP BY on normalized table | Columnar aggregation, no join needed if denormalized |
+| Motif search (EXISTS subqueries) | B-tree index on `motif` column, correlated subquery | Columnar scan of `motif_occurrences`, predicate pushdown on `motif` string column |
+| Aggregate queries (motif counts) | COUNT + GROUP BY on normalized table | Columnar aggregation, vectorized filter |
 | Storage cost | ~120 bytes/row uncompressed | ~15-25 bytes/row with Snappy, columnar compression |
 | Bulk ingest (Lichess dump) | INSERT per row, index maintenance | Write sorted Parquet files offline, register instantly |
 | Horizontal scaling | Read replicas, connection pooling | Stateless query over object storage (S3/local) |
 | Schema evolution | ALTER TABLE migrations | Schema-on-read, additive columns are free |
 | Cold/warm tiering | Manual partition management | Partition by month, drop old partitions = delete files |
 
-The workload is write-once, read-many analytical queries over boolean flags
-and low-cardinality string columns — the exact sweet spot for columnar
-storage. The current `game_features` table has 11 boolean motif columns
-plus metadata: a textbook columnar layout.
+The workload is write-once, read-many analytical queries. All motif
+queries compile to correlated EXISTS subqueries (or GROUP BY/HAVING
+variants) against the `motif_occurrences` table — a narrow, high-volume
+table that is the ideal target for columnar storage and predicate
+pushdown.
 
 ## Architecture
 
@@ -63,14 +70,14 @@ plus metadata: a textbook columnar layout.
 │  ParquetExportJob (weekly/monthly cron)        │   │
 │    SELECT from SQL ─────────────────────────┐ │   │
 │                                             │ │   │
-│  /v1/query ─► SubstraitCompiler ─► Plan     │ │   │
+│  /v1/query ─► Parser ─► ParsedQuery         │ │   │
 │                    │                        │ │   │
 │    ┌───────────────┤                        │ │   │
 │    ▼               ▼                        │ │   │
-│  ┌──────────┐  ┌──────────────┐             │ │   │
-│  │ SQL      │  │ DataFusion   │             │ │   │
-│  │ Router   │  │ Router       │             │ │   │
-│  └────┬─────┘  └──────┬───────┘             │ │   │
+│  ┌──────────┐  ┌─────────────────────┐      │ │   │
+│  │ SqlComp. │  │ DataFusionSqlComp.  │      │ │   │
+│  │ → JDBC   │  │ → DataFusion SQL    │      │ │   │
+│  └────┬─────┘  └──────┬──────────────┘      │ │   │
 │       │               │                     │ │   │
 │  game_storage_backends table                │ │   │
 │  (tracks which backend has each partition)  │ │   │
@@ -80,9 +87,9 @@ plus metadata: a textbook columnar layout.
         ▼               ▼                     ▼     ▼
 ┌────────────────┐   ┌──────────────────────────────────┐
 │  PostgreSQL/H2 │   │  motif_query (Rust)              │
-│  - game_features│   │  - /v1/query/substrait           │
-│  - motif_occ   │   │    (datafusion-substrait →       │
-│  - PGN text    │   │     LogicalPlan → Parquet scan)  │
+│  - game_features│   │  - /v1/query                     │
+│  - motif_occ   │   │    (DataFusion SQL → LogicalPlan  │
+│  - PGN text    │   │     → Parquet scan)               │
 │  - index state │   │  - /v1/write                     │
 │  - storage meta│   │    (JSON batch → Parquet file)   │
 └────────────────┘   └───────────────┬──────────────────┘
@@ -92,12 +99,18 @@ plus metadata: a textbook columnar layout.
                      │  Parquet files on disk/S3        │
                      │                                  │
                      │  /data/games/                    │
-                     │    platform=chess.com/           │
-                     │      month=2024-03/             │
-                     │        part-0001.parquet         │
-                     │    platform=lichess/             │
-                     │      month=2024-01/             │
-                     │        part-0001.parquet         │
+                     │    game_features/                │
+                     │      platform=chess.com/         │
+                     │        month=2024-03/            │
+                     │          part-0001.parquet       │
+                     │    motif_occurrences/            │
+                     │      platform=lichess/           │
+                     │        month=2024-01/            │
+                     │          part-0001.parquet       │
+                     │    game_pgns/                    │
+                     │      platform=lichess/           │
+                     │        month=2024-01/            │
+                     │          part-0001.parquet       │
                      └──────────────────────────────────┘
 ```
 
@@ -105,9 +118,9 @@ plus metadata: a textbook columnar layout.
 
 | Component | Language | Role |
 |-----------|----------|------|
-| `one_d4` (existing) | Java | REST API, indexing (SQL writes), motif detection (chariot), ChessQL parse + Substrait compile, query routing, Parquet export job |
-| `chessql` (existing lib) | Java | Parser, AST, `SubstraitCompiler` (new), `SqlCompiler` (existing) |
-| `motif_query` (new) | Rust | DataFusion query engine via Substrait consumer, Parquet file writes (batch, not streaming) |
+| `one_d4` (existing) | Java | REST API, indexing (SQL writes), motif detection (chariot), ChessQL parse, query routing, Parquet export job |
+| `chessql` (existing lib) | Java | Parser, AST, `SqlCompiler` (existing → PostgreSQL), `DataFusionSqlCompiler` (new → DataFusion SQL) |
+| `motif_query` (new) | Rust | DataFusion query engine via SQL, Parquet file writes (batch, not streaming) |
 | `lichess_ingest` (new) | Java | Bulk PGN streaming, GM filtering, motif detection (reuses one_d4 detectors), batch POST to motif_query |
 
 ## Parquet Schema
@@ -128,14 +141,12 @@ result:             Utf8
 played_at:          TimestampMillisecond
 num_moves:          Int32
 indexed_at:         TimestampMillisecond
-pgn:                Utf8
 ```
 
-Motif data is exported from `motif_occurrences` as a separate Parquet table and joined at query time.
-
-PGN text is **not** stored in the Parquet files — it bloats columnar scans
-and is only needed for game replay, not motif search. See "Where does PGN
-go?" below.
+PGN text is **not** stored in `game_features` — it bloats columnar scans
+and is only needed for game replay, not motif search. For Chess.com games,
+PGN stays in PostgreSQL. For Lichess games, PGN is stored in the
+`game_pgns` Parquet table (see below).
 
 ### `motif_occurrences` table (one row per motif firing)
 
@@ -143,12 +154,36 @@ go?" below.
 game_url:           Utf8
 platform:           Utf8        (partition column)
 month:              Utf8        (partition column)
-motif:              Utf8        (e.g. "PIN", "FORK")
+motif:              Utf8        (e.g. "ATTACK", "PIN", "FORK")
 ply:                Int32
 side:               Utf8        ("white" or "black")
 move_number:        Int32
 description:        Utf8
+attacker:           Utf8        (nullable — piece notation, e.g. "Nf3")
+target:             Utf8        (nullable — piece or square, e.g. "Ke8")
+is_discovered:      Boolean     (nullable — true for discovered attacks)
+is_mate:            Boolean     (nullable — true for checkmate attacks)
 ```
+
+The `attacker`, `target`, `is_discovered`, and `is_mate` columns are
+**load-bearing** for ATTACK-derived motifs. `motif(fork)`, `motif(checkmate)`,
+`motif(discovered_attack)`, `motif(discovered_check)`, and
+`motif(double_check)` are all derived at query time from `ATTACK` rows
+using these columns. Omitting them would break those five motifs in
+DataFusion.
+
+### `game_pgns` table (Lichess only — for re-analysis)
+
+```
+game_url:           Utf8
+platform:           Utf8        (partition column — always "lichess")
+month:              Utf8        (partition column)
+pgn:                Utf8
+```
+
+Stored during initial Lichess ingest to enable re-analysis without
+re-downloading the source dump files. Chess.com PGN stays in PostgreSQL.
+See [Lichess Games — Parquet-Only Re-Analysis](#lichess-games--parquet-only-re-analysis).
 
 ### Partitioning Strategy
 
@@ -168,6 +203,10 @@ Hive-style partitioning: `{base_path}/{table}/platform={p}/month={m}/part-NNNN.p
     platform=lichess/
       month=2024-01/
         part-0000.parquet
+  game_pgns/
+    platform=lichess/
+      month=2024-01/
+        part-0000.parquet    # ~500K rows, ~1-2 GB (PGN text)
 ```
 
 DataFusion's `ListingTable` with `ListingOptions::new(ParquetFormat)` and
@@ -177,29 +216,12 @@ partitions from `WHERE platform = 'lichess' AND month >= '2024-01'`.
 Target file size: ~50 MB uncompressed (~10-15 MB Snappy). This gives good
 row group pruning without too many small files.
 
-## ChessQL Compilation via Substrait IR
+## ChessQL Dual-Backend Compilation
 
-### The Problem
+### Two Compilers, One AST
 
-The current `SqlCompiler` compiles ChessQL AST → PostgreSQL SQL. Adding
-DataFusion requires a second compiler targeting DataFusion SQL dialect.
-While the dialects are similar, maintaining two SQL compilers creates
-drift, and tightly couples ChessQL to specific SQL dialects:
-
-- PostgreSQL uses `?` bind parameters; DataFusion uses `ParamValues` or
-  inline literals
-- PostgreSQL uses `::timestamp` casts; DataFusion uses
-  `CAST(... AS TIMESTAMP)`
-- `sequence()` queries use correlated subqueries that differ in optimizer
-  behavior between backends
-- Adding a third backend (e.g. DuckDB, ClickHouse) would require yet
-  another SQL dialect compiler
-
-### Substrait as Query IR
-
-[Substrait](https://substrait.io/) is a cross-language specification for
-relational algebra plans. It defines a protobuf-based format for query
-plans that multiple engines can consume. The compilation pipeline becomes:
+The ChessQL parser produces a `ParsedQuery` (AST) that is backend-agnostic.
+Two compiler implementations produce SQL strings from the same AST:
 
 ```
 ChessQL string
@@ -207,180 +229,149 @@ ChessQL string
      ▼
   Parser (Java) → ParsedQuery (AST)
      │
-     ▼
-  SubstraitCompiler (Java) → Substrait Plan (protobuf)
+     ├──► SqlCompiler → PostgreSQL SQL + JDBC bind params
+     │         (existing path, unchanged)
      │
-     ├──► PostgreSQL backend: substrait-java consumer → JDBC SQL
-     │         (current path, keeps working)
-     │
-     └──► DataFusion backend: datafusion-substrait consumer → LogicalPlan
-              (new path, Parquet query engine)
+     └──► DataFusionSqlCompiler → DataFusion SQL string
+              (new path, sent to motif_query/v1/query)
 ```
 
-This gives us:
+Both compilers implement `QueryCompiler<CompiledQuery>` (or a
+`DataFusionCompiledQuery` variant). The dialect differences are small and
+isolated:
 
-1. **Single compilation step.** ChessQL compiles to Substrait once. No
-   SQL dialect-specific compilers.
-2. **Backend portability.** The same Substrait plan executes on PostgreSQL,
-   DataFusion, or any future engine that consumes Substrait.
-3. **Feature flag / cost-based routing.** The `QueryController` can route
-   plans to SQL or DataFusion based on configuration, query complexity,
-   or data locality.
-4. **No ChessQL port to Rust.** The Java side owns parsing and compilation.
-   The Rust side only needs to consume Substrait plans, which DataFusion
-   already supports via the `datafusion-substrait` crate.
+| Construct | PostgreSQL SQL (`SqlCompiler`) | DataFusion SQL (`DataFusionSqlCompiler`) |
+|-----------|-------------------------------|------------------------------------------|
+| Bind parameters | `?` (JDBC positional) | Inline literals (DataFusion SQL parser does not use JDBC) |
+| String equality | `LOWER(col) = LOWER(?)` | `lower(col) = lower('value')` |
+| Timestamp literals | `CAST(? AS TIMESTAMP)` | `CAST('...' AS TIMESTAMP)` |
+| EXISTS subqueries | Standard SQL — supported | Standard SQL — supported |
+| GROUP BY / HAVING | Standard SQL — supported | Standard SQL — supported |
+| Correlated EXISTS | Standard SQL — supported | Standard SQL — supported |
+| `sequence()` self-JOINs | Standard SQL — supported | Standard SQL — supported |
 
-### SubstraitCompiler Implementation
+DataFusion's SQL dialect is ANSI-compatible and handles the full query
+surface of ChessQL including correlated EXISTS, GROUP BY/HAVING, and
+arithmetic join keys (`sq2.ply = sq1.ply + 2`). These patterns are
+well-exercised in DataFusion's SQL planner and do not require the
+correlated subquery extensions that limit the Substrait toolchain.
 
-New class: `SubstraitCompiler implements QueryCompiler<Plan>` where `Plan`
-is `io.substrait.proto.Plan` from the `substrait-java` library.
+### DataFusionSqlCompiler Implementation
 
-The compiler walks the ChessQL AST and produces Substrait relational
-algebra nodes:
-
-| ChessQL construct | Substrait equivalent |
-|-------------------|---------------------|
-| `motif(fork)` | `Filter(ReadRel("game_features"), ExistsSubquery(Filter(ReadRel("motif_occurrences"), and(equal(FieldRef("motif"), "ATTACK"), equal(FieldRef("is_discovered"), false), isNotNull(FieldRef("attacker"))), GroupBy(ply, attacker), Having(gte(count, 2))))` |
-| `white.elo >= 2500` | `Filter(ReadRel, ScalarFunction(gte, FieldRef("white_elo"), I32Literal(2500)))` |
-| `AND` / `OR` / `NOT` | `ScalarFunction(and/or/not, ...)` |
-| `eco IN ["B90", "C65"]` | `ScalarFunction(or, equal(eco, "B90"), equal(eco, "C65"))` or `SingularOrList` |
-| `ORDER BY motif_count(fork) DESC` | `SortRel(AggregateRel(JoinRel(game_features, motif_occurrences), count), SortField(desc))` |
-| `sequence(fork THEN pin)` | `Filter(ReadRel, ExistsSubquery(JoinRel(motif_occurrences aliases, ply constraints)))` |
-| String case-insensitivity | `ScalarFunction(equal, ScalarFunction(lower, FieldRef), ScalarFunction(lower, Literal))` |
-
-The Substrait plan includes the full schema (named struct) for
-`game_features` and `motif_occurrences`, so consumers know the table
-layout without out-of-band schema exchange.
+New class: `DataFusionSqlCompiler implements QueryCompiler<DataFusionCompiledQuery>`
+in the `chessql` library. It walks the same ChessQL AST as `SqlCompiler`
+but produces DataFusion SQL with inline literals:
 
 ```java
-public class SubstraitCompiler implements QueryCompiler<Plan> {
-
-  private final SubstraitSchema schema;  // table + column definitions
+public class DataFusionSqlCompiler implements QueryCompiler<DataFusionCompiledQuery> {
 
   @Override
-  public Plan compile(ParsedQuery pq) {
-    Rel baseRel = namedScan("game_features", schema.gameFeaturesCols());
-    Expression filter = compileExpr(pq.expr());
-    Rel filtered = filterRel(baseRel, filter);
+  public DataFusionCompiledQuery compile(ParsedQuery pq) {
+    String whereClause = compileExpr(pq.expr());
 
-    if (pq.orderBy() != null) {
-      // Join with motif_occurrences, aggregate count, sort
-      filtered = compileOrderBy(filtered, pq.orderBy());
-    } else {
-      filtered = sortRel(filtered, fieldRef("played_at"), DESCENDING);
+    OrderByClause orderBy = pq.orderBy();
+    if (orderBy != null) {
+      // Build LEFT JOIN + COUNT aggregate, same structure as SqlCompiler
+      // Difference: inline literals, DataFusion function names
+      ...
     }
+    String sql = "SELECT g.* FROM game_features g WHERE " + whereClause
+        + " ORDER BY g.played_at DESC";
+    return new DataFusionCompiledQuery(sql);
+  }
 
-    return Plan.newBuilder()
-        .addRelations(PlanRel.newBuilder().setRoot(
-            RelRoot.newBuilder().setInput(filtered).build()
-        )).build();
+  private String compileMotif(MotifExpr motif) {
+    return switch (motif.motifName()) {
+      case "fork" ->
+          "EXISTS (SELECT 1 FROM motif_occurrences mo"
+              + " WHERE mo.game_url = g.game_url AND mo.motif = 'ATTACK'"
+              + " AND mo.is_discovered = false AND mo.attacker IS NOT NULL"
+              + " GROUP BY mo.ply, mo.attacker HAVING COUNT(*) >= 2)";
+      // ... same structure as SqlCompiler for all other motifs
+    };
   }
 }
 ```
 
+The implementation mirrors `SqlCompiler` closely. When a new motif or
+field is added to ChessQL, both compilers are updated together — guarded
+by the contract test suite (see below).
+
+### Contract Test Suite
+
+Before routing any real queries to DataFusion, a contract test suite
+validates result equivalence between backends:
+
+- Seeds both PostgreSQL (H2 in-memory) and DataFusion (test Parquet files)
+  with identical game + motif occurrence data
+- Runs every ChessQL pattern against both backends:
+  - All 16 motifs (`motif(pin)`, `motif(fork)`, `motif(double_check)`, ...)
+  - `sequence(fork THEN pin)`, `sequence(checkmate THEN promotion)`
+  - `ORDER BY motif_count(fork) DESC`
+  - `AND`, `OR`, `NOT` combinations
+  - `IN` expressions, numeric comparisons, string equality
+- Asserts result-set equivalence (same game_urls, same ordering)
+- Runs in CI on every change to `chessql` or `motif_query`
+
+This is the structural safety net that makes a dual-compiler system
+maintainable. A test failure in the contract suite flags a divergence
+before it reaches production.
+
 ### Query Routing
 
-The `QueryController` chooses which backend executes the Substrait plan:
+The `QueryController` parses ChessQL once and routes based on storage
+metadata:
 
 ```java
 @POST
 public QueryResponse query(QueryRequest request) {
   ParsedQuery parsed = Parser.parse(request.query());
-  Plan plan = substraitCompiler.compile(parsed);
-
-  // Route based on configuration or query characteristics
-  List<GameFeature> rows = queryRouter.execute(plan, request.limit(), request.offset());
+  List<GameFeature> rows = queryRouter.route(parsed, request.limit(), request.offset());
   // ... format response
 }
 ```
 
-The `QueryRouter` decides the backend:
+The `StorageAwareQueryRouter` uses time-based routing for Phase 1
+(simplest, avoids fan-out):
 
 ```java
-public interface QueryRouter {
-  List<GameFeature> execute(Plan plan, int limit, int offset);
+public class StorageAwareQueryRouter implements QueryRouter {
+
+  List<GameFeature> route(ParsedQuery parsed, int limit, int offset) {
+    // Phase 1: time-based shortcut
+    // Current (incomplete) month → SQL; completed months → DataFusion
+    if (queryTouchesCurrentMonth(parsed)) {
+      CompiledQuery q = sqlCompiler.compile(parsed);
+      return sqlDao.query(q, limit, offset);
+    }
+    DataFusionCompiledQuery q = dataFusionSqlCompiler.compile(parsed);
+    return dataFusionClient.query(q, limit, offset);
+  }
 }
 ```
 
-Implementations:
+**Phase 1 routing guarantee:** queries are eventually consistent.
+Recently indexed Chess.com games appear in SQL-backed results immediately
+and in DataFusion-backed results after the next export. Lichess data
+appears in DataFusion only (there is no "current month" for Lichess since
+ingest is always after month-end).
 
-| Strategy | Description |
-|----------|-------------|
-| `SqlQueryRouter` | Convert Substrait → SQL via `substrait-java` `SubstraitToSql`, execute on PostgreSQL/H2 via JDBC. Drop-in replacement for current `SqlCompiler` path. |
-| `DataFusionQueryRouter` | Serialize Substrait plan to protobuf bytes, POST to `motif_query/v1/query/substrait`. DataFusion deserializes and executes. |
-| `ConfigQueryRouter` | Feature flag: `QUERY_BACKEND=sql|datafusion`. Simple toggle for migration. |
-| `CostQueryRouter` | Inspect the plan: if it touches only `game_features` (metadata filters, no motif predicates), route to DataFusion (fast columnar scan). Motif predicates always join `motif_occurrences`; route `sequence()` and complex motif queries to SQL (mature optimizer) or DataFusion depending on dataset size. |
+**Phase 2 routing (partition-level):** after shadow mode validation, use
+`game_storage_backends` to decide per-partition:
 
-### How Substrait Flows to Each Backend
+| `backend` | `parquet_stale` | Query route |
+|-----------|-----------------|-------------|
+| `sql` | n/a | SQL |
+| `parquet` | `false` | DataFusion |
+| `parquet` | `true` | DataFusion (stale warning logged) |
+| `both` | `false` | DataFusion |
+| `both` | `true` | SQL (until re-export) |
 
-**PostgreSQL path (existing, adapted):**
-
-```
-Plan (protobuf)
-  → substrait-java SqlConverter → SQL string + bind params
-  → JDBC PreparedStatement → PostgreSQL
-  → ResultSet → GameFeature list
-```
-
-The `substrait-java` library includes `SubstraitToSql` which converts
-plans to ANSI SQL. For PostgreSQL-specific syntax, we extend the converter
-or post-process the SQL. This replaces `SqlCompiler` — same output, but
-generated from Substrait rather than directly from the AST.
-
-**DataFusion path (new):**
-
-```
-Plan (protobuf bytes)
-  → HTTP POST to motif_query/v1/query/substrait
-  → datafusion-substrait::from_substrait_plan() → LogicalPlan
-  → DataFusion optimizer → PhysicalPlan
-  → execute over Parquet → RecordBatches
-  → JSON response
-```
-
-DataFusion's Substrait consumer is mature — it handles filters, projections,
-joins, aggregations, and sort. The `datafusion-substrait` crate translates
-directly to `LogicalPlan` without an intermediate SQL string, giving the
-optimizer full visibility.
-
-### Why Not Just Two SQL Compilers?
-
-The direct approach (write a `DataFusionSqlCompiler` alongside `SqlCompiler`)
-is simpler for the initial step. But:
-
-1. **Drift.** Every ChessQL feature (new motif, new field, new operator)
-   must be implemented in both compilers and tested independently.
-2. **SQL is lossy.** SQL strings discard semantic information that
-   optimizers could use. Substrait preserves the relational algebra
-   structure — DataFusion can optimize better from a `LogicalPlan` than
-   from re-parsing a SQL string.
-3. **Testing.** With Substrait, you test one compilation (ChessQL → plan)
-   and two consumers. With two SQL compilers, you test two compilations.
-4. **Future backends.** DuckDB, Velox, Acero all consume Substrait. SQL
-   compatibility varies per engine.
-
-### Dependencies
-
-**Java (substrait-java):**
-
-```
-maven_install:
-  io.substrait:core:0.42.0        # Substrait protobuf types + plan builder
-  io.substrait:isthmus:0.42.0     # SQL ↔ Substrait conversion (for SqlQueryRouter)
-```
-
-The `isthmus` module provides `SubstraitToSql` for the PostgreSQL path
-and `SqlToSubstrait` if we ever want to go the other direction.
-
-**Rust (datafusion-substrait):**
-
-```toml
-[dependencies]
-datafusion-substrait = { version = "46" }  # matches datafusion version
-```
-
-This crate provides `from_substrait_plan()` which converts a Substrait
-`Plan` protobuf into a DataFusion `LogicalPlan`.
+The fan-out (mixed) case — some partitions in SQL, some in Parquet — is
+deliberately deferred. Merging paginated results and `ORDER BY motif_count()`
+aggregates across two backends requires a federated query coordinator.
+Time-based routing avoids this entirely for the common case. If the need
+arises, it can be added in a follow-on phase.
 
 ## motif_query Service
 
@@ -406,11 +397,9 @@ writes one Parquet file per call — no in-memory buffer needed.
 
 ```toml
 [dependencies]
-arrow = { version = "55" }
-datafusion = { version = "46" }
-datafusion-substrait = { version = "46" }  # Substrait plan → LogicalPlan
-parquet = { version = "55", features = ["snap"] }
-prost = "0.13"                              # protobuf deserialization
+arrow = { version = "57" }
+datafusion = { version = "52" }
+parquet = { version = "57", features = ["snap"] }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
@@ -423,10 +412,9 @@ chrono = { workspace = true }
 ### API Endpoints
 
 ```
-POST /motif_query/v1/query/substrait
-  Body: <Substrait Plan protobuf bytes>
-  Content-Type: application/x-substrait-plan
-  Query params: ?limit=50&offset=0
+POST /motif_query/v1/query
+  Body: { "sql": "SELECT g.* FROM game_features g WHERE ...", "limit": 50, "offset": 0 }
+  Content-Type: application/json
   Response: { "rows": [...], "row_count": N }
 
 POST /motif_query/v1/write
@@ -441,17 +429,16 @@ GET /health
   Response: 200 OK
 ```
 
-Note: the `/v1/query` SQL endpoint is removed. The Java side compiles
-ChessQL → Substrait and sends the plan bytes directly. No SQL strings
-cross the wire.
+The query endpoint accepts a DataFusion SQL string produced by
+`DataFusionSqlCompiler`. DataFusion parses and plans this against
+registered Parquet listing tables. No SQL strings cross the wire as
+user-controlled input — the SQL is always compiler-generated from a
+validated ChessQL AST.
 
-### DataFusion Setup + Substrait Execution
+### DataFusion Setup + Query Execution
 
 ```rust
 use datafusion::prelude::*;
-use datafusion_substrait::logical_plan::consumer::from_substrait_plan;
-use substrait::proto::Plan;
-use prost::Message;
 
 async fn create_session(data_dir: &str) -> SessionContext {
     let ctx = SessionContext::new();
@@ -472,26 +459,18 @@ async fn create_session(data_dir: &str) -> SessionContext {
         None,
     ).await.unwrap();
 
-    // Register motif_occurrences similarly
+    // Register motif_occurrences and game_pgns similarly
     // ...
 
     ctx
 }
 
-/// Execute a Substrait plan received from the Java SubstraitCompiler.
-async fn execute_substrait(
+/// Execute a DataFusion SQL query produced by DataFusionSqlCompiler.
+async fn execute_sql(
     ctx: &SessionContext,
-    plan_bytes: &[u8],
+    sql: &str,
 ) -> datafusion::error::Result<Vec<RecordBatch>> {
-    // Deserialize protobuf → Substrait Plan
-    let plan = Plan::decode(plan_bytes)
-        .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-    // Convert Substrait → DataFusion LogicalPlan
-    let logical_plan = from_substrait_plan(ctx, &plan).await?;
-
-    // Execute (DataFusion optimizes → physical plan → Parquet scan)
-    let df = ctx.execute_logical_plan(logical_plan).await?;
+    let df = ctx.sql(sql).await?;
     df.collect().await
 }
 ```
@@ -521,28 +500,6 @@ Criteria (configurable):
 This typically reduces the dataset to ~1-3% of total games (~1-3M
 games/month), which is very manageable.
 
-### Pipeline Steps
-
-```
-1. Download .pgn.zst file (streaming, don't buffer full file)
-     ↓
-2. Decompress zstd stream
-     ↓
-3. Parse PGN headers (extract players, Elo, title, time control, result)
-     ↓
-4. Filter: does this game meet GM/titled criteria?
-     ↓  (skip ~97% of games here, before parsing moves)
-5. Parse movetext for qualifying games
-     ↓
-6. Replay positions + run motif detectors
-     ↓
-7. Accumulate into Arrow RecordBatch (buffer ~50K games)
-     ↓
-8. Write Parquet partition file
-     ↓
-9. Register new partition with DataFusion catalog
-```
-
 ### Motif Detection — Java Only (chariot)
 
 Motif detection stays in Java. The current detectors use chariot
@@ -552,9 +509,9 @@ generation. Issue #1049 (Phase 9) plans to deepen the chariot integration:
 - **Check attribution**: distinguish promoted-piece check vs discovered
   check vs double check, requiring chariot's board model to identify which
   piece delivers the check.
-- **5 new motifs**: back rank mate, smothered mate, zugzwang,
-  double check, overloaded piece — several of these need
-  full board state analysis that goes well beyond FEN string parsing.
+- **New motifs**: back rank mate, smothered mate, zugzwang, double check,
+  overloaded piece — several of these need full board state analysis that
+  goes well beyond FEN string parsing.
 - **Re-analysis pipeline**: admin endpoint to reprocess existing games with
   new/improved detectors.
 
@@ -569,23 +526,7 @@ no chess logic.
 
 ### Lichess Ingest Architecture (Java)
 
-The bulk ingest is a Java batch job, either as:
-
-- **Option A: Standalone CLI jar** — a new `lichess_ingest` binary target
-  in `domains/games/apis/one_d4/` that reuses `GameReplayer`,
-  `FeatureExtractor`, and all `MotifDetector` implementations. Streams
-  `.pgn.zst` files, filters to titled/high-Elo games, runs detection,
-  and writes results to `motif_query`'s Parquet write endpoint.
-
-- **Option B: Admin endpoint in one_d4** — `POST /admin/ingest/lichess`
-  accepts a URL or file path, streams + filters + detects in-process,
-  and writes Parquet batches. Simpler deployment but ties the batch
-  workload to the API server's resources.
-
-**Recommendation: Option A.** A standalone CLI jar keeps the long-running
-bulk workload isolated from the API server. It shares the same motif
-detection code via library targets. The CLI can run as a cron job or
-one-off invocation.
+The bulk ingest is a standalone Java CLI jar:
 
 ```
 java -jar lichess_ingest.jar \
@@ -596,6 +537,10 @@ java -jar lichess_ingest.jar \
   --time-controls standard,rapid,blitz \
   --batch-size 1000
 ```
+
+A standalone CLI jar keeps the long-running bulk workload isolated from
+the API server. It shares the same motif detection code via library
+targets and can run as a cron job or one-off invocation.
 
 ### Ingest Pipeline Steps
 
@@ -612,10 +557,17 @@ java -jar lichess_ingest.jar \
      ↓
 6. Batch results (1000 games)
      ↓
-7. POST batch to motif_query/v1/write → Parquet
+7a. POST batch to motif_query/v1/write → game_features Parquet
+7b. POST batch to motif_query/v1/write → motif_occurrences Parquet
+7c. POST batch to motif_query/v1/write → game_pgns Parquet  ← new
      ↓
-8. motif_query flushes to partitioned Parquet files
+8. motif_query writes partitioned Parquet files
 ```
+
+Step 7c writes PGN to a separate `game_pgns` Parquet table during initial
+ingest. The incremental cost is ~2-4 GB/month of Parquet storage (PGN
+compresses well with dictionary encoding). This enables re-analysis
+without re-downloading source dumps (see below).
 
 ### Performance Considerations
 
@@ -656,16 +608,6 @@ SQL handles this write rate trivially. At 10K-100K games/month
 the bottleneck (~200ms/request). No reason to complicate the write
 path with real-time Parquet writes, buffering, or dual-write logic.
 
-### Expected Write Throughput
-
-| Metric | Value |
-|--------|-------|
-| Games per month (total, Chess.com) | 10,000 - 100,000 |
-| Games per day (avg) | ~300 - 3,300 |
-| Games per player-month (from API) | 10 - 100 |
-| Index requests per day (estimated) | ~10 - 50 |
-| Motif occurrences per game (avg) | ~5 - 20 |
-
 ### Two Write Paths, Not One
 
 Instead of making the indexer write to Parquet in real-time, we separate
@@ -698,22 +640,26 @@ SQL to Parquet:
 ```
 ParquetExportJob (runs weekly or monthly)
 
-for each (platform, month) with unexported games:
-  rows = SELECT * FROM game_features
-         WHERE platform = ? AND month = ?
-         AND game_url NOT IN (already exported)
-  occurrences = SELECT * FROM motif_occurrences
-                WHERE game_url IN (row.game_url for row in rows)
+for each (platform, month) partition needing export or re-export:
+  rows = SELECT * FROM game_features WHERE platform = ? AND month = ?
+  occurrences = SELECT * FROM motif_occurrences WHERE platform = ? AND month = ?
 
-  POST motif_query/v1/write
-    { "table": "game_features", rows }
-  POST motif_query/v1/write
-    { "table": "motif_occurrences", occurrences }
+  POST motif_query/v1/write { "table": "game_features", rows }
+  POST motif_query/v1/write { "table": "motif_occurrences", occurrences }
 
   UPDATE game_storage_backends
-    SET backend = 'both', parquet_exported_at = now()
+    SET backend = 'both',
+        parquet_exported_at = now(),
+        parquet_stale = false
     WHERE platform = ? AND month = ?
 ```
+
+The export job reads the **complete partition** in one SELECT and writes
+exactly one Parquet file per partition — a full overwrite of any previous
+file. No partial writes, no "already exported" per-game tracking, no
+compaction. A partition needs re-export when any of its games have
+`indexed_at > parquet_exported_at` (staleness check) or when
+`parquet_stale = true` (re-analysis).
 
 #### Export Job Characteristics
 
@@ -727,10 +673,6 @@ for each (platform, month) with unexported games:
 | Duration | Seconds (SQL SELECT is fast, Parquet write is fast) |
 | Compaction needed | **No** — one file per partition, no small-file problem |
 
-This is the key advantage over real-time Parquet writes: the export job
-reads the complete partition in one SELECT and writes exactly one
-well-formed Parquet file. No buffering, no tail flushes, no compaction.
-
 #### Re-export After Re-analysis
 
 When new motif detectors are added (issue #1049 Phase 9), an admin
@@ -739,21 +681,16 @@ updates the SQL rows, the export job re-runs for affected partitions:
 
 ```
 1. Admin triggers re-analysis → SQL rows updated with new motif flags
-2. Export job detects stale Parquet (SQL rows newer than parquet_exported_at)
-3. Re-export: read all rows for partition → overwrite Parquet file
-4. Update game_storage_backends.parquet_exported_at
+2. game_storage_backends.parquet_stale = true for affected partitions
+3. Export job detects stale partitions (parquet_stale = true)
+4. Re-export: read all rows for partition → overwrite Parquet file
+5. Update game_storage_backends.parquet_stale = false
 ```
 
 Since we write one file per partition, re-export is a simple overwrite —
 no merge logic needed.
 
 ### Re-Analysis and Schema Evolution
-
-Adding new motifs or correcting existing detectors requires updating
-stored game data in both SQL and Parquet. This is a two-step process:
-first update SQL (source of truth for Chess.com games), then re-export
-to Parquet. Lichess-only games need a different path since they're never
-in SQL.
 
 #### Step 1: Schema Evolution
 
@@ -762,7 +699,6 @@ New motif columns must be added to both stores:
 **SQL:**
 ```sql
 ALTER TABLE game_features ADD COLUMN has_back_rank_mate BOOLEAN DEFAULT FALSE;
-ALTER TABLE game_features ADD COLUMN has_smothered_mate BOOLEAN DEFAULT FALSE;
 -- ... repeat for each new motif
 ```
 
@@ -771,21 +707,15 @@ export/ingest writes files with the new columns. Old Parquet files
 missing the column return NULL, which DataFusion treats as FALSE for
 boolean filters. New Parquet files include the column with real values.
 
-This asymmetry is a strength: SQL requires `ALTER TABLE`, but Parquet
-files are simply rewritten with the updated schema on the next export.
-No downtime, no backfill-then-migrate sequencing.
-
 **Code changes:**
 - `GameFeatureDao` INSERT/MERGE statements: add new columns
 - `GameFeature` record: add new fields
 - `FeatureExtractor` / `MotifDetector`: add new detectors
 - `SqlCompiler.VALID_MOTIFS`: add new motif names
-- `SubstraitCompiler`: schema `NamedStruct` includes new columns
+- `DataFusionSqlCompiler.VALID_MOTIFS`: add new motif names
 - Parquet schema in `motif_query` `catalog.rs`: add new columns
 
 #### Step 2: Re-Analysis Pipeline (Chess.com games in SQL)
-
-The re-analysis pipeline from ROADMAP.md Phase 9:
 
 ```
 POST /admin/reanalyze
@@ -802,7 +732,6 @@ Pipeline:
 
     for each game in batch:
       features = featureExtractor.extract(game.pgn())
-      // Only run specified detectors, or all if not specified
       UPDATE game_features
         SET has_back_rank_mate = ?,
             has_smothered_mate = ?,
@@ -821,123 +750,39 @@ Pipeline:
       WHERE platform = ? AND month = ?
 ```
 
-Key point: **PGN is already in SQL** for Chess.com games. Re-analysis
-reads it, re-runs detection, and UPDATEs the rows in place. The existing
-`ON CONFLICT` upsert in `GameFeatureDao` only updates `indexed_at` and
-`request_id` — re-analysis needs a dedicated UPDATE path that sets
-motif columns.
-
-#### Step 3: Re-Export Stale Partitions
-
-After re-analysis updates SQL rows, the export job detects stale
-Parquet:
-
-```java
-// ParquetExportJob — modified to handle staleness
-List<StorageBackend> stale = storageBackendStore.findStalePartitions();
-// Returns partitions where parquet_stale = true
-// OR where parquet_exported_at < max(indexed_at) for games in partition
-
-for (StorageBackend sb : stale) {
-  exportPartition(sb.platform(), sb.month());  // SELECT → write Parquet
-  storageBackendStore.markExported(sb.platform(), sb.month());
-}
-```
-
-Since the export writes one complete file per partition (overwriting the
-old one), re-export is identical to first export. No incremental merge.
-
 #### Lichess Games — Parquet-Only Re-Analysis
 
-Lichess games are `backend='parquet'` — they were never in SQL and
-there's no PGN to re-read from the database. Re-analysis needs a
-different approach:
-
-**Option A: Re-ingest from Lichess dump.** Download the original
-`.pgn.zst` file for the month, re-run the `lichess_ingest` pipeline
-with updated detectors, overwrite the Parquet files. This is the
-cleanest path — same code as initial ingest, just with new detectors.
-Cost: ~15-30 minutes per monthly dump.
-
-**Option B: Store Lichess PGN in SQL for re-analysis.** During initial
-ingest, also INSERT the PGN into a `lichess_pgns` SQL table (or the
-existing `game_features.pgn` column). This makes Lichess games
-re-analyzable the same way as Chess.com games. Downside: 2M PGN
-strings/month in SQL (~2-4 GB/month, mostly PGN text). This defeats
-one of the benefits of the Parquet-only path.
-
-**Option C: Store Lichess PGN in a separate Parquet table.** A
-`game_pgns` Parquet table with just `(game_url, pgn)`. The re-analysis
-pipeline reads PGN from this table via DataFusion, re-runs detectors,
-and writes updated `game_features` Parquet files. This keeps PGN out
-of SQL while enabling re-analysis.
-
-**Recommendation: Option A for now, Option C if re-analysis frequency
-is high.** Re-analysis is a rare event (when new detectors are added).
-Re-ingesting from the Lichess dump is simple and doesn't require
-storing PGN. If re-analysis becomes frequent (e.g. detector accuracy
-improvements every month), storing PGN in a separate Parquet table is
-worth the storage cost.
-
-#### Update to `game_storage_backends`
-
-Add a `parquet_stale` flag to track when SQL data has been updated but
-Parquet hasn't been re-exported yet:
-
-```sql
-CREATE TABLE game_storage_backends (
-  platform            TEXT NOT NULL,
-  month               TEXT NOT NULL,
-  backend             TEXT NOT NULL,      -- 'sql', 'parquet', 'both'
-  games_in_sql        INTEGER DEFAULT 0,
-  games_in_parquet    INTEGER DEFAULT 0,
-  parquet_exported_at TIMESTAMP,
-  parquet_stale       BOOLEAN DEFAULT FALSE,  -- true after re-analysis
-  last_reanalyzed_at  TIMESTAMP,               -- when re-analysis last ran
-  PRIMARY KEY (platform, month)
-);
-```
-
-The query router uses `parquet_stale` to decide routing during the
-window between re-analysis and re-export:
+Lichess games are `backend='parquet'` — they were never in SQL and there
+is no PGN to re-read from the database. Re-analysis reads PGN from the
+`game_pgns` Parquet table:
 
 ```
-if backend = 'both' AND parquet_stale = true:
-  → route to SQL (Parquet data is outdated)
-if backend = 'both' AND parquet_stale = false:
-  → route to DataFusion (Parquet is current)
-if backend = 'parquet' AND parquet_stale = true:
-  → route to DataFusion anyway (no SQL alternative),
-    but log warning — Lichess data needs re-ingest
+POST /admin/reanalyze/lichess
+  Query params: ?motifs=back_rank_mate&months=2024-01,...
+
+Pipeline:
+  for each (platform, month) in scope:
+    batch = DataFusion: SELECT game_url, pgn FROM game_pgns
+            WHERE platform = 'lichess' AND month = ?
+            LIMIT 1000 OFFSET ?
+
+    for each game in batch:
+      features = featureExtractor.extract(game.pgn())
+      // Write updated game_features and motif_occurrences to Parquet
+      // Overwrite the affected partition file
 ```
 
-#### Timeline: Re-Analysis → Re-Export
+This is fast (minutes per partition, no download needed) and does not
+require any SQL involvement for Lichess data.
 
-```
-t=0:  Admin triggers POST /admin/reanalyze
-      Re-analysis begins processing games in SQL.
-      game_storage_backends.parquet_stale = true for affected partitions.
-      Query router falls back to SQL for stale partitions.
-
-t=N:  Re-analysis completes (minutes for 10K-100K games).
-      SQL rows now have updated motif flags.
-      Queries hitting SQL return correct results immediately.
-
-t=N+1: ParquetExportJob runs (next scheduled cron, or admin-triggered).
-       Reads updated SQL rows, writes new Parquet files.
-       game_storage_backends.parquet_stale = false.
-       Query router resumes routing to DataFusion.
-```
-
-For Lichess partitions (Option A), the window is longer — re-ingest
-takes 15-30 minutes per monthly dump, and must be triggered manually.
-During this window, queries against Lichess data return stale motif
-results for the new detectors (old detectors still correct).
+**Why not re-ingest from the Lichess dump (Option A)?** With 36 months
+of history, re-analysis would require downloading ~700 GB of compressed
+PGN, decompressing ~3.6B games, and filtering for ~60-100M qualifying
+games — 18-45 hours of wall-clock time. Storing PGN in a dedicated
+`game_pgns` Parquet table during initial ingest (~2-4 GB/month, stored
+once) eliminates this cost entirely.
 
 ### Storage Routing — `game_storage_backends` Table
-
-A metadata table in PostgreSQL tracks which backend holds motif data for
-each partition:
 
 ```sql
 CREATE TABLE game_storage_backends (
@@ -953,84 +798,24 @@ CREATE TABLE game_storage_backends (
 );
 ```
 
-| `backend` value | `parquet_stale` | Meaning | Query route |
-|-----------------|-----------------|---------|-------------|
-| `sql` | n/a | Games only in SQL, not yet exported | SQL |
-| `parquet` | `false` | Lichess games, Parquet is current | DataFusion |
-| `parquet` | `true` | Lichess games, needs re-ingest | DataFusion (stale warning) |
-| `both` | `false` | Exported, Parquet is current | DataFusion |
-| `both` | `true` | Re-analyzed in SQL, Parquet outdated | SQL (until re-export) |
+The query router uses this table for Phase 2 routing (partition-level).
+Phase 1 uses time-based routing (current month → SQL, completed months →
+DataFusion) and does not require this table for routing decisions.
 
-#### How the Query Router Uses This
-
-```java
-public class StorageAwareQueryRouter implements QueryRouter {
-
-  List<GameFeature> execute(Plan plan, int limit, int offset) {
-    // Extract platform/month predicates from the Substrait plan
-    Set<PartitionKey> partitions = extractPartitions(plan);
-
-    Set<String> backends = partitions.stream()
-        .map(p -> storageBackendStore.getBackend(p.platform(), p.month()))
-        .collect(Collectors.toSet());
-
-    if (backends.equals(Set.of("parquet")) || backends.equals(Set.of("both"))) {
-      // All partitions have Parquet data — use DataFusion
-      return dataFusionRouter.execute(plan, limit, offset);
-    } else if (backends.contains("sql") && !backends.contains("parquet")) {
-      // Some partitions only in SQL — use PostgreSQL
-      return sqlRouter.execute(plan, limit, offset);
-    } else {
-      // Mixed: some partitions in SQL only, some in Parquet only.
-      // Fan out to both backends, merge results.
-      return mergeResults(
-          sqlRouter.execute(restrictToPlatformMonths(plan, sqlOnlyPartitions), limit, offset),
-          dataFusionRouter.execute(restrictToPlatformMonths(plan, parquetPartitions), limit, offset),
-          limit, offset
-      );
-    }
-  }
-}
-```
-
-In practice, the mixed case is rare — it only happens for the current
-month (Chess.com games indexed but not yet exported) when combined with
-Lichess data. Most queries will hit either all-SQL (recent Chess.com
-only) or all-Parquet (historical data after export + Lichess).
-
-#### Simpler Alternative: Time-Based Routing
-
-If partition-level routing is too complex for Phase 1, use a simpler
-time-based rule:
-
-```
-if query touches only months older than EXPORT_CUTOFF (e.g. last month):
-  → DataFusion (Parquet)  // all historical data is exported
-else:
-  → SQL (PostgreSQL)       // current month is still in SQL
-```
-
-This works because the export job runs monthly. All completed months
-have Parquet data. Only the current (incomplete) month is SQL-only.
-
-### PGN and Game Metadata — SQL Only
-
-PGN text stays in PostgreSQL. It's large, variable-length, and only
-needed for game replay — not for motif search. The Parquet files contain
-only the columns needed for ChessQL analytical queries (motif flags,
-player info, Elo, time class, ECO, result).
+### PGN and Game Metadata — SQL Only (Chess.com)
 
 | Data | Storage | Reason |
 |------|---------|--------|
 | Motif queries (`motif(pin)`, `motif(fork)`, ...) | SQL EXISTS subqueries + Parquet join (after export) | Analytical queries |
 | Game metadata (Elo, ECO, result, ...) | SQL + Parquet (after export) | Needed for ChessQL filters |
-| PGN text | SQL only | Large, variable-length, not scanned by ChessQL |
-| Motif occurrences (ply, side, ...) | SQL + Parquet (after export) | Needed for `sequence()` and `ORDER BY motif_count()` |
+| PGN text (Chess.com) | SQL only | Large, variable-length, not scanned by ChessQL |
+| PGN text (Lichess) | `game_pgns` Parquet table | Needed for re-analysis without re-download |
+| Motif occurrences (ply, side, attacker, ...) | SQL + Parquet (after export) | Needed for derived motifs and `sequence()` |
 | `indexing_requests` | SQL only | Mutable operational state |
 | `indexed_periods` | SQL only | Mutable cache |
 | `game_storage_backends` | SQL only | Routing metadata |
 
-### Query Flow (Substrait-based)
+### Query Flow
 
 ```
 POST /v1/query { "query": "motif(fork) AND white.elo >= 2500" }
@@ -1039,22 +824,15 @@ one_d4 QueryController
   ↓
 Parser.parse() → ParsedQuery (AST)
   ↓
-SubstraitCompiler.compile() → Substrait Plan (protobuf)
-  ↓
-StorageAwareQueryRouter.execute(plan)
+StorageAwareQueryRouter.route(parsed)
   │
-  ├─ Check game_storage_backends for queried partitions
+  ├─ Phase 1: time-based check
+  │     current month? → SqlCompiler → JDBC → PostgreSQL → ResultSet
   │
-  ├── All partitions in Parquet → DataFusion backend:
-  │     plan.toByteArray() → POST motif_query/v1/query/substrait
-  │     → datafusion-substrait → LogicalPlan → Parquet scan
-  │     → JSON results back to one_d4
-  │
-  ├── All partitions in SQL only → SQL backend:
-  │     substrait-java SqlConverter → SQL string + bind params
-  │     → JDBC PreparedStatement → PostgreSQL → ResultSet
-  │
-  └── Mixed → fan out to both, merge results
+  └─ completed months? → DataFusionSqlCompiler → SQL string
+        → POST motif_query/v1/query { "sql": "...", "limit": 50 }
+        → DataFusion optimizer → PhysicalPlan → Parquet scan
+        → JSON results back to one_d4
   ↓
 one_d4 formats response, returns to client
 ```
@@ -1073,10 +851,9 @@ one_d4 formats response, returns to client
 | Data freshness in Parquet | Seconds-minutes (buffer flush lag) | Weekly/monthly (export schedule) |
 
 The only tradeoff is data freshness in Parquet — recently indexed
-Chess.com games are SQL-only until the next export runs. But this is
-fine: the SQL backend handles these queries today, and the export
-frequency is configurable. For users who just indexed their games,
-queries hit SQL immediately.
+Chess.com games are SQL-only until the next export runs. The SQL backend
+handles these queries today, and the export frequency is configurable.
+For users who just indexed their games, queries hit SQL immediately.
 
 ## Do We Keep H2/PostgreSQL?
 
@@ -1089,26 +866,18 @@ games and keeps all data that Parquet doesn't need.**
 |------|-----------|---------|-------|
 | `game_features` (motif flags, metadata) | Always (source of truth for Chess.com) | After export job / Lichess ingest | Parquet is derived for Chess.com, primary for Lichess |
 | `motif_occurrences` | Always (source of truth for Chess.com) | After export job / Lichess ingest | Same as above |
-| PGN text | Always (Chess.com) | Never | Large, variable-length, not needed for analytical queries |
-| `indexing_requests` | Always | Never | Mutable operational state (PENDING → PROCESSING → COMPLETED) |
+| PGN text (Chess.com) | Always | Never | Large, variable-length, not needed for analytical queries |
+| PGN text (Lichess) | Never | `game_pgns` table | For re-analysis; Chess.com PGN stays in SQL |
+| `indexing_requests` | Always | Never | Mutable operational state |
 | `indexed_periods` | Always | Never | Mutable cache of fetched (player, platform, month) combos |
-| `game_storage_backends` | Always | Never | Routing metadata — which backend has which partitions |
-
-### PGN Storage
-
-PGN text stays in PostgreSQL for Chess.com games. For Lichess games,
-link back to `https://lichess.org/game/export/{id}` — no need to store
-the PGN at all. This keeps Parquet files lean (only columns needed for
-ChessQL queries).
+| `game_storage_backends` | Always | Never | Routing metadata |
 
 ### When Can We Drop SQL Game Tables?
 
-In the previous (dual-write) design, the goal was to eventually drop
-`game_features` and `motif_occurrences` from PostgreSQL. With the
-SQL-first approach, **we don't drop them** — PostgreSQL remains the
-write store for Chess.com games and the source of PGN text. The tables
-stay, but the analytical query load shifts to DataFusion/Parquet for
-historical data.
+With the SQL-first approach, **we don't drop them** — PostgreSQL remains
+the write store for Chess.com games and the source of PGN text. The
+analytical query load shifts to DataFusion/Parquet for historical data,
+but the tables stay.
 
 If we later want to stop storing Chess.com game data in SQL (e.g. to
 reduce PostgreSQL storage), we'd need to solve PGN storage separately
@@ -1118,97 +887,104 @@ optimization, not a near-term goal.
 ### Migration Path
 
 ```
-Phase 1: SubstraitCompiler + motif_query crate scaffold.
-         ChessQL compiles to Substrait. SqlQueryRouter converts
-         Substrait → SQL and executes on PostgreSQL (functionally
-         equivalent to today's SqlCompiler path). motif_query Rust
-         service accepts Substrait plans over Parquet. IndexWorker
-         is unchanged — still writes to SQL.
+Phase 1: DataFusionSqlCompiler + motif_query crate scaffold.
+         DataFusionSqlCompiler produces DataFusion SQL from the same
+         ChessQL AST as SqlCompiler. motif_query Rust service accepts
+         DataFusion SQL strings, queries Parquet, returns JSON.
+         Contract tests validate result equivalence with PostgreSQL.
+         IndexWorker is unchanged — still writes to SQL.
 
-Phase 2: Parquet export job + storage routing.
+Phase 2: Parquet export job + time-based routing.
          Export job runs weekly/monthly: SELECT from SQL → write
          Parquet via motif_query/v1/write. game_storage_backends
          tracks which partitions have Parquet data.
-         StorageAwareQueryRouter dispatches to SQL or DataFusion
-         based on storage metadata.
+         StorageAwareQueryRouter dispatches using time-based rule:
+         current month → SqlCompiler + JDBC; older months → DataFusion.
 
 Phase 3: Shadow mode validation.
-         For partitions in 'both' state, run queries on both
-         backends, compare results, log mismatches. SQL results
-         are returned to client.
+         For partitions with Parquet data, run queries on both
+         backends in parallel, compare results, log mismatches.
+         SQL results are returned to client.
 
 Phase 4: DataFusion primary for exported partitions.
-         Queries for partitions in 'both' or 'parquet' state go
-         to DataFusion. Only current-month (unexported) queries
-         hit SQL.
+         After shadow mode shows 100% result parity, queries for
+         completed months route to DataFusion. Only current-month
+         (unexported) queries hit SQL.
 
 Phase 5: Lichess bulk ingest (after Phase 9 / issue #1049 lands).
          Run lichess_ingest Java CLI on historical Lichess dumps.
-         All 18 motif detectors (11 existing + 7 new chariot-based)
-         are included in bulk processing. Lichess partitions are
-         'parquet' only.
+         All 16 motif detectors are included in bulk processing.
+         Lichess partitions are 'parquet' only.
+         game_pgns Parquet table written during ingest for future
+         re-analysis.
 ```
 
 ## Implementation Plan
 
-### Phase 1: SubstraitCompiler in chessql (2-3 days)
+### Phase 1: DataFusionSqlCompiler + motif_query scaffold (3-4 days)
 
-- Add `io.substrait:core` and `io.substrait:isthmus` maven dependencies
-- New `SubstraitCompiler implements QueryCompiler<Plan>` in chessql library
-  - Walk ChessQL AST → Substrait `ReadRel`, `FilterRel`, `SortRel`,
-    `AggregateRel`, `JoinRel` nodes
-  - Handle `MotifExpr` → EXISTS subquery on `motif_occurrences` (most motifs by stored name; `fork`, `checkmate`, `discovered_attack`, `discovered_check`, `double_check` derived from `ATTACK` rows)
-  - Handle `ComparisonExpr` / `InExpr` → scalar functions
-  - Handle `SequenceExpr` → join-based exists subquery
-  - Handle `OrderByClause` → aggregate + sort on motif_occurrences
-  - Include `NamedStruct` schema for `game_features` and
-    `motif_occurrences` tables in the plan
-- New `SqlQueryRouter` that consumes Substrait plans:
-  - Use `isthmus` `SubstraitToSql` to convert Plan → SQL + params
-  - Execute via JDBC (same as today's `GameFeatureDao.query()`)
-  - This replaces `SqlCompiler` as the production path, keeping
-    PostgreSQL as the query backend while compiling through Substrait
-- Unit tests:
-  - `SubstraitCompilerTest`: verify plan structure for each AST node type
-  - `SqlQueryRouterTest`: verify roundtrip ChessQL → Substrait → SQL
-    produces equivalent SQL to `SqlCompiler` output
-  - Keep `SqlCompilerTest` passing (existing compiler not yet removed)
-- Wire `SubstraitCompiler` + `SqlQueryRouter` into `QueryController`
-  behind a config flag (`USE_SUBSTRAIT=true|false`, default false)
+**Java — DataFusionSqlCompiler in chessql library:**
+- New `DataFusionSqlCompiler implements QueryCompiler<DataFusionCompiledQuery>`
+  - Walk ChessQL AST → DataFusion SQL with inline literals
+  - Handle all 16 motifs: stored motifs by name, ATTACK-derived motifs
+    by the same GROUP BY / HAVING patterns as `SqlCompiler`
+  - Handle `SequenceExpr` → correlated EXISTS + JOIN
+  - Handle `OrderByClause` → LEFT JOIN + COUNT aggregate + ORDER BY
+  - Handle `InExpr`, `ComparisonExpr` → inline literals (no bind params)
+  - String case-insensitivity via `lower()` inline
+- Unit tests: `DataFusionSqlCompilerTest` — verify SQL output for each
+  AST node type, including all ATTACK-derived motifs and `sequence()`
+- Keep `SqlCompiler` and all existing tests passing — no changes to
+  current production path
 
-### Phase 2: motif_query crate scaffold (1-2 days)
-
+**Rust — motif_query crate:**
 - Create `domains/games/apis/motif_query/` with Cargo.toml, BUILD.bazel
-- Add `datafusion`, `datafusion-substrait`, `arrow`, `parquet`, `prost`
-  workspace dependencies
-- Implement `catalog.rs`: register Parquet listing tables with partition
-  columns
-- Implement `query.rs`: accept Substrait plan bytes, decode protobuf,
-  call `from_substrait_plan()` → `LogicalPlan`, execute, return JSON
-- Implement `writer.rs`: accept JSON rows, write directly to partitioned
+- Add `datafusion`, `arrow`, `parquet` workspace dependencies
+- Implement `catalog.rs`: register `game_features`, `motif_occurrences`,
+  `game_pgns` as Parquet listing tables with partition columns
+  (include `attacker`, `target`, `is_discovered`, `is_mate` in
+  `motif_occurrences` schema)
+- Implement `query.rs`: accept `{ "sql": "...", "limit": N, "offset": N }`,
+  execute via `ctx.sql()`, return JSON rows
+- Implement `writer.rs`: accept JSON batch, write directly to partitioned
   Parquet (no buffering needed — callers send complete batches)
-- axum server with `/v1/query/substrait`, `/v1/write`, `/health` endpoints
-- Unit tests with in-memory Parquet roundtrips + a sample Substrait plan
+- axum server with `/v1/query`, `/v1/write`, `/v1/partitions`, `/health`
+- Unit tests: in-memory Parquet roundtrips for all derived motif patterns
+  (especially fork, double_check, sequence)
 
-### Phase 3: Parquet export job + storage routing (2-3 days)
+**Contract tests (critical):**
+- `DataFusionContractTest` in one_d4 test suite
+- Seeds H2 (in-memory) and test Parquet files with identical data
+- Runs all 16 motifs + sequence + ORDER BY + IN expressions against both
+- Asserts result-set equivalence
+- Runs in CI via Bazel
+
+### Phase 2: Parquet export job + time-based routing (2-3 days)
 
 - New `game_storage_backends` SQL table + DAO
 - New `ParquetExportJob`:
-  - SELECT game_features + motif_occurrences for each (platform, month)
-    with games not yet exported
-  - POST complete partition to `motif_query/v1/write`
-  - UPDATE `game_storage_backends` to 'both'
+  - SELECT all `game_features` + `motif_occurrences` for each (platform, month)
+    partition that has `indexed_at > parquet_exported_at` or `parquet_stale = true`
+  - POST complete partition to `motif_query/v1/write` (full overwrite, no
+    per-game tracking)
+  - UPDATE `game_storage_backends` to `backend='both'`, `parquet_stale=false`,
+    `parquet_exported_at=now()`
 - Admin endpoint: `POST /admin/export/parquet?platform=X&month=Y`
-  (trigger export for specific partition)
 - Cron scheduling: weekly or monthly via config
-- `StorageAwareQueryRouter`:
-  - Check `game_storage_backends` to determine which backend has data
-  - Route to SQL, DataFusion, or fan-out to both
-  - Start with time-based routing (simpler): current month → SQL,
-    older months → DataFusion (if exported)
-- `DataFusionQueryRouter`: serialize Substrait plan → HTTP POST to
-  motif_query → deserialize JSON response
-- Shadow mode: for 'both' partitions, run both backends, compare, log
+- `StorageAwareQueryRouter` (Phase 1 implementation):
+  - Time-based: is the query asking for only the current month?
+    → SqlCompiler + JDBC; otherwise → DataFusionSqlCompiler + motif_query
+- `DataFusionQueryClient`: serialize compiled SQL → HTTP POST to
+  `motif_query/v1/query` → deserialize JSON response
+
+### Phase 3: Shadow mode + partition-level routing (1-2 days)
+
+- For completed partitions (backend='both'), run both backends, compare
+  results, log mismatches to a `query_shadow_mismatches` table
+- After N days with zero mismatches, enable DataFusion as primary for
+  those partitions
+- Upgrade `StorageAwareQueryRouter` to use `game_storage_backends` lookup
+  instead of time-based shortcut
 
 ### Phase 4: Lichess ingest pipeline — Java (3-5 days)
 
@@ -1218,27 +994,19 @@ Phase 5: Lichess bulk ingest (after Phase 9 / issue #1049 lands).
 - Reuse existing Java motif detectors (GameReplayer + FeatureExtractor +
   all MotifDetector implementations — no porting needed)
 - HTTP client to batch-POST results to `motif_query/v1/write`
+  (game_features, motif_occurrences, and game_pgns in separate calls)
 - CLI interface: `java -jar lichess_ingest.jar --input ... --motif-query-url ...`
-- Insert `game_storage_backends` rows with backend='parquet' for Lichess
+- Insert `game_storage_backends` rows with `backend='parquet'` for Lichess
   partitions
 - Test against a small Lichess sample file
 - **Dependency:** Should run after Phase 9 (issue #1049) lands so that
-  the 7 new chariot-based motifs are included in the bulk ingest
+  all chariot-based motifs are included in the bulk ingest
 
-### Phase 5: Cost-based routing (optional, 1 day)
+### Phase 5: Remove SqlCompiler (after shadow mode proves parity)
 
-- `CostQueryRouter` inspects the Substrait plan:
-  - Simple boolean filter on `game_features` → DataFusion (fast scan)
-  - `sequence()` with small expected result set → SQL (mature optimizer)
-  - Aggregate queries → DataFusion (columnar aggregation)
-- Configurable cost thresholds, with override via `QUERY_BACKEND` env var
-
-### Phase 6: Remove `SqlCompiler` (1 day)
-
-- All compilation goes through Substrait
-- Remove `SqlCompiler`, `CompiledQuery`
-- Simplify `QueryController` — only uses `SubstraitCompiler`
-- Remove `USE_SUBSTRAIT` feature flag (always on)
+- All compilation goes through `DataFusionSqlCompiler` for DataFusion
+  queries; `SqlCompiler` stays for the PostgreSQL path indefinitely
+- Remove `USE_DATAFUSION` feature flag (always on for completed partitions)
 
 ## Cost and Performance Estimates
 
@@ -1249,14 +1017,20 @@ Phase 5: Lichess bulk ingest (after Phase 9 / issue #1049 lands).
 | 1 month Chess.com (50K games) | ~40 MB | ~2.5-5 MB |
 | 12 months Chess.com (600K games) | ~480 MB | ~30-60 MB |
 | 12 months Lichess GM games (~20M) | ~16 GB | ~1.5-2.5 GB |
-| Combined (12 mo Chess.com + Lichess) | ~16.5 GB | ~1.6-2.6 GB |
+| Lichess game_pgns (12 months) | — | ~24-48 GB (PGN text) |
+| Combined (12 mo Chess.com + Lichess) | ~16.5 GB | ~26-51 GB |
 
 ### Query Performance (estimated, single-node)
 
+All motif queries execute as EXISTS subqueries or GROUP BY/HAVING on
+`motif_occurrences`. The DataFusion advantage comes from columnar scan
+and predicate pushdown on the `motif` string column, not from boolean
+flag scans.
+
 | Query pattern | PostgreSQL (indexed) | DataFusion (Parquet) |
 |--------------|---------------------|---------------------|
-| `motif(fork) AND white.elo >= 2500` | ~50-200ms (index scan) | ~20-80ms (column pruning + predicate pushdown) |
-| `motif(fork) AND motif(pin)` (2 booleans) | ~100-300ms | ~15-50ms (vectorized AND on boolean columns) |
+| `motif(pin)` (EXISTS) | ~50-200ms (index on motif column) | ~20-80ms (column pruning + predicate pushdown) |
+| `motif(fork) AND motif(pin)` (2 EXISTS) | ~100-300ms | ~15-50ms (parallel column scans) |
 | `ORDER BY motif_count(check)` | ~500ms+ (JOIN + COUNT) | ~100-300ms (columnar aggregation) |
 | Full scan, no filters | ~2-5s (1M rows) | ~200-500ms (columnar, compressed) |
 
@@ -1275,60 +1049,116 @@ Phase 5: Lichess bulk ingest (after Phase 9 / issue #1049 lands).
    DataFusion supports `object_store` for S3/GCS — add it later when
    deploying to cloud.
 
-2. **Do we need the motif_occurrences table at all in Parquet?** The
-   `game_features` boolean flags handle most ChessQL queries. The
-   occurrences table is only needed for `sequence()` queries and
-   `ORDER BY motif_count()`. If those features are rarely used, we could
-   keep `sequence()` queries routed to SQL permanently and skip
-   exporting motif_occurrences to Parquet entirely.
+2. **Do we need the motif_occurrences table in Parquet for Phase 1?** For
+   most ChessQL queries, only `game_features` is needed. The occurrences
+   table is required for `sequence()` and `ORDER BY motif_count()`. If
+   those features are used infrequently, they could stay SQL-only while
+   the rest migrates to DataFusion. Export `motif_occurrences` in Phase 2
+   alongside `game_features`.
 
 3. **Phase 9 before or after Lichess ingest?** Ideally Phase 9 (issue
-   #1049 — 7 new chariot-based motifs) lands before the first Lichess
-   bulk ingest, so all 18 motifs are captured in one pass. If Phase 9 is
-   delayed, we could ingest with the current 11 detectors and re-analyze
-   later via the admin endpoint, but that doubles the processing cost.
+   #1049 — chariot-based motifs) lands before the first Lichess bulk
+   ingest, so all 16 motifs are captured in one pass. If Phase 9 is
+   delayed, we could ingest with the current detectors and re-analyze
+   later using the `game_pgns` Parquet table, but that doubles processing
+   cost.
 
 4. **Java Parquet writer alternative?** Instead of HTTP POST to the Rust
-   motif_query service, the export job and `lichess_ingest` CLI could
+   `motif_query` service, the export job and `lichess_ingest` CLI could
    write Parquet directly using `org.apache.parquet:parquet-avro` or
    `org.apache.arrow:arrow-dataset`. This eliminates the HTTP hop but
    means two codepaths for Parquet writing (Java for writes, Rust for
    reads). The Rust write endpoint is simpler to keep consistent with
    the query schema.
 
-5. **Substrait coverage for `sequence()`?** The `sequence()` construct
-   compiles to a correlated EXISTS with self-joins on `motif_occurrences`.
-   Substrait's `SetPredicateRel` (EXISTS) and `JoinRel` should handle
-   this, but `datafusion-substrait` may not support all Substrait
-   relation types. If `sequence()` hits a gap, we can either:
-   (a) extend the DataFusion Substrait consumer,
-   (b) always route `sequence()` queries to SQL, or
-   (c) represent sequences differently (e.g. pre-materialized boolean
-   columns like `has_sequence_fork_then_pin`).
-
-6. **Substrait version pinning.** The `substrait-java` library and
-   `datafusion-substrait` crate must agree on the Substrait protobuf
-   spec version. Pin both to the same Substrait spec release (e.g.
-   v0.42.x). Mismatches cause deserialization failures.
-
-7. **Export frequency — weekly vs monthly?** Weekly exports mean fresher
+5. **Export frequency — weekly vs monthly?** Weekly exports mean fresher
    Parquet data and faster query routing to DataFusion for recent games.
    Monthly exports are simpler and produce cleaner partition boundaries.
    At 10K-100K games/month, the difference is small. Could also be
    event-driven: export when a partition reaches N games or on admin
    trigger.
 
-8. **Handling re-indexed games in export?** If a player is re-indexed
-   (e.g. after new motif detectors land), the SQL rows are updated but
-   the Parquet file for that partition is now stale. The export job
-   needs to detect this — either by comparing `indexed_at` timestamps
-   against `parquet_exported_at`, or by always re-exporting partitions
-   that have been touched since the last export.
+6. **Mixed-backend query fan-out** (deferred): When a query spans the
+   current month (SQL) and older months (DataFusion), the router must
+   either route entirely to SQL or fan out to both and merge. For Phase 1,
+   time-based routing sends the whole query to SQL when the current month
+   is involved. This is correct but means historical DataFusion data is
+   not queried in the same call as current data. Revisit in Phase 3 once
+   shadow mode validates result parity.
 
-9. **Mixed-backend query merging.** When a query spans partitions in
-   different backends (e.g. current month in SQL, older months in
-   Parquet), the `StorageAwareQueryRouter` needs to merge results. For
-   simple queries this is concatenation + re-sort. For aggregates and
-   `ORDER BY motif_count()`, merging is more complex. The time-based
-   routing shortcut (current month → SQL, older → DataFusion) avoids
-   this for most queries.
+7. **game_pgns storage cost**: At ~2-4 GB/month of Parquet, 36 months of
+   Lichess history ≈ 72-144 GB. This is acceptable and much cheaper than
+   re-downloading the raw dumps. Monitor actual PGN compression ratios
+   during the first Lichess ingest.
+
+## Future Enhancement: Substrait
+
+The current design uses two SQL compilers (PostgreSQL and DataFusion
+dialects) rather than a shared Substrait IR. This is a deliberate
+trade-off based on the state of the Substrait toolchain in early 2026.
+
+**Why Substrait was deferred:**
+
+The `sequence()` and ATTACK-derived motif patterns require correlated
+EXISTS subqueries with GROUP BY/HAVING inside the correlated scope:
+
+```sql
+-- motif(fork): correlated EXISTS over an aggregate
+EXISTS (SELECT 1 FROM motif_occurrences mo
+  WHERE mo.game_url = g.game_url AND mo.motif = 'ATTACK'
+  AND mo.is_discovered = FALSE AND mo.attacker IS NOT NULL
+  GROUP BY mo.ply, mo.attacker HAVING COUNT(*) >= 2)
+```
+
+In Substrait terms, this requires `SetPredicateRel(EXISTS,
+AggregateRel(...))` where the inner scan is correlated to the outer
+relation. `datafusion-substrait` 52.x still explicitly documents that
+"Substrait does not (yet) support the full range of plans and expressions
+that DataFusion offers" — correlated EXISTS with aggregates is one of the
+known gaps. DataFusion decorrelates subqueries during planning, which
+works for simple EXISTS but has known limitations when the correlated
+scope contains GROUP BY/HAVING.
+
+Additionally, `substrait-java`'s `SubstraitToSql` produces ANSI SQL with
+inline literals rather than JDBC `?` bind parameters. Replacing
+`SqlCompiler`'s parameterized queries with Substrait-generated SQL would
+be a regression in query safety without significant work to re-extract
+parameters.
+
+**When to revisit:**
+
+Consider Substrait as the query IR when:
+
+1. `datafusion-substrait` (currently 52.x) removes its "does not yet
+   support the full range of plans" caveat and demonstrates reliable
+   support for correlated EXISTS + GROUP BY/HAVING. Test against all 5
+   ATTACK-derived motifs and `sequence()` before adopting.
+2. A third query backend is needed (e.g. DuckDB, ClickHouse, Velox),
+   making two-compiler maintenance genuinely costly.
+3. The `substrait-java` `isthmus` `SubstraitToSql` produces
+   parameterized output (or a safe inline-literal model is standardized).
+
+**Migration path if/when Substrait is adopted:**
+
+```
+1. Spike: manually construct Substrait protobuf for motif(fork) and
+   sequence(fork THEN pin). Verify round-trip through substrait-java
+   SubstraitToSql (PostgreSQL path) and datafusion-substrait
+   from_substrait_plan (DataFusion path). Both must produce correct
+   results against test data.
+
+2. Add SubstraitCompiler alongside SqlCompiler and
+   DataFusionSqlCompiler. Route a small percentage of queries through
+   all three, compare results.
+
+3. Once SubstraitCompiler achieves parity on all query patterns,
+   deprecate SqlCompiler and DataFusionSqlCompiler in favor of the
+   single Substrait compilation path.
+
+4. Benefits realized: one compilation path, backend portability, cleaner
+   optimizer visibility into query structure.
+```
+
+The two-compiler approach with contract tests is explicitly designed to
+be replaced by Substrait when the toolchain matures without requiring
+a big-bang migration.


### PR DESCRIPTION
## Summary

- **Replace Substrait IR with dual-compiler model**: `SqlCompiler` (PostgreSQL, unchanged) + new `DataFusionSqlCompiler` (DataFusion SQL). `datafusion-substrait` 52.x still documents that correlated EXISTS + GROUP BY/HAVING is unsupported — a hard requirement for all 5 ATTACK-derived motifs (`fork`, `checkmate`, `discovered_attack`, `discovered_check`, `double_check`) and `sequence()` queries.
- **Fix `motif_occurrences` Parquet schema**: add `attacker`, `target`, `is_discovered`, `is_mate` columns (previously missing; load-bearing for ATTACK-derived motifs in DataFusion).
- **Fix stale narrative**: motif queries use EXISTS subqueries on `motif_occurrences`, not boolean flag scans on `game_features`.
- **Add `game_pgns` Parquet table** (Lichess only): written during initial ingest, enables re-analysis without re-downloading source dumps (~700 GB for 36 months of history).
- **Fix export job wording**: full partition overwrite per export run; staleness via `indexed_at > parquet_exported_at`.
- **Add contract test suite design**: both backends seeded with identical data, all 16 motifs + `sequence()` + `ORDER BY`, result equivalence asserted in CI.
- **Reorder implementation phases**: `DataFusionSqlCompiler` + `motif_query` scaffold → export + time-based routing → shadow mode → Lichess ingest.
- **Bump crate versions**: DataFusion/arrow/parquet 46/55 → 52/57.
- **Add Future Enhancement: Substrait section**: criteria for revisiting once the toolchain matures, with a concrete migration path.
- **Fix `CHESSQL.md`**: remove `motif(attack)` from directly-stored motifs (removed in #1080); update count to 11 stored + 5 ATTACK-derived = 16.

## Test plan

- [ ] Doc-only change — no code changes, no tests required
- [ ] Verify CHESSQL.md motif table matches `SqlCompiler.VALID_MOTIFS`
- [ ] Verify Parquet schema columns match actual `motif_occurrences` SQL schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)