### PR TITLE
golf_hub: attribute gameCreated to its creator

### DIFF
--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -417,6 +417,7 @@ void HubHandler::CreateGameMove(const std::string& player_id) {
 
       moonbase::golf::GameCreated announcement;
       announcement.gameId = game_id;
+      announcement.createdBy = player_id;
       for (const auto& member : room->members) {
         outbox.To(member.first, GolfUpdateEvent(GolfUpdate::FromGamecreated(announcement)));
       }

--- a/domains/games/apis/golf_hub/model/games.smithy
+++ b/domains/games/apis/golf_hub/model/games.smithy
@@ -143,10 +143,14 @@ structure StartGame {}
 structure LeaveGame {}
 
 /// A game was created and is open to join. Distinct from gameStarted,
-/// which fires when play actually begins.
+/// which fires when play actually begins. createdBy lets the creator's
+/// client tell its own echo apart from other players' creations.
 structure GameCreated {
     @required
     gameId: String
+
+    @required
+    createdBy: String
 }
 
 /// Play has begun: seats are locked and the game's opening is dealt.


### PR DESCRIPTION
Small phase-2 follow-up feeding phase 3 (muchq/muchq.github.io#232): `GameCreated` gains a required `createdBy`.

The v2 client must swallow the room-wide `gameCreated` echo for its own create — the creator is auto-seated and receives `gameJoined`, so announcing its own create would make the UI double-join. The review panel flagged that matching by an in-flight counter is order-fragile under concurrent creates in a shared room (another player's announcement arriving between your send and your echo gets mis-attributed). `createdBy` makes the filter identity-based; e2e coverage for the attribution landed in #1192.