### PR TITLE
Adopt smithy-cpp PerClientRateLimit; retire the hand-rolled composition

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "43f6d26c12326bc413b6b722af0bcad10f728ec3",
+    commit = "e407003e26c849e340a0cb21396391782365169f",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )

--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -142,7 +142,6 @@ cc_library(
     srcs = ["smithy_middleware.cc"],
     hdrs = ["smithy_middleware.h"],
     deps = [
-        "//domains/platform/libs/futility/rate_limiter:sliding_window_rate_limiter",
         "//domains/platform/libs/meerkat:metrics_manager",
         "@com_google_absl//absl/log",
         "@smithy_cpp//runtime:http",

--- a/domains/graphics/apis/portrait/PORTRAIT_TODO.md
+++ b/domains/graphics/apis/portrait/PORTRAIT_TODO.md
@@ -33,6 +33,11 @@ validation, multi-threaded serving, and the tracy::Tracer RNG race.
       meerkat line-shape constraint lifts — since the limiter keys on it,
       a 429's actual bucket is currently not reconstructible from the line,
       which logs only the raw X-Forwarded-For
+- [ ] Put the `DeriveClient` source distribution on a dashboard (the
+      trust-boundary drift signal: ~100% kUntrustedHeaderIgnored behind
+      Caddy means the trust set no longer matches the topology — recipe in
+      smithy-cpp docs/production-guide.md). Needs an instrument outside the
+      meerkat-parity set, so decide naming with the metrics rehoming above
 
 ## Feature backlog (pre-migration items still open)
 

--- a/domains/graphics/apis/portrait/portrait_smithy_main.cc
+++ b/domains/graphics/apis/portrait/portrait_smithy_main.cc
@@ -11,9 +11,11 @@
 
 #include <chrono>
 #include <csignal>
+#include <cstdlib>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "absl/log/globals.h"
 #include "absl/log/initialize.h"
@@ -63,14 +65,22 @@ int main() {
 
   // The reverse-proxy trust boundary (smithy-cpp ADR-0012, contract in
   // smithy/http/forwarded.h): deploy/consolidated/compose.yaml pins Caddy's
-  // address and passes it here; unset means no proxy tier and every client
-  // keys as its TCP peer. Malformed entries fail startup by design.
-  smithy::http::TrustedProxies trusted_proxies;
-  try {
-    trusted_proxies = smithy::http::TrustedProxies(futility::env::ReadList("TRUSTED_PROXY_CIDRS"));
-  } catch (const std::invalid_argument& error) {
-    LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
-    return 1;
+  // address and passes it here. Unset is the deliberate direct-connect
+  // statement (TrustedProxies::None()); set-but-empty or malformed fails
+  // startup rather than silently collapsing proxied traffic onto one key.
+  smithy::http::TrustedProxies trusted_proxies = smithy::http::TrustedProxies::None();
+  if (std::getenv("TRUSTED_PROXY_CIDRS") != nullptr) {
+    const std::vector<std::string> cidrs = futility::env::ReadList("TRUSTED_PROXY_CIDRS");
+    if (cidrs.empty()) {
+      LOG(ERROR) << "TRUSTED_PROXY_CIDRS is set but empty; unset it to serve direct-connect";
+      return 1;
+    }
+    try {
+      trusted_proxies = smithy::http::TrustedProxies(cidrs);
+    } catch (const std::invalid_argument& error) {
+      LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
+      return 1;
+    }
   }
 
   // Observability outermost: health probes and 429s are counted and logged,
@@ -79,8 +89,9 @@ int main() {
   // from meerkat, where /health shared the empty X-Forwarded-For bucket.
   auto handler = smithy::server::Chain(
       {portrait::MeerkatParityObservability(metrics), smithy::server::HealthEndpoint("/health"),
-       portrait::RateLimitByClientAddress(rate_limiter, std::move(trusted_proxies),
-                                          std::chrono::seconds(60))},
+       smithy::server::PerClientRateLimit(
+           [rate_limiter](const std::string& client) { return rate_limiter->allow(client); },
+           std::move(trusted_proxies), std::chrono::seconds(60))},
       server.Handler());
 
   smithy::http::BeastServerTransport::Options options;

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -107,15 +107,4 @@ std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> 
   };
 }
 
-smithy::server::Middleware RateLimitByClientAddress(
-    std::shared_ptr<futility::rate_limiter::SlidingWindowRateLimiter<std::string>> limiter,
-    smithy::http::TrustedProxies trusted, std::chrono::seconds retry_after) {
-  return smithy::server::Guard(
-      [limiter = std::move(limiter),
-       trusted = std::move(trusted)](const smithy::http::HttpRequest& request) {
-        return limiter->allow(smithy::http::ClientAddress(request, trusted));
-      },
-      smithy::server::TooManyRequests(retry_after));
-}
-
 }  // namespace portrait

--- a/domains/graphics/apis/portrait/smithy_middleware.h
+++ b/domains/graphics/apis/portrait/smithy_middleware.h
@@ -6,9 +6,7 @@
 #include <memory>
 #include <string>
 
-#include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
 #include "smithy/http/beast_transport.h"
-#include "smithy/http/forwarded.h"
 #include "smithy/server/middleware.h"
 
 namespace meerkat {
@@ -56,17 +54,6 @@ smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetric
 /// previously invisible to metrics — a capability meerkat never had).
 std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> RejectionMetrics(
     std::shared_ptr<HttpMetricsSink> metrics);
-
-/// Per-client admission control keyed on the derived client address
-/// (smithy/http/forwarded.h, ADR-0012): x-forwarded-for counts only when
-/// appended through the trusted proxy tier, so a direct client cannot forge
-/// its key — it keys as its TCP peer, and spoofed headers are ignored.
-/// Rejects with 429 {"error":"Too many requests"} plus Retry-After. Compose
-/// inside MeerkatParityObservability (so 429s are counted) and after
-/// HealthEndpoint (so probes are never rate limited).
-smithy::server::Middleware RateLimitByClientAddress(
-    std::shared_ptr<futility::rate_limiter::SlidingWindowRateLimiter<std::string>> limiter,
-    smithy::http::TrustedProxies trusted, std::chrono::seconds retry_after);
 
 }  // namespace portrait
 

--- a/domains/graphics/apis/portrait/smithy_middleware_test.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware_test.cc
@@ -125,8 +125,9 @@ class SmithyMiddlewareTest : public ::testing::Test {
     server_ = std::make_unique<PortraitServer>(std::make_shared<StubHandler>());
     handler_ = smithy::server::Chain(
         {portrait::MeerkatParityObservability(sink_), smithy::server::HealthEndpoint("/health"),
-         portrait::RateLimitByClientAddress(limiter_, smithy::http::TrustedProxies({kProxy}),
-                                            std::chrono::seconds(60))},
+         smithy::server::PerClientRateLimit(
+             [limiter = limiter_](const std::string& client) { return limiter->allow(client); },
+             smithy::http::TrustedProxies({kProxy}), std::chrono::seconds(60))},
         server_->Handler());
     loopback_ = std::make_shared<smithy::http::Loopback>();
     ASSERT_TRUE(loopback_->Start(handler_).ok());


### PR DESCRIPTION
Bumps smithy-cpp `43f6d26` → `e407003` (upstream #105 — the response to the ADR-0012 hardening feedback filed as upstream #104) and adopts all three changes. Net −8 lines: portrait sheds its hand-rolled middleware onto the framework.

## What changes

- **`portrait::RateLimitByClientAddress` is deleted.** The derivation-into-admission wiring — the exact spot where the review's mutant analysis found silently-fatal mis-wiring was possible — now ships upstream as `smithy::server::PerClientRateLimit`, written and tested once for every consumer. Portrait passes only its policy (the sliding-window limiter callback) and its trust boundary.
- **`TrustedProxies::None()` replaces default construction** (upstream deleted the default constructor — the accident-shaped state). Main also follows the new upstream convention: unset `TRUSTED_PROXY_CIDRS` is the deliberate direct-connect statement; **set-but-empty now fails startup** instead of silently becoming an empty trust set and collapsing proxied traffic onto one bucket (the config edition of the accident).
- **`DeriveClient` source distribution** (the trust-boundary drift dashboard signal) is noted in PORTRAIT_TODO rather than wired now — it needs an instrument outside the meerkat-parity set, so it's bundled with the post-soak metrics rehoming decision.

## Notes for review

- Test assertions are unchanged: the per-client, spoofed-header, and health-exemption cases now exercise the upstream composition inside portrait's chain, which is what they're for post-#105 — pinning that portrait passes the right trust set and policy into the framework.
- One behavior nuance from upstream: `PerClientRateLimit` admits `Source::kUnknown` (no derivable peer — Loopback in tests) without consulting the limiter. Production is unaffected (Beast always stamps a peer); portrait's tests always stamp peers, so no test relied on the old "" bucket.
- No compose/deploy changes — `TRUSTED_PROXY_CIDRS` plumbing from #1176 carries over unchanged.
- Local compilation isn't possible in this sandbox; validated statically against the pinned smithy-cpp source (`forwarded.h`, `middleware.h`, the updated production guide and consumer example), buildifier/clang-format clean. CI compiles and runs everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_