### PR TITLE
Golf v2 phase 4: deploy golf_hub behind Caddy

### DIFF
--- a/deploy/consolidated/Caddyfile
+++ b/deploy/consolidated/Caddyfile
@@ -67,6 +67,15 @@ api.muchq.com {
 		path /games/v1/golf-ws
 	}
 
+	@post_golf_v2_session {
+		method POST
+		path /games/v2/session
+	}
+
+	@ws_golf_v2 {
+		path /games/v2/golf/play
+	}
+
 	@options {
 		method OPTIONS
 	}
@@ -90,6 +99,8 @@ api.muchq.com {
 
 	reverse_proxy @ws_thoughts games_ws_backend:8080
 	reverse_proxy @ws_golf games_ws_backend:8080
+	reverse_proxy @post_golf_v2_session golf_hub:8089
+	reverse_proxy @ws_golf_v2 golf_hub:8089
 	reverse_proxy @post_portrait portrait:8081
 	reverse_proxy @get_timeseries prom_proxy:8082
 	reverse_proxy @get_metrics prom_proxy:8082

--- a/deploy/consolidated/Caddyfile.local
+++ b/deploy/consolidated/Caddyfile.local
@@ -37,6 +37,15 @@
 		path /games/v1/golf-ws
 	}
 
+	@post_golf_v2_session {
+		method POST
+		path /games/v2/session
+	}
+
+	@ws_golf_v2 {
+		path /games/v2/golf/play
+	}
+
 	@options {
 		method OPTIONS
 	}
@@ -60,6 +69,8 @@
 
 	reverse_proxy @ws_thoughts localhost:8080
 	reverse_proxy @ws_golf localhost:8080
+	reverse_proxy @post_golf_v2_session localhost:8089
+	reverse_proxy @ws_golf_v2 localhost:8089
 	reverse_proxy @post_portrait localhost:8081
 	reverse_proxy @post_mithril localhost:8083
 	reverse_proxy @post_posterize_blur localhost:8084

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -7,6 +7,7 @@ This directory contains the consolidated deployment configuration for multiple s
 - **api.muchq.com** - API backend services
   - [`games_ws_backend`](../../domains/games/apis/games_ws_backend) (port 8080)
   - [`portrait`](../../domains/graphics/apis/portrait) (port 8081)
+  - [`golf_hub`](../../domains/games/apis/golf_hub) (port 8089, `/games/v2/*`)
   - [`prom_proxy`](../../domains/platform/apis/prom_proxy) (port 8082)
   - [`mithril`](../../domains/games/apis/mithril) (port 8083)
   - [`posterize`](../../domains/graphics/apis/posterize) (port 8084)

--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -13,6 +13,7 @@ services:
       - /var/www/r3dr:/var/www/r3dr
     depends_on:
       - games_ws_backend
+      - golf_hub
       - microgpt-serve
       - mithril
       - one_d4
@@ -46,6 +47,30 @@ services:
         limits:
           cpus: '0.25'
           memory: 256M
+
+  # The smithy event-stream golf service (/games/v2/*, MoonBase#1187);
+  # serves the v2 beta while games_ws_backend keeps serving v1.
+  golf_hub:
+    image: ghcr.io/muchq/golf_hub:latest
+    restart: always
+    ports:
+      - "8089:8089"
+    environment:
+      PORT: "8089"
+      # CSWSH defense: the play socket admits only the deployed UI's
+      # origins (parity with the Go hub's allowlist).
+      ALLOWED_ORIGINS: https://muchq.com,https://www.muchq.com
+      TRUSTED_PROXY_CIDRS: *caddy_ip
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
+      OTEL_SERVICE_NAME: golf_hub
+      OTEL_RESOURCE_ATTRIBUTES: service.name=golf_hub,service.version=latest
+    networks:
+      - app_network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
 
   portrait:
     image: ghcr.io/muchq/portrait:latest

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@smithy_cpp//bazel:defs.bzl", "smithy_cpp_client_library", "smithy_cpp_server_library")
+load("//bazel/rules:oci.bzl", "linux_amd64_oci_binary")
 
 # Phase 2 of the Golf hub rebuild on smithy-cpp event streams (#1187):
 # the game-agnostic room layer (model/games.smithy, per #79) plus golf's
