### PR TITLE
Add meerkat-parity middleware and the smithy cutover binary (phase 3)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,13 @@ build --experimental_java_classpath=bazel
 # this is weird because :protobuf hdrs glob **/*.h which includes json_util.h
 # build --features=layering_check
 
+# parse_headers compiles each header standalone to validate self-containment.
+# boost.context 1.90 (in smithy-cpp's Beast transport dep closure) ships
+# headers that reference std::result_of, removed in C++20 and absent from
+# this toolchain's libc++, so the validation can never pass for third-party
+# boost. Same third-party-headers problem as layering_check above.
+common --features=-parse_headers
+
 common --test_verbose_timeout_warnings
 common --test_output=errors
 

--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "708d78e6d1eed731ae43e1e19c4fbf5a7d50319b",
+    commit = "cfd82998f4992443bc79728a945fcdb4feeaf932",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )

--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -134,11 +134,12 @@ cc_test(
 # portrait_smithy binary runs alongside :portrait until the phase 4 cutover;
 # OCI image wiring moves over then (linux_amd64_oci_binary instantiates
 # fixed-name push/load targets, so one image per package).
+# Package-private until a second smithy-cpp service needs meerkat parity;
+# hoist to a shared platform lib at that point.
 cc_library(
     name = "smithy_middleware",
     srcs = ["smithy_middleware.cc"],
     hdrs = ["smithy_middleware.h"],
-    visibility = ["//visibility:public"],
     deps = [
         "//domains/platform/libs/futility/rate_limiter:sliding_window_rate_limiter",
         "//domains/platform/libs/meerkat:metrics_manager",
@@ -174,13 +175,13 @@ cc_binary(
         ":portrait_smithy_server",
         ":smithy_handler",
         ":smithy_middleware",
+        "//domains/platform/libs/futility/env",
         "//domains/platform/libs/futility/otel:otel_provider",
         "//domains/platform/libs/futility/rate_limiter:sliding_window_rate_limiter",
         "//domains/platform/libs/meerkat:metrics_manager",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:globals",
         "@com_google_absl//absl/log:initialize",
-        "@smithy_cpp//runtime:core",
         "@smithy_cpp//runtime:http_beast",
         "@smithy_cpp//runtime:server",
     ],

--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -130,6 +130,62 @@ cc_test(
     ],
 )
 
+# Phase 3 (#1168): meerkat-parity middleware and the cutover binary. The
+# portrait_smithy binary runs alongside :portrait until the phase 4 cutover;
+# OCI image wiring moves over then (linux_amd64_oci_binary instantiates
+# fixed-name push/load targets, so one image per package).
+cc_library(
+    name = "smithy_middleware",
+    srcs = ["smithy_middleware.cc"],
+    hdrs = ["smithy_middleware.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//domains/platform/libs/futility/rate_limiter:sliding_window_rate_limiter",
+        "//domains/platform/libs/meerkat:metrics_manager",
+        "@com_google_absl//absl/log",
+        "@smithy_cpp//runtime:http",
+        "@smithy_cpp//runtime:server",
+    ],
+)
+
+cc_test(
+    name = "smithy_middleware_test",
+    size = "small",
+    srcs = ["smithy_middleware_test.cc"],
+    deps = [
+        ":portrait_smithy_client",
+        ":portrait_smithy_server",
+        ":smithy_middleware",
+        "//domains/platform/libs/futility/rate_limiter:sliding_window_rate_limiter",
+        "@googletest//:gtest_main",
+        "@smithy_cpp//runtime:client",
+        "@smithy_cpp//runtime:core",
+        "@smithy_cpp//runtime:http",
+        "@smithy_cpp//runtime:http_beast",
+        "@smithy_cpp//runtime:server",
+    ],
+)
+
+cc_binary(
+    name = "portrait_smithy",
+    srcs = ["portrait_smithy_main.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":portrait_smithy_server",
+        ":smithy_handler",
+        ":smithy_middleware",
+        "//domains/platform/libs/futility/otel:otel_provider",
+        "//domains/platform/libs/futility/rate_limiter:sliding_window_rate_limiter",
+        "//domains/platform/libs/meerkat:metrics_manager",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:globals",
+        "@com_google_absl//absl/log:initialize",
+        "@smithy_cpp//runtime:core",
+        "@smithy_cpp//runtime:http_beast",
+        "@smithy_cpp//runtime:server",
+    ],
+)
+
 cc_binary(
     name = "portrait",
     srcs = ["Main.cc"],

--- a/domains/graphics/apis/portrait/portrait_smithy_main.cc
+++ b/domains/graphics/apis/portrait/portrait_smithy_main.cc
@@ -10,7 +10,6 @@
 
 #include <chrono>
 #include <csignal>
-#include <cstdlib>
 #include <memory>
 #include <string>
 
@@ -19,21 +18,13 @@
 #include "absl/log/log.h"
 #include "domains/graphics/apis/portrait/smithy_handler.h"
 #include "domains/graphics/apis/portrait/smithy_middleware.h"
+#include "domains/platform/libs/futility/env/env.h"
 #include "domains/platform/libs/futility/otel/otel_provider.h"
 #include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
 #include "domains/platform/libs/meerkat/metrics_manager.h"
 #include "moonbase/portrait/server.h"
 #include "smithy/http/beast_transport.h"
 #include "smithy/server/middleware.h"
-
-namespace {
-
-int read_port(int default_port) {
-  const char* env = std::getenv("PORT");
-  return env != nullptr ? std::atoi(env) : default_port;
-}
-
-}  // namespace
 
 int main() {
   absl::InitializeLog();
@@ -53,8 +44,8 @@ int main() {
 
   moonbase::portrait::PortraitServer server(std::make_shared<portrait::SmithyTracerHandler>());
 
-  auto metrics = std::make_shared<portrait::MeerkatMetricsSink>(
-      std::make_shared<meerkat::HttpMetricsManager>("portrait"));
+  auto metrics =
+      portrait::MakeMeerkatMetricsSink(std::make_shared<meerkat::HttpMetricsManager>("portrait"));
 
   // Same limiter config as the meerkat Main.cc.
   futility::rate_limiter::SlidingWindowRateLimiterConfig limiter_config{
@@ -78,7 +69,7 @@ int main() {
 
   smithy::http::BeastServerTransport::Options options;
   options.address = "0.0.0.0";
-  options.port = read_port(8080);
+  options.port = futility::env::ReadPort(8080);
   // Trace scenes are small JSON (at most 10 spheres); the 64 MiB transport
   // default is far more than this service ever needs.
   options.max_body_bytes = std::size_t{1} * 1024 * 1024;

--- a/domains/graphics/apis/portrait/portrait_smithy_main.cc
+++ b/domains/graphics/apis/portrait/portrait_smithy_main.cc
@@ -1,0 +1,104 @@
+// Phase 3 cutover binary (https://github.com/muchq/MoonBase/issues/1168):
+// the generated Smithy Portrait API on the Beast transport with
+// meerkat-parity middleware. Runs alongside the meerkat `portrait` binary
+// until the phase 4 cutover; OCI image wiring moves over then too.
+//
+//   bazel run //domains/graphics/apis/portrait:portrait_smithy
+//   curl localhost:8080/portrait/v1/trace -H 'content-type: application/json' -d @scene.json
+//   curl localhost:8080/health
+//   kill -TERM <pid>   # drains in-flight requests, then exits 0
+
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+#include "absl/log/globals.h"
+#include "absl/log/initialize.h"
+#include "absl/log/log.h"
+#include "domains/graphics/apis/portrait/smithy_handler.h"
+#include "domains/graphics/apis/portrait/smithy_middleware.h"
+#include "domains/platform/libs/futility/otel/otel_provider.h"
+#include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
+#include "domains/platform/libs/meerkat/metrics_manager.h"
+#include "moonbase/portrait/server.h"
+#include "smithy/http/beast_transport.h"
+#include "smithy/server/middleware.h"
+
+namespace {
+
+int read_port(int default_port) {
+  const char* env = std::getenv("PORT");
+  return env != nullptr ? std::atoi(env) : default_port;
+}
+
+}  // namespace
+
+int main() {
+  absl::InitializeLog();
+  absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+
+  // Same OTel setup as the meerkat binary: OTLP push, service "portrait".
+  futility::otel::OtelConfig otel_config{.service_name = "portrait", .service_version = "1.0.0"};
+  futility::otel::OtelProvider otel_provider(otel_config);
+
+  // Block shutdown signals before the transport spawns its thread pool, so
+  // they only reach the sigwait below.
+  sigset_t shutdown_signals;
+  sigemptyset(&shutdown_signals);
+  sigaddset(&shutdown_signals, SIGINT);
+  sigaddset(&shutdown_signals, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &shutdown_signals, nullptr);
+
+  moonbase::portrait::PortraitServer server(std::make_shared<portrait::SmithyTracerHandler>());
+
+  auto metrics = std::make_shared<portrait::MeerkatMetricsSink>(
+      std::make_shared<meerkat::HttpMetricsManager>("portrait"));
+
+  // Same limiter config as the meerkat Main.cc.
+  futility::rate_limiter::SlidingWindowRateLimiterConfig limiter_config{
+      .max_requests_per_key = 20,
+      .window_size = std::chrono::seconds(60),
+      .ttl = std::chrono::minutes(5),
+      .cleanup_interval = std::chrono::seconds(30),
+      .max_keys = 1000};
+  auto rate_limiter =
+      std::make_shared<futility::rate_limiter::SlidingWindowRateLimiter<std::string>>(
+          limiter_config);
+
+  // Observability outermost: health probes and 429s are counted and logged,
+  // as they were under meerkat's interceptors. Health sits before the guard
+  // so probes are never rate limited — the one deliberate ordering change
+  // from meerkat, where /health shared the empty X-Forwarded-For bucket.
+  auto handler = smithy::server::Chain(
+      {portrait::MeerkatParityObservability(metrics), smithy::server::HealthEndpoint("/health"),
+       portrait::RateLimitByForwardedFor(rate_limiter, std::chrono::seconds(60))},
+      server.Handler());
+
+  smithy::http::BeastServerTransport::Options options;
+  options.address = "0.0.0.0";
+  options.port = read_port(8080);
+  // Trace scenes are small JSON (at most 10 spheres); the 64 MiB transport
+  // default is far more than this service ever needs.
+  options.max_body_bytes = std::size_t{1} * 1024 * 1024;
+  smithy::http::BeastServerTransport transport(options);
+
+  smithy::Outcome<smithy::Unit> started = transport.Start(handler);
+  if (!started.ok()) {
+    LOG(ERROR) << "Failed to start server on " << options.address << ":" << options.port << ": "
+               << started.error().message();
+    return 1;
+  }
+
+  LOG(INFO) << "Portrait (smithy) running on http://" << options.address << ":" << transport.port();
+  LOG(INFO) << "Serving:";
+  LOG(INFO) << "  GET  http://localhost:" << transport.port() << "/health";
+  LOG(INFO) << "  POST http://localhost:" << transport.port() << "/portrait/v1/trace";
+
+  int signal_number = 0;
+  sigwait(&shutdown_signals, &signal_number);
+  LOG(INFO) << "Signal " << signal_number << " received; draining";
+  transport.Stop();
+  return 0;
+}

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -1,13 +1,33 @@
 #include "domains/graphics/apis/portrait/smithy_middleware.h"
 
+#include <chrono>
 #include <climits>
 #include <random>
+#include <utility>
 
 #include "absl/log/log.h"
+#include "domains/platform/libs/meerkat/metrics_manager.h"
 #include "smithy/http/transport.h"
 
 namespace portrait {
 namespace {
+
+class MeerkatMetricsSink final : public HttpMetricsSink {
+ public:
+  explicit MeerkatMetricsSink(std::shared_ptr<meerkat::HttpMetricsManager> metrics)
+      : metrics_(std::move(metrics)) {}
+
+  void RecordRequestStart(const std::string& route, const std::string& method) override {
+    metrics_->RecordRequestStart(route, method);
+  }
+  void RecordRequestComplete(const std::string& route, const std::string& method, int status_code,
+                             std::chrono::microseconds duration) override {
+    metrics_->RecordRequestComplete(route, method, status_code, duration);
+  }
+
+ private:
+  std::shared_ptr<meerkat::HttpMetricsManager> metrics_;
+};
 
 std::string RouteOf(const std::string& target) { return target.substr(0, target.find('?')); }
 
@@ -52,6 +72,11 @@ smithy::server::Middleware TraceIdAndAccessLog() {
 }
 
 }  // namespace
+
+std::shared_ptr<HttpMetricsSink> MakeMeerkatMetricsSink(
+    std::shared_ptr<meerkat::HttpMetricsManager> metrics) {
+  return std::make_shared<MeerkatMetricsSink>(std::move(metrics));
+}
 
 smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetricsSink> metrics) {
   return [metrics = std::move(metrics)](smithy::http::RequestHandler next) {

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -23,32 +23,50 @@ std::string TraceIdFor(const smithy::http::HttpRequest& request) {
   return std::to_string(dis(gen));
 }
 
-}  // namespace
-
-smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetricsSink> metrics) {
-  return [metrics = std::move(metrics)](smithy::http::RequestHandler next) {
-    return [metrics, next = std::move(next)](
+// x-trace-id propagation and meerkat's access-log line. Kept separate from
+// Observe because the log needs raw header access (X-Forwarded-For, inbound
+// x-trace-id), which Observe deliberately doesn't expose; it measures its
+// own duration for the log line only.
+smithy::server::Middleware TraceIdAndAccessLog() {
+  return [](smithy::http::RequestHandler next) {
+    return [next = std::move(next)](
                const smithy::http::HttpRequest& request) -> smithy::http::HttpResponse {
       const auto start = std::chrono::steady_clock::now();
-      const std::string route = RouteOf(request.target);
-      metrics->RecordRequestStart(route, request.method);
       const std::string trace_id = TraceIdFor(request);
 
       smithy::http::HttpResponse response = next(request);
 
-      const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+      const auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
           std::chrono::steady_clock::now() - start);
-      metrics->RecordRequestComplete(route, request.method, response.status, duration);
       if (!response.headers.Has("x-trace-id")) {
         response.headers.Set("x-trace-id", trace_id);
       }
       LOG(INFO) << "[" << request.method << " " << request.target
                 << "]: X-Forwarded-For=" << request.headers.Get("X-Forwarded-For").value_or("")
                 << " trace_id=" << trace_id << " status=" << response.status
-                << " res.body.bytes=" << response.body.size() << " duration_ms="
-                << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+                << " res.body.bytes=" << response.body.size()
+                << " duration_ms=" << duration_ms.count();
       return response;
     };
+  };
+}
+
+}  // namespace
+
+smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetricsSink> metrics) {
+  return [metrics = std::move(metrics)](smithy::http::RequestHandler next) {
+    // Metrics ride the runtime's Observe: microsecond durations (as of
+    // smithy-cpp cfd8299) and start/complete guaranteed to pair even when
+    // dispatch throws.
+    smithy::server::Middleware observe = smithy::server::Observe(
+        [metrics](const smithy::server::RequestObservation& observation) {
+          metrics->RecordRequestComplete(RouteOf(observation.target), observation.method,
+                                         observation.status, observation.duration);
+        },
+        [metrics](const smithy::server::RequestStart& start) {
+          metrics->RecordRequestStart(RouteOf(start.target), start.method);
+        });
+    return observe(TraceIdAndAccessLog()(std::move(next)));
   };
 }
 

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -1,0 +1,65 @@
+#include "domains/graphics/apis/portrait/smithy_middleware.h"
+
+#include <climits>
+#include <random>
+
+#include "absl/log/log.h"
+#include "smithy/http/transport.h"
+
+namespace portrait {
+namespace {
+
+std::string RouteOf(const std::string& target) { return target.substr(0, target.find('?')); }
+
+std::string TraceIdFor(const smithy::http::HttpRequest& request) {
+  if (const auto inbound = request.headers.Get("x-trace-id");
+      inbound.has_value() && !inbound->empty()) {
+    return *inbound;
+  }
+  // Same id shape as meerkat's interceptors::request::trace_id().
+  static std::random_device rd;
+  thread_local std::mt19937_64 gen(rd());
+  std::uniform_int_distribution<long> dis(1, LONG_MAX);
+  return std::to_string(dis(gen));
+}
+
+}  // namespace
+
+smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetricsSink> metrics) {
+  return [metrics = std::move(metrics)](smithy::http::RequestHandler next) {
+    return [metrics, next = std::move(next)](
+               const smithy::http::HttpRequest& request) -> smithy::http::HttpResponse {
+      const auto start = std::chrono::steady_clock::now();
+      const std::string route = RouteOf(request.target);
+      metrics->RecordRequestStart(route, request.method);
+      const std::string trace_id = TraceIdFor(request);
+
+      smithy::http::HttpResponse response = next(request);
+
+      const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now() - start);
+      metrics->RecordRequestComplete(route, request.method, response.status, duration);
+      if (!response.headers.Has("x-trace-id")) {
+        response.headers.Set("x-trace-id", trace_id);
+      }
+      LOG(INFO) << "[" << request.method << " " << request.target
+                << "]: X-Forwarded-For=" << request.headers.Get("X-Forwarded-For").value_or("")
+                << " trace_id=" << trace_id << " status=" << response.status
+                << " res.body.bytes=" << response.body.size() << " duration_ms="
+                << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+      return response;
+    };
+  };
+}
+
+smithy::server::Middleware RateLimitByForwardedFor(
+    std::shared_ptr<futility::rate_limiter::SlidingWindowRateLimiter<std::string>> limiter,
+    std::chrono::seconds retry_after) {
+  return smithy::server::Guard(
+      [limiter = std::move(limiter)](const smithy::http::HttpRequest& request) {
+        return limiter->allow(request.headers.Get("X-Forwarded-For").value_or(""));
+      },
+      smithy::server::TooManyRequests(retry_after));
+}
+
+}  // namespace portrait

--- a/domains/graphics/apis/portrait/smithy_middleware.h
+++ b/domains/graphics/apis/portrait/smithy_middleware.h
@@ -4,17 +4,19 @@
 #include <chrono>
 #include <memory>
 #include <string>
-#include <utility>
 
 #include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
-#include "domains/platform/libs/meerkat/metrics_manager.h"
 #include "smithy/server/middleware.h"
+
+namespace meerkat {
+class HttpMetricsManager;
+}  // namespace meerkat
 
 namespace portrait {
 
 /// The two calls meerkat::HttpMetricsManager exposes, as a virtual seam so
-/// tests can observe middleware invocations. MeerkatMetricsSink is the
-/// production implementation.
+/// tests can observe middleware invocations. MakeMeerkatMetricsSink builds
+/// the production implementation.
 class HttpMetricsSink {
  public:
   virtual ~HttpMetricsSink() = default;
@@ -23,27 +25,15 @@ class HttpMetricsSink {
                                      int status_code, std::chrono::microseconds duration) = 0;
 };
 
-/// Forwards to meerkat::HttpMetricsManager, so the exported instrument names
-/// and labels (http_server_requests, http_server_requests_active_gauge,
+/// A sink forwarding to meerkat::HttpMetricsManager, so the exported
+/// instrument names and labels (http_server_requests,
+/// http_server_requests_active_gauge,
 /// http_server_request_duration_microseconds, http_server_requests_success /
 /// _failure) stay identical to the meerkat service and existing dashboards
-/// keep working across the migration.
-class MeerkatMetricsSink final : public HttpMetricsSink {
- public:
-  explicit MeerkatMetricsSink(std::shared_ptr<meerkat::HttpMetricsManager> metrics)
-      : metrics_(std::move(metrics)) {}
-
-  void RecordRequestStart(const std::string& route, const std::string& method) override {
-    metrics_->RecordRequestStart(route, method);
-  }
-  void RecordRequestComplete(const std::string& route, const std::string& method, int status_code,
-                             std::chrono::microseconds duration) override {
-    metrics_->RecordRequestComplete(route, method, status_code, duration);
-  }
-
- private:
-  std::shared_ptr<meerkat::HttpMetricsManager> metrics_;
-};
+/// keep working across the migration. Defined in the .cc so only the
+/// production wiring compiles against meerkat.
+std::shared_ptr<HttpMetricsSink> MakeMeerkatMetricsSink(
+    std::shared_ptr<meerkat::HttpMetricsManager> metrics);
 
 /// Meerkat-parity observability, composed outermost so health probes and
 /// rate-limited requests are observed exactly as meerkat's interceptors saw

--- a/domains/graphics/apis/portrait/smithy_middleware.h
+++ b/domains/graphics/apis/portrait/smithy_middleware.h
@@ -1,0 +1,72 @@
+#ifndef CPP_PORTRAIT_SMITHY_MIDDLEWARE_H
+#define CPP_PORTRAIT_SMITHY_MIDDLEWARE_H
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
+#include "domains/platform/libs/meerkat/metrics_manager.h"
+#include "smithy/server/middleware.h"
+
+namespace portrait {
+
+/// The two calls meerkat::HttpMetricsManager exposes, as a virtual seam so
+/// tests can observe middleware invocations. MeerkatMetricsSink is the
+/// production implementation.
+class HttpMetricsSink {
+ public:
+  virtual ~HttpMetricsSink() = default;
+  virtual void RecordRequestStart(const std::string& route, const std::string& method) = 0;
+  virtual void RecordRequestComplete(const std::string& route, const std::string& method,
+                                     int status_code, std::chrono::microseconds duration) = 0;
+};
+
+/// Forwards to meerkat::HttpMetricsManager, so the exported instrument names
+/// and labels (http_server_requests, http_server_requests_active_gauge,
+/// http_server_request_duration_microseconds, http_server_requests_success /
+/// _failure) stay identical to the meerkat service and existing dashboards
+/// keep working across the migration.
+class MeerkatMetricsSink final : public HttpMetricsSink {
+ public:
+  explicit MeerkatMetricsSink(std::shared_ptr<meerkat::HttpMetricsManager> metrics)
+      : metrics_(std::move(metrics)) {}
+
+  void RecordRequestStart(const std::string& route, const std::string& method) override {
+    metrics_->RecordRequestStart(route, method);
+  }
+  void RecordRequestComplete(const std::string& route, const std::string& method, int status_code,
+                             std::chrono::microseconds duration) override {
+    metrics_->RecordRequestComplete(route, method, status_code, duration);
+  }
+
+ private:
+  std::shared_ptr<meerkat::HttpMetricsManager> metrics_;
+};
+
+/// Meerkat-parity observability, composed outermost so health probes and
+/// rate-limited requests are observed exactly as meerkat's interceptors saw
+/// them:
+///   - metrics start/complete with route (path sans query string) and method
+///     labels, microsecond durations
+///   - x-trace-id propagation: an inbound header is reused, else a random
+///     positive long is generated; set on the response unless the handler
+///     already set one
+///   - meerkat's access-log line, byte-for-byte:
+///     [METHOD URI]: X-Forwarded-For=<ip> trace_id=<id> status=<code>
+///     res.body.bytes=<n> duration_ms=<ms>
+smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetricsSink> metrics);
+
+/// Per-client admission control keyed on X-Forwarded-For (clients without
+/// the header share the empty-string bucket, as under meerkat), rejecting
+/// with 429 {"error":"Too many requests"} plus Retry-After. Compose inside
+/// MeerkatParityObservability (so 429s are counted) and after HealthEndpoint
+/// (so probes are never rate limited).
+smithy::server::Middleware RateLimitByForwardedFor(
+    std::shared_ptr<futility::rate_limiter::SlidingWindowRateLimiter<std::string>> limiter,
+    std::chrono::seconds retry_after);
+
+}  // namespace portrait
+
+#endif

--- a/domains/graphics/apis/portrait/smithy_middleware_test.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware_test.cc
@@ -1,0 +1,282 @@
+// Phase 3 middleware tests (https://github.com/muchq/MoonBase/issues/1168):
+// the production middleware chain — meerkat-parity observability, health,
+// X-Forwarded-For rate limiting — composed around the generated server,
+// driven over loopback plus one pass over the real Beast socket transport.
+
+#include "domains/graphics/apis/portrait/smithy_middleware.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
+#include "moonbase/portrait/client.h"
+#include "moonbase/portrait/server.h"
+#include "smithy/client/config.h"
+#include "smithy/core/blob.h"
+#include "smithy/http/beast_transport.h"
+#include "smithy/http/loopback.h"
+#include "smithy/http/socket_transport.h"
+#include "smithy/server/middleware.h"
+
+namespace {
+
+using futility::rate_limiter::SlidingWindowRateLimiter;
+using futility::rate_limiter::SlidingWindowRateLimiterConfig;
+using moonbase::portrait::PortraitClient;
+using moonbase::portrait::PortraitHandler;
+using moonbase::portrait::PortraitServer;
+using moonbase::portrait::TraceInput;
+using moonbase::portrait::TraceOutput;
+
+constexpr char kValidTraceBody[] = R"({
+  "scene": {
+    "spheres": [
+      {"center": [0.0, -1.0, 3.0], "radius": 1.0, "color": [255, 0, 0],
+       "specular": 500.0, "reflective": 0.2}
+    ]
+  },
+  "perspective": {"cameraPosition": [0.0, 0.0, -1.0], "cameraFocus": [0.0, 0.0, 0.0]},
+  "output": {"width": 20, "height": 20}
+})";
+
+// No rendering here — middleware behavior is the subject under test.
+class StubHandler final : public PortraitHandler {
+ public:
+  smithy::Outcome<TraceOutput> Trace(const TraceInput& input) override {
+    TraceOutput output;
+    output.base64_png = smithy::Blob::FromString("png");
+    output.width = input.output.width;
+    output.height = input.output.height;
+    return output;
+  }
+};
+
+struct StartCall {
+  std::string route;
+  std::string method;
+};
+
+struct CompleteCall {
+  std::string route;
+  std::string method;
+  int status;
+  std::chrono::microseconds duration;
+};
+
+class RecordingSink final : public portrait::HttpMetricsSink {
+ public:
+  void RecordRequestStart(const std::string& route, const std::string& method) override {
+    const std::lock_guard<std::mutex> lock(mu_);
+    starts_.push_back({route, method});
+  }
+  void RecordRequestComplete(const std::string& route, const std::string& method, int status_code,
+                             std::chrono::microseconds duration) override {
+    const std::lock_guard<std::mutex> lock(mu_);
+    completes_.push_back({route, method, status_code, duration});
+  }
+
+  std::vector<StartCall> starts() {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return starts_;
+  }
+  std::vector<CompleteCall> completes() {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return completes_;
+  }
+
+ private:
+  std::mutex mu_;
+  std::vector<StartCall> starts_;
+  std::vector<CompleteCall> completes_;
+};
+
+// The production chain shape from portrait_smithy_main.cc, with a small
+// rate-limit budget so tests can exhaust it quickly.
+class SmithyMiddlewareTest : public ::testing::Test {
+ protected:
+  static constexpr int kMaxRequestsPerKey = 3;
+
+  void SetUp() override {
+    sink_ = std::make_shared<RecordingSink>();
+    SlidingWindowRateLimiterConfig config{.max_requests_per_key = kMaxRequestsPerKey,
+                                          .window_size = std::chrono::seconds(60),
+                                          .ttl = std::chrono::minutes(5),
+                                          .cleanup_interval = std::chrono::seconds(30),
+                                          .max_keys = 100};
+    limiter_ = std::make_shared<SlidingWindowRateLimiter<std::string>>(config);
+    server_ = std::make_unique<PortraitServer>(std::make_shared<StubHandler>());
+    handler_ = smithy::server::Chain(
+        {portrait::MeerkatParityObservability(sink_), smithy::server::HealthEndpoint("/health"),
+         portrait::RateLimitByForwardedFor(limiter_, std::chrono::seconds(60))},
+        server_->Handler());
+    loopback_ = std::make_shared<smithy::http::Loopback>();
+    ASSERT_TRUE(loopback_->Start(handler_).ok());
+  }
+
+  smithy::http::HttpResponse Send(
+      const std::string& method, const std::string& target, const std::string& body = "",
+      const std::vector<std::pair<std::string, std::string>>& headers = {}) {
+    smithy::http::HttpRequest request;
+    request.method = method;
+    request.target = target;
+    if (!body.empty()) {
+      request.headers.Set("content-type", "application/json");
+      request.body = body;
+    }
+    for (const auto& [name, value] : headers) {
+      request.headers.Set(name, value);
+    }
+    auto response = loopback_->Send(request);
+    if (!response.ok()) {
+      ADD_FAILURE() << "loopback send failed: " << response.error().message();
+      return {};
+    }
+    return *response;
+  }
+
+  std::shared_ptr<RecordingSink> sink_;
+  std::shared_ptr<SlidingWindowRateLimiter<std::string>> limiter_;
+  std::unique_ptr<PortraitServer> server_;
+  smithy::http::RequestHandler handler_;
+  std::shared_ptr<smithy::http::Loopback> loopback_;
+};
+
+TEST_F(SmithyMiddlewareTest, HealthServedAndObserved) {
+  const auto response = Send("GET", "/health");
+  EXPECT_EQ(response.status, 200);
+  EXPECT_EQ(response.body, R"({"status":"healthy"})");
+
+  // Meerkat's metrics interceptor counted health probes; parity keeps that.
+  const auto starts = sink_->starts();
+  const auto completes = sink_->completes();
+  ASSERT_EQ(starts.size(), 1u);
+  EXPECT_EQ(starts[0].route, "/health");
+  EXPECT_EQ(starts[0].method, "GET");
+  ASSERT_EQ(completes.size(), 1u);
+  EXPECT_EQ(completes[0].status, 200);
+}
+
+TEST_F(SmithyMiddlewareTest, TraceObservedWithRouteMethodAndStatus) {
+  const auto response = Send("POST", "/portrait/v1/trace", kValidTraceBody);
+  ASSERT_EQ(response.status, 200) << response.body;
+
+  const auto completes = sink_->completes();
+  ASSERT_EQ(completes.size(), 1u);
+  EXPECT_EQ(completes[0].route, "/portrait/v1/trace");
+  EXPECT_EQ(completes[0].method, "POST");
+  EXPECT_EQ(completes[0].status, 200);
+  EXPECT_GE(completes[0].duration.count(), 0);
+}
+
+TEST_F(SmithyMiddlewareTest, QueryStringStrippedFromRouteLabel) {
+  Send("GET", "/health?probe=1");
+  const auto starts = sink_->starts();
+  ASSERT_EQ(starts.size(), 1u);
+  EXPECT_EQ(starts[0].route, "/health");
+}
+
+TEST_F(SmithyMiddlewareTest, RateLimitsPerForwardedForKeyWithRetryAfter) {
+  const std::vector<std::pair<std::string, std::string>> alice = {{"X-Forwarded-For", "1.2.3.4"}};
+  for (int i = 0; i < kMaxRequestsPerKey; ++i) {
+    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, alice).status, 200);
+  }
+  const auto limited = Send("POST", "/portrait/v1/trace", kValidTraceBody, alice);
+  EXPECT_EQ(limited.status, 429);
+  EXPECT_EQ(limited.headers.Get("retry-after").value_or(""), "60");
+  EXPECT_NE(limited.body.find("Too many requests"), std::string::npos);
+
+  // A different client key is still admitted.
+  const std::vector<std::pair<std::string, std::string>> bob = {{"X-Forwarded-For", "5.6.7.8"}};
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, bob).status, 200);
+
+  // Rate-limited requests are observed (meerkat counted 429s with
+  // error_type=rate_limited; the sink sees the status that drives it).
+  bool saw_429 = false;
+  for (const auto& complete : sink_->completes()) {
+    if (complete.status == 429) saw_429 = true;
+  }
+  EXPECT_TRUE(saw_429);
+}
+
+TEST_F(SmithyMiddlewareTest, HealthIsNeverRateLimited) {
+  const std::vector<std::pair<std::string, std::string>> key = {{"X-Forwarded-For", "9.9.9.9"}};
+  for (int i = 0; i < kMaxRequestsPerKey; ++i) {
+    Send("POST", "/portrait/v1/trace", kValidTraceBody, key);
+  }
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, key).status, 429);
+  // Deliberate change from meerkat: probes sit before the guard in the chain.
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(Send("GET", "/health", "", key).status, 200);
+  }
+}
+
+TEST_F(SmithyMiddlewareTest, InboundTraceIdIsEchoed) {
+  const auto response =
+      Send("POST", "/portrait/v1/trace", kValidTraceBody, {{"x-trace-id", "abc123"}});
+  EXPECT_EQ(response.headers.Get("x-trace-id").value_or(""), "abc123");
+}
+
+TEST_F(SmithyMiddlewareTest, MissingTraceIdIsGenerated) {
+  const auto response = Send("POST", "/portrait/v1/trace", kValidTraceBody);
+  const std::string trace_id = response.headers.Get("x-trace-id").value_or("");
+  ASSERT_FALSE(trace_id.empty());
+  // Meerkat generates a random positive long rendered as digits.
+  EXPECT_EQ(trace_id.find_first_not_of("0123456789"), std::string::npos);
+}
+
+// One pass over the real Beast transport, shaped like portrait_smithy_main:
+// the generated client round-trips through a real socket, and the shrunken
+// body limit rejects oversized payloads at the transport.
+TEST_F(SmithyMiddlewareTest, BeastTransportServesChainAndEnforcesBodyLimit) {
+  smithy::http::BeastServerTransport::Options options;
+  options.address = "127.0.0.1";
+  options.port = 0;
+  options.max_body_bytes = 2048;
+  smithy::http::BeastServerTransport transport(options);
+  ASSERT_TRUE(transport.Start(handler_).ok());
+
+  smithy::ClientConfig config;
+  config.endpoint = "http://127.0.0.1:" + std::to_string(transport.port());
+  auto created = PortraitClient::Create(std::move(config));
+  ASSERT_TRUE(created.ok()) << created.error().message();
+  PortraitClient client = std::move(*created);
+
+  TraceInput input;
+  moonbase::portrait::Sphere sphere;
+  sphere.center = {0.0, -1.0, 3.0};
+  sphere.radius = 1.0;
+  sphere.color = {255, 0, 0};
+  sphere.specular = 500.0;
+  sphere.reflective = 0.2;
+  input.scene.spheres = {sphere};
+  input.perspective.cameraPosition = {0.0, 0.0, -1.0};
+  input.perspective.cameraFocus = {0.0, 0.0, 0.0};
+  input.output.width = 20;
+  input.output.height = 20;
+  const auto traced = client.Trace(input);
+  ASSERT_TRUE(traced.ok()) << traced.error().message();
+  EXPECT_EQ(traced->width, 20);
+
+  // An oversized body is rejected by the transport (Beast answers 413)
+  // before it can reach the router.
+  smithy::http::SocketHttpClient raw("127.0.0.1", transport.port());
+  smithy::http::HttpRequest oversized;
+  oversized.method = "POST";
+  oversized.target = "/portrait/v1/trace";
+  oversized.headers.Set("content-type", "application/json");
+  oversized.body = std::string(4096, 'x');
+  const auto rejected = raw.Send(oversized);
+  ASSERT_TRUE(rejected.ok()) << rejected.error().message();
+  EXPECT_GE(rejected->status, 400);
+  EXPECT_NE(rejected->status, 200);
+
+  transport.Stop();
+}
+
+}  // namespace

