### PR TITLE
fix(one_d4): delete occurrences before re-inserting in flushBatch

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -214,6 +214,7 @@ public class IndexWorker {
       Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesBatch) {
     if (featureBatch.isEmpty()) return;
     gameFeatureStore.insertBatch(featureBatch);
+    gameFeatureStore.deleteOccurrencesByGameUrls(new ArrayList<>(occurrencesBatch.keySet()));
     gameFeatureStore.insertOccurrencesBatch(occurrencesBatch);
     featureBatch.clear();
     occurrencesBatch.clear();

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
@@ -572,6 +572,29 @@ public class GameFeatureDaoTest {
     assertThat(page2.get(0).gameUrl()).isEqualTo("https://chess.com/game/zzz-last");
   }
 
+  @Test
+  public void deleteOccurrencesByGameUrls_thenReinsert_doesNotDuplicate() {
+    // Regression test: re-indexing a partial month must not accumulate duplicate occurrences.
+    // The fix is in IndexWorker.flushBatch: delete occurrences for each game_url before inserting.
+    String gameUrl = "https://chess.com/game/reindex-dedup";
+    dao.insertBatch(List.of(createGame(gameUrl)));
+
+    GameFeatures.MotifOccurrence pin =
+        new GameFeatures.MotifOccurrence(
+            5, 3, "white", "Pin on c6", null, "Bb5", "nc6", false, false, "ABSOLUTE");
+    Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrences =
+        Map.of(gameUrl, Map.of(Motif.PIN, List.of(pin)));
+
+    // First index run
+    dao.insertOccurrencesBatch(occurrences);
+    // Simulate re-index: delete then re-insert (what flushBatch now does)
+    dao.deleteOccurrencesByGameUrls(List.of(gameUrl));
+    dao.insertOccurrencesBatch(occurrences);
+
+    Map<String, Map<String, List<OccurrenceRow>>> result = dao.queryOccurrences(List.of(gameUrl));
+    assertThat(result.get(gameUrl).get("pin")).hasSize(1);
+  }
+
   private GameFeature createGame(String url) {
     return new GameFeature(
         null,


### PR DESCRIPTION
## Summary

- Re-indexing a partial month accumulated duplicate `motif_occurrences` rows for previously-indexed games: `insertOccurrencesBatch` used a plain `INSERT` with no conflict protection, and the `ON DELETE CASCADE` on `game_features` never fired because the upsert updates the row rather than deleting it
- Fix: `flushBatch` now calls `deleteOccurrencesByGameUrls` before `insertOccurrencesBatch`, mirroring what the admin `/reanalyze` endpoint already did correctly
- Adds a regression test verifying that delete-then-reinsert produces exactly one occurrence row, not two

## Test plan

- [ ] `bazel test //domains/games/apis/one_d4/...` — 35/35 pass
- [ ] New test `deleteOccurrencesByGameUrls_thenReinsert_doesNotDuplicate` in `GameFeatureDaoTest` covers the regression