### PR TITLE
Golf phase 0: fix Go hub rules bugs and room-state leak

### DIFF
--- a/domains/games/apis/games_ws_backend/golf/game.go
+++ b/domains/games/apis/games_ws_backend/golf/game.go
@@ -2,6 +2,7 @@ package golf
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,7 +17,7 @@ type Game struct {
 	playersByClient  map[string]*Player // client ID -> player
 	finalRoundPlayed map[string]bool    // track who has played their final turn
 	idGenerator      players.PlayerIDGenerator
-	roomID           string             // ID of the room this game belongs to
+	roomID           string // ID of the room this game belongs to
 }
 
 // NewGame creates a new game instance
@@ -45,7 +46,7 @@ func NewGameInRoom(gameID string, roomID string, roomPlayers []*Player, idGenera
 	// Create game players from room players with reset game-specific state
 	gamePlayers := make([]*Player, len(roomPlayers))
 	playersByClient := make(map[string]*Player)
-	
+
 	for i, roomPlayer := range roomPlayers {
 		gamePlayer := &Player{
 			// Copy persistent room data
@@ -57,7 +58,7 @@ func NewGameInRoom(gameID string, roomID string, roomPlayers []*Player, idGenera
 			GamesWon:    roomPlayer.GamesWon,
 			IsConnected: roomPlayer.IsConnected,
 			JoinedAt:    roomPlayer.JoinedAt,
-			
+
 			// Reset game-specific state
 			Cards:         CreateHiddenCards(),
 			Score:         0,
@@ -68,7 +69,7 @@ func NewGameInRoom(gameID string, roomID string, roomPlayers []*Player, idGenera
 		gamePlayers[i] = gamePlayer
 		playersByClient[roomPlayer.ClientID] = gamePlayer
 	}
-	
+
 	return &Game{
 		state: &GameState{
 			ID:                 gameID,
@@ -449,6 +450,23 @@ func (g *Game) GetState() *GameState {
 	return stateCopy
 }
 
+// GetPublicState is GetState redacted for an audience with no seat at the
+// table (room broadcasts — issue #1187 phase 0): no card faces, no revealed
+// indexes, and no held drawn card until the game has ended, at which point
+// everything is public anyway.
+func (g *Game) GetPublicState() *GameState {
+	state := g.GetState()
+	if state.GamePhase == "ended" {
+		return state
+	}
+	state.DrawnCard = nil
+	for _, player := range state.Players {
+		player.Cards = make([]*Card, 4)
+		player.RevealedCards = nil
+	}
+	return state
+}
+
 // GetPlayerByClientID returns the player associated with a client ID
 func (g *Game) GetPlayerByClientID(clientID string) *Player {
 	g.mu.RLock()
@@ -565,6 +583,14 @@ func (g *Game) endTurn(clientID string) error {
 		}
 	}
 
+	// An exhausted draw pile ends the game with normal scoring instead of
+	// wedging the next player on "deck is empty". Issue #1187 phase 0.
+	if len(g.deck) == 0 {
+		g.state.GamePhase = "ended"
+		g.calculateFinalScores()
+		return nil
+	}
+
 	// Reset peeked state for next turn
 	g.state.PeekedAtDrawPile = false
 
@@ -593,27 +619,28 @@ func (g *Game) calculatePlayerFinalScore(player *Player) int {
 		}
 	}
 
-	// Calculate score with pairs canceling out
+	// Pairwise cancellation: each pair of a rank cancels, so only an odd
+	// remainder scores — and exactly one card of it (three of a kind = one
+	// pair cancelled + one card counted). Issue #1187 phase 0.
 	score := 0
+	counted := make(map[string]bool)
 	for i := 0; i < 4; i++ {
 		if player.Cards[i] != nil {
 			rank := player.Cards[i].Rank
-			// Only count cards that don't have a pair
-			if rankCounts[rank] == 1 || rankCounts[rank] == 3 {
+			if rankCounts[rank]%2 == 1 && !counted[rank] {
 				score += GetCardValue(player.Cards[i])
+				counted[rank] = true
 			}
-			// If there are 2 or 4 of the same rank, they cancel out
 		}
 	}
 
 	return score
 }
 
-// GetWinner returns the player with the lowest score
-func (g *Game) GetWinner() *Player {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-
+// winnersLocked returns every winner: the knocker alone if the knocker is
+// among the lowest scores, otherwise all tied lowest scorers (shared win —
+// issue #1187 phase 0). Caller must hold g.mu.
+func (g *Game) winnersLocked() []*Player {
 	if g.state.GamePhase != "ended" || len(g.state.Players) == 0 {
 		return nil
 	}
@@ -638,17 +665,29 @@ func (g *Game) GetWinner() *Player {
 	if g.state.KnockedPlayerID != nil {
 		for _, winner := range winners {
 			if winner.ID == *g.state.KnockedPlayerID {
-				return winner
+				return []*Player{winner}
 			}
 		}
 	}
 
-	// Otherwise, return the first winner (or handle ties differently if needed)
-	if len(winners) > 0 {
-		return winners[0]
-	}
+	return winners
+}
 
-	return nil
+// GetWinners returns all winners (ties are shared wins).
+func (g *Game) GetWinners() []*Player {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.winnersLocked()
+}
+
+// GetWinner returns the first winner, or nil. Kept for callers that only
+// display a single name; GetWinners is the authority on ties.
+func (g *Game) GetWinner() *Player {
+	winners := g.GetWinners()
+	if len(winners) == 0 {
+		return nil
+	}
+	return winners[0]
 }
 
 // GetFinalScores returns the final scores of all players
@@ -745,21 +784,22 @@ func (g *Game) GetRoomID() string {
 
 // GetGameResult returns the result of this game for room tracking
 func (g *Game) GetGameResult() *GameResult {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	
-	if g.state.GamePhase != "ended" {
+	winners := g.GetWinners()
+	if len(winners) == 0 {
 		return nil
 	}
-	
-	winner := g.GetWinner()
-	if winner == nil {
-		return nil
+	names := make([]string, len(winners))
+	for i, winner := range winners {
+		names[i] = winner.Name
 	}
-	
+
 	return &GameResult{
-		GameID:      g.state.ID,
-		Winner:      winner.Name,
+		GameID: g.state.ID,
+		// Winner stays the display string ("A & B" on a shared win) so
+		// existing consumers render ties without changes; Winners is the
+		// typed list.
+		Winner:      strings.Join(names, " & "),
+		Winners:     names,
 		FinalScores: g.GetFinalScores(),
 		CompletedAt: time.Now(),
 	}

--- a/domains/games/apis/games_ws_backend/golf/game_test.go
+++ b/domains/games/apis/games_ws_backend/golf/game_test.go
@@ -1288,6 +1288,46 @@ func TestFinalScorePairCancellation(t *testing.T) {
 			},
 			expected: 20,
 		},
+		{
+			name: "four of a kind cancels to zero",
+			cards: []*Card{
+				{Rank: "Q", Suit: "♠"},
+				{Rank: "Q", Suit: "♥"},
+				{Rank: "Q", Suit: "♦"},
+				{Rank: "Q", Suit: "♣"},
+			},
+			expected: 0,
+		},
+		{
+			name: "three of a kind with a jack",
+			cards: []*Card{
+				{Rank: "K", Suit: "♠"},
+				{Rank: "K", Suit: "♥"},
+				{Rank: "K", Suit: "♦"},
+				{Rank: "J", Suit: "♣"},
+			},
+			expected: 10, // one K; the jack is worth 0
+		},
+		{
+			name: "unpaired jacks are worth zero",
+			cards: []*Card{
+				{Rank: "J", Suit: "♠"},
+				{Rank: "2", Suit: "♥"},
+				{Rank: "3", Suit: "♦"},
+				{Rank: "A", Suit: "♣"},
+			},
+			expected: 6, // 2 + 3 + A
+		},
+		{
+			name: "nil card slot is skipped, pair still cancels",
+			cards: []*Card{
+				{Rank: "K", Suit: "♠"},
+				{Rank: "K", Suit: "♥"},
+				nil,
+				{Rank: "5", Suit: "♣"},
+			},
+			expected: 5,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1449,5 +1489,160 @@ func TestGetPublicStateRedactsInProgressGame(t *testing.T) {
 				t.Errorf("Ended game should expose %s's card %d", player.Name, i)
 			}
 		}
+	}
+}
+
+func TestDeckNotEmptyDoesNotEndGame(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	// Two cards left: the draw leaves one, which must NOT end the game.
+	game.deck = game.deck[:2]
+
+	if err := game.DrawCard("client1"); err != nil {
+		t.Fatalf("Failed to draw: %v", err)
+	}
+	if err := game.DiscardDrawn("client1"); err != nil {
+		t.Fatalf("Failed to discard: %v", err)
+	}
+
+	if game.state.GamePhase != "playing" {
+		t.Errorf("Game must continue with cards in the deck, got phase %s", game.state.GamePhase)
+	}
+	if game.state.CurrentPlayerIndex != 1 {
+		t.Errorf("Turn should advance to player 2, got index %d", game.state.CurrentPlayerIndex)
+	}
+	if game.GetWinners() != nil {
+		t.Error("No winners while the game is still in progress")
+	}
+}
+
+func TestEmptyDeckEndsGameViaDiscardPath(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	// Deck already exhausted; the turn ends via take-from-discard + swap,
+	// which must also trigger the empty-deck game end.
+	game.deck = nil
+
+	if err := game.TakeFromDiscard("client1"); err != nil {
+		t.Fatalf("Failed to take from discard: %v", err)
+	}
+	if err := game.SwapCard("client1", 0); err != nil {
+		t.Fatalf("Failed to swap: %v", err)
+	}
+
+	if game.state.GamePhase != "ended" {
+		t.Fatalf("Expected empty deck to end the game after swap, got phase %s", game.state.GamePhase)
+	}
+	if len(game.GetWinners()) == 0 {
+		t.Error("Expected winners after empty-deck game end")
+	}
+}
+
+func TestEmptyDeckDuringKnockedPhaseEndsEarly(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	addTestPlayerToGame(game, "client3")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	// Player 1 knocks; player 2 draws the last card. The game ends on deck
+	// exhaustion even though player 3 never got a final turn.
+	if err := game.Knock("client1"); err != nil {
+		t.Fatalf("Failed to knock: %v", err)
+	}
+	game.deck = game.deck[:1]
+
+	if err := game.DrawCard("client2"); err != nil {
+		t.Fatalf("Failed to draw: %v", err)
+	}
+	if err := game.DiscardDrawn("client2"); err != nil {
+		t.Fatalf("Failed to discard: %v", err)
+	}
+
+	if game.state.GamePhase != "ended" {
+		t.Fatalf("Expected game to end when the deck ran out mid final round, got phase %s",
+			game.state.GamePhase)
+	}
+	if len(game.GetWinners()) == 0 {
+		t.Error("Expected winners after the deck ran out")
+	}
+}
+
+func TestNoWinnersOrResultBeforeGameEnds(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+
+	// Waiting phase: no players dealt, nothing to win.
+	if game.GetWinners() != nil {
+		t.Error("GetWinners must be nil in waiting phase")
+	}
+	if game.GetWinner() != nil {
+		t.Error("GetWinner must be nil in waiting phase")
+	}
+	if game.GetGameResult() != nil {
+		t.Error("GetGameResult must be nil in waiting phase")
+	}
+
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	game.StartGame()
+
+	// Playing phase: still nothing.
+	if game.GetWinners() != nil {
+		t.Error("GetWinners must be nil while the game is in progress")
+	}
+	if game.GetGameResult() != nil {
+		t.Error("GetGameResult must be nil while the game is in progress")
+	}
+}
+
+func TestSoloWinnerIsNotShared(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	addTestPlayerToGame(game, "client3")
+	game.StartGame()
+
+	// Distinct scores: exactly one winner, no spurious sharing.
+	game.state.Players[0].Cards = []*Card{
+		{Rank: "A", Suit: "♠"}, {Rank: "2", Suit: "♥"},
+		{Rank: "3", Suit: "♦"}, {Rank: "4", Suit: "♣"}, // 10
+	}
+	game.state.Players[1].Cards = []*Card{
+		{Rank: "5", Suit: "♠"}, {Rank: "6", Suit: "♥"},
+		{Rank: "7", Suit: "♦"}, {Rank: "8", Suit: "♣"}, // 26
+	}
+	game.state.Players[2].Cards = []*Card{
+		{Rank: "K", Suit: "♠"}, {Rank: "Q", Suit: "♥"},
+		{Rank: "10", Suit: "♦"}, {Rank: "9", Suit: "♣"}, // 39
+	}
+	game.state.GamePhase = "ended"
+	game.calculateFinalScores()
+
+	winners := game.GetWinners()
+	if len(winners) != 1 {
+		t.Fatalf("Expected exactly 1 winner, got %d", len(winners))
+	}
+	if winners[0].Name != "TestPlayerclient1" {
+		t.Errorf("Expected TestPlayerclient1 to win, got %s", winners[0].Name)
+	}
+
+	result := game.GetGameResult()
+	if result.Winner != "TestPlayerclient1" {
+		t.Errorf("Solo win must not be a joined string, got %q", result.Winner)
+	}
+	if len(result.Winners) != 1 || result.Winners[0] != "TestPlayerclient1" {
+		t.Errorf("Expected Winners == [TestPlayerclient1], got %v", result.Winners)
 	}
 }

--- a/domains/games/apis/games_ws_backend/golf/game_test.go
+++ b/domains/games/apis/games_ws_backend/golf/game_test.go
@@ -688,7 +688,7 @@ func TestMaxPlayers(t *testing.T) {
 
 	// Add 4 players (max)
 	for i := 0; i < 4; i++ {
-		_, err := addTestPlayerToGame(game, string(rune('a' + i)))
+		_, err := addTestPlayerToGame(game, string(rune('a'+i)))
 		if err != nil {
 			t.Fatalf("Failed to add player %d: %v", i+1, err)
 		}
@@ -1233,5 +1233,221 @@ func TestAddPlayerTwiceAfterGameStarted(t *testing.T) {
 
 	if err.Error() != "game already started" {
 		t.Errorf("Expected 'game already started' error, got: %s", err.Error())
+	}
+}
+
+// Phase 0 rules fixes (issue #1187): pair scoring counts exactly one card of
+// an odd-remainder rank, an exhausted deck ends the game with normal scoring,
+// and non-knocker ties are shared wins.
+
+func TestFinalScorePairCancellation(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+
+	cases := []struct {
+		name     string
+		cards    []*Card
+		expected int
+	}{
+		{
+			name: "three of a kind scores exactly one card",
+			cards: []*Card{
+				{Rank: "K", Suit: "♠"},
+				{Rank: "K", Suit: "♥"},
+				{Rank: "K", Suit: "♦"},
+				{Rank: "A", Suit: "♣"},
+			},
+			expected: 11, // one K (pair cancelled) + A
+		},
+		{
+			name: "two pairs cancel to zero",
+			cards: []*Card{
+				{Rank: "5", Suit: "♠"},
+				{Rank: "5", Suit: "♥"},
+				{Rank: "9", Suit: "♦"},
+				{Rank: "9", Suit: "♣"},
+			},
+			expected: 0,
+		},
+		{
+			name: "one pair cancels, rest count",
+			cards: []*Card{
+				{Rank: "7", Suit: "♠"},
+				{Rank: "7", Suit: "♥"},
+				{Rank: "3", Suit: "♦"},
+				{Rank: "Q", Suit: "♣"},
+			},
+			expected: 13, // 3 + Q
+		},
+		{
+			name: "no pairs, everything counts",
+			cards: []*Card{
+				{Rank: "2", Suit: "♠"},
+				{Rank: "4", Suit: "♥"},
+				{Rank: "6", Suit: "♦"},
+				{Rank: "8", Suit: "♣"},
+			},
+			expected: 20,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			player := &Player{Cards: tc.cards}
+			if got := game.calculatePlayerFinalScore(player); got != tc.expected {
+				t.Errorf("Expected score %d, got %d", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestEmptyDeckEndsGame(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	// Leave exactly one card so player 1's draw exhausts the deck.
+	game.deck = game.deck[:1]
+
+	if err := game.DrawCard("client1"); err != nil {
+		t.Fatalf("Failed to draw last card: %v", err)
+	}
+	if err := game.DiscardDrawn("client1"); err != nil {
+		t.Fatalf("Failed to discard: %v", err)
+	}
+
+	if game.state.GamePhase != "ended" {
+		t.Fatalf("Expected empty deck to end the game, got phase %s", game.state.GamePhase)
+	}
+
+	// Scoring ran: all cards revealed and winners determined without a knock.
+	for _, player := range game.state.Players {
+		if len(player.RevealedCards) != 4 {
+			t.Errorf("Expected all 4 cards revealed for %s, got %d",
+				player.Name, len(player.RevealedCards))
+		}
+	}
+	if len(game.GetWinners()) == 0 {
+		t.Error("Expected winners after empty-deck game end")
+	}
+}
+
+func TestSharedWinOnNonKnockerTie(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	addTestPlayerToGame(game, "client3")
+	game.StartGame()
+
+	// Players 1 and 2 tie at zero; player 3 knocked but scores higher.
+	game.state.Players[0].Cards = []*Card{
+		{Rank: "A", Suit: "♠"}, {Rank: "A", Suit: "♥"},
+		{Rank: "3", Suit: "♦"}, {Rank: "3", Suit: "♣"},
+	}
+	game.state.Players[1].Cards = []*Card{
+		{Rank: "5", Suit: "♠"}, {Rank: "5", Suit: "♥"},
+		{Rank: "9", Suit: "♦"}, {Rank: "9", Suit: "♣"},
+	}
+	game.state.Players[2].Cards = []*Card{
+		{Rank: "K", Suit: "♠"}, {Rank: "Q", Suit: "♥"},
+		{Rank: "8", Suit: "♦"}, {Rank: "2", Suit: "♣"},
+	}
+	game.state.KnockedPlayerID = &game.state.Players[2].ID
+	game.state.GamePhase = "ended"
+	game.calculateFinalScores()
+
+	winners := game.GetWinners()
+	if len(winners) != 2 {
+		t.Fatalf("Expected 2 shared winners, got %d", len(winners))
+	}
+	if winners[0].Name != "TestPlayerclient1" || winners[1].Name != "TestPlayerclient2" {
+		t.Errorf("Expected players 1 and 2 to share the win, got %s and %s",
+			winners[0].Name, winners[1].Name)
+	}
+
+	result := game.GetGameResult()
+	if result == nil {
+		t.Fatal("Expected a game result")
+	}
+	if result.Winner != "TestPlayerclient1 & TestPlayerclient2" {
+		t.Errorf("Expected joined display winner, got %q", result.Winner)
+	}
+	if len(result.Winners) != 2 {
+		t.Errorf("Expected 2 entries in Winners, got %d", len(result.Winners))
+	}
+}
+
+func TestKnockerAmongTiedWinsAlone(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	game.StartGame()
+
+	// Both players tie at zero, but player 2 knocked and takes the win solo.
+	game.state.Players[0].Cards = []*Card{
+		{Rank: "A", Suit: "♠"}, {Rank: "A", Suit: "♥"},
+		{Rank: "3", Suit: "♦"}, {Rank: "3", Suit: "♣"},
+	}
+	game.state.Players[1].Cards = []*Card{
+		{Rank: "5", Suit: "♠"}, {Rank: "5", Suit: "♥"},
+		{Rank: "9", Suit: "♦"}, {Rank: "9", Suit: "♣"},
+	}
+	game.state.KnockedPlayerID = &game.state.Players[1].ID
+	game.state.GamePhase = "ended"
+	game.calculateFinalScores()
+
+	winners := game.GetWinners()
+	if len(winners) != 1 {
+		t.Fatalf("Expected knocker to win alone, got %d winners", len(winners))
+	}
+	if winners[0].Name != "TestPlayerclient2" {
+		t.Errorf("Expected TestPlayerclient2 (knocker) to win, got %s", winners[0].Name)
+	}
+
+	result := game.GetGameResult()
+	if result.Winner != "TestPlayerclient2" {
+		t.Errorf("Expected single-name display winner, got %q", result.Winner)
+	}
+	if len(result.Winners) != 1 {
+		t.Errorf("Expected 1 entry in Winners, got %d", len(result.Winners))
+	}
+}
+
+func TestGetPublicStateRedactsInProgressGame(t *testing.T) {
+	game := NewGame("TEST123", &players.DeterministicIDGenerator{})
+	addTestPlayerToGame(game, "client1")
+	addTestPlayerToGame(game, "client2")
+	game.StartGame()
+	if err := game.DrawCard("client1"); err != nil {
+		t.Fatalf("Failed to draw: %v", err)
+	}
+
+	public := game.GetPublicState()
+	if public.DrawnCard != nil {
+		t.Error("Public state must not expose the held drawn card")
+	}
+	for _, player := range public.Players {
+		for i, card := range player.Cards {
+			if card != nil {
+				t.Errorf("Public state must not expose %s's card %d", player.Name, i)
+			}
+		}
+		if len(player.RevealedCards) != 0 {
+			t.Errorf("Public state must not expose %s's revealed indexes", player.Name)
+		}
+	}
+
+	// After the game ends everything is public again.
+	game.state.GamePhase = "ended"
+	game.calculateFinalScores()
+	ended := game.GetPublicState()
+	for _, player := range ended.Players {
+		for i, card := range player.Cards {
+			if card == nil {
+				t.Errorf("Ended game should expose %s's card %d", player.Name, i)
+			}
+		}
 	}
 }

--- a/domains/games/apis/games_ws_backend/golf/golf_hub.go
+++ b/domains/games/apis/games_ws_backend/golf/golf_hub.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -1303,14 +1304,19 @@ func (h *GolfHub) broadcastTurnChanged(game *Game) {
 }
 
 func (h *GolfHub) broadcastGameEnded(game *Game) {
-	winner := game.GetWinner()
-	if winner == nil {
+	winners := game.GetWinners()
+	if len(winners) == 0 {
 		return
+	}
+	names := make([]string, len(winners))
+	for i, winner := range winners {
+		names[i] = winner.Name
 	}
 
 	msg := &GameEndedMessage{
 		Type:        "gameEnded",
-		Winner:      winner.Name,
+		Winner:      strings.Join(names, " & "),
+		Winners:     names,
 		FinalScores: game.GetFinalScores(),
 	}
 	h.broadcastToGameLocked(game, msg)
@@ -1561,13 +1567,19 @@ func (h *GolfHub) completeGameInRoom(roomID string, gameID string) error {
 	room.GameHistory = append(room.GameHistory, gameResult)
 	room.LastActivity = time.Now()
 
-	// Update player statistics
+	// Update player statistics. Winners is the typed list — on a shared win
+	// (non-knocker tie, issue #1187 phase 0) every winner gets the credit,
+	// and Winner is just the joined display string.
+	winnerSet := make(map[string]bool, len(gameResult.Winners))
+	for _, name := range gameResult.Winners {
+		winnerSet[name] = true
+	}
 	for _, finalScore := range gameResult.FinalScores {
 		for _, roomPlayer := range room.Players {
 			if roomPlayer.Name == finalScore.PlayerName {
 				roomPlayer.TotalScore += finalScore.Score
 				roomPlayer.GamesPlayed++
-				if finalScore.PlayerName == gameResult.Winner {
+				if winnerSet[finalScore.PlayerName] {
 					roomPlayer.GamesWon++
 				}
 				break

--- a/domains/games/apis/games_ws_backend/golf/golf_hub_test.go
+++ b/domains/games/apis/games_ws_backend/golf/golf_hub_test.go
@@ -516,7 +516,7 @@ func TestHub_CreateAndJoinGame(t *testing.T) {
 			break
 		}
 	}
-	
+
 	if !foundGameJoined {
 		t.Fatal("Expected to find gameJoined message")
 	}
@@ -635,7 +635,7 @@ func TestHub_StartGame(t *testing.T) {
 	player2Messages := client2.getMessages()
 	foundGameJoined := false
 	var player2GameJoinedMsg GameJoinedMessage
-	
+
 	for _, msg := range player2Messages {
 		var testMsg struct {
 			Type string `json:"type"`
@@ -647,19 +647,19 @@ func TestHub_StartGame(t *testing.T) {
 			}
 		}
 	}
-	
+
 	if !foundGameJoined {
 		t.Fatal("Player 2 should have received gameJoined message when joining the game")
 	}
-	
+
 	if player2GameJoinedMsg.Type != "gameJoined" {
 		t.Errorf("Expected gameJoined message for player 2, got %s", player2GameJoinedMsg.Type)
 	}
-	
+
 	if player2GameJoinedMsg.GameState.ID != gameID {
 		t.Errorf("Expected game ID %s in gameJoined message, got %s", gameID, player2GameJoinedMsg.GameState.ID)
 	}
-	
+
 	if len(player2GameJoinedMsg.GameState.Players) != 2 {
 		t.Errorf("Expected 2 players in game state, got %d", len(player2GameJoinedMsg.GameState.Players))
 	}
@@ -1173,7 +1173,7 @@ func TestHub_MultiGameSupport(t *testing.T) {
 	})
 	time.Sleep(10 * time.Millisecond)
 
-	// Client 3 joins the room first  
+	// Client 3 joins the room first
 	joinRoomMsg3 := `{"type": "joinRoom", "roomId": "` + roomID + `"}`
 	golfHub.GameMessage(hub.GameMessageData{
 		Message: []byte(joinRoomMsg3),
@@ -1189,7 +1189,7 @@ func TestHub_MultiGameSupport(t *testing.T) {
 	})
 	time.Sleep(10 * time.Millisecond)
 
-	// Client 3 creates game "GAME2"  
+	// Client 3 creates game "GAME2"
 	createGame2Msg := `{"type": "createGame", "roomId": "` + roomID + `"}`
 	golfHub.GameMessage(hub.GameMessageData{
 		Message: []byte(createGame2Msg),
@@ -1974,4 +1974,169 @@ func TestHub_LeaveGame(t *testing.T) {
 			t.Error("Expected error when leaving game while not in one")
 		}
 	})
+}
+
+// Stats credit for shared wins (issue #1187 phase 0): every tied winner's
+// GamesWon increments. Under the old exact-match against the display string
+// ("Alice & Bob"), nobody got credit on a tie.
+func TestCompleteGameInRoom_SharedWinStats(t *testing.T) {
+	golfHub := NewGolfHub(&players.DeterministicIDGenerator{}).(*GolfHub)
+
+	game := NewGame("GAME01", &players.DeterministicIDGenerator{})
+	game.AddPlayer("client1", "p1", "Alice")
+	game.AddPlayer("client2", "p2", "Bob")
+	game.AddPlayer("client3", "p3", "Carol")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	// Alice and Bob tie at zero; Carol scores 39. Nobody knocked.
+	game.state.Players[0].Cards = []*Card{
+		{Rank: "A", Suit: "♠"}, {Rank: "A", Suit: "♥"},
+		{Rank: "3", Suit: "♦"}, {Rank: "3", Suit: "♣"},
+	}
+	game.state.Players[1].Cards = []*Card{
+		{Rank: "5", Suit: "♠"}, {Rank: "5", Suit: "♥"},
+		{Rank: "9", Suit: "♦"}, {Rank: "9", Suit: "♣"},
+	}
+	game.state.Players[2].Cards = []*Card{
+		{Rank: "K", Suit: "♠"}, {Rank: "Q", Suit: "♥"},
+		{Rank: "10", Suit: "♦"}, {Rank: "9", Suit: "♣"},
+	}
+	game.state.GamePhase = "ended"
+	game.calculateFinalScores()
+
+	alice := &Player{Name: "Alice"}
+	bob := &Player{Name: "Bob"}
+	carol := &Player{Name: "Carol"}
+	room := &Room{
+		ID:      "ROOM01",
+		Players: []*Player{alice, bob, carol},
+		Games:   map[string]*Game{"GAME01": game},
+	}
+	golfHub.rooms["ROOM01"] = room
+
+	if err := golfHub.completeGameInRoom("ROOM01", "GAME01"); err != nil {
+		t.Fatalf("completeGameInRoom failed: %v", err)
+	}
+
+	if alice.GamesWon != 1 || bob.GamesWon != 1 {
+		t.Errorf("Both shared winners must get credit, got Alice=%d Bob=%d",
+			alice.GamesWon, bob.GamesWon)
+	}
+	if carol.GamesWon != 0 {
+		t.Errorf("Loser must not get win credit, got %d", carol.GamesWon)
+	}
+	for _, p := range []*Player{alice, bob, carol} {
+		if p.GamesPlayed != 1 {
+			t.Errorf("Expected GamesPlayed 1 for %s, got %d", p.Name, p.GamesPlayed)
+		}
+	}
+	if carol.TotalScore != 39 {
+		t.Errorf("Expected Carol's total score 39, got %d", carol.TotalScore)
+	}
+
+	if len(room.GameHistory) != 1 {
+		t.Fatalf("Expected 1 game in history, got %d", len(room.GameHistory))
+	}
+	result := room.GameHistory[0]
+	if result.Winner != "Alice & Bob" {
+		t.Errorf("Expected display winner 'Alice & Bob', got %q", result.Winner)
+	}
+	if len(result.Winners) != 2 || result.Winners[0] != "Alice" || result.Winners[1] != "Bob" {
+		t.Errorf("Expected Winners == [Alice Bob], got %v", result.Winners)
+	}
+	if len(room.Games) != 0 {
+		t.Errorf("Expected game removed from active games, got %d", len(room.Games))
+	}
+}
+
+// The knocker-alone rule at the stats layer: a knocker who ties keeps the
+// sole credit, and the tied non-knocker gets none.
+func TestCompleteGameInRoom_KnockerTieSoloCredit(t *testing.T) {
+	golfHub := NewGolfHub(&players.DeterministicIDGenerator{}).(*GolfHub)
+
+	game := NewGame("GAME01", &players.DeterministicIDGenerator{})
+	game.AddPlayer("client1", "p1", "Alice")
+	game.AddPlayer("client2", "p2", "Bob")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	game.state.Players[0].Cards = []*Card{
+		{Rank: "A", Suit: "♠"}, {Rank: "A", Suit: "♥"},
+		{Rank: "3", Suit: "♦"}, {Rank: "3", Suit: "♣"},
+	}
+	game.state.Players[1].Cards = []*Card{
+		{Rank: "5", Suit: "♠"}, {Rank: "5", Suit: "♥"},
+		{Rank: "9", Suit: "♦"}, {Rank: "9", Suit: "♣"},
+	}
+	game.state.KnockedPlayerID = &game.state.Players[1].ID
+	game.state.GamePhase = "ended"
+	game.calculateFinalScores()
+
+	alice := &Player{Name: "Alice"}
+	bob := &Player{Name: "Bob"}
+	room := &Room{
+		ID:      "ROOM01",
+		Players: []*Player{alice, bob},
+		Games:   map[string]*Game{"GAME01": game},
+	}
+	golfHub.rooms["ROOM01"] = room
+
+	if err := golfHub.completeGameInRoom("ROOM01", "GAME01"); err != nil {
+		t.Fatalf("completeGameInRoom failed: %v", err)
+	}
+
+	if bob.GamesWon != 1 {
+		t.Errorf("Knocker must get the sole credit, got %d", bob.GamesWon)
+	}
+	if alice.GamesWon != 0 {
+		t.Errorf("Tied non-knocker must not get credit when the knocker ties, got %d", alice.GamesWon)
+	}
+	if result := room.GameHistory[0]; result.Winner != "Bob" || len(result.Winners) != 1 {
+		t.Errorf("Expected solo winner Bob, got %q / %v", result.Winner, result.Winners)
+	}
+}
+
+// Negative paths: unknown room, unknown game, and a game still in progress
+// must all error without touching stats or history.
+func TestCompleteGameInRoom_Errors(t *testing.T) {
+	golfHub := NewGolfHub(&players.DeterministicIDGenerator{}).(*GolfHub)
+
+	game := NewGame("GAME01", &players.DeterministicIDGenerator{})
+	game.AddPlayer("client1", "p1", "Alice")
+	game.AddPlayer("client2", "p2", "Bob")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	alice := &Player{Name: "Alice"}
+	bob := &Player{Name: "Bob"}
+	room := &Room{
+		ID:      "ROOM01",
+		Players: []*Player{alice, bob},
+		Games:   map[string]*Game{"GAME01": game},
+	}
+	golfHub.rooms["ROOM01"] = room
+
+	if err := golfHub.completeGameInRoom("NOROOM", "GAME01"); err == nil {
+		t.Error("Expected error for unknown room")
+	}
+	if err := golfHub.completeGameInRoom("ROOM01", "NOGAME"); err == nil {
+		t.Error("Expected error for unknown game")
+	}
+	if err := golfHub.completeGameInRoom("ROOM01", "GAME01"); err == nil {
+		t.Error("Expected error for a game still in progress")
+	}
+
+	if alice.GamesPlayed != 0 || bob.GamesPlayed != 0 || alice.GamesWon != 0 || bob.GamesWon != 0 {
+		t.Error("Failed completion must not touch player stats")
+	}
+	if len(room.GameHistory) != 0 {
+		t.Errorf("Failed completion must not append history, got %d entries", len(room.GameHistory))
+	}
+	if len(room.Games) != 1 {
+		t.Errorf("Failed completion must not remove the game, got %d games", len(room.Games))
+	}
 }

--- a/domains/games/apis/games_ws_backend/golf/types.go
+++ b/domains/games/apis/games_ws_backend/golf/types.go
@@ -11,12 +11,12 @@ import (
 
 // Room represents a persistent room where multiple games can be played
 type Room struct {
-	ID              string                 `json:"id"`
-	Players         []*Player              `json:"players"`
-	Games           map[string]*Game       `json:"games"` // Active games mapped by game ID
-	GameHistory     []*GameResult          `json:"gameHistory"`
-	CreatedAt       time.Time              `json:"createdAt"`
-	LastActivity    time.Time              `json:"lastActivity"`
+	ID           string           `json:"id"`
+	Players      []*Player        `json:"players"`
+	Games        map[string]*Game `json:"games"` // Active games mapped by game ID
+	GameHistory  []*GameResult    `json:"gameHistory"`
+	CreatedAt    time.Time        `json:"createdAt"`
+	LastActivity time.Time        `json:"lastActivity"`
 }
 
 // MarshalJSON implements custom JSON marshaling for Room
@@ -24,15 +24,19 @@ type Room struct {
 func (r *Room) MarshalJSON() ([]byte, error) {
 	// Create a temporary struct for JSON serialization
 	type Alias Room
-	
-	// Convert Games map to GameState map
+
+	// Convert Games map to GameState map. Room serialization reaches every
+	// room member (and any future spectator), so it must carry NO private
+	// state: GetPublicState strips card faces, revealed indexes, and the
+	// held drawn card for in-progress games (issue #1187 phase 0 — the
+	// room-state redaction leak).
 	gameStates := make(map[string]*GameState)
 	for gameID, game := range r.Games {
 		if game != nil {
-			gameStates[gameID] = game.GetState()
+			gameStates[gameID] = game.GetPublicState()
 		}
 	}
-	
+
 	// Create the JSON representation
 	return json.Marshal(&struct {
 		*Alias
@@ -52,12 +56,15 @@ type ClientContext struct {
 	LastAction time.Time `json:"lastAction"` // Last action timestamp
 }
 
-// GameResult stores the outcome of a completed game
+// GameResult stores the outcome of a completed game. Winner is the display
+// string ("A & B" on a shared win); Winners is the typed list (issue #1187
+// phase 0 — non-knocker ties are shared wins).
 type GameResult struct {
-	GameID          string        `json:"gameId"`
-	Winner          string        `json:"winner"`
-	FinalScores     []*FinalScore `json:"finalScores"`
-	CompletedAt     time.Time     `json:"completedAt"`
+	GameID      string        `json:"gameId"`
+	Winner      string        `json:"winner"`
+	Winners     []string      `json:"winners"`
+	FinalScores []*FinalScore `json:"finalScores"`
+	CompletedAt time.Time     `json:"completedAt"`
 }
 
 // Card represents a playing card
@@ -76,14 +83,14 @@ type Player struct {
 	RevealedCards []int   `json:"revealedCards"`
 	IsReady       bool    `json:"isReady"`
 	HasPeeked     bool    `json:"hasPeeked"`
-	
+
 	// Room/persistence fields
-	ClientID      string    `json:"clientId"`
-	TotalScore    int       `json:"totalScore"`    // Running total across all games
-	GamesPlayed   int       `json:"gamesPlayed"`
-	GamesWon      int       `json:"gamesWon"`
-	IsConnected   bool      `json:"isConnected"`
-	JoinedAt      time.Time `json:"joinedAt"`
+	ClientID    string    `json:"clientId"`
+	TotalScore  int       `json:"totalScore"` // Running total across all games
+	GamesPlayed int       `json:"gamesPlayed"`
+	GamesWon    int       `json:"gamesWon"`
+	IsConnected bool      `json:"isConnected"`
+	JoinedAt    time.Time `json:"joinedAt"`
 }
 
 // GameState represents the full game state
@@ -207,16 +214,20 @@ type FinalScore struct {
 	Score      int    `json:"score"`
 }
 
+// GameEndedMessage announces the end of a game. Winner is the display
+// string ("A & B" on a shared win) so existing clients render ties
+// unchanged; Winners is the typed list.
 type GameEndedMessage struct {
 	Type        string        `json:"type"`
 	Winner      string        `json:"winner"`
+	Winners     []string      `json:"winners"`
 	FinalScores []*FinalScore `json:"finalScores"`
 }
 
 type RoomJoinedMessage struct {
-	Type      string     `json:"type"`
-	PlayerID  string     `json:"playerId"`
-	RoomState *Room      `json:"roomState"`
+	Type      string `json:"type"`
+	PlayerID  string `json:"playerId"`
+	RoomState *Room  `json:"roomState"`
 }
 
 type RoomStateUpdateMessage struct {
@@ -232,8 +243,8 @@ type NewGameStartedMessage struct {
 
 // Server-to-client message types for multi-game support
 type GameListMessage struct {
-	Type  string            `json:"type"`
-	Games map[string]*Game  `json:"games"` // Games in current room
+	Type  string           `json:"type"`
+	Games map[string]*Game `json:"games"` // Games in current room
 }
 
 type GameListUpdateMessage struct {

--- a/domains/games/apis/games_ws_backend/golf/types_test.go
+++ b/domains/games/apis/games_ws_backend/golf/types_test.go
@@ -3,6 +3,8 @@ package golf
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/muchq/moonbase/domains/games/apis/games_ws_backend/players"
 )
 
 // Message Creation and Serialization Tests
@@ -11,17 +13,17 @@ func TestCreateGameMessage(t *testing.T) {
 	msg := CreateGameMessage{
 		Type: "createGame",
 	}
-	
+
 	data, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("Failed to marshal CreateGameMessage: %v", err)
 	}
-	
+
 	var parsed CreateGameMessage
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal CreateGameMessage: %v", err)
 	}
-	
+
 	if parsed.Type != "createGame" {
 		t.Errorf("Expected type 'createGame', got %s", parsed.Type)
 	}
@@ -32,17 +34,17 @@ func TestJoinGameMessage(t *testing.T) {
 		Type:   "joinGame",
 		GameID: "ABC123",
 	}
-	
+
 	data, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("Failed to marshal JoinGameMessage: %v", err)
 	}
-	
+
 	var parsed JoinGameMessage
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal JoinGameMessage: %v", err)
 	}
-	
+
 	if parsed.Type != "joinGame" {
 		t.Errorf("Expected type 'joinGame', got %s", parsed.Type)
 	}
@@ -71,23 +73,23 @@ func TestGameJoinedMessage(t *testing.T) {
 		KnockedPlayerID:    nil,
 		DrawnCard:          nil,
 	}
-	
+
 	msg := GameJoinedMessage{
 		Type:      "gameJoined",
 		PlayerID:  "player1",
 		GameState: gameState,
 	}
-	
+
 	data, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("Failed to marshal GameJoinedMessage: %v", err)
 	}
-	
+
 	var parsed GameJoinedMessage
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal GameJoinedMessage: %v", err)
 	}
-	
+
 	if parsed.Type != "gameJoined" {
 		t.Errorf("Expected type 'gameJoined', got %s", parsed.Type)
 	}
@@ -104,17 +106,17 @@ func TestErrorMessage(t *testing.T) {
 		Type:    "error",
 		Message: "Not your turn",
 	}
-	
+
 	data, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("Failed to marshal ErrorMessage: %v", err)
 	}
-	
+
 	var parsed ErrorMessage
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal ErrorMessage: %v", err)
 	}
-	
+
 	if parsed.Type != "error" {
 		t.Errorf("Expected type 'error', got %s", parsed.Type)
 	}
@@ -128,17 +130,17 @@ func TestTurnChangedMessage(t *testing.T) {
 		Type:       "turnChanged",
 		PlayerName: "Player 2",
 	}
-	
+
 	data, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("Failed to marshal TurnChangedMessage: %v", err)
 	}
-	
+
 	var parsed TurnChangedMessage
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal TurnChangedMessage: %v", err)
 	}
-	
+
 	if parsed.Type != "turnChanged" {
 		t.Errorf("Expected type 'turnChanged', got %s", parsed.Type)
 	}
@@ -156,17 +158,17 @@ func TestGameEndedMessage(t *testing.T) {
 			{PlayerName: "Player 2", Score: 15},
 		},
 	}
-	
+
 	data, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("Failed to marshal GameEndedMessage: %v", err)
 	}
-	
+
 	var parsed GameEndedMessage
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal GameEndedMessage: %v", err)
 	}
-	
+
 	if parsed.Type != "gameEnded" {
 		t.Errorf("Expected type 'gameEnded', got %s", parsed.Type)
 	}
@@ -186,17 +188,17 @@ func TestCardSerialization(t *testing.T) {
 		Rank: "K",
 		Suit: "♠",
 	}
-	
+
 	data, err := json.Marshal(card)
 	if err != nil {
 		t.Fatalf("Failed to marshal Card: %v", err)
 	}
-	
+
 	var parsed Card
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal Card: %v", err)
 	}
-	
+
 	if parsed.Rank != "K" {
 		t.Errorf("Expected rank 'K', got %s", parsed.Rank)
 	}
@@ -219,17 +221,17 @@ func TestPlayerSerialization(t *testing.T) {
 		RevealedCards: []int{0, 1},
 		IsReady:       true,
 	}
-	
+
 	data, err := json.Marshal(player)
 	if err != nil {
 		t.Fatalf("Failed to marshal Player: %v", err)
 	}
-	
+
 	var parsed Player
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal Player: %v", err)
 	}
-	
+
 	if parsed.ID != "player123" {
 		t.Errorf("Expected ID 'player123', got %s", parsed.ID)
 	}
@@ -281,17 +283,17 @@ func TestGameStateSerialization(t *testing.T) {
 		KnockedPlayerID: &knockedID,
 		DrawnCard:       &Card{Rank: "5", Suit: "♠"},
 	}
-	
+
 	data, err := json.Marshal(gameState)
 	if err != nil {
 		t.Fatalf("Failed to marshal GameState: %v", err)
 	}
-	
+
 	var parsed GameState
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal GameState: %v", err)
 	}
-	
+
 	if parsed.ID != "GAME123" {
 		t.Errorf("Expected ID 'GAME123', got %s", parsed.ID)
 	}
@@ -356,7 +358,7 @@ func TestMessageRoundTrip(t *testing.T) {
 			typ:  "knock",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Marshal to JSON
@@ -364,13 +366,13 @@ func TestMessageRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to marshal message: %v", err)
 			}
-			
+
 			// Parse as incoming message
 			parsed, err := ParseIncomingMessage(data)
 			if err != nil {
 				t.Fatalf("Failed to parse message: %v", err)
 			}
-			
+
 			if parsed.Type != tt.typ {
 				t.Errorf("Expected type %s, got %s", tt.typ, parsed.Type)
 			}
@@ -380,11 +382,11 @@ func TestMessageRoundTrip(t *testing.T) {
 
 func TestCreateDeck(t *testing.T) {
 	deck := CreateDeck()
-	
+
 	if len(deck) != 52 {
 		t.Errorf("Expected 52 cards, got %d", len(deck))
 	}
-	
+
 	// Check for duplicates
 	cardMap := make(map[string]bool)
 	for _, card := range deck {
@@ -394,22 +396,22 @@ func TestCreateDeck(t *testing.T) {
 		}
 		cardMap[key] = true
 	}
-	
+
 	// Check all suits and ranks are present
 	suitCount := make(map[string]int)
 	rankCount := make(map[string]int)
-	
+
 	for _, card := range deck {
 		suitCount[card.Suit]++
 		rankCount[card.Rank]++
 	}
-	
+
 	for _, suit := range Suits {
 		if suitCount[suit] != 13 {
 			t.Errorf("Expected 13 cards of suit %s, got %d", suit, suitCount[suit])
 		}
 	}
-	
+
 	for _, rank := range Ranks {
 		if rankCount[rank] != 4 {
 			t.Errorf("Expected 4 cards of rank %s, got %d", rank, rankCount[rank])
@@ -420,18 +422,18 @@ func TestCreateDeck(t *testing.T) {
 func TestShuffleDeck(t *testing.T) {
 	deck1 := CreateDeck()
 	deck2 := CreateDeck()
-	
+
 	// Create copies for comparison
 	original := make([]*Card, 52)
 	copy(original, deck1)
-	
+
 	ShuffleDeck(deck1)
 	ShuffleDeck(deck2)
-	
+
 	// Check that deck is shuffled (extremely unlikely to be in same order)
 	sameOrder1 := true
 	sameOrder2 := true
-	
+
 	for i := 0; i < 52; i++ {
 		if original[i].Rank != deck1[i].Rank || original[i].Suit != deck1[i].Suit {
 			sameOrder1 = false
@@ -440,15 +442,15 @@ func TestShuffleDeck(t *testing.T) {
 			sameOrder2 = false
 		}
 	}
-	
+
 	if sameOrder1 {
 		t.Error("Deck was not shuffled (same as original)")
 	}
-	
+
 	if !sameOrder2 {
 		// Good - two shuffles produced different results
 	}
-	
+
 	// Verify all cards still present
 	if len(deck1) != 52 {
 		t.Errorf("Shuffled deck has wrong size: %d", len(deck1))
@@ -466,11 +468,11 @@ func TestGeneratePlayerName(t *testing.T) {
 		{4, "Player 4"},
 		{100, "Player 100"},
 	}
-	
+
 	for _, tt := range tests {
 		name := GeneratePlayerName(tt.playerNum)
 		if name != tt.expected {
-			t.Errorf("GeneratePlayerName(%d) = %s, expected %s", 
+			t.Errorf("GeneratePlayerName(%d) = %s, expected %s",
 				tt.playerNum, name, tt.expected)
 		}
 	}
@@ -479,26 +481,26 @@ func TestGeneratePlayerName(t *testing.T) {
 func TestCalculatePlayerScore(t *testing.T) {
 	player := &Player{
 		Cards: []*Card{
-			{Rank: "A", Suit: "♠"},  // 1
-			{Rank: "5", Suit: "♥"},  // 5
-			{Rank: "K", Suit: "♦"},  // 10
-			{Rank: "7", Suit: "♣"},  // 7
+			{Rank: "A", Suit: "♠"}, // 1
+			{Rank: "5", Suit: "♥"}, // 5
+			{Rank: "K", Suit: "♦"}, // 10
+			{Rank: "7", Suit: "♣"}, // 7
 		},
 		RevealedCards: []int{0, 1, 2}, // Total: 1 + 5 + 10 = 16
 	}
-	
+
 	score := CalculatePlayerScore(player)
 	if score != 16 {
 		t.Errorf("Expected score 16, got %d", score)
 	}
-	
+
 	// Test with no revealed cards
 	player.RevealedCards = []int{}
 	score = CalculatePlayerScore(player)
 	if score != 0 {
 		t.Errorf("Expected score 0 with no revealed cards, got %d", score)
 	}
-	
+
 	// Test with nil cards
 	player.Cards[1] = nil
 	player.RevealedCards = []int{0, 1, 2}
@@ -516,20 +518,71 @@ func TestNilHandling(t *testing.T) {
 		Cards: []*Card{nil, nil, nil, nil},
 		Score: 0,
 	}
-	
+
 	data, err := json.Marshal(player)
 	if err != nil {
 		t.Fatalf("Failed to marshal player with nil cards: %v", err)
 	}
-	
+
 	var parsed Player
 	if err := json.Unmarshal(data, &parsed); err != nil {
 		t.Fatalf("Failed to unmarshal player with nil cards: %v", err)
 	}
-	
+
 	for i, card := range parsed.Cards {
 		if card != nil {
 			t.Errorf("Expected nil card at index %d", i)
+		}
+	}
+}
+
+// Room serialization reaches every room member, so in-progress games must be
+// redacted (issue #1187 phase 0 — the room-state leak).
+func TestRoomMarshalRedactsInProgressGames(t *testing.T) {
+	game := NewGame("GAME01", &players.DeterministicIDGenerator{})
+	if _, err := game.AddPlayer("client1", "p1", "Alice"); err != nil {
+		t.Fatalf("Failed to add player: %v", err)
+	}
+	if _, err := game.AddPlayer("client2", "p2", "Bob"); err != nil {
+		t.Fatalf("Failed to add player: %v", err)
+	}
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+	if err := game.DrawCard("client1"); err != nil {
+		t.Fatalf("Failed to draw: %v", err)
+	}
+
+	room := &Room{
+		ID:    "ROOM01",
+		Games: map[string]*Game{"GAME01": game},
+	}
+	data, err := json.Marshal(room)
+	if err != nil {
+		t.Fatalf("Failed to marshal room: %v", err)
+	}
+
+	var parsed struct {
+		Games map[string]*GameState `json:"games"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal room: %v", err)
+	}
+	state, ok := parsed.Games["GAME01"]
+	if !ok {
+		t.Fatal("Expected game GAME01 in serialized room")
+	}
+	if state.DrawnCard != nil {
+		t.Error("Serialized room must not expose the held drawn card")
+	}
+	for _, player := range state.Players {
+		for i, card := range player.Cards {
+			if card != nil {
+				t.Errorf("Serialized room must not expose %s's card %d", player.Name, i)
+			}
+		}
+		if len(player.RevealedCards) != 0 {
+			t.Errorf("Serialized room must not expose %s's revealed indexes", player.Name)
 		}
 	}
 }

--- a/domains/games/apis/games_ws_backend/golf/types_test.go
+++ b/domains/games/apis/games_ws_backend/golf/types_test.go
@@ -586,3 +586,137 @@ func TestRoomMarshalRedactsInProgressGames(t *testing.T) {
 		}
 	}
 }
+
+// The redaction must not eat the fields the lobby renders: game IDs, phase,
+// player counts and names, and the public discard pile.
+func TestRoomMarshalKeepsPublicGameFields(t *testing.T) {
+	game := NewGame("GAME01", &players.DeterministicIDGenerator{})
+	game.AddPlayer("client1", "p1", "Alice")
+	game.AddPlayer("client2", "p2", "Bob")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+
+	room := &Room{
+		ID:    "ROOM01",
+		Games: map[string]*Game{"GAME01": game},
+	}
+	data, err := json.Marshal(room)
+	if err != nil {
+		t.Fatalf("Failed to marshal room: %v", err)
+	}
+
+	var parsed struct {
+		Games map[string]*GameState `json:"games"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal room: %v", err)
+	}
+	state := parsed.Games["GAME01"]
+	if state == nil {
+		t.Fatal("Expected game GAME01 in serialized room")
+	}
+	if state.GamePhase != "playing" {
+		t.Errorf("Expected gamePhase 'playing', got %q", state.GamePhase)
+	}
+	if len(state.Players) != 2 {
+		t.Fatalf("Expected 2 players, got %d", len(state.Players))
+	}
+	if state.Players[0].Name != "Alice" || state.Players[1].Name != "Bob" {
+		t.Errorf("Expected player names preserved, got %q and %q",
+			state.Players[0].Name, state.Players[1].Name)
+	}
+	if len(state.DiscardPile) != 1 {
+		t.Errorf("Expected the public discard pile intact, got %d cards", len(state.DiscardPile))
+	}
+	if state.DrawPile == 0 {
+		t.Error("Expected the draw pile count preserved")
+	}
+}
+
+// Once a game ends everything is public: the room serialization must keep
+// card faces and scores (no over-redaction).
+func TestRoomMarshalEndedGameKeepsCards(t *testing.T) {
+	game := NewGame("GAME01", &players.DeterministicIDGenerator{})
+	game.AddPlayer("client1", "p1", "Alice")
+	game.AddPlayer("client2", "p2", "Bob")
+	if err := game.StartGame(); err != nil {
+		t.Fatalf("Failed to start game: %v", err)
+	}
+	game.state.GamePhase = "ended"
+	game.calculateFinalScores()
+
+	room := &Room{
+		ID:    "ROOM01",
+		Games: map[string]*Game{"GAME01": game},
+	}
+	data, err := json.Marshal(room)
+	if err != nil {
+		t.Fatalf("Failed to marshal room: %v", err)
+	}
+
+	var parsed struct {
+		Games map[string]*GameState `json:"games"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal room: %v", err)
+	}
+	state := parsed.Games["GAME01"]
+	if state == nil {
+		t.Fatal("Expected game GAME01 in serialized room")
+	}
+	for _, player := range state.Players {
+		for i, card := range player.Cards {
+			if card == nil || card.Rank == "" {
+				t.Errorf("Ended game should serialize %s's card %d", player.Name, i)
+			}
+		}
+		if len(player.RevealedCards) != 4 {
+			t.Errorf("Ended game should serialize %s's revealed indexes, got %d",
+				player.Name, len(player.RevealedCards))
+		}
+	}
+}
+
+// gameEnded on a shared win: winner is the joined display string for legacy
+// clients, winners is the typed list.
+func TestGameEndedMessageSharedWin(t *testing.T) {
+	msg := GameEndedMessage{
+		Type:    "gameEnded",
+		Winner:  "Alice & Bob",
+		Winners: []string{"Alice", "Bob"},
+		FinalScores: []*FinalScore{
+			{PlayerName: "Alice", Score: 5},
+			{PlayerName: "Bob", Score: 5},
+			{PlayerName: "Carol", Score: 12},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal GameEndedMessage: %v", err)
+	}
+
+	// The raw wire must carry both fields.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Failed to unmarshal raw message: %v", err)
+	}
+	if _, ok := raw["winner"]; !ok {
+		t.Error("Wire message must keep the legacy winner field")
+	}
+	if _, ok := raw["winners"]; !ok {
+		t.Error("Wire message must carry the typed winners field")
+	}
+
+	var parsed GameEndedMessage
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Failed to unmarshal GameEndedMessage: %v", err)
+	}
+	if parsed.Winner != "Alice & Bob" {
+		t.Errorf("Expected joined display winner, got %q", parsed.Winner)
+	}
+	if len(parsed.Winners) != 2 || parsed.Winners[0] != "Alice" || parsed.Winners[1] != "Bob" {
+		t.Errorf("Expected Winners == [Alice Bob], got %v", parsed.Winners)
+	}
+}


### PR DESCRIPTION
Phase 0 of #1187: the agreed rules fixes (Go semantics with the three C++ corrections), applied to the deployed Go hub so v1 players get correct games while the v2 smithy hub is built.

## Fixes

- **Pair scoring** — three of a kind now scores exactly one card (one pair cancels), not all three. `calculatePlayerFinalScore` counts a single card of any odd-remainder rank. Example: `K K K A` scores 11 (one K + ace), not 31.
- **Empty deck** — an exhausted draw pile ends the game with normal scoring instead of wedging the next player on repeated `deck is empty` errors with no way to finish.
- **Shared wins** — non-knocker ties are shared wins. New `GetWinners` returns every tied lowest scorer (the knocker-alone rule is unchanged when the knocker is among them). `GameResult` and the `gameEnded` message carry a typed `winners` list, while `winner` stays a display string that becomes the joined names (`"A & B"`) on a tie — so the deployed UI renders shared wins with zero changes. `GamesWon` stats now credit every shared winner instead of exact-matching the display string.
- **Room-state leak** — `Room.MarshalJSON` now serializes games via a new `GetPublicState`, which strips card faces, revealed indexes, and the held drawn card from in-progress games. Room broadcasts previously serialized full `GetState`, leaking every player's hand and the current drawn card to all room members. Verified the lobby UI only reads game IDs, player counts, and `gamePhase` from room state — all preserved.

Also unwinds `GetGameResult`'s recursive `RLock` (it held the lock while calling `GetWinner`, which locked again — a deadlock hazard if a writer queued between the two).

## Tests

New tests pin each fix: table-driven pair-cancellation cases, empty-deck end via a drained deck, shared-tie `GetWinners` plus the knocker-tie-wins-alone case, `GetPublicState` redaction, and a `Room.MarshalJSON` test asserting no cards/drawn card in serialized in-progress games. Negative and boundary coverage: non-empty deck must not end the game, discard-path exhaustion, mid-knocked-round exhaustion, nil winners/result before game end, no over-redaction of ended games, and direct `completeGameInRoom` stats tests (shared winners credited, loser not, knocker-tie solo credit, error paths leave state untouched). `go vet` and the full package suite pass. gofmt applied to touched files.

Note: `go test -race` fails on `TestHub_GameCleanup` on `main` as well — the hub mutates room player stats while a send goroutine marshals the room. Pre-existing, out of phase-0 scope; noted on #1187.