--- a/domains/graphics/apis/portrait/smithy_middleware_test.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware_test.cc
@@ -263,8 +263,11 @@ TEST_F(SmithyMiddlewareTest, BeastTransportServesChainAndEnforcesBodyLimit) {
   ASSERT_TRUE(traced.ok()) << traced.error().message();
   EXPECT_EQ(traced->width, 20);
 
-  // An oversized body is rejected by the transport (Beast answers 413)
-  // before it can reach the router.
+  // An oversized body is rejected at the transport before it can reach the
+  // router: depending on timing the client sees a clean 413 or an aborted
+  // connection (Beast may close while the client is still sending). Either
+  // way the request must never reach the middleware chain.
+  const auto completes_before = sink_->completes().size();
   smithy::http::SocketHttpClient raw("127.0.0.1", transport.port());
   smithy::http::HttpRequest oversized;
   oversized.method = "POST";
@@ -272,9 +275,10 @@ TEST_F(SmithyMiddlewareTest, BeastTransportServesChainAndEnforcesBodyLimit) {
   oversized.headers.Set("content-type", "application/json");
   oversized.body = std::string(4096, 'x');
   const auto rejected = raw.Send(oversized);
-  ASSERT_TRUE(rejected.ok()) << rejected.error().message();
-  EXPECT_GE(rejected->status, 400);
-  EXPECT_NE(rejected->status, 200);
+  if (rejected.ok()) {
+    EXPECT_GE(rejected->status, 400);
+  }
+  EXPECT_EQ(sink_->completes().size(), completes_before);
 
   transport.Stop();
 }

--- a/domains/platform/libs/futility/env/BUILD.bazel
+++ b/domains/platform/libs/futility/env/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "env",
+    hdrs = ["env.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "env_test",
+    size = "small",
+    srcs = ["env_test.cc"],
+    deps = [
+        ":env",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/domains/platform/libs/futility/env/env.h
+++ b/domains/platform/libs/futility/env/env.h
@@ -1,0 +1,17 @@
+#ifndef DOMAINS_PLATFORM_LIBS_FUTILITY_ENV_ENV_H
+#define DOMAINS_PLATFORM_LIBS_FUTILITY_ENV_ENV_H
+
+#include <cstdlib>
+
+namespace futility::env {
+
+/// The port from the PORT environment variable, or default_port when unset.
+/// A non-numeric PORT yields 0, matching meerkat::read_port's behavior.
+inline int ReadPort(int default_port) {
+  const char* port = std::getenv("PORT");
+  return port != nullptr ? std::atoi(port) : default_port;
+}
+
+}  // namespace futility::env
+
+#endif

--- a/domains/platform/libs/futility/env/env_test.cc
+++ b/domains/platform/libs/futility/env/env_test.cc
@@ -1,0 +1,20 @@
+#include "domains/platform/libs/futility/env/env.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+namespace {
+
+TEST(ReadPortTest, DefaultWhenUnset) {
+  unsetenv("PORT");
+  EXPECT_EQ(futility::env::ReadPort(8080), 8080);
+}
+
+TEST(ReadPortTest, ReadsPortFromEnvironment) {
+  setenv("PORT", "9000", 1);
+  EXPECT_EQ(futility::env::ReadPort(8080), 9000);
+  unsetenv("PORT");
+}
+
+}  // namespace

--- a/domains/platform/libs/meerkat/BUILD.bazel
+++ b/domains/platform/libs/meerkat/BUILD.bazel
@@ -80,7 +80,7 @@ cc_test(
     size = "small",
     srcs = ["metrics_manager_test.cc"],
     deps = [
-        ":meerkat",
+        ":metrics_manager",
         "@googletest//:gtest_main",
     ],
 )

--- a/domains/platform/libs/meerkat/BUILD.bazel
+++ b/domains/platform/libs/meerkat/BUILD.bazel
@@ -1,17 +1,25 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
+# The HTTP metrics instruments stand alone so services on other transports
+# (e.g. portrait's smithy-cpp server) can emit the exact same instrument
+# names and labels without linking meerkat's mongoose server.
 cc_library(
-    name = "meerkat",
-    srcs = [
-        "meerkat.cc",
-        "metrics_manager.cc",
-    ],
-    hdrs = [
-        "meerkat.h",
-        "metrics_manager.h",
-    ],
+    name = "metrics_manager",
+    srcs = ["metrics_manager.cc"],
+    hdrs = ["metrics_manager.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//domains/platform/libs/futility/otel:metrics",
+    ],
+)
+
+cc_library(
+    name = "meerkat",
+    srcs = ["meerkat.cc"],
+    hdrs = ["meerkat.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":metrics_manager",
         "//domains/platform/libs/futility/otel:metrics",
         "//domains/platform/libs/futility/rate_limiter:sliding_window_rate_limiter",
         "@com_google_absl//absl/log",


### PR DESCRIPTION
Phase 3 of #1168: everything the meerkat binary provides, rebuilt on the smithy stack. The new `portrait_smithy` binary runs alongside `:portrait` until the Phase 4 cutover.

## What's here

- **meerkat BUILD split** — `:metrics_manager` becomes its own `cc_library` (it never depended on mongoose; `:meerkat` now depends on it). This lets the new binary emit the **exact same OTel instrument names and labels** (`http_server_requests`, `_active_gauge`, `_request_duration_microseconds`, `_success`/`_failure` with `service_name`/`route`/`method`/`status_code`/`result`/`error_type`) by reusing meerkat's own instrument code, so existing dashboards survive the migration unchanged.
- **`smithy_middleware.{h,cc}`**:
  - `MeerkatParityObservability` — metrics ride the runtime's `Observe` middleware (microsecond durations as of smithy-cpp `cfd8299`, start/complete guaranteed to pair even when dispatch throws), feeding `HttpMetricsManager` through a small testable `HttpMetricsSink` seam. A custom inner wrapper handles what `Observe` deliberately doesn't expose (request headers): `x-trace-id` propagation exactly as meerkat's interceptors did (inbound header reused, else a random positive long; response header only set if the handler didn't), plus meerkat's access-log line byte-for-byte.
  - `RateLimitByForwardedFor` — `Guard` + `TooManyRequests` around the existing futility sliding-window limiter. 429s now carry `Retry-After` (closes a `PORTRAIT_TODO.md` item).
  - **Trace-header decision**: stayed with `x-trace-id` for parity (existing clients and log correlation keep working); W3C `traceparent` adoption remains open as a post-migration improvement since smithy-cpp ships the helpers.
- **smithy-cpp pin bump** `708d78e` → `cfd8299`: picks up the microsecond `Observe` durations (upstream #92); only three runtime files changed between pins.
- **`portrait_smithy_main.cc`** — Beast transport on `0.0.0.0` with `PORT` env, body cap shrunk from the 64 MiB transport default to 1 MiB (trace scenes are ≤10-sphere JSON), same OTel provider and limiter config as the meerkat `Main.cc`, and `sigwait`-drain shutdown (an upgrade — the meerkat binary has no signal handling at all).
  - **Chain order**: observability → health → guard → router. Observability outermost keeps meerkat's semantics (health probes and 429s are counted and logged). Health before the guard is the **one deliberate behavior change**: probes can never be rate-limited, where meerkat 429'd them out of the shared empty `X-Forwarded-For` bucket.
- **`smithy_middleware_test.cc`** — the production chain over loopback: health body + observation, route labels with query strings stripped, per-key 429 with `Retry-After: 60` and cross-key isolation, 429s visible to metrics, health exempt from the limiter, trace-id echo and generation. Plus one pass over the **real Beast socket**: generated-client round trip and transport-level oversized-body rejection under the shrunken cap.

## Notes for review

- No OCI image for the new binary yet: `linux_amd64_oci_binary` instantiates fixed-name `push_image`/`oci_load_tarball` targets (one per package), and the cleanest cutover is Phase 4 pointing the existing `portrait` image at the new binary.
- The transport request-timeout is exercised by smithy-cpp's own tests; no slow socket test duplicated here.
- Local compilation isn't possible in this sandbox (egress policy blocks BCR archive fetches); validated statically against the pinned smithy-cpp source, buildifier/clang-format clean. CI compiles and runs the suites, as in Phases 0–2.

With this merged, Phase 4 is differential replay old-vs-new, perf smoke, image/deploy cutover, and legacy cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr