### PR TITLE
golf_hub: room ids become shareable 6-char codes

### DIFF
--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -30,7 +30,6 @@ cc_library(
     srcs = ["id_generator.cc"],
     hdrs = ["id_generator.h"],
     deps = [
-        ":ticket_vault",
         "@com_google_absl//absl/random",
         "@com_google_absl//absl/random:distributions",
         "@com_google_absl//absl/strings:str_format",

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -36,6 +36,16 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "id_generator_test",
+    size = "small",
+    srcs = ["id_generator_test.cc"],
+    deps = [
+        ":id_generator",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "ticket_vault",
     srcs = ["ticket_vault.cc"],

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -583,12 +583,13 @@ TEST_F(GolfGameFixture, RoomStatsAccumulateAcrossGames) {
   }
 }
 
-// The id seam at work: a generator that hands out the same game code
-// twice, forcing the create path's collision loop to roll again.
+// The id seam at work: a generator that hands out the same room id or
+// game code twice, forcing the create paths' collision loops to roll
+// again.
 class CollidingIds final : public IdGenerator {
  public:
   std::string PlayerId() override { return "player-" + std::to_string(++players_); }
-  std::string RoomId() override { return "room-" + std::to_string(++rooms_); }
+  std::string RoomId() override { return ++rooms_ <= 2 ? "SAMERM" : "ROOM2X"; }
   std::string GameCode() override { return ++codes_ <= 2 ? "DUPLIC" : "FRESH1"; }
 
  private:
@@ -627,6 +628,24 @@ TEST_F(CollidingIdsFixture, GameCodeCollisionRollsAgain) {
   auto second = ReceiveGolf(bob->stream, "gameJoined");
   ASSERT_TRUE(second.has_value());
   EXPECT_EQ(second->as_gameJoined_or_null()->view.gameId, "FRESH1");
+}
+
+TEST_F(CollidingIdsFixture, RoomCodeCollisionRollsAgain) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto first = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->as_roomState_or_null()->roomId, "SAMERM");
+
+  // Bob's create draws "SAMERM" again; the hub rolls until it's fresh.
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto second = ReceiveCase(bob->stream, "roomState");
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(second->as_roomState_or_null()->roomId, "ROOM2X");
 }
 
 }  // namespace

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -186,6 +186,7 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
       const std::lock_guard<std::mutex> lock(mu_);
       if (!player_room_.contains(player_id)) {
         room_id = ids_->RoomId();
+        while (rooms_.contains(room_id)) room_id = ids_->RoomId();
         rooms_[room_id].members.emplace(player_id, Member{});
         player_room_[player_id] = room_id;
         StageRoomStateLocked(room_id, outbox);

--- a/domains/games/apis/golf_hub/id_generator.cc
+++ b/domains/games/apis/golf_hub/id_generator.cc
@@ -6,7 +6,6 @@
 #include "absl/random/distributions.h"
 #include "absl/random/random.h"
 #include "absl/strings/str_format.h"
-#include "domains/games/apis/golf_hub/ticket_vault.h"
 
 namespace golf_hub {
 
@@ -31,6 +30,18 @@ std::string_view Pick(absl::BitGen& gen, const std::string_view (&words)[N]) {
   return words[absl::Uniform<std::size_t>(gen, 0u, N)];
 }
 
+// The shareable-code alphabet for rooms and games: strictly alphanumeric
+// so the UI's permalink validation accepts it verbatim.
+std::string Code6() {
+  thread_local absl::BitGen gen;
+  constexpr char kCode[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  std::string code;
+  for (int i = 0; i < 6; ++i) {
+    code.push_back(kCode[absl::Uniform<std::size_t>(gen, 0u, sizeof(kCode) - 1)]);
+  }
+  return code;
+}
+
 }  // namespace
 
 std::string WhimsicalIdGenerator::PlayerId() {
@@ -49,17 +60,9 @@ std::string WhimsicalIdGenerator::PlayerId() {
   return id;
 }
 
-std::string WhimsicalIdGenerator::RoomId() { return RandomId("r"); }
+std::string WhimsicalIdGenerator::RoomId() { return Code6(); }
 
-std::string WhimsicalIdGenerator::GameCode() {
-  thread_local absl::BitGen gen;
-  constexpr char kCode[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  std::string code;
-  for (int i = 0; i < 6; ++i) {
-    code.push_back(kCode[absl::Uniform<std::size_t>(gen, 0u, sizeof(kCode) - 1)]);
-  }
-  return code;
-}
+std::string WhimsicalIdGenerator::GameCode() { return Code6(); }
 
 std::string SequentialIdGenerator::PlayerId() { return absl::StrFormat("player-%d", ++players_); }
 

--- a/domains/games/apis/golf_hub/id_generator.h
+++ b/domains/games/apis/golf_hub/id_generator.h
@@ -16,7 +16,9 @@ class IdGenerator {
   /// A player id; doubles as the display name.
   virtual std::string PlayerId() = 0;
 
-  /// An opaque room id.
+  /// A 6-char uppercase alphanumeric room code: rooms are the shareable
+  /// unit (joining a friend's game means joining their room first), so
+  /// the id must survive a permalink and a "type this code" exchange.
   virtual std::string RoomId() = 0;
 
   /// A 6-char uppercase alphanumeric game code — the Go hub's format,
@@ -26,7 +28,7 @@ class IdGenerator {
 
 /// Production ids: whimsical player names ("bouncy-coral-quokka-x9k2",
 /// the Go hub's word lists, so beta players never see opaque ids),
-/// "r-<hex>" rooms, random game codes.
+/// short codes for rooms and games.
 class WhimsicalIdGenerator final : public IdGenerator {
  public:
   std::string PlayerId() override;

--- a/domains/games/apis/golf_hub/id_generator_test.cc
+++ b/domains/games/apis/golf_hub/id_generator_test.cc
@@ -1,0 +1,55 @@
+// Production id shapes are contracts, not aesthetics: the UI's permalink
+// validation admits alphanumeric ids and the lobby's room-code input
+// upshifts exactly six characters. Shape only — values are random and
+// collisions are legal (the hub rerolls), so neither is asserted.
+
+#include "domains/games/apis/golf_hub/id_generator.h"
+
+#include <gtest/gtest.h>
+
+#include <cctype>
+#include <string>
+
+namespace golf_hub {
+namespace {
+
+bool IsSixCharUppercaseAlnum(const std::string& id) {
+  if (id.size() != 6) return false;
+  for (const char c : id) {
+    const auto uc = static_cast<unsigned char>(c);
+    if (!std::isupper(uc) && !std::isdigit(uc)) return false;
+  }
+  return true;
+}
+
+TEST(WhimsicalIdGenerator, RoomAndGameCodesAreSixCharUppercaseAlnum) {
+  WhimsicalIdGenerator ids;
+  for (int i = 0; i < 200; ++i) {
+    const std::string room = ids.RoomId();
+    const std::string game = ids.GameCode();
+    EXPECT_TRUE(IsSixCharUppercaseAlnum(room)) << room;
+    EXPECT_TRUE(IsSixCharUppercaseAlnum(game)) << game;
+  }
+}
+
+TEST(WhimsicalIdGenerator, PlayerIdIsLowercaseSlugWithThreeWords) {
+  WhimsicalIdGenerator ids;
+  for (int i = 0; i < 200; ++i) {
+    const std::string id = ids.PlayerId();
+    int hyphens = 0;
+    for (const char c : id) {
+      if (c == '-') {
+        ++hyphens;
+        continue;
+      }
+      const auto uc = static_cast<unsigned char>(c);
+      EXPECT_TRUE(std::islower(uc) || std::isdigit(uc)) << id;
+    }
+    EXPECT_EQ(hyphens, 3) << id;
+    // adjective-color-animal-xxxx: the final segment is the 4-char slug.
+    EXPECT_EQ(id.rfind('-'), id.size() - 5) << id;
+  }
+}
+
+}  // namespace
+}  // namespace golf_hub


### PR DESCRIPTION
Prod-soak finding on #1187 phase 4: the README promised 6-char codes for rooms and games, but rooms actually minted `r-<hex>`. Rooms are the shareable unit — a friend joins your room before your game — and the hex form fails the UI's alphanumeric permalink validation (`generateRoomPermalink` throws on it) besides being hostile to "type this code" sharing.

`RoomId()` now uses the game-code format via a shared `Code6()`, createRoom gains the same collision roll createGame already had, and the id seam scripts a room collision in e2e alongside the existing game-code one. This makes the README's existing claim true rather than editing the claim.

Companion UI change (permalinks carrying the beta flag + toggle) goes to muchq.github.io separately.