### PR TITLE
Key portrait rate limiting on the derived client address (smithy-cpp ADR-0012)

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "d3748c0343bcc30cc5e1d5669d110dd2adc4dcc1",
+    commit = "43f6d26c12326bc413b6b722af0bcad10f728ec3",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )

--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -22,9 +22,10 @@ services:
       - mcpserver
     networks:
       # Static address so services can name Caddy — and only Caddy — as
-      # their x-forwarded-for trust boundary (smithy-cpp ADR-0012).
+      # their x-forwarded-for trust boundary (smithy-cpp ADR-0012). The
+      # anchor is the single source; consumers alias it as *caddy_ip.
       app_network:
-        ipv4_address: 172.28.0.2
+        ipv4_address: &caddy_ip 172.28.0.2
     deploy:
       resources:
         limits:
@@ -52,13 +53,13 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - PORT=8081
+      PORT: "8081"
       # x-forwarded-for counts only from Caddy's pinned address; requests
       # reaching portrait any other way key as their TCP peer.
-      - TRUSTED_PROXY_CIDRS=172.28.0.2
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
-      - OTEL_SERVICE_NAME=portrait
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=portrait,service.version=latest
+      TRUSTED_PROXY_CIDRS: *caddy_ip
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
+      OTEL_SERVICE_NAME: portrait
+      OTEL_RESOURCE_ATTRIBUTES: service.name=portrait,service.version=latest
     volumes:
       - /etc/portrait:/etc/portrait
     networks:
@@ -258,8 +259,8 @@ networks:
     name: muchq_network
     driver: bridge
     # Pinned so Caddy's static address (and the trust boundary derived from
-    # it) survives network recreation. Changing an existing network's subnet
-    # needs `docker compose down && docker compose up -d` once.
+    # it) survives network recreation. Compose can't change a live network's
+    # subnet in place: apply subnet edits with `docker compose down && up`.
     ipam:
       config:
         - subnet: 172.28.0.0/16

--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -21,7 +21,10 @@ services:
       - r3dr
       - mcpserver
     networks:
-      - app_network
+      # Static address so services can name Caddy — and only Caddy — as
+      # their x-forwarded-for trust boundary (smithy-cpp ADR-0012).
+      app_network:
+        ipv4_address: 172.28.0.2
     deploy:
       resources:
         limits:
@@ -50,6 +53,9 @@ services:
       - "8081:8081"
     environment:
       - PORT=8081
+      # x-forwarded-for counts only from Caddy's pinned address; requests
+      # reaching portrait any other way key as their TCP peer.
+      - TRUSTED_PROXY_CIDRS=172.28.0.2
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=portrait
       - OTEL_RESOURCE_ATTRIBUTES=service.name=portrait,service.version=latest
@@ -251,3 +257,10 @@ networks:
   app_network:
     name: muchq_network
     driver: bridge
+    # Pinned so Caddy's static address (and the trust boundary derived from
+    # it) survives network recreation. Changing an existing network's subnet
+    # needs `docker compose down && docker compose up -d` once.
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16
+          gateway: 172.28.0.1

--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -206,6 +206,7 @@ cc_binary(
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:globals",
         "@com_google_absl//absl/log:initialize",
+        "@smithy_cpp//runtime:http",
         "@smithy_cpp//runtime:http_beast",
         "@smithy_cpp//runtime:server",
     ],

--- a/domains/graphics/apis/portrait/PORTRAIT_TODO.md
+++ b/domains/graphics/apis/portrait/PORTRAIT_TODO.md
@@ -29,6 +29,10 @@ validation, multi-threaded serving, and the tracy::Tracer RNG race.
       so tests exercise the real wiring instead of simplified copies
 - [ ] Revisit `meerkat::HttpMetricsManager` as a portrait dep — rehome the
       instruments (e.g. under futility) once meerkat has no other consumers
+- [ ] Log the derived client address (ADR-0012) in the access log once the
+      meerkat line-shape constraint lifts — since the limiter keys on it,
+      a 429's actual bucket is currently not reconstructible from the line,
+      which logs only the raw X-Forwarded-For
 
 ## Feature backlog (pre-migration items still open)
 

