### PR TITLE
Serve the portrait API through the generated Smithy handler (phase 2)

### DIFF
--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -96,6 +96,39 @@ cc_test(
     ],
 )
 
+# Phase 2 (#1168): TracerService behind the generated PortraitHandler.
+# Main.cc switches to this handler (plus middleware parity) in phase 3.
+cc_library(
+    name = "smithy_handler",
+    srcs = ["smithy_handler.cc"],
+    hdrs = ["smithy_handler.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":portrait_smithy_server",
+        ":tracer_service",
+        ":types",
+        "//domains/platform/libs/futility/base64",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@smithy_cpp//runtime:core",
+    ],
+)
+
+cc_test(
+    name = "smithy_handler_test",
+    size = "small",
+    srcs = ["smithy_handler_test.cc"],
+    deps = [
+        ":portrait_smithy_client",
+        ":portrait_smithy_server",
+        ":smithy_handler",
+        "@googletest//:gtest_main",
+        "@smithy_cpp//runtime:client",
+        "@smithy_cpp//runtime:core",
+        "@smithy_cpp//runtime:http",
+    ],
+)
+
 cc_binary(
     name = "portrait",
     srcs = ["Main.cc"],

--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -122,6 +122,7 @@ cc_test(
         ":portrait_smithy_client",
         ":portrait_smithy_server",
         ":smithy_handler",
+        "//domains/graphics/libs/png_plusplus",
         "@googletest//:gtest_main",
         "@smithy_cpp//runtime:client",
         "@smithy_cpp//runtime:core",

--- a/domains/graphics/apis/portrait/smithy_handler.cc
+++ b/domains/graphics/apis/portrait/smithy_handler.cc
@@ -1,0 +1,93 @@
+#include "domains/graphics/apis/portrait/smithy_handler.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "domains/graphics/apis/portrait/types.h"
+#include "domains/platform/libs/futility/base64/base64.h"
+#include "smithy/core/blob.h"
+#include "smithy/core/error.h"
+
+namespace portrait {
+namespace {
+
+namespace gen = moonbase::portrait;
+
+Vec3 toVec3(const std::vector<double>& v) {
+  // @length(3, 3) validation guarantees exactly three elements.
+  return Vec3{v[0], v[1], v[2]};
+}
+
+Color toColor(const std::vector<int32_t>& c) {
+  // @range(0, 255) validation guarantees the channels fit unsigned char.
+  return Color{static_cast<unsigned char>(c[0]), static_cast<unsigned char>(c[1]),
+               static_cast<unsigned char>(c[2])};
+}
+
+LightType toLightType(const gen::LightType& lightType) {
+  switch (lightType.value()) {
+    case gen::LightType::Value::kAmbient:
+      return AMBIENT;
+    case gen::LightType::Value::kPoint:
+      return POINT;
+    case gen::LightType::Value::kDirectional:
+      return DIRECTIONAL;
+    default:
+      return UNKNOWN;  // rejected by validateTraceRequest -> InvalidSceneError
+  }
+}
+
+TraceRequest toLegacyRequest(const gen::TraceInput& input) {
+  TraceRequest request;
+  request.scene.backgroundColor = input.scene.backgroundColor.has_value()
+                                      ? toColor(*input.scene.backgroundColor)
+                                      : Color{0, 0, 0};
+  request.scene.backgroundStarProbability = input.scene.backgroundStarProbability;
+  for (const auto& sphere : input.scene.spheres) {
+    request.scene.spheres.push_back(Sphere{.center = toVec3(sphere.center),
+                                           .radius = sphere.radius,
+                                           .color = toColor(sphere.color),
+                                           .specular = sphere.specular,
+                                           .reflective = sphere.reflective});
+  }
+  for (const auto& light : input.scene.lights) {
+    request.scene.lights.push_back(Light{.lightType = toLightType(light.lightType),
+                                         .intensity = light.intensity,
+                                         .position = toVec3(light.position)});
+  }
+  request.perspective.cameraPosition = toVec3(input.perspective.cameraPosition);
+  request.perspective.cameraFocus = toVec3(input.perspective.cameraFocus);
+  request.output.width = input.output.width;
+  request.output.height = input.output.height;
+  return request;
+}
+
+}  // namespace
+
+smithy::Outcome<gen::TraceOutput> SmithyTracerHandler::Trace(const gen::TraceInput& input) {
+  TraceRequest request = toLegacyRequest(input);
+  absl::StatusOr<TraceResponse> response = tracer_service_.trace(request);
+  if (!response.ok()) {
+    const std::string message(response.status().message());
+    if (response.status().code() == absl::StatusCode::kInvalidArgument) {
+      smithy::Error error = smithy::Error::Modeled("InvalidSceneError", message);
+      error.set_detail(gen::InvalidSceneError{.message = message});
+      return error;
+    }
+    return smithy::Error::Unknown(message);  // undeclared -> non-leaking 500
+  }
+
+  gen::TraceOutput output;
+  // TraceResponse carries the PNG already base64-encoded (it predates the
+  // Blob-typed API); decode so the generated serde re-encodes it identically
+  // on the wire. Phase 4 cleanup can have TracerService hand back raw bytes.
+  output.base64_png = smithy::Blob(futility::base64::Base64::decode(response->base64_png));
+  output.width = response->width;
+  output.height = response->height;
+  return output;
+}
+
+}  // namespace portrait

--- a/domains/graphics/apis/portrait/smithy_handler.cc
+++ b/domains/graphics/apis/portrait/smithy_handler.cc
@@ -42,10 +42,12 @@ LightType toLightType(const gen::LightType& lightType) {
 
 TraceRequest toLegacyRequest(const gen::TraceInput& input) {
   TraceRequest request;
-  request.scene.backgroundColor = input.scene.backgroundColor.has_value()
-                                      ? toColor(*input.scene.backgroundColor)
-                                      : Color{0, 0, 0};
+  // Absent backgroundColor keeps Scene's own {0, 0, 0} default member value.
+  if (input.scene.backgroundColor.has_value()) {
+    request.scene.backgroundColor = toColor(*input.scene.backgroundColor);
+  }
   request.scene.backgroundStarProbability = input.scene.backgroundStarProbability;
+  request.scene.spheres.reserve(input.scene.spheres.size());
   for (const auto& sphere : input.scene.spheres) {
     request.scene.spheres.push_back(Sphere{.center = toVec3(sphere.center),
                                            .radius = sphere.radius,
@@ -53,6 +55,7 @@ TraceRequest toLegacyRequest(const gen::TraceInput& input) {
                                            .specular = sphere.specular,
                                            .reflective = sphere.reflective});
   }
+  request.scene.lights.reserve(input.scene.lights.size());
   for (const auto& light : input.scene.lights) {
     request.scene.lights.push_back(Light{.lightType = toLightType(light.lightType),
                                          .intensity = light.intensity,

--- a/domains/graphics/apis/portrait/smithy_handler.h
+++ b/domains/graphics/apis/portrait/smithy_handler.h
@@ -1,0 +1,36 @@
+#ifndef CPP_PORTRAIT_SMITHY_HANDLER_H
+#define CPP_PORTRAIT_SMITHY_HANDLER_H
+
+#include <cstdint>
+
+#include "domains/graphics/apis/portrait/tracer_service.h"
+#include "moonbase/portrait/server.h"
+#include "smithy/core/outcome.h"
+
+namespace portrait {
+
+/// Serves the generated Smithy Portrait API by wrapping TracerService
+/// (phase 2 of https://github.com/muchq/MoonBase/issues/1168): generated
+/// inputs convert to the legacy portrait types, so TracerService keeps its
+/// validation, response cache, and metrics unchanged. Cross-field rules the
+/// constraint traits can't express (camera != focus, aspect ratio, strictly
+/// positive radius) surface as the modeled InvalidSceneError.
+///
+/// Must be thread-safe: transports dispatch one handler instance across a
+/// thread pool. TracerService's cache and metrics are mutex-guarded/atomic,
+/// and each render constructs its own tracy::Tracer.
+class SmithyTracerHandler final : public moonbase::portrait::PortraitHandler {
+ public:
+  SmithyTracerHandler() = default;
+  explicit SmithyTracerHandler(uint16_t cache_size) : tracer_service_(cache_size) {}
+
+  smithy::Outcome<moonbase::portrait::TraceOutput> Trace(
+      const moonbase::portrait::TraceInput& input) override;
+
+ private:
+  TracerService tracer_service_;
+};
+
+}  // namespace portrait
+
+#endif

--- a/domains/graphics/apis/portrait/smithy_handler_test.cc
+++ b/domains/graphics/apis/portrait/smithy_handler_test.cc
@@ -1,0 +1,178 @@
+// Phase 2 handler tests (https://github.com/muchq/MoonBase/issues/1168): the
+// generated client drives SmithyTracerHandler — real ray tracing — over
+// loopback. Covers the happy path (a decodable PNG comes back), cache reuse,
+// each cross-field rule surfacing as the modeled InvalidSceneError, and a
+// concurrency hammer that regression-tests the tracy::Tracer RNG fix (run it
+// under TSan to prove the data race is gone:
+//   bazel test --copt=-fsanitize=thread --linkopt=-fsanitize=thread \
+//     //domains/graphics/apis/portrait:smithy_handler_test).
+
+#include "domains/graphics/apis/portrait/smithy_handler.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "moonbase/portrait/client.h"
+#include "moonbase/portrait/server.h"
+#include "smithy/client/config.h"
+#include "smithy/http/loopback.h"
+
+namespace {
+
+using moonbase::portrait::InvalidSceneError;
+using moonbase::portrait::Light;
+using moonbase::portrait::LightType;
+using moonbase::portrait::PortraitClient;
+using moonbase::portrait::PortraitServer;
+using moonbase::portrait::Sphere;
+using moonbase::portrait::TraceInput;
+using portrait::SmithyTracerHandler;
+
+constexpr uint8_t kPngSignature[] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+
+// A minimal valid scene: deterministic (no background stars) and cheap to
+// render (the 20x20 minimum output size).
+TraceInput ValidInput(double sphere_x = 0.0) {
+  Sphere sphere;
+  sphere.center = {sphere_x, -1.0, 3.0};
+  sphere.radius = 1.0;
+  sphere.color = {255, 0, 0};
+  sphere.specular = 500.0;
+  sphere.reflective = 0.2;
+
+  Light light;
+  light.lightType = LightType::Value::kAmbient;
+  light.intensity = 0.4;
+  light.position = {0.0, 0.0, 0.0};
+
+  TraceInput input;
+  input.scene.spheres = {sphere};
+  input.scene.lights = {light};
+  input.perspective.cameraPosition = {0.0, 0.0, -1.0};
+  input.perspective.cameraFocus = {0.0, 0.0, 0.0};
+  input.output.width = 20;
+  input.output.height = 20;
+  return input;
+}
+
+bool LooksLikePng(const smithy::Blob& blob) {
+  if (blob.size() < sizeof(kPngSignature)) return false;
+  for (size_t i = 0; i < sizeof(kPngSignature); ++i) {
+    if (blob.bytes()[i] != kPngSignature[i]) return false;
+  }
+  return true;
+}
+
+class SmithyHandlerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    server_ = std::make_unique<PortraitServer>(std::make_shared<SmithyTracerHandler>());
+    loopback_ = std::make_shared<smithy::http::Loopback>();
+    ASSERT_TRUE(loopback_->Start(server_->Handler()).ok());
+  }
+
+  PortraitClient MakeClient() {
+    smithy::ClientConfig config;
+    config.http_client = loopback_;
+    auto client = PortraitClient::Create(std::move(config));
+    EXPECT_TRUE(client.ok()) << client.error().message();
+    return std::move(*client);
+  }
+
+  std::unique_ptr<PortraitServer> server_;
+  std::shared_ptr<smithy::http::Loopback> loopback_;
+};
+
+TEST_F(SmithyHandlerTest, TracesSceneToPng) {
+  PortraitClient client = MakeClient();
+  const auto traced = client.Trace(ValidInput());
+  ASSERT_TRUE(traced.ok()) << traced.error().message();
+  EXPECT_EQ(traced->width, 20);
+  EXPECT_EQ(traced->height, 20);
+  EXPECT_TRUE(LooksLikePng(traced->base64_png)) << "blob size: " << traced->base64_png.size();
+}
+
+TEST_F(SmithyHandlerTest, IdenticalRequestsServeTheCachedRender) {
+  PortraitClient client = MakeClient();
+  const auto first = client.Trace(ValidInput());
+  ASSERT_TRUE(first.ok()) << first.error().message();
+  const auto second = client.Trace(ValidInput());
+  ASSERT_TRUE(second.ok()) << second.error().message();
+  // The second call is served from TracerService's LRU cache; either way the
+  // bytes must be identical for identical scenes.
+  EXPECT_EQ(first->base64_png, second->base64_png);
+}
+
+// The cross-field rules that constraint traits can't express: each must
+// surface as the modeled InvalidSceneError with types.cc's message.
+struct CrossFieldCase {
+  const char* name;
+  void (*mutate)(TraceInput&);
+  const char* expected_message;
+};
+
+class SmithyHandlerCrossFieldTest : public SmithyHandlerTest,
+                                    public ::testing::WithParamInterface<CrossFieldCase> {};
+
+TEST_P(SmithyHandlerCrossFieldTest, RejectsWithInvalidSceneError) {
+  TraceInput input = ValidInput();
+  GetParam().mutate(input);
+
+  PortraitClient client = MakeClient();
+  const auto denied = client.Trace(input);
+  ASSERT_FALSE(denied.ok());
+  EXPECT_EQ(denied.error().code(), "InvalidSceneError");
+  ASSERT_NE(denied.error().detail<InvalidSceneError>(), nullptr);
+  EXPECT_EQ(denied.error().detail<InvalidSceneError>()->message, GetParam().expected_message);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CrossFieldRules, SmithyHandlerCrossFieldTest,
+    ::testing::Values(
+        CrossFieldCase{"CameraAtFocus",
+                       [](TraceInput& in) { in.perspective.cameraFocus = {0.0, 0.0, -1.0}; },
+                       "Camera position and focus cannot be the same"},
+        CrossFieldCase{"ExtremeAspectRatio",
+                       [](TraceInput& in) {
+                         in.output.width = 1200;
+                         in.output.height = 20;
+                       },
+                       "Aspect ratio too extreme"},
+        CrossFieldCase{"ZeroRadius", [](TraceInput& in) { in.scene.spheres[0].radius = 0.0; },
+                       "Sphere radius must be positive"}),
+    [](const auto& info) { return info.param.name; });
+
+TEST_F(SmithyHandlerTest, ConcurrentTracesAreSafe) {
+  // Regression test for the shared tracy::Tracer RNG data race: one handler
+  // instance, many threads, a mix of fresh renders and cache hits.
+  constexpr int kThreads = 8;
+  constexpr int kRequestsPerThread = 4;
+  std::vector<std::thread> threads;
+  std::vector<int> failures(kThreads, 0);
+
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([this, t, &failures] {
+      PortraitClient client = MakeClient();
+      for (int i = 0; i < kRequestsPerThread; ++i) {
+        // Half the requests collide across threads (cache contention), half
+        // are unique to the thread (concurrent fresh renders).
+        const double x = (i % 2 == 0) ? 0.5 * i : 0.1 * (t + 1);
+        const auto traced = client.Trace(ValidInput(x));
+        if (!traced.ok() || !LooksLikePng(traced->base64_png)) ++failures[t];
+      }
+    });
+  }
+  for (auto& thread : threads) thread.join();
+
+  for (int t = 0; t < kThreads; ++t) {
+    EXPECT_EQ(failures[t], 0) << "thread " << t << " had failing traces";
+  }
+}
+
+}  // namespace

--- a/domains/graphics/apis/portrait/smithy_handler_test.cc
+++ b/domains/graphics/apis/portrait/smithy_handler_test.cc
@@ -11,13 +11,13 @@
 
 #include <gtest/gtest.h>
 
-#include <cstdint>
 #include <memory>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "domains/graphics/libs/png_plusplus/png_plusplus.h"
 #include "moonbase/portrait/client.h"
 #include "moonbase/portrait/server.h"
 #include "smithy/client/config.h"
@@ -33,8 +33,6 @@ using moonbase::portrait::PortraitServer;
 using moonbase::portrait::Sphere;
 using moonbase::portrait::TraceInput;
 using portrait::SmithyTracerHandler;
-
-constexpr uint8_t kPngSignature[] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
 
 // A minimal valid scene: deterministic (no background stars) and cheap to
 // render (the 20x20 minimum output size).
@@ -61,13 +59,7 @@ TraceInput ValidInput(double sphere_x = 0.0) {
   return input;
 }
 
-bool LooksLikePng(const smithy::Blob& blob) {
-  if (blob.size() < sizeof(kPngSignature)) return false;
-  for (size_t i = 0; i < sizeof(kPngSignature); ++i) {
-    if (blob.bytes()[i] != kPngSignature[i]) return false;
-  }
-  return true;
-}
+bool LooksLikePng(const smithy::Blob& blob) { return pngpp::isPng(blob.data(), blob.size()); }
 
 class SmithyHandlerTest : public ::testing::Test {
  protected:

--- a/domains/graphics/apis/portrait/tracer_service.cc
+++ b/domains/graphics/apis/portrait/tracer_service.cc
@@ -69,7 +69,10 @@ Image<RGB_Double> TracerService::do_trace(Scene& scene, Perspective& perspective
   auto [x, y, z] = perspective.cameraPosition;
   const tracy::Vec3 cameraPosition{x, y, z};
 
-  tracer_.drawScene(tracyScene, image, cameraPosition);
+  // tracy::Tracer holds unsynchronized RNG state, and trace() runs
+  // concurrently under thread-pool transports; each render gets its own.
+  tracy::Tracer tracer;
+  tracer.drawScene(tracyScene, image, cameraPosition);
   return image;
 }
 

--- a/domains/graphics/apis/portrait/tracer_service.h
+++ b/domains/graphics/apis/portrait/tracer_service.h
@@ -32,7 +32,6 @@ class TracerService {
   std::string imageToBase64(const image_core::Image<image_core::RGB_Double>& image);
   TraceResponse toResponse(const Output& output, std::string& base64);
 
-  tracy::Tracer tracer_;
   futility::cache::LRUCache<TraceRequest, std::string> cache_;
   futility::otel::MetricsRecorder metrics_;
 };

--- a/domains/graphics/libs/png_plusplus/png_plusplus.h
+++ b/domains/graphics/libs/png_plusplus/png_plusplus.h
@@ -473,6 +473,17 @@ class MemoryPngReader {
   size_t read_pos_;
 };
 
+// True when the buffer starts with the 8-byte PNG file signature.
+inline bool isPng(const unsigned char* data, size_t size) {
+  static constexpr unsigned char kPngSignature[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+  return size >= sizeof(kPngSignature) &&
+         std::memcmp(data, kPngSignature, sizeof(kPngSignature)) == 0;
+}
+
+inline bool isPng(const std::vector<unsigned char>& buffer) {
+  return isPng(buffer.data(), buffer.size());
+}
+
 // Convenience functions for Image<RGB_Double> conversion
 inline std::vector<unsigned char> imageToPng(const image_core::Image<image_core::RGB_Double>& image,
                                              int compression_level = -1) {

--- a/domains/graphics/libs/png_plusplus/png_plusplus_test.cc
+++ b/domains/graphics/libs/png_plusplus/png_plusplus_test.cc
@@ -472,12 +472,7 @@ TEST_F(PngPlusPlusTest, MemoryPngWriterBasicFunctionality) {
   EXPECT_EQ(writer.getWidth(), width);
   EXPECT_EQ(writer.getHeight(), height);
 
-  // Verify PNG signature (first 8 bytes should be PNG signature)
-  EXPECT_GE(buffer.size(), 8);
-  const unsigned char png_signature[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
-  for (int i = 0; i < 8; ++i) {
-    EXPECT_EQ(buffer[i], png_signature[i]) << "PNG signature mismatch at byte " << i;
-  }
+  EXPECT_TRUE(pngpp::isPng(buffer));
 }
 
 TEST_F(PngPlusPlusTest, MemoryPngReaderBasicFunctionality) {
@@ -620,13 +615,9 @@ TEST_F(PngPlusPlusTest, CompressionLevelSupport) {
   EXPECT_GT(default_compression.size(), 0);
   EXPECT_GT(best_compression.size(), 0);
 
-  // Verify PNG signatures
-  const unsigned char png_signature[] = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
-  for (int i = 0; i < 8; ++i) {
-    EXPECT_EQ(no_compression[i], png_signature[i]);
-    EXPECT_EQ(default_compression[i], png_signature[i]);
-    EXPECT_EQ(best_compression[i], png_signature[i]);
-  }
+  EXPECT_TRUE(pngpp::isPng(no_compression));
+  EXPECT_TRUE(pngpp::isPng(default_compression));
+  EXPECT_TRUE(pngpp::isPng(best_compression));
 
   // Best compression should generally produce smaller files than no compression
   // Note: For small images, overhead might make this not always true, so we just verify they're


### PR DESCRIPTION
Phase 2 of #1168: `TracerService` behind the generated `PortraitHandler`. The meerkat service keeps running unchanged — `Main.cc` switches over in Phase 3 once middleware parity (metrics bridge, rate limiter, tracing) is in place.

## What's here

- **`smithy_handler.{h,cc}`** — `SmithyTracerHandler` implements the generated `PortraitHandler` by converting generated types to the legacy `portrait::` types, so `TracerService` keeps its validation, LRU response cache, and metrics untouched:
  - The cache stays keyed by the absl-hashable legacy `TraceRequest` — the "cache re-key" contingency from the issue turned out unnecessary with the wrapper approach.
  - `absl::StatusCode::kInvalidArgument` → modeled `InvalidSceneError` with typed detail; any other status → non-leaking 500 (`Error::Unknown`).
  - The PNG is decoded from `TraceResponse`'s base64 string into the `Blob` so the generated serde re-encodes it identically on the wire (Phase 4 cleanup: have `TracerService` hand back raw bytes and drop the round-trip).
- **`tracer_service.{h,cc}` — thread-safety fix**: the shared `tracy::Tracer` member holds unsynchronized RNG state (`tracy.h:96`), which was safe under meerkat's single-threaded event loop but is a data race under thread-pool transports. Each render now constructs its own `Tracer` — it's only an RNG, trivial next to tracing an image. This also fixes the latent race for anyone driving `TracerService` concurrently today.
- **`smithy_handler_test.cc`** — generated client → generated server → **real ray tracing** over loopback:
  - Happy path renders 20×20 and asserts the PNG signature on the decoded blob.
  - Identical requests return identical bytes through the cache.
  - Cross-field rule table: camera-at-focus, extreme aspect ratio (1200×20 passes the `@range` traits but violates the 50:1 bound), and zero radius (passes `@range(0, 10000)` but must be strictly positive) — each surfaces as `InvalidSceneError` with `types.cc`'s exact message, proving the handler-level rules from the Phase 1 mapping table.
  - **Concurrency hammer**: 8 threads × 4 requests against one handler instance, mixing cache collisions and fresh renders — the regression test for the RNG fix. To prove the race is gone under TSan (not wired into CI):
    ```
    bazel test --copt=-fsanitize=thread --linkopt=-fsanitize=thread \
      //domains/graphics/apis/portrait:smithy_handler_test
    ```

## Notes for review

- With this merged, every layer of the Phase 3 cutover exists and is tested: model → validation → handler → renderer → wire. Phase 3 is middleware parity + the new `main()`.
- Local compilation isn't possible in this sandbox (egress policy blocks BCR archive fetches); validated statically against the pinned smithy-cpp source, buildifier/clang-format clean. CI compiles and runs the suites, as it did for Phases 0 and 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_