### PR TITLE
chore: bump forgejo image to v15

### DIFF
--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -220,7 +220,7 @@ services:
           memory: 512M
 
   forgejo:
-    image: codeberg.org/forgejo/forgejo:14
+    image: codeberg.org/forgejo/forgejo:15
     restart: always
     ports:
       - "222:22"


### PR DESCRIPTION
Bump forgejo container image from v14 to v15 in consolidated compose.