--- a/domains/graphics/apis/portrait/portrait_smithy_main.cc
+++ b/domains/graphics/apis/portrait/portrait_smithy_main.cc
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <csignal>
 #include <memory>
+#include <stdexcept>
 #include <string>
 
 #include "absl/log/globals.h"
@@ -25,6 +26,7 @@
 #include "domains/platform/libs/meerkat/metrics_manager.h"
 #include "moonbase/portrait/server.h"
 #include "smithy/http/beast_transport.h"
+#include "smithy/http/forwarded.h"
 #include "smithy/server/middleware.h"
 
 int main() {
@@ -59,13 +61,27 @@ int main() {
       std::make_shared<futility::rate_limiter::SlidingWindowRateLimiter<std::string>>(
           limiter_config);
 
+  // The reverse-proxy trust boundary (smithy-cpp ADR-0012): x-forwarded-for
+  // entries count toward client-address derivation only when appended by
+  // these addresses — deploy/consolidated/compose.yaml pins Caddy's address
+  // and passes it here. Unset trusts nothing: the header is ignored and
+  // every client keys as its TCP peer. A malformed entry must fail
+  // deployment, not silently widen or narrow the boundary.
+  smithy::http::TrustedProxies trusted_proxies;
+  try {
+    trusted_proxies = smithy::http::TrustedProxies(futility::env::ReadList("TRUSTED_PROXY_CIDRS"));
+  } catch (const std::invalid_argument& error) {
+    LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
+    return 1;
+  }
+
   // Observability outermost: health probes and 429s are counted and logged,
   // as they were under meerkat's interceptors. Health sits before the guard
   // so probes are never rate limited — the one deliberate ordering change
   // from meerkat, where /health shared the empty X-Forwarded-For bucket.
   auto handler = smithy::server::Chain(
       {portrait::MeerkatParityObservability(metrics), smithy::server::HealthEndpoint("/health"),
-       portrait::RateLimitByForwardedFor(rate_limiter, std::chrono::seconds(60))},
+       portrait::RateLimitByClientAddress(rate_limiter, trusted_proxies, std::chrono::seconds(60))},
       server.Handler());
 
   smithy::http::BeastServerTransport::Options options;

--- a/domains/graphics/apis/portrait/portrait_smithy_main.cc
+++ b/domains/graphics/apis/portrait/portrait_smithy_main.cc
@@ -61,12 +61,10 @@ int main() {
       std::make_shared<futility::rate_limiter::SlidingWindowRateLimiter<std::string>>(
           limiter_config);
 
-  // The reverse-proxy trust boundary (smithy-cpp ADR-0012): x-forwarded-for
-  // entries count toward client-address derivation only when appended by
-  // these addresses — deploy/consolidated/compose.yaml pins Caddy's address
-  // and passes it here. Unset trusts nothing: the header is ignored and
-  // every client keys as its TCP peer. A malformed entry must fail
-  // deployment, not silently widen or narrow the boundary.
+  // The reverse-proxy trust boundary (smithy-cpp ADR-0012, contract in
+  // smithy/http/forwarded.h): deploy/consolidated/compose.yaml pins Caddy's
+  // address and passes it here; unset means no proxy tier and every client
+  // keys as its TCP peer. Malformed entries fail startup by design.
   smithy::http::TrustedProxies trusted_proxies;
   try {
     trusted_proxies = smithy::http::TrustedProxies(futility::env::ReadList("TRUSTED_PROXY_CIDRS"));
@@ -81,7 +79,8 @@ int main() {
   // from meerkat, where /health shared the empty X-Forwarded-For bucket.
   auto handler = smithy::server::Chain(
       {portrait::MeerkatParityObservability(metrics), smithy::server::HealthEndpoint("/health"),
-       portrait::RateLimitByClientAddress(rate_limiter, trusted_proxies, std::chrono::seconds(60))},
+       portrait::RateLimitByClientAddress(rate_limiter, std::move(trusted_proxies),
+                                          std::chrono::seconds(60))},
       server.Handler());
 
   smithy::http::BeastServerTransport::Options options;

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -101,12 +101,13 @@ std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> 
   };
 }
 
-smithy::server::Middleware RateLimitByForwardedFor(
+smithy::server::Middleware RateLimitByClientAddress(
     std::shared_ptr<futility::rate_limiter::SlidingWindowRateLimiter<std::string>> limiter,
-    std::chrono::seconds retry_after) {
+    smithy::http::TrustedProxies trusted, std::chrono::seconds retry_after) {
   return smithy::server::Guard(
-      [limiter = std::move(limiter)](const smithy::http::HttpRequest& request) {
-        return limiter->allow(request.headers.Get("X-Forwarded-For").value_or(""));
+      [limiter = std::move(limiter),
+       trusted = std::move(trusted)](const smithy::http::HttpRequest& request) {
+        return limiter->allow(smithy::http::ClientAddress(request, trusted));
       },
       smithy::server::TooManyRequests(retry_after));
 }

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -37,6 +37,12 @@ std::string RouteOf(const std::string& target) { return target.substr(0, target.
 // request's traceparent — the transport guard mints or joins it at ingress
 // (smithy-cpp ADR-0011), so on transport-served requests it always parses.
 // Empty only for hand-driven handler chains in tests.
+//
+// X-Forwarded-For= is deliberately the raw header (the line shape meerkat's
+// dashboards parse), which since ADR-0012 is NOT the identity the rate
+// limiter keys on — a 429's actual bucket (the derived client address) is
+// not on this line. Logging the derived client is a post-soak TODO once the
+// meerkat line-shape constraint lifts (PORTRAIT_TODO.md).
 smithy::server::Middleware AccessLog() {
   return [](smithy::http::RequestHandler next) {
     return [next = std::move(next)](

--- a/domains/graphics/apis/portrait/smithy_middleware.h
+++ b/domains/graphics/apis/portrait/smithy_middleware.h
@@ -63,9 +63,7 @@ std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> 
 /// its key — it keys as its TCP peer, and spoofed headers are ignored.
 /// Rejects with 429 {"error":"Too many requests"} plus Retry-After. Compose
 /// inside MeerkatParityObservability (so 429s are counted) and after
-/// HealthEndpoint (so probes are never rate limited). Over Loopback there is
-/// no peer to derive from: every request shares the one empty key unless the
-/// test stamps HttpRequest::peer_address.
+/// HealthEndpoint (so probes are never rate limited).
 smithy::server::Middleware RateLimitByClientAddress(
     std::shared_ptr<futility::rate_limiter::SlidingWindowRateLimiter<std::string>> limiter,
     smithy::http::TrustedProxies trusted, std::chrono::seconds retry_after);

--- a/domains/graphics/apis/portrait/smithy_middleware.h
+++ b/domains/graphics/apis/portrait/smithy_middleware.h
@@ -8,6 +8,7 @@
 
 #include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
 #include "smithy/http/beast_transport.h"
+#include "smithy/http/forwarded.h"
 #include "smithy/server/middleware.h"
 
 namespace meerkat {
@@ -56,14 +57,18 @@ smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetric
 std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> RejectionMetrics(
     std::shared_ptr<HttpMetricsSink> metrics);
 
-/// Per-client admission control keyed on X-Forwarded-For (clients without
-/// the header share the empty-string bucket, as under meerkat), rejecting
-/// with 429 {"error":"Too many requests"} plus Retry-After. Compose inside
-/// MeerkatParityObservability (so 429s are counted) and after HealthEndpoint
-/// (so probes are never rate limited).
-smithy::server::Middleware RateLimitByForwardedFor(
+/// Per-client admission control keyed on the derived client address
+/// (smithy/http/forwarded.h, ADR-0012): x-forwarded-for counts only when
+/// appended through the trusted proxy tier, so a direct client cannot forge
+/// its key — it keys as its TCP peer, and spoofed headers are ignored.
+/// Rejects with 429 {"error":"Too many requests"} plus Retry-After. Compose
+/// inside MeerkatParityObservability (so 429s are counted) and after
+/// HealthEndpoint (so probes are never rate limited). Over Loopback there is
+/// no peer to derive from: every request shares the one empty key unless the
+/// test stamps HttpRequest::peer_address.
+smithy::server::Middleware RateLimitByClientAddress(
     std::shared_ptr<futility::rate_limiter::SlidingWindowRateLimiter<std::string>> limiter,
-    std::chrono::seconds retry_after);
+    smithy::http::TrustedProxies trusted, std::chrono::seconds retry_after);
 
 }  // namespace portrait
 

--- a/domains/graphics/apis/portrait/smithy_middleware_test.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware_test.cc
@@ -132,14 +132,18 @@ class SmithyMiddlewareTest : public ::testing::Test {
     ASSERT_TRUE(loopback_->Start(handler_).ok());
   }
 
+  // peer is the L4 identity the client-address derivation anchors on. An
+  // unnamed peer gets a fresh TEST-NET address per send, so sends that don't
+  // exercise keying never share a rate-limit bucket; pass an explicit peer
+  // to exercise it.
   smithy::http::HttpResponse Send(
       const std::string& method, const std::string& target, const std::string& body = "",
-      const std::vector<std::pair<std::string, std::string>>& headers = {},
-      const std::string& peer = "") {
+      const std::string& peer = "",
+      const std::vector<std::pair<std::string, std::string>>& headers = {}) {
     smithy::http::HttpRequest request;
     request.method = method;
     request.target = target;
-    request.peer_address = peer;
+    request.peer_address = peer.empty() ? "192.0.2." + std::to_string(++next_default_peer_) : peer;
     if (!body.empty()) {
       request.headers.Set("content-type", "application/json");
       request.body = body;
@@ -163,7 +167,7 @@ class SmithyMiddlewareTest : public ::testing::Test {
     EXPECT_CALL(log, Log(absl::LogSeverity::kInfo, testing::_, testing::HasSubstr("trace_id=")))
         .WillOnce(testing::SaveArg<2>(&line));
     log.StartCapturingLogs();
-    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, headers).status, 200);
+    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, "", headers).status, 200);
     log.StopCapturingLogs();
     return line;
   }
@@ -173,6 +177,7 @@ class SmithyMiddlewareTest : public ::testing::Test {
   std::unique_ptr<PortraitServer> server_;
   smithy::http::RequestHandler handler_;
   std::shared_ptr<smithy::http::Loopback> loopback_;
+  int next_default_peer_ = 0;
 };
 
 TEST_F(SmithyMiddlewareTest, HealthServedAndObserved) {
@@ -211,15 +216,15 @@ TEST_F(SmithyMiddlewareTest, QueryStringStrippedFromRouteLabel) {
 
 TEST_F(SmithyMiddlewareTest, RateLimitsPerClientAddressWithRetryAfter) {
   for (int i = 0; i < kMaxRequestsPerKey; ++i) {
-    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.4").status, 200);
+    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, "203.0.113.4").status, 200);
   }
-  const auto limited = Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.4");
+  const auto limited = Send("POST", "/portrait/v1/trace", kValidTraceBody, "203.0.113.4");
   EXPECT_EQ(limited.status, 429);
   EXPECT_EQ(limited.headers.Get("retry-after").value_or(""), "60");
   EXPECT_NE(limited.body.find("Too many requests"), std::string::npos);
 
   // A different client is still admitted.
-  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.8").status, 200);
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, "203.0.113.8").status, 200);
 
   // Rate-limited requests are observed (meerkat counted 429s with
   // error_type=rate_limited; the sink sees the status that drives it).
@@ -238,25 +243,34 @@ TEST_F(SmithyMiddlewareTest, SpoofedForwardedForCannotReachAnotherClientsBucket)
   const std::vector<std::pair<std::string, std::string>> forwarded = {
       {"X-Forwarded-For", "203.0.113.9"}};
   for (int i = 0; i < kMaxRequestsPerKey; ++i) {
-    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, forwarded, kProxy).status, 200);
+    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, kProxy, forwarded).status, 200);
   }
-  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, forwarded, kProxy).status, 429);
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, kProxy, forwarded).status, 429);
+
+  // A different client behind the same trusted proxy has its own budget:
+  // the key is the forwarded client, not the proxy peer. (This is the
+  // assertion that fails if the trust-set walk is dropped and all Caddy
+  // traffic collapses into one bucket.)
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, kProxy,
+                 {{"X-Forwarded-For", "203.0.113.50"}})
+                .status,
+            200);
 
   // Same header from an untrusted peer: client-authored noise. The request
   // keys as the peer itself and is admitted despite the exhausted bucket
   // its header names.
