### PR TITLE
Bump impact-mcp, microgpt, wordchains to trigger new releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "impact_mcp"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "chrono",
  "clap",
@@ -2490,7 +2490,7 @@ dependencies = [
 
 [[package]]
 name = "microgpt_cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "microgpt",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "wordchains-bin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "log",

--- a/domains/ai/apps/impact_mcp/Cargo.toml
+++ b/domains/ai/apps/impact_mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "impact_mcp"
-version = "0.0.10"
+version = "0.0.11"
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true

--- a/domains/ai/apps/impact_mcp/src/cli.rs
+++ b/domains/ai/apps/impact_mcp/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 #[command(
     name = "impact-mcp",
     about = "impact-mcp — amplify your impact and make it visible",
-    version = "0.0.10",
+    version = "0.0.11",
     long_about = "A local-first AI toolkit that helps engineers capture evidence of impact, \
                    understand role expectations, close gaps, and communicate contributions \
                    clearly — for better project results and growth in your career."

--- a/domains/ai/apps/microgpt_cli/Cargo.toml
+++ b/domains/ai/apps/microgpt_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microgpt_cli"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 readme.workspace = true

--- a/domains/ai/apps/microgpt_cli/src/main.rs
+++ b/domains/ai/apps/microgpt_cli/src/main.rs
@@ -14,7 +14,7 @@ use microgpt::{ChatDataset, Dataset, ModelConfig, TrainState};
 #[command(
     name = "microgpt",
     about = "microgpt — a minimal GPT trainer and generator",
-    version = "0.6.1",
+    version = "0.6.2",
     long_about = "A minimal GPT implementation in Rust using candle for tensor ops.\n\
                   Trains BPE-tokenized language models and generates samples.\n\
                   Ported from karpathy's microgpt.py — the complete algorithm,\n\

--- a/domains/games/apps/wordchains/Cargo.toml
+++ b/domains/games/apps/wordchains/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wordchains-bin"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/domains/games/apps/wordchains/src/args.rs
+++ b/domains/games/apps/wordchains/src/args.rs
@@ -3,7 +3,7 @@ use clap::{Command, Arg, arg, value_parser};
 pub fn get_cmd() -> Command {
     Command::new("wordchains")
         .bin_name("wordchains")
-        .version("0.1.2")
+        .version("0.1.3")
         .subcommand_required(false)
         .arg(
             Arg::new("start")


### PR DESCRIPTION
Bumps all three homebrew-muchq-tapped tools to cut fresh releases.

| Package | Old → New |
|---|---|
| impact-mcp | 0.0.10 → 0.0.11 |
| microgpt | 0.6.1 → 0.6.2 |
| wordchains | 0.1.2 → 0.1.3 |

Each bump updates the version in the crate's `Cargo.toml`, its clap parser (`--version` output), and `Cargo.lock`.

On merge to `main`, the "Test and Publish" workflow completes and the `release-*` workflows fire via `workflow_run`. `release-rust-tool.yml` reads `version` from each `Cargo.toml`, sees it differs from the existing remote tag, and pushes `impact-mcp-v0.0.11` / `microgpt-v0.6.2` / `wordchains-v0.1.3`, publishing new GitHub releases.

Follow-up: the `homebrew-muchq` formula `url`/`sha256` still need updating once the release tarballs exist.