@@ -69,6 +70,7 @@ cc_library(
         "//domains/games/libs/cards:dealer",
         "//domains/games/libs/cards/golf:game_state",
         "//domains/games/libs/cards/golf:player",
+        "//domains/platform/libs/futility/otel:metrics",
         "@com_google_absl//absl/strings",
         "@smithy_cpp//runtime:eventstream",
         "@smithy_cpp//runtime:server",
@@ -89,6 +91,7 @@ cc_test(
         ":id_generator",
         ":ticket_vault",
         "//domains/games/libs/cards:dealer",
+        "//domains/platform/libs/futility/otel:metrics",
         "@googletest//:gtest_main",
         "@smithy_cpp//runtime:client",
         "@smithy_cpp//runtime:core",
@@ -107,10 +110,13 @@ cc_binary(
     deps = [
         ":golf_hub_smithy_server",
         ":hub_handler",
+        ":id_generator",
         ":ticket_vault",
+        "//domains/games/libs/cards:dealer",
         "//domains/platform/libs/aura",
         "//domains/platform/libs/futility/env",
         "//domains/platform/libs/futility/otel:http_metrics",
+        "//domains/platform/libs/futility/otel:metrics",
         "//domains/platform/libs/futility/otel:otel_provider",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:globals",
@@ -120,3 +126,5 @@ cc_binary(
         "@smithy_cpp//runtime:server",
     ],
 )
+
+linux_amd64_oci_binary(bin_name = "golf_hub")

--- a/domains/games/apis/golf_hub/README.md
+++ b/domains/games/apis/golf_hub/README.md
@@ -47,9 +47,11 @@ lobby-safe summaries only.
 - Player ids are whimsical (`bouncy-coral-quokka-x9k2`, the Go
   generator's word lists) and double as display names. Room and game ids
   are 6-char uppercase codes for permalink compatibility.
-- Observability: unary requests ride the shared aura chain (#1185);
-  stream-level instruments are a later addition.
+- Observability: unary requests ride the shared aura chain (#1185); the
+  stream side counts admissions, live sessions, disconnects, grace
+  expiries, and the command/event flow (`stream_*`, phase 4).
 - `ALLOWED_ORIGINS` unset admits all origins (dev parity with the Go
   hub's DEV_MODE); production sets the allowlist.
-- Next phases (#1187): UI v2 client behind a beta opt-in (phase 3),
-  deploy + soak (phase 4), default flip + retirements (phase 5).
+- Deployed behind Caddy at `/games/v2/*` (phase 4,
+  `deploy/consolidated`); the UI's v2 beta switch is `?golf=v2` (phase
+  3). Next (#1187): default flip + retirements (phase 5).

--- a/domains/games/apis/golf_hub/golf_hub_main.cc
+++ b/domains/games/apis/golf_hub/golf_hub_main.cc
@@ -12,8 +12,10 @@
 #include <chrono>
 #include <csignal>
 #include <cstddef>
+#include <cstdlib>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -22,13 +24,17 @@
 #include "absl/log/initialize.h"
 #include "absl/log/log.h"
 #include "domains/games/apis/golf_hub/hub_handler.h"
+#include "domains/games/apis/golf_hub/id_generator.h"
 #include "domains/games/apis/golf_hub/ticket_vault.h"
+#include "domains/games/libs/cards/dealer.h"
 #include "domains/platform/libs/aura/middleware.h"
 #include "domains/platform/libs/futility/env/env.h"
 #include "domains/platform/libs/futility/otel/http_metrics.h"
+#include "domains/platform/libs/futility/otel/metrics.h"
 #include "domains/platform/libs/futility/otel/otel_provider.h"
 #include "moonbase/golf/server.h"
 #include "smithy/http/beast_transport.h"
+#include "smithy/http/forwarded.h"
 #include "smithy/http/message.h"
 #include "smithy/server/origin_gate.h"
 
@@ -65,7 +71,12 @@ int main() {
 
   auto vault = std::make_shared<golf_hub::TicketVault>(
       /*ticket_ttl=*/std::chrono::seconds(30), /*resume_ttl=*/std::chrono::hours(24));
-  auto handler = std::make_shared<golf_hub::HubHandler>(vault);
+  // Stream-side instruments (sessions, commands, events) ride the same
+  // meter the aura chain's unary instruments use.
+  auto handler = std::make_shared<golf_hub::HubHandler>(
+      vault, std::make_shared<cards::Dealer>(), std::make_shared<golf_hub::WhimsicalIdGenerator>(),
+      /*grace_period=*/std::chrono::minutes(5),
+      std::make_shared<futility::otel::MetricsRecorder>("golf_hub"));
 
   // Block shutdown signals before the transport spawns its thread pool.
   sigset_t shutdown_signals;
@@ -82,7 +93,30 @@ int main() {
   // a per-client budget can slot into ChainOptions when it earns its keep.
   auto metrics =
       aura::MakeHttpMetricsSink(std::make_shared<futility::otel::HttpMetricsManager>("golf_hub"));
-  auto unary = aura::ProductionChain(aura::ChainOptions{.metrics = metrics}, server.Handler());
+
+  // The reverse-proxy trust boundary (smithy-cpp ADR-0012, contract in
+  // smithy/http/forwarded.h): deploy/consolidated/compose.yaml pins Caddy's
+  // address and passes it here. Unset is the deliberate direct-connect
+  // statement (TrustedProxies::None()); set-but-empty or malformed fails
+  // startup rather than silently collapsing proxied traffic onto one key.
+  smithy::http::TrustedProxies trusted_proxies = smithy::http::TrustedProxies::None();
+  if (std::getenv("TRUSTED_PROXY_CIDRS") != nullptr) {
+    const std::vector<std::string> cidrs = futility::env::ReadList("TRUSTED_PROXY_CIDRS");
+    if (cidrs.empty()) {
+      LOG(ERROR) << "TRUSTED_PROXY_CIDRS is set but empty; unset it to serve direct-connect";
+      return 1;
+    }
+    try {
+      trusted_proxies = smithy::http::TrustedProxies(cidrs);
+    } catch (const std::invalid_argument& error) {
+      LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
+      return 1;
+    }
+  }
+
+  auto unary = aura::ProductionChain(
+      aura::ChainOptions{.metrics = metrics, .trusted_proxies = std::move(trusted_proxies)},
+      server.Handler());
 
   // Gate chain: origin allowlist (browser CSWSH defense; unset
   // ALLOWED_ORIGINS admits all origins — dev parity with the Go hub's

--- a/domains/games/apis/golf_hub/golf_hub_main.cc
+++ b/domains/games/apis/golf_hub/golf_hub_main.cc
@@ -12,10 +12,8 @@
 #include <chrono>
 #include <csignal>
 #include <cstddef>
-#include <cstdlib>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -34,7 +32,6 @@
 #include "domains/platform/libs/futility/otel/otel_provider.h"
 #include "moonbase/golf/server.h"
 #include "smithy/http/beast_transport.h"
-#include "smithy/http/forwarded.h"
 #include "smithy/http/message.h"
 #include "smithy/server/origin_gate.h"
 
@@ -94,28 +91,14 @@ int main() {
   auto metrics =
       aura::MakeHttpMetricsSink(std::make_shared<futility::otel::HttpMetricsManager>("golf_hub"));
 
-  // The reverse-proxy trust boundary (smithy-cpp ADR-0012, contract in
-  // smithy/http/forwarded.h): deploy/consolidated/compose.yaml pins Caddy's
-  // address and passes it here. Unset is the deliberate direct-connect
-  // statement (TrustedProxies::None()); set-but-empty or malformed fails
-  // startup rather than silently collapsing proxied traffic onto one key.
-  smithy::http::TrustedProxies trusted_proxies = smithy::http::TrustedProxies::None();
-  if (std::getenv("TRUSTED_PROXY_CIDRS") != nullptr) {
-    const std::vector<std::string> cidrs = futility::env::ReadList("TRUSTED_PROXY_CIDRS");
-    if (cidrs.empty()) {
-      LOG(ERROR) << "TRUSTED_PROXY_CIDRS is set but empty; unset it to serve direct-connect";
-      return 1;
-    }
-    try {
-      trusted_proxies = smithy::http::TrustedProxies(cidrs);
-    } catch (const std::invalid_argument& error) {
-      LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
-      return 1;
-    }
-  }
+  // The reverse-proxy trust boundary (smithy-cpp ADR-0012):
+  // deploy/consolidated/compose.yaml pins Caddy's address into
+  // TRUSTED_PROXY_CIDRS. A refused value already logged why.
+  auto trusted_proxies = aura::TrustedProxiesFromEnv();
+  if (!trusted_proxies.has_value()) return 1;
 
   auto unary = aura::ProductionChain(
-      aura::ChainOptions{.metrics = metrics, .trusted_proxies = std::move(trusted_proxies)},
+      aura::ChainOptions{.metrics = metrics, .trusted_proxies = std::move(*trusted_proxies)},
       server.Handler());
 
   // Gate chain: origin allowlist (browser CSWSH defense; unset

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -255,7 +255,7 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
       }
     }
     if (snapshot.has_value()) {
-      registry_.SendTo(player_id, std::move(*snapshot));
+      Send(player_id, std::move(*snapshot));
     } else {
       Reject(player_id, "not in a room");
     }

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "domains/games/libs/cards/card_mapper.h"
 #include "domains/games/libs/cards/golf/player.h"
@@ -66,10 +67,12 @@ GolfEvents GolfUpdateEvent(GolfUpdate update) {
 }  // namespace
 
 HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards::Dealer> dealer,
-                       std::shared_ptr<IdGenerator> ids, std::chrono::seconds grace_period)
+                       std::shared_ptr<IdGenerator> ids, std::chrono::seconds grace_period,
+                       std::shared_ptr<futility::otel::MetricsRecorder> metrics)
     : vault_(std::move(vault)),
       dealer_(std::move(dealer)),
       ids_(std::move(ids)),
+      metrics_(std::move(metrics)),
       registry_([this, grace_period] {
         Registry::Options options;
         options.async_delivery = true;  // chains, not writer threads (ADR-0019)
@@ -102,6 +105,7 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
                                                  moonbase::golf::PlayAsyncServerStream& stream) {
   auto player = vault_->SpendTicket(input.ticket);
   if (!player.has_value()) {
+    Count("stream_admissions_refused", {{"reason", "bad_ticket"}});
     co_return smithy::Error::Modeled("Unauthenticated", "ticket expired or already spent");
   }
   const std::string player_id = *player;
@@ -111,9 +115,12 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
   const auto admission = registry_.ResumeOrAdd(
       player_id, [&stream] { return stream.Share(); }, std::chrono::seconds(1));
   if (admission == Registry::Admission::kRefused) {
+    Count("stream_admissions_refused", {{"reason", "seat_conflict"}});
     co_return smithy::Error::Modeled("SeatConflict", "player already has a live connection");
   }
   const bool resumed = admission == Registry::Admission::kResumed;
+  Count("stream_sessions", {{"resumed", resumed ? "true" : "false"}});
+  TrackActive(+1);
 
   std::optional<std::string> room;
   Outbox resync;
@@ -133,7 +140,7 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
   ready.playerId = player_id;
   ready.resumed = resumed;
   if (room.has_value()) ready.roomId = *room;
-  registry_.SendTo(player_id, GolfEvents::FromSessionready(std::move(ready)));
+  Send(player_id, GolfEvents::FromSessionready(std::move(ready)));
   // A resumed seat's room sees the connected flip (and the resumer gets
   // the current snapshot it missed).
   if (room.has_value()) BroadcastRoom(*room);
@@ -146,6 +153,8 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
       // the grace window (ADR-0020); expiry reaps it. Detach fails only
       // when the entry is already gone — nothing left to do then.
       if (registry_.Detach(player_id)) {
+        TrackActive(-1);
+        Count("stream_disconnects", {{"kind", "abrupt"}});
         SetConnected(player_id, false);
         if (auto current = CurrentRoom(player_id)) BroadcastRoom(*current);
       }
@@ -154,6 +163,8 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
     if (!received->has_value()) {
       // Clean close: a deliberate leave. Free the seat, game, and room.
       registry_.Remove(player_id);
+      TrackActive(-1);
+      Count("stream_disconnects", {{"kind", "clean"}});
       Outbox outbox;
       {
         const std::lock_guard<std::mutex> lock(mu_);
@@ -167,6 +178,7 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
 }
 
 void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands& command) {
+  CountCommand(command);
   if (command.as_createRoom_or_null() != nullptr) {
     std::string room_id;
     Outbox outbox;
@@ -682,14 +694,16 @@ void HubHandler::BroadcastRoom(const std::string& room_id) {
 }
 
 void HubHandler::Reject(const std::string& player_id, std::string reason) {
+  Count("stream_rejections", {{"reason", reason}});
   moonbase::golf::CommandRejected rejected;
   rejected.reason = std::move(reason);
-  registry_.SendTo(player_id, GolfEvents::FromCommandrejected(std::move(rejected)));
+  Send(player_id, GolfEvents::FromCommandrejected(std::move(rejected)));
 }
 
 void HubHandler::OnExpired(const std::string& player_id) {
   // Grace ran out (ADR-0020): the seat is gone; free the room and game
   // slots and tell whoever remains. Runs on the registry's expiry thread.
+  Count("stream_seats_expired");
   Outbox outbox;
   {
     const std::lock_guard<std::mutex> lock(mu_);
@@ -700,9 +714,38 @@ void HubHandler::OnExpired(const std::string& player_id) {
 
 void HubHandler::Deliver(Outbox& outbox) {
   for (auto& [player_id, event] : outbox.events) {
-    registry_.SendTo(player_id, std::move(event));
+    Send(player_id, std::move(event));
   }
   outbox.events.clear();
+}
+
+void HubHandler::Count(const char* name, const std::map<std::string, std::string>& attributes) {
+  if (metrics_) metrics_->RecordCounter(name, 1, attributes);
+}
+
+void HubHandler::TrackActive(int delta) {
+  // Delta form, matching http_server_requests_active: the collector sums
+  // an up-down counter into the live-session count.
+  if (metrics_) metrics_->RecordGauge("stream_sessions_active", delta);
+}
+
+void HubHandler::CountCommand(const GolfCommands& command) {
+  if (!metrics_) return;
+  const auto* envelope = command.as_golf_or_null();
+  const std::string name = envelope != nullptr ? absl::StrCat("golf.", envelope->move.case_name())
+                                               : std::string(command.case_name());
+  metrics_->RecordCounter("stream_commands", 1, {{"command", name}});
+}
+
+void HubHandler::Send(const std::string& player_id, GolfEvents event) {
+  if (metrics_) {
+    const auto* envelope = event.as_golf_or_null();
+    const std::string name = envelope != nullptr
+                                 ? absl::StrCat("golf.", envelope->update.case_name())
+                                 : std::string(event.case_name());
+    metrics_->RecordCounter("stream_events", 1, {{"event", name}});
+  }
+  registry_.SendTo(player_id, std::move(event));
 }
 
 moonbase::golf::RoomState HubHandler::RoomStateLocked(const std::string& room_id,

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -16,6 +16,7 @@
 #include "domains/games/apis/golf_hub/ticket_vault.h"
 #include "domains/games/libs/cards/dealer.h"
 #include "domains/games/libs/cards/golf/game_state.h"
+#include "domains/platform/libs/futility/otel/metrics.h"
 #include "moonbase/golf/server.h"
 #include "smithy/server/session_registry.h"
 
@@ -38,7 +39,8 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   explicit HubHandler(std::shared_ptr<TicketVault> vault,
                       std::shared_ptr<cards::Dealer> dealer = std::make_shared<cards::Dealer>(),
                       std::shared_ptr<IdGenerator> ids = std::make_shared<WhimsicalIdGenerator>(),
-                      std::chrono::seconds grace_period = std::chrono::minutes(5));
+                      std::chrono::seconds grace_period = std::chrono::minutes(5),
+                      std::shared_ptr<futility::otel::MetricsRecorder> metrics = nullptr);
 
   // Note: operation IO generates as <Op>Input/<Op>Output regardless of
   // the named shapes bound in the model, and moonbase.games shapes land
@@ -112,6 +114,16 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// stage the fan-out (views, turn change, game end) the result implies.
   void EngineMove(const std::string& player_id, const MoveFn& move, MoveEffects effects);
 
+  /// Stream-side observability (#1187 phase 4): the aura chain instruments
+  /// only unary requests, so admissions, live-session count, disconnects,
+  /// and the command/event flow are counted here. All no-ops when no
+  /// recorder is injected.
+  void Count(const char* name, const std::map<std::string, std::string>& attributes = {});
+  void TrackActive(int delta);
+  void CountCommand(const moonbase::golf::GolfCommands& command);
+  /// Every event leaves through here so stream_events sees each send.
+  void Send(const std::string& player_id, moonbase::golf::GolfEvents event);
+
   void SetConnected(const std::string& player_id, bool connected);
   std::optional<std::string> CurrentRoom(const std::string& player_id);
   Room* FindRoomLocked(const std::string& player_id);
@@ -138,6 +150,7 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   const std::shared_ptr<TicketVault> vault_;
   const std::shared_ptr<cards::Dealer> dealer_;
   const std::shared_ptr<IdGenerator> ids_;
+  const std::shared_ptr<futility::otel::MetricsRecorder> metrics_;
   std::mutex mu_;
   std::unordered_map<std::string, Room> rooms_;
   std::unordered_map<std::string, std::string> player_room_;

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -21,6 +21,7 @@
 #include "domains/games/apis/golf_hub/id_generator.h"
 #include "domains/games/apis/golf_hub/ticket_vault.h"
 #include "domains/games/libs/cards/dealer.h"
+#include "domains/platform/libs/futility/otel/metrics.h"
 #include "moonbase/golf/client.h"
 #include "moonbase/golf/server.h"
 #include "smithy/client/config.h"
@@ -40,8 +41,12 @@ class GolfHubStreamFixture : public testing::Test {
     // NoShuffleDealer: hands are dealt from the back of the pristine deck,
     // so every card in every test is known (first seat gets the aces).
     // Sequential ids keep players and game codes readable in failures.
-    handler_ = std::make_shared<HubHandler>(vault_, std::make_shared<cards::NoShuffleDealer>(),
-                                            ids_, /*grace_period=*/std::chrono::seconds(60));
+    // The recorder rides the global (no-op) meter here — values go nowhere,
+    // but every counting path runs under the e2e suite.
+    handler_ = std::make_shared<HubHandler>(
+        vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
+        /*grace_period=*/std::chrono::seconds(60),
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"));
     server_ = std::make_unique<moonbase::golf::GolfHubServer>(handler_);
 
     auto loopback = std::make_shared<smithy::http::Loopback>();

--- a/domains/graphics/apis/portrait/main.cc
+++ b/domains/graphics/apis/portrait/main.cc
@@ -9,11 +9,8 @@
 
 #include <chrono>
 #include <csignal>
-#include <cstdlib>
 #include <memory>
-#include <stdexcept>
 #include <string>
-#include <vector>
 
 #include "absl/log/globals.h"
 #include "absl/log/initialize.h"
@@ -26,7 +23,6 @@
 #include "domains/platform/libs/futility/rate_limiter/sliding_window_rate_limiter.h"
 #include "moonbase/portrait/server.h"
 #include "smithy/http/beast_transport.h"
-#include "smithy/http/forwarded.h"
 #include "smithy/server/middleware.h"
 
 int main() {
@@ -60,32 +56,18 @@ int main() {
       std::make_shared<futility::rate_limiter::SlidingWindowRateLimiter<std::string>>(
           limiter_config);
 
-  // The reverse-proxy trust boundary (smithy-cpp ADR-0012, contract in
-  // smithy/http/forwarded.h): deploy/consolidated/compose.yaml pins Caddy's
-  // address and passes it here. Unset is the deliberate direct-connect
-  // statement (TrustedProxies::None()); set-but-empty or malformed fails
-  // startup rather than silently collapsing proxied traffic onto one key.
-  smithy::http::TrustedProxies trusted_proxies = smithy::http::TrustedProxies::None();
-  if (std::getenv("TRUSTED_PROXY_CIDRS") != nullptr) {
-    const std::vector<std::string> cidrs = futility::env::ReadList("TRUSTED_PROXY_CIDRS");
-    if (cidrs.empty()) {
-      LOG(ERROR) << "TRUSTED_PROXY_CIDRS is set but empty; unset it to serve direct-connect";
-      return 1;
-    }
-    try {
-      trusted_proxies = smithy::http::TrustedProxies(cidrs);
-    } catch (const std::invalid_argument& error) {
-      LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
-      return 1;
-    }
-  }
+  // The reverse-proxy trust boundary (smithy-cpp ADR-0012):
+  // deploy/consolidated/compose.yaml pins Caddy's address into
+  // TRUSTED_PROXY_CIDRS. A refused value already logged why.
+  auto trusted_proxies = aura::TrustedProxiesFromEnv();
+  if (!trusted_proxies.has_value()) return 1;
 
   auto handler = aura::ProductionChain(
       aura::ChainOptions{
           .metrics = metrics,
           .allow_request =
               [rate_limiter](const std::string& client) { return rate_limiter->allow(client); },
-          .trusted_proxies = std::move(trusted_proxies),
+          .trusted_proxies = std::move(*trusted_proxies),
           .retry_after = std::chrono::seconds(60)},
       server.Handler());
 

--- a/domains/platform/libs/aura/BUILD.bazel
+++ b/domains/platform/libs/aura/BUILD.bazel
@@ -10,6 +10,7 @@ cc_library(
     hdrs = ["middleware.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//domains/platform/libs/futility/env",
         "//domains/platform/libs/futility/otel:http_metrics",
         "@com_google_absl//absl/log",
         "@smithy_cpp//runtime:http",

--- a/domains/platform/libs/aura/middleware.cc
+++ b/domains/platform/libs/aura/middleware.cc
@@ -1,10 +1,13 @@
 #include "domains/platform/libs/aura/middleware.h"
 
 #include <chrono>
+#include <cstdlib>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
 #include "absl/log/log.h"
+#include "domains/platform/libs/futility/env/env.h"
 #include "domains/platform/libs/futility/otel/http_metrics.h"
 #include "smithy/http/trace_context.h"
 #include "smithy/http/transport.h"
@@ -143,6 +146,23 @@ ConnectionEventLog() {
                  << " peer=" << event.peer_address << " detail=" << event.detail << " elapsed_ms="
                  << std::chrono::duration_cast<std::chrono::milliseconds>(event.elapsed).count();
   };
+}
+
+std::optional<smithy::http::TrustedProxies> TrustedProxiesFromEnv() {
+  if (std::getenv("TRUSTED_PROXY_CIDRS") == nullptr) {
+    return smithy::http::TrustedProxies::None();
+  }
+  const std::vector<std::string> cidrs = futility::env::ReadList("TRUSTED_PROXY_CIDRS");
+  if (cidrs.empty()) {
+    LOG(ERROR) << "TRUSTED_PROXY_CIDRS is set but empty; unset it to serve direct-connect";
+    return std::nullopt;
+  }
+  try {
+    return smithy::http::TrustedProxies(cidrs);
+  } catch (const std::invalid_argument& error) {
+    LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
+    return std::nullopt;
+  }
 }
 
 }  // namespace aura

--- a/domains/platform/libs/aura/middleware.h
+++ b/domains/platform/libs/aura/middleware.h
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "smithy/http/beast_transport.h"
@@ -68,6 +69,15 @@ struct ChainOptions {
 };
 smithy::http::RequestHandler ProductionChain(ChainOptions options,
                                              smithy::http::RequestHandler handler);
+
+/// ChainOptions::trusted_proxies from TRUSTED_PROXY_CIDRS, single-sourced
+/// because every service behind the same Caddy must read the trust
+/// boundary identically (smithy-cpp ADR-0012; the deployment pins Caddy's
+/// address in deploy/consolidated/compose.yaml). Unset is the deliberate
+/// direct-connect statement (TrustedProxies::None()); set-but-empty or
+/// malformed logs the refusal and returns nullopt — fail startup rather
+/// than silently collapsing proxied traffic onto one client key.
+std::optional<smithy::http::TrustedProxies> TrustedProxiesFromEnv();
 
 /// Sink callback for BeastServerTransport::Options::on_rejected, so the
 /// 413/431 rejections the transport writes before any handler chain exists

--- a/domains/platform/libs/aura/middleware_test.cc
+++ b/domains/platform/libs/aura/middleware_test.cc
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -377,6 +378,25 @@ TEST_F(AuraMiddlewareTest, BeastTransportServesChainAndEnforcesBodyLimit) {
   EXPECT_EQ(completes.back().status, 413);
 
   transport.Stop();
+}
+
+// The env contract every service main relies on: unset serves
+// direct-connect, a parseable list is accepted, and set-but-empty or
+// malformed is a refusal (nullopt) rather than a silent None().
+TEST(TrustedProxiesFromEnvTest, UnsetEmptyValidAndMalformed) {
+  unsetenv("TRUSTED_PROXY_CIDRS");
+  EXPECT_TRUE(aura::TrustedProxiesFromEnv().has_value());
+
+  setenv("TRUSTED_PROXY_CIDRS", " , ", 1);
+  EXPECT_FALSE(aura::TrustedProxiesFromEnv().has_value());
+
+  setenv("TRUSTED_PROXY_CIDRS", "172.28.0.2,10.0.0.0/8", 1);
+  EXPECT_TRUE(aura::TrustedProxiesFromEnv().has_value());
+
+  setenv("TRUSTED_PROXY_CIDRS", "not-a-cidr", 1);
+  EXPECT_FALSE(aura::TrustedProxiesFromEnv().has_value());
+
+  unsetenv("TRUSTED_PROXY_CIDRS");
 }
 
 }  // namespace

--- a/domains/platform/libs/futility/otel/metrics.cc
+++ b/domains/platform/libs/futility/otel/metrics.cc
@@ -11,27 +11,35 @@ MetricsRecorder::MetricsRecorder(const std::string& service_name) {
   meter_ = provider->GetMeter(service_name, "1.0.0");
 }
 
+template <typename Instrument, typename Factory>
+Instrument* MetricsRecorder::FindOrCreate(
+    std::unordered_map<std::string, std::unique_ptr<Instrument>>& cache,
+    const std::string& metric_name, const Factory& make) {
+  const std::lock_guard<std::mutex> lock(mu_);
+  auto it = cache.find(metric_name);
+  if (it == cache.end()) {
+    it = cache.emplace(metric_name, make()).first;
+  }
+  return it->second.get();
+}
+
 void MetricsRecorder::RecordCounter(const std::string& metric_name, int64_t value,
                                     const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;
 
-  auto it = counters_.find(metric_name);
-  if (it == counters_.end()) {
-    counters_[metric_name] = meter_->CreateUInt64Counter(metric_name);
-    it = counters_.find(metric_name);
-  }
-
-  if (it->second) {
+  auto* counter = FindOrCreate(counters_, metric_name,
+                               [&] { return meter_->CreateUInt64Counter(metric_name); });
+  if (counter != nullptr) {
     auto context = opentelemetry::context::Context{};
     if (attributes.empty()) {
-      it->second->Add(static_cast<uint64_t>(value), context);
+      counter->Add(static_cast<uint64_t>(value), context);
     } else {
       // Convert attributes to OpenTelemetry format
       std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
                                                                 attributes.end());
       auto kv_iterable = opentelemetry::common::KeyValueIterableView<
           std::vector<std::pair<std::string, std::string>>>(attr_vec);
-      it->second->Add(static_cast<uint64_t>(value), kv_iterable, context);
+      counter->Add(static_cast<uint64_t>(value), kv_iterable, context);
     }
   }
 }
@@ -41,23 +49,20 @@ void MetricsRecorder::RecordLatency(const std::string& metric_name,
                                     const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;
 
-  auto it = histograms_.find(metric_name);
-  if (it == histograms_.end()) {
-    histograms_[metric_name] = meter_->CreateUInt64Histogram(metric_name + "_microseconds");
-    it = histograms_.find(metric_name);
-  }
-
-  if (it->second) {
+  auto* histogram = FindOrCreate(histograms_, metric_name, [&] {
+    return meter_->CreateUInt64Histogram(metric_name + "_microseconds");
+  });
+  if (histogram != nullptr) {
     auto context = opentelemetry::context::Context{};
     if (attributes.empty()) {
-      it->second->Record(static_cast<uint64_t>(duration.count()), context);
+      histogram->Record(static_cast<uint64_t>(duration.count()), context);
     } else {
       // Convert attributes to OpenTelemetry format
       std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
                                                                 attributes.end());
       auto kv_iterable = opentelemetry::common::KeyValueIterableView<
           std::vector<std::pair<std::string, std::string>>>(attr_vec);
-      it->second->Record(static_cast<uint64_t>(duration.count()), kv_iterable, context);
+      histogram->Record(static_cast<uint64_t>(duration.count()), kv_iterable, context);
     }
   }
 }
@@ -66,23 +71,20 @@ void MetricsRecorder::RecordGauge(const std::string& metric_name, double value,
                                   const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;
 
-  auto it = gauges_.find(metric_name);
-  if (it == gauges_.end()) {
-    gauges_[metric_name] = meter_->CreateInt64UpDownCounter(metric_name + "_gauge");
-    it = gauges_.find(metric_name);
-  }
-
-  if (it->second) {
+  auto* gauge = FindOrCreate(gauges_, metric_name, [&] {
+    return meter_->CreateInt64UpDownCounter(metric_name + "_gauge");
+  });
+  if (gauge != nullptr) {
     auto context = opentelemetry::context::Context{};
     if (attributes.empty()) {
-      it->second->Add(static_cast<int64_t>(value), context);
+      gauge->Add(static_cast<int64_t>(value), context);
     } else {
       // Convert attributes to OpenTelemetry format
       std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
                                                                 attributes.end());
       auto kv_iterable = opentelemetry::common::KeyValueIterableView<
           std::vector<std::pair<std::string, std::string>>>(attr_vec);
-      it->second->Add(static_cast<int64_t>(value), kv_iterable, context);
+      gauge->Add(static_cast<int64_t>(value), kv_iterable, context);
     }
   }
 }

--- a/domains/platform/libs/futility/otel/metrics.h
+++ b/domains/platform/libs/futility/otel/metrics.h
@@ -31,6 +31,7 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -88,9 +89,18 @@ class MetricsRecorder {
                    const std::map<std::string, std::string>& attributes = {});
 
  private:
+  /// The cached instrument, created under mu_ on first use. Element
+  /// pointers survive rehash and instruments record thread-safely, so
+  /// callers record outside the lock.
+  template <typename Instrument, typename Factory>
+  Instrument* FindOrCreate(std::unordered_map<std::string, std::unique_ptr<Instrument>>& cache,
+                           const std::string& metric_name, const Factory& make);
+
   std::shared_ptr<opentelemetry::metrics::Meter> meter_;
 
-  // Cache metric instruments to avoid recreating them
+  // Cache metric instruments to avoid recreating them. Recorders are
+  // called from arbitrary threads; mu_ guards the caches.
+  std::mutex mu_;
   std::unordered_map<std::string, std::unique_ptr<opentelemetry::metrics::Counter<uint64_t>>>
       counters_;
   std::unordered_map<std::string, std::unique_ptr<opentelemetry::metrics::Histogram<uint64_t>>>


### PR DESCRIPTION
Phase 4 of #1187: golf_hub into the consolidated stack, serving the `?golf=v2` beta while the Go hub keeps v1.

**Delivery.** `linux_amd64_oci_binary` in golf_hub's BUILD, so the existing publish workflow pushes `ghcr.io/muchq/golf_hub` (latest + SHA) on merge to main. Compose service on port 8089 with `ALLOWED_ORIGINS=https://muchq.com,https://www.muchq.com` (parity with the Go hub's allowlist; entries are full origins as the browser sends the `Origin` header), `TRUSTED_PROXY_CIDRS` pinned to Caddy's address like portrait, and OTLP push to otelcol. Caddyfile (+ local) routes `POST /games/v2/session` and the `/games/v2/golf/play` upgrade to golf_hub; the existing api.muchq.com CORS block already covers the session preflight.

**Main.** Grows portrait's `TRUSTED_PROXY_CIDRS` parsing (ADR-0012 — unset stays direct-connect, set-but-invalid fails startup) and passes a `MetricsRecorder` into the handler.

**Stream observability** (the aura chain sees only unary requests): `stream_sessions` (by resumed), `stream_sessions_active`, `stream_admissions_refused` (bad_ticket/seat_conflict), `stream_disconnects` (abrupt/clean), `stream_seats_expired`, `stream_commands`/`stream_events` by union case (golf envelope unwrapped to `golf.<move>`), `stream_rejections` by reason. All events funnel through one `Send` choke point so the event counter can't miss a path. The e2e fixture now injects a recorder on the global no-op meter, so every counting path runs under the suite.

Separate first commit: `MetricsRecorder`'s lazy instrument caches had no synchronization while every service records from concurrent transport threads — creation now happens under a lock, recording stays outside it.

After merge: wait for publish to push the image, then `./deploy/consolidated/deploy.sh`. Soak = beta users on `?golf=v2` while watching `stream_*` and the aura instruments.