-  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, forwarded, "198.51.100.7").status,
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, "198.51.100.7", forwarded).status,
             200);
 }
 
 TEST_F(SmithyMiddlewareTest, HealthIsNeverRateLimited) {
   for (int i = 0; i < kMaxRequestsPerKey; ++i) {
-    Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.7");
+    Send("POST", "/portrait/v1/trace", kValidTraceBody, "203.0.113.7");
   }
-  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.7").status, 429);
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, "203.0.113.7").status, 429);
   // Deliberate change from meerkat: probes sit before the guard in the chain.
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(Send("GET", "/health", "", {}, "203.0.113.7").status, 200);
+    EXPECT_EQ(Send("GET", "/health", "", "203.0.113.7").status, 200);
   }
 }
 

--- a/domains/graphics/apis/portrait/smithy_middleware_test.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware_test.cc
@@ -1,7 +1,8 @@
 // Phase 3 middleware tests (https://github.com/muchq/MoonBase/issues/1168):
 // the production middleware chain — meerkat-parity observability, health,
-// X-Forwarded-For rate limiting — composed around the generated server,
-// driven over loopback plus one pass over the real Beast socket transport.
+// per-client rate limiting keyed on the derived client address — composed
+// around the generated server, driven over loopback plus one pass over the
+// real Beast socket transport.
 
 #include "domains/graphics/apis/portrait/smithy_middleware.h"
 
