### PR TITLE
Pin CI base image to ubuntu 24.04

### DIFF
--- a/.github/docker/Dockerfile.ci
+++ b/.github/docker/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 # Set up UTF-8 locale to handle files with special characters
 ENV LANG=C.UTF-8


### PR DESCRIPTION
ubuntu:latest rolled to 26.04. The scheduled CI image rebuild baked in the newer glibc, which broke the no-sysroot LLVM toolchain's link step during the foreign_cc GNU Make bootstrap ("C compiler cannot create executables") on full builds.

Pin the base image to 24.04 (the release in use when the last full build passed) to restore a stable host C runtime. Merging republishes ci-base:latest from 24.04.