### PR TITLE
Bump smithy-cpp to 2ba6bd8 (Phase 8: WebSocket + event streams, upstream #107–#124)

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "fd79e85412d71fe7600c004e15f3804ffff09ca1",
+    commit = "2ba6bd84023d231d8ed30cb12e3e3551f31a3d08",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )


### PR DESCRIPTION
Bumps smithy-cpp `fd79e85` → `2ba6bd8`, picking up the full Phase 8 streaming stack ahead of the Golf-on-smithy work: event-stream framing + WebSocket transports (ADR-0014/0015), generated event streams (ADR-0016), session handles + the fan-out `SessionRegistry` (ADR-0017), the JSON-text browser wire with `RequireOrigin` and ticket auth (ADR-0018), the async adapter + generated async streaming handlers (ADR-0019/0021), reconnect grace via `Detach`/`Resume` (ADR-0020), and the `ResumeOrAdd`/`Close` admission primitives (ADR-0022).

## Impact on portrait (the only smithy consumer today)

None expected — verified statically across the range:
- `BeastServerTransport::Options` gains only additive WebSocket fields; the fields portrait sets (`on_rejected`, `on_connection_event`, `max_body_bytes`, TLS/etc.) are unchanged.
- `router.h`'s diff is an internal pattern-matcher extraction (shared by the new `WebSocketRouter`); `RequestContext` is untouched.
- Generated-BUILD dep changes are gated on streaming models; portrait's model has no streams, so its generated targets are identical.
- smithy-cpp's `MODULE.bazel` didn't change — no new bzlmod deps for MoonBase.

CI compiles and runs everything, as with every prior pin bump. Golf scaffolding follows as a separate PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_