@@ -23,6 +24,7 @@
 #include "smithy/client/config.h"
 #include "smithy/core/blob.h"
 #include "smithy/http/beast_transport.h"
+#include "smithy/http/forwarded.h"
 #include "smithy/http/loopback.h"
 #include "smithy/http/socket_transport.h"
 #include "smithy/server/middleware.h"
@@ -101,10 +103,16 @@ class RecordingSink final : public portrait::HttpMetricsSink {
 };
 
 // The production chain shape from portrait_smithy_main.cc, with a small
-// rate-limit budget so tests can exhaust it quickly.
+// rate-limit budget so tests can exhaust it quickly. The rate limiter keys
+// on the ADR-0012 derived client address anchored at peer_address, which
+// Loopback lets tests stamp directly (a real transport stamps it from the
+// connection).
 class SmithyMiddlewareTest : public ::testing::Test {
  protected:
   static constexpr int kMaxRequestsPerKey = 3;
+  // The trusted reverse-proxy tier, standing in for compose's pinned Caddy
+  // address. x-forwarded-for entries count only through this peer.
+  static constexpr char kProxy[] = "10.0.0.2";
 
   void SetUp() override {
     sink_ = std::make_shared<RecordingSink>();
@@ -117,7 +125,8 @@ class SmithyMiddlewareTest : public ::testing::Test {
     server_ = std::make_unique<PortraitServer>(std::make_shared<StubHandler>());
     handler_ = smithy::server::Chain(
         {portrait::MeerkatParityObservability(sink_), smithy::server::HealthEndpoint("/health"),
-         portrait::RateLimitByForwardedFor(limiter_, std::chrono::seconds(60))},
+         portrait::RateLimitByClientAddress(limiter_, smithy::http::TrustedProxies({kProxy}),
+                                            std::chrono::seconds(60))},
         server_->Handler());
     loopback_ = std::make_shared<smithy::http::Loopback>();
     ASSERT_TRUE(loopback_->Start(handler_).ok());
@@ -125,10 +134,12 @@ class SmithyMiddlewareTest : public ::testing::Test {
 
   smithy::http::HttpResponse Send(
       const std::string& method, const std::string& target, const std::string& body = "",
-      const std::vector<std::pair<std::string, std::string>>& headers = {}) {
+      const std::vector<std::pair<std::string, std::string>>& headers = {},
+      const std::string& peer = "") {
     smithy::http::HttpRequest request;
     request.method = method;
     request.target = target;
+    request.peer_address = peer;
     if (!body.empty()) {
       request.headers.Set("content-type", "application/json");
       request.body = body;
@@ -198,19 +209,17 @@ TEST_F(SmithyMiddlewareTest, QueryStringStrippedFromRouteLabel) {
   EXPECT_EQ(starts[0].route, "/health");
 }
 
-TEST_F(SmithyMiddlewareTest, RateLimitsPerForwardedForKeyWithRetryAfter) {
-  const std::vector<std::pair<std::string, std::string>> alice = {{"X-Forwarded-For", "1.2.3.4"}};
+TEST_F(SmithyMiddlewareTest, RateLimitsPerClientAddressWithRetryAfter) {
   for (int i = 0; i < kMaxRequestsPerKey; ++i) {
-    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, alice).status, 200);
+    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.4").status, 200);
   }
-  const auto limited = Send("POST", "/portrait/v1/trace", kValidTraceBody, alice);
+  const auto limited = Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.4");
   EXPECT_EQ(limited.status, 429);
   EXPECT_EQ(limited.headers.Get("retry-after").value_or(""), "60");
   EXPECT_NE(limited.body.find("Too many requests"), std::string::npos);
 
-  // A different client key is still admitted.
-  const std::vector<std::pair<std::string, std::string>> bob = {{"X-Forwarded-For", "5.6.7.8"}};
-  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, bob).status, 200);
+  // A different client is still admitted.
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.8").status, 200);
 
   // Rate-limited requests are observed (meerkat counted 429s with
   // error_type=rate_limited; the sink sees the status that drives it).
@@ -221,15 +230,33 @@ TEST_F(SmithyMiddlewareTest, RateLimitsPerForwardedForKeyWithRetryAfter) {
   EXPECT_TRUE(saw_429);
 }
 
-TEST_F(SmithyMiddlewareTest, HealthIsNeverRateLimited) {
-  const std::vector<std::pair<std::string, std::string>> key = {{"X-Forwarded-For", "9.9.9.9"}};
+// ADR-0012 keying through the production chain shape: behind the trusted
+// proxy the forwarded client is the key; a direct client writing the same
+// header keys as its own peer, so spoofing cannot drain another client's
+// bucket (or mint fresh buckets to evade its own).
+TEST_F(SmithyMiddlewareTest, SpoofedForwardedForCannotReachAnotherClientsBucket) {
+  const std::vector<std::pair<std::string, std::string>> forwarded = {
+      {"X-Forwarded-For", "203.0.113.9"}};
   for (int i = 0; i < kMaxRequestsPerKey; ++i) {
-    Send("POST", "/portrait/v1/trace", kValidTraceBody, key);
+    EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, forwarded, kProxy).status, 200);
   }
-  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, key).status, 429);
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, forwarded, kProxy).status, 429);
+
+  // Same header from an untrusted peer: client-authored noise. The request
+  // keys as the peer itself and is admitted despite the exhausted bucket
+  // its header names.
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, forwarded, "198.51.100.7").status,
+            200);
+}
+
+TEST_F(SmithyMiddlewareTest, HealthIsNeverRateLimited) {
+  for (int i = 0; i < kMaxRequestsPerKey; ++i) {
+    Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.7");
+  }
+  EXPECT_EQ(Send("POST", "/portrait/v1/trace", kValidTraceBody, {}, "203.0.113.7").status, 429);
   // Deliberate change from meerkat: probes sit before the guard in the chain.
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(Send("GET", "/health", "", key).status, 200);
+    EXPECT_EQ(Send("GET", "/health", "", {}, "203.0.113.7").status, 200);
   }
 }
 

--- a/domains/platform/libs/futility/env/BUILD.bazel
+++ b/domains/platform/libs/futility/env/BUILD.bazel
@@ -4,6 +4,7 @@ cc_library(
     name = "env",
     hdrs = ["env.h"],
     visibility = ["//visibility:public"],
+    deps = ["@com_google_absl//absl/strings"],
 )
 
 cc_test(

--- a/domains/platform/libs/futility/env/env.h
+++ b/domains/platform/libs/futility/env/env.h
@@ -2,6 +2,9 @@
 #define DOMAINS_PLATFORM_LIBS_FUTILITY_ENV_ENV_H
 
 #include <cstdlib>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace futility::env {
 
@@ -10,6 +13,25 @@ namespace futility::env {
 inline int ReadPort(int default_port) {
   const char* port = std::getenv("PORT");
   return port != nullptr ? std::atoi(port) : default_port;
+}
+
+/// The named environment variable as a comma-separated list: entries split
+/// on commas, surrounding spaces trimmed, empty entries dropped. Unset and
+/// empty both yield {}.
+inline std::vector<std::string> ReadList(const char* name) {
+  std::vector<std::string> values;
+  const char* raw = std::getenv(name);
+  if (raw == nullptr) return values;
+  std::string_view remaining(raw);
+  while (!remaining.empty()) {
+    const auto comma = remaining.find(',');
+    std::string_view entry = remaining.substr(0, comma);
+    remaining = comma == std::string_view::npos ? std::string_view{} : remaining.substr(comma + 1);
+    while (!entry.empty() && entry.front() == ' ') entry.remove_prefix(1);
+    while (!entry.empty() && entry.back() == ' ') entry.remove_suffix(1);
+    if (!entry.empty()) values.emplace_back(entry);
+  }
+  return values;
 }
 
 }  // namespace futility::env

--- a/domains/platform/libs/futility/env/env.h
+++ b/domains/platform/libs/futility/env/env.h
@@ -3,8 +3,10 @@
 
 #include <cstdlib>
 #include <string>
-#include <string_view>
 #include <vector>
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/str_split.h"
 
 namespace futility::env {
 
@@ -16,19 +18,14 @@ inline int ReadPort(int default_port) {
 }
 
 /// The named environment variable as a comma-separated list: entries split
-/// on commas, surrounding spaces trimmed, empty entries dropped. Unset and
-/// empty both yield {}.
+/// on commas, surrounding whitespace trimmed, empty entries dropped. Unset
+/// and empty both yield {}.
 inline std::vector<std::string> ReadList(const char* name) {
   std::vector<std::string> values;
   const char* raw = std::getenv(name);
   if (raw == nullptr) return values;
-  std::string_view remaining(raw);
-  while (!remaining.empty()) {
-    const auto comma = remaining.find(',');
-    std::string_view entry = remaining.substr(0, comma);
-    remaining = comma == std::string_view::npos ? std::string_view{} : remaining.substr(comma + 1);
-    while (!entry.empty() && entry.front() == ' ') entry.remove_prefix(1);
-    while (!entry.empty() && entry.back() == ' ') entry.remove_suffix(1);
+  for (absl::string_view entry : absl::StrSplit(raw, ',')) {
+    entry = absl::StripAsciiWhitespace(entry);
     if (!entry.empty()) values.emplace_back(entry);
   }
   return values;

--- a/domains/platform/libs/futility/env/env_test.cc
+++ b/domains/platform/libs/futility/env/env_test.cc
@@ -19,10 +19,12 @@ TEST(ReadPortTest, ReadsPortFromEnvironment) {
   unsetenv("PORT");
 }
 
-TEST(ReadListTest, EmptyWhenUnsetOrEmpty) {
+TEST(ReadListTest, EmptyWhenUnsetOrEmptyOrWhitespaceOnly) {
   unsetenv("READ_LIST_TEST");
   EXPECT_TRUE(futility::env::ReadList("READ_LIST_TEST").empty());
   setenv("READ_LIST_TEST", "", 1);
+  EXPECT_TRUE(futility::env::ReadList("READ_LIST_TEST").empty());
+  setenv("READ_LIST_TEST", " ", 1);
   EXPECT_TRUE(futility::env::ReadList("READ_LIST_TEST").empty());
   unsetenv("READ_LIST_TEST");
 }
@@ -31,6 +33,14 @@ TEST(ReadListTest, SplitsOnCommasTrimsSpacesDropsEmptyEntries) {
   setenv("READ_LIST_TEST", " 10.0.0.0/8, 172.28.0.2 ,,2600:1f00::/24", 1);
   EXPECT_EQ(futility::env::ReadList("READ_LIST_TEST"),
             (std::vector<std::string>{"10.0.0.0/8", "172.28.0.2", "2600:1f00::/24"}));
+  unsetenv("READ_LIST_TEST");
+}
+
+// The compose-typo shape: a trailing comma must yield the entry alone, not a
+// trailing "" that TrustedProxies would reject at startup.
+TEST(ReadListTest, TrailingCommaDropsTheEmptyTail) {
+  setenv("READ_LIST_TEST", "172.28.0.2,", 1);
+  EXPECT_EQ(futility::env::ReadList("READ_LIST_TEST"), (std::vector<std::string>{"172.28.0.2"}));
   unsetenv("READ_LIST_TEST");
 }
 

--- a/domains/platform/libs/futility/env/env_test.cc
+++ b/domains/platform/libs/futility/env/env_test.cc
@@ -3,6 +3,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <string>
+#include <vector>
 
 namespace {
 
@@ -15,6 +17,21 @@ TEST(ReadPortTest, ReadsPortFromEnvironment) {
   setenv("PORT", "9000", 1);
   EXPECT_EQ(futility::env::ReadPort(8080), 9000);
   unsetenv("PORT");
+}
+
+TEST(ReadListTest, EmptyWhenUnsetOrEmpty) {
+  unsetenv("READ_LIST_TEST");
+  EXPECT_TRUE(futility::env::ReadList("READ_LIST_TEST").empty());
+  setenv("READ_LIST_TEST", "", 1);
+  EXPECT_TRUE(futility::env::ReadList("READ_LIST_TEST").empty());
+  unsetenv("READ_LIST_TEST");
+}
+
+TEST(ReadListTest, SplitsOnCommasTrimsSpacesDropsEmptyEntries) {
+  setenv("READ_LIST_TEST", " 10.0.0.0/8, 172.28.0.2 ,,2600:1f00::/24", 1);
+  EXPECT_EQ(futility::env::ReadList("READ_LIST_TEST"),
+            (std::vector<std::string>{"10.0.0.0/8", "172.28.0.2", "2600:1f00::/24"}));
+  unsetenv("READ_LIST_TEST");
 }
 
 }  // namespace


### PR DESCRIPTION
Bumps smithy-cpp `d3748c0` → `43f6d26` (upstream #103) and adopts ADR-0012: portrait's rate limiter stops keying on the raw `x-forwarded-for` value and keys on the derived client address instead.

## Why

`RateLimitByForwardedFor` used the header verbatim. Via Caddy that was fed clean values (Caddy strips client-supplied XFF), but portrait's `:8081` is also published on the host, and on that direct path the header is client-authored: a fresh value per request evades the limiter (and churns `max_keys`), a victim's address drains the victim's bucket.

## What changes

- **`RateLimitByClientAddress`** replaces `RateLimitByForwardedFor`: admission keys on `smithy::http::ClientAddress(request, trusted)` — the rightmost-untrusted walk over `x-forwarded-for`, anchored at the transport-stamped TCP peer. Behind Caddy the real client is the key; direct clients key as their peer and their header is ignored wholly.
- **The trust boundary is deployment config, not code**: `compose.yaml` pins the bridge subnet (`172.28.0.0/16`), gives Caddy a static address (`172.28.0.2`), and passes it to portrait as `TRUSTED_PROXY_CIDRS`. Main reads it via the new `futility::env::ReadList` and fails startup with a readable error on a malformed entry (a misconfigured trust boundary must fail deployment, per the ADR). Unset trusts nothing — every client then keys as its TCP peer.
- **Tests** stamp `Loopback` peer addresses (the documented upstream pattern): per-peer budgets with Retry-After, spoofed-header immunity through the production chain shape (a direct client naming a victim's address cannot reach the victim's bucket), and health-probe exemption.

## Deploy note

The first rollout needs the compose network recreated once (`docker compose down && docker compose up -d`) — subnet pinning doesn't apply to a live network. Client-visible behavior is otherwise unchanged: Caddy-path keys are identical to today's, only the spoofable direct path changes.

## Notes for review

- Keying behavior change vs meerkat: no more shared empty-string bucket; direct/no-header clients each budget as their real peer.
- Local compilation isn't possible in this sandbox; validated statically against the pinned smithy-cpp source (`forwarded.h`, ADR-0012, the upstream consumer example), buildifier/clang-format clean. CI compiles and runs everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_