### PR TITLE
Observe transport-terminated connections (smithy-cpp ADR-0013); pick up the write-deadline fix

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "e407003e26c849e340a0cb21396391782365169f",
+    commit = "fd79e85412d71fe7600c004e15f3804ffff09ca1",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )

--- a/domains/graphics/apis/portrait/PORTRAIT_TODO.md
+++ b/domains/graphics/apis/portrait/PORTRAIT_TODO.md
@@ -36,7 +36,9 @@ validation, multi-threaded serving, and the tracy::Tracer RNG race.
 - [ ] Put the `DeriveClient` source distribution on a dashboard (the
       trust-boundary drift signal: ~100% kUntrustedHeaderIgnored behind
       Caddy means the trust set no longer matches the topology — recipe in
-      smithy-cpp docs/production-guide.md). Needs an instrument outside the
+      smithy-cpp docs/production-guide.md). Same decision for ADR-0013
+      connection-event kind counters, currently log-only WARNING lines
+      (`ConnectionEventLog`). Both need instruments outside the
       meerkat-parity set, so decide naming with the metrics rehoming above
 
 ## Feature backlog (pre-migration items still open)

--- a/domains/graphics/apis/portrait/portrait_smithy_main.cc
+++ b/domains/graphics/apis/portrait/portrait_smithy_main.cc
@@ -102,6 +102,9 @@ int main() {
   options.max_body_bytes = std::size_t{1} * 1024 * 1024;
   // 413/431s the transport writes itself land in the same instruments.
   options.on_rejected = portrait::RejectionMetrics(metrics);
+  // Connections the transport terminates without a response — framing
+  // garbage, slowloris stalls, drops — get a WARNING line (ADR-0013).
+  options.on_connection_event = portrait::ConnectionEventLog();
   smithy::http::BeastServerTransport transport(options);
 
   smithy::Outcome<smithy::Unit> started = transport.Start(handler);

--- a/domains/graphics/apis/portrait/portrait_smithy_main.cc
+++ b/domains/graphics/apis/portrait/portrait_smithy_main.cc
@@ -102,8 +102,8 @@ int main() {
   options.max_body_bytes = std::size_t{1} * 1024 * 1024;
   // 413/431s the transport writes itself land in the same instruments.
   options.on_rejected = portrait::RejectionMetrics(metrics);
-  // Connections the transport terminates without a response — framing
-  // garbage, slowloris stalls, drops — get a WARNING line (ADR-0013).
+  // Connections the transport terminates without a response get a WARNING
+  // line (ADR-0013).
   options.on_connection_event = portrait::ConnectionEventLog();
   smithy::http::BeastServerTransport transport(options);
 

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -30,7 +30,7 @@ class MeerkatMetricsSink final : public HttpMetricsSink {
 
 std::string RouteOf(const std::string& target) { return target.substr(0, target.find('?')); }
 
-const char* KindName(smithy::http::BeastServerTransport::ConnectionEvent::Kind kind) {
+std::string KindName(smithy::http::BeastServerTransport::ConnectionEvent::Kind kind) {
   using Kind = smithy::http::BeastServerTransport::ConnectionEvent::Kind;
   switch (kind) {
     case Kind::kTlsHandshakeFailure:
@@ -42,7 +42,10 @@ const char* KindName(smithy::http::BeastServerTransport::ConnectionEvent::Kind k
     case Kind::kDropped:
       return "dropped";
   }
-  return "unknown";
+  // Reached only when a pin bump adds a Kind this mapping doesn't know yet
+  // (-Wswitch flags the missing case, but it isn't an error here): surface
+  // the numeric value so the log line stays diagnosable — then add the case.
+  return "unknown(" + std::to_string(static_cast<int>(kind)) + ")";
 }
 
 // Meerkat's access-log line shape. Kept separate from Observe because the
@@ -125,8 +128,7 @@ std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> 
 std::function<void(const smithy::http::BeastServerTransport::ConnectionEvent&)>
 ConnectionEventLog() {
   return [](const smithy::http::BeastServerTransport::ConnectionEvent& event) {
-    // Runs on the transport's io thread; one line, no locks beyond the
-    // logger's own.
+    // One line, no locks beyond the logger's own.
     LOG(WARNING) << "connection_event kind=" << KindName(event.kind)
                  << " peer=" << event.peer_address << " detail=" << event.detail << " elapsed_ms="
                  << std::chrono::duration_cast<std::chrono::milliseconds>(event.elapsed).count();

--- a/domains/graphics/apis/portrait/smithy_middleware.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware.cc
@@ -30,6 +30,21 @@ class MeerkatMetricsSink final : public HttpMetricsSink {
 
 std::string RouteOf(const std::string& target) { return target.substr(0, target.find('?')); }
 
+const char* KindName(smithy::http::BeastServerTransport::ConnectionEvent::Kind kind) {
+  using Kind = smithy::http::BeastServerTransport::ConnectionEvent::Kind;
+  switch (kind) {
+    case Kind::kTlsHandshakeFailure:
+      return "tls_handshake_failure";
+    case Kind::kFramingError:
+      return "framing_error";
+    case Kind::kReadTimeout:
+      return "read_timeout";
+    case Kind::kDropped:
+      return "dropped";
+  }
+  return "unknown";
+}
+
 // Meerkat's access-log line shape. Kept separate from Observe because the
 // log line needs X-Forwarded-For and the response body size, which
 // RequestObservation doesn't carry; it measures its own duration for the
@@ -104,6 +119,17 @@ std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> 
     // the rejection happens at parse time, so zero duration is accurate.
     metrics->RecordRequestStart(route, method);
     metrics->RecordRequestComplete(route, method, rejected.status, std::chrono::microseconds{0});
+  };
+}
+
+std::function<void(const smithy::http::BeastServerTransport::ConnectionEvent&)>
+ConnectionEventLog() {
+  return [](const smithy::http::BeastServerTransport::ConnectionEvent& event) {
+    // Runs on the transport's io thread; one line, no locks beyond the
+    // logger's own.
+    LOG(WARNING) << "connection_event kind=" << KindName(event.kind)
+                 << " peer=" << event.peer_address << " detail=" << event.detail << " elapsed_ms="
+                 << std::chrono::duration_cast<std::chrono::milliseconds>(event.elapsed).count();
   };
 }
 

--- a/domains/graphics/apis/portrait/smithy_middleware.h
+++ b/domains/graphics/apis/portrait/smithy_middleware.h
@@ -56,12 +56,12 @@ std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> 
     std::shared_ptr<HttpMetricsSink> metrics);
 
 /// Log-only observer for BeastServerTransport::Options::on_connection_event
-/// (smithy-cpp ADR-0013): connections the transport terminated without
-/// delivering a response — framing garbage, slowloris stalls, mid-request
-/// and mid-response drops — one WARNING line each. Log-only because these
-/// are connections, not requests: mapping them into the request-shaped
-/// meerkat instruments would distort request counts. Kind counters are a
-/// post-soak instrument decision (PORTRAIT_TODO.md).
+/// (smithy-cpp ADR-0013, kinds in beast_transport.h): each connection the
+/// transport terminates without delivering a response gets one WARNING
+/// line. Log-only because these are connections, not requests — mapping
+/// them into the request-shaped meerkat instruments would distort request
+/// counts. Kind counters are a post-soak instrument decision
+/// (PORTRAIT_TODO.md).
 std::function<void(const smithy::http::BeastServerTransport::ConnectionEvent&)>
 ConnectionEventLog();
 

--- a/domains/graphics/apis/portrait/smithy_middleware.h
+++ b/domains/graphics/apis/portrait/smithy_middleware.h
@@ -55,6 +55,16 @@ smithy::server::Middleware MeerkatParityObservability(std::shared_ptr<HttpMetric
 std::function<void(const smithy::http::BeastServerTransport::RejectedRequest&)> RejectionMetrics(
     std::shared_ptr<HttpMetricsSink> metrics);
 
+/// Log-only observer for BeastServerTransport::Options::on_connection_event
+/// (smithy-cpp ADR-0013): connections the transport terminated without
+/// delivering a response — framing garbage, slowloris stalls, mid-request
+/// and mid-response drops — one WARNING line each. Log-only because these
+/// are connections, not requests: mapping them into the request-shaped
+/// meerkat instruments would distort request counts. Kind counters are a
+/// post-soak instrument decision (PORTRAIT_TODO.md).
+std::function<void(const smithy::http::BeastServerTransport::ConnectionEvent&)>
+ConnectionEventLog();
+
 }  // namespace portrait
 
 #endif

--- a/domains/graphics/apis/portrait/smithy_middleware_test.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware_test.cc
@@ -308,6 +308,32 @@ TEST_F(SmithyMiddlewareTest, AccessLogCarriesMintedTraceIdWhenInboundIsAbsentOrM
   EXPECT_TRUE(IsLowercaseHex32(replaced)) << "replaced: " << replaced;
 }
 
+// ADR-0013 connection events are log-only (connections, not requests — the
+// request-shaped instruments would miscount them); pin the WARNING line an
+// operator greps for during an incident. Transport-to-hook delivery is
+// upstream-tested; the mapping is portrait's.
+TEST(ConnectionEventLogTest, LogsKindPeerDetailAndElapsed) {
+  smithy::http::BeastServerTransport::ConnectionEvent event;
+  event.kind = smithy::http::BeastServerTransport::ConnectionEvent::Kind::kFramingError;
+  event.peer_address = "203.0.113.9:4711";
+  event.detail = "bad method";
+  event.elapsed = std::chrono::milliseconds(250);
+
+  std::string line;
+  absl::ScopedMockLog log(absl::MockLogDefault::kIgnoreUnexpected);
+  EXPECT_CALL(log,
+              Log(absl::LogSeverity::kWarning, testing::_, testing::HasSubstr("connection_event")))
+      .WillOnce(testing::SaveArg<2>(&line));
+  log.StartCapturingLogs();
+  portrait::ConnectionEventLog()(event);
+  log.StopCapturingLogs();
+
+  EXPECT_NE(line.find("kind=framing_error"), std::string::npos) << line;
+  EXPECT_NE(line.find("peer=203.0.113.9:4711"), std::string::npos) << line;
+  EXPECT_NE(line.find("detail=bad method"), std::string::npos) << line;
+  EXPECT_NE(line.find("elapsed_ms=250"), std::string::npos) << line;
+}
+
 // A 431 can fire before Beast parses the method or target; the adapter maps
 // those to a stable label instead of empty strings dashboards would drop.
 TEST(RejectionMetricsTest, UnparsedRejectionLandsOnStableLabels) {
@@ -329,6 +355,7 @@ TEST_F(SmithyMiddlewareTest, BeastTransportServesChainAndEnforcesBodyLimit) {
   options.port = 0;
   options.max_body_bytes = 2048;
   options.on_rejected = portrait::RejectionMetrics(sink_);
+  options.on_connection_event = portrait::ConnectionEventLog();
   smithy::http::BeastServerTransport transport(options);
   ASSERT_TRUE(transport.Start(handler_).ok());
 

--- a/domains/graphics/apis/portrait/smithy_middleware_test.cc
+++ b/domains/graphics/apis/portrait/smithy_middleware_test.cc
@@ -308,10 +308,8 @@ TEST_F(SmithyMiddlewareTest, AccessLogCarriesMintedTraceIdWhenInboundIsAbsentOrM
   EXPECT_TRUE(IsLowercaseHex32(replaced)) << "replaced: " << replaced;
 }
 
-// ADR-0013 connection events are log-only (connections, not requests — the
-// request-shaped instruments would miscount them); pin the WARNING line an
-// operator greps for during an incident. Transport-to-hook delivery is
-// upstream-tested; the mapping is portrait's.
+// Pin the WARNING line an operator greps for during an incident.
+// Transport-to-hook delivery is upstream-tested; the mapping is portrait's.
 TEST(ConnectionEventLogTest, LogsKindPeerDetailAndElapsed) {
   smithy::http::BeastServerTransport::ConnectionEvent event;
   event.kind = smithy::http::BeastServerTransport::ConnectionEvent::Kind::kFramingError;
@@ -319,19 +317,13 @@ TEST(ConnectionEventLogTest, LogsKindPeerDetailAndElapsed) {
   event.detail = "bad method";
   event.elapsed = std::chrono::milliseconds(250);
 
-  std::string line;
   absl::ScopedMockLog log(absl::MockLogDefault::kIgnoreUnexpected);
-  EXPECT_CALL(log,
-              Log(absl::LogSeverity::kWarning, testing::_, testing::HasSubstr("connection_event")))
-      .WillOnce(testing::SaveArg<2>(&line));
+  EXPECT_CALL(log, Log(absl::LogSeverity::kWarning, testing::_,
+                       "connection_event kind=framing_error peer=203.0.113.9:4711 "
+                       "detail=bad method elapsed_ms=250"));
   log.StartCapturingLogs();
   portrait::ConnectionEventLog()(event);
   log.StopCapturingLogs();
-
-  EXPECT_NE(line.find("kind=framing_error"), std::string::npos) << line;
-  EXPECT_NE(line.find("peer=203.0.113.9:4711"), std::string::npos) << line;
-  EXPECT_NE(line.find("detail=bad method"), std::string::npos) << line;
-  EXPECT_NE(line.find("elapsed_ms=250"), std::string::npos) << line;
 }
 
 // A 431 can fire before Beast parses the method or target; the adapter maps
@@ -355,6 +347,8 @@ TEST_F(SmithyMiddlewareTest, BeastTransportServesChainAndEnforcesBodyLimit) {
   options.port = 0;
   options.max_body_bytes = 2048;
   options.on_rejected = portrait::RejectionMetrics(sink_);
+  // Production-shaped options; no event can fire in this test (the 413 is
+  // on_rejected-only by design).
   options.on_connection_event = portrait::ConnectionEventLog();
   smithy::http::BeastServerTransport transport(options);
   ASSERT_TRUE(transport.Start(handler_).ok());


### PR DESCRIPTION
Bumps smithy-cpp `e407003` → `fd79e85` (upstream #106, ADR-0013: transport connection failures are observable events; silence means healthy).

## What changes

- **The pin bump alone fixes a real hazard for portrait.** Beast's request deadline was previously set at read start and never re-armed, so a render outrunning the 30-second residue had its *completed response cancelled at the write* — all the ray-tracing CPU spent, then the client saw a silent drop. Upstream now gives each wire phase its own budget; handler time is bounded by drain policy, not the wire deadline. For a seconds-per-render service this is the difference between "slow render, delivered" and "slow render, wasted."
- **`portrait::ConnectionEventLog()`** — the `on_connection_event` sibling of the existing `RejectionMetrics` adapter. Connections the transport terminates without a response — framing garbage to the exposed port, slowloris stalls, mid-request/response drops — were previously invisible to both `Observe` and the logs; each now emits one WARNING line: `connection_event kind=<kind> peer=<ip:port> detail=<error> elapsed_ms=<n>`. (`kTlsHandshakeFailure` can't fire here — Caddy terminates TLS.)
- **Log-only by design**: these are connections, not requests — mapping them into the request-shaped meerkat instruments (`http_server_requests`) would distort the counts dashboards trust. Kind counters join the parked post-soak instrument decision in PORTRAIT_TODO, alongside the `DeriveClient` source distribution.

## Notes for review

- The adapter's line shape is pinned by a direct unit test; transport→hook delivery is upstream-tested (`beast_transport_test`, consumer acceptance test), so no ClientHello-style integration test here — event delivery is asynchronous relative to the client's error return, which would make a log-capture assertion racy. The Beast transport test runs with the hook installed, production-shaped.
- Local compilation isn't possible in this sandbox; validated statically against the pinned smithy-cpp source (ADR-0013, `beast_transport.h`), buildifier/clang-format clean. CI compiles and runs everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_