### PR TITLE
feat(1d4_web): accordion game detail panel opens inline in table row

### DIFF
--- a/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
@@ -3,6 +3,12 @@ import { describe, it, expect, vi } from 'vitest';
 import GameTable from '../components/GameTable';
 import type { GameRow } from '../types';
 
+vi.mock('react-chessboard', () => ({
+  Chessboard: ({ position }: { position: string }) => (
+    <div data-testid="chessboard" data-fen={position} />
+  ),
+}));
+
 const mockGames: GameRow[] = [
   {
     gameUrl: 'https://chess.com/game/1',
@@ -94,5 +100,24 @@ describe('GameTable', () => {
     // 1700000000 seconds = 2023-11-14 (both playedAt and indexedAt land on same day)
     const dateCells = screen.getAllByText('2023-11-14');
     expect(dateCells.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows game detail accordion inline when selectedGame matches a row', () => {
+    render(
+      <GameTable
+        games={mockGames}
+        sortBy=""
+        sortDir="asc"
+        onSort={() => {}}
+        selectedGame={mockGames[0]}
+        onClose={() => {}}
+      />
+    );
+    expect(screen.getByText('Alice vs Bob')).toBeInTheDocument();
+  });
+
+  it('does not show game detail accordion when no game is selected', () => {
+    render(<GameTable games={mockGames} sortBy="" sortDir="asc" onSort={() => {}} />);
+    expect(screen.queryByTestId('chessboard')).not.toBeInTheDocument();
   });
 });

--- a/domains/games/apps/1d4_web/src/components/GameTable.tsx
+++ b/domains/games/apps/1d4_web/src/components/GameTable.tsx
@@ -1,5 +1,7 @@
+import { Fragment } from 'react';
 import type { GameRow } from '../types';
 import MotifBadge from './MotifBadge';
+import GameDetailPanel from './GameDetailPanel';
 
 
 const COLUMNS = [
@@ -76,9 +78,11 @@ interface Props {
   sortDir: 'asc' | 'desc';
   onSort: (col: string) => void;
   onRowClick?: (game: GameRow) => void;
+  selectedGame?: GameRow | null;
+  onClose?: () => void;
 }
 
-export default function GameTable({ games, sortBy, sortDir, onSort, onRowClick }: Props) {
+export default function GameTable({ games, sortBy, sortDir, onSort, onRowClick, selectedGame, onClose }: Props) {
   return (
     <div className="table-wrap">
       <table>
@@ -101,15 +105,27 @@ export default function GameTable({ games, sortBy, sortDir, onSort, onRowClick }
         </thead>
         <tbody>
           {games.map((game, i) => (
-            <tr
-              key={game.gameUrl || i}
-              onClick={onRowClick ? () => onRowClick(game) : undefined}
-              style={{ cursor: onRowClick ? 'pointer' : 'default' }}
-            >
-              {COLUMNS.map((col) => (
-                <td key={col.id}>{renderCell(col.id, game, onRowClick)}</td>
-              ))}
-            </tr>
+            <Fragment key={game.gameUrl || i}>
+              <tr
+                onClick={onRowClick ? () => onRowClick(game) : undefined}
+                style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                className={selectedGame?.gameUrl === game.gameUrl ? 'selected' : undefined}
+              >
+                {COLUMNS.map((col) => (
+                  <td key={col.id}>{renderCell(col.id, game, onRowClick)}</td>
+                ))}
+              </tr>
+              {selectedGame?.gameUrl === game.gameUrl && (
+                <tr>
+                  <td colSpan={COLUMNS.length} style={{ padding: 0 }}>
+                    <GameDetailPanel
+                      game={selectedGame}
+                      onClose={onClose ?? (() => {})}
+                    />
+                  </td>
+                </tr>
+              )}
+            </Fragment>
           ))}
         </tbody>
       </table>

--- a/domains/games/apps/1d4_web/src/views/GamesView.tsx
+++ b/domains/games/apps/1d4_web/src/views/GamesView.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { query as apiQuery } from '../api';
 import type { GameRow } from '../types';
 import GameTable from '../components/GameTable';
-import GameDetailPanel from '../components/GameDetailPanel';
 import Pagination from '../components/Pagination';
 
 const DEFAULT_QUERY = 'num.moves >= 0';
@@ -140,7 +139,13 @@ export default function GamesView() {
             sortBy={sortBy}
             sortDir={sortDir}
             onSort={handleSort}
-            onRowClick={(game) => setSelectedGame(game)}
+            onRowClick={(game) =>
+              setSelectedGame((prev) =>
+                prev?.gameUrl === game.gameUrl ? null : game
+              )
+            }
+            selectedGame={selectedGame}
+            onClose={() => setSelectedGame(null)}
           />
           <Pagination
             offset={offset}
@@ -155,13 +160,6 @@ export default function GamesView() {
               setOffset((o) => Math.min(o + limit, sorted.length - limit))
             }
           />
-          {selectedGame && (
-            <GameDetailPanel
-              key={selectedGame.gameUrl}
-              game={selectedGame}
-              onClose={() => setSelectedGame(null)}
-            />
-          )}
         </>
       )}
     </>


### PR DESCRIPTION
## Summary
- Clicking a game row now expands an accordion inline immediately below that row, showing the `GameDetailPanel` without requiring the user to scroll past pagination
- Only one row can be open at a time; clicking a different row closes the previous one and opens the new one
- Clicking the active row (or pressing ×) collapses it
- `GameTable` accepts two new optional props: `selectedGame` and `onClose`

## Test plan
- [x] All 54 existing tests pass
- [x] New `GameTable` test: accordion panel renders inline when `selectedGame` matches a row
- [x] New `GameTable` test: no panel rendered when nothing is selected
- [x] Typecheck clean
- [x] Production build succeeds