### PR TITLE
prom_proxy: expose golf_hub stream metrics

### DIFF
--- a/domains/platform/apis/prom_proxy/handlers.go
+++ b/domains/platform/apis/prom_proxy/handlers.go
@@ -896,3 +896,117 @@ func (h *MetricsHandler) fetchContainerMetricsTimeSeries(ctx context.Context, ti
 
 	return response, nil
 }
+
+func (h *MetricsHandler) GetGolfMetrics(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	metrics, err := h.fetchGolfMetrics(ctx)
+	if err != nil {
+		problem := mucks.NewServerError(500)
+		problem.Detail = "Failed to fetch golf metrics: " + err.Error()
+		mucks.JsonError(w, problem)
+		return
+	}
+
+	mucks.JsonOk(w, metrics)
+}
+
+func (h *MetricsHandler) GetGolfMetricsTimeSeries(w http.ResponseWriter, r *http.Request) {
+	timeRange := r.PathValue("range")
+
+	if !ValidTimeRange(timeRange) {
+		problem := mucks.NewBadRequest("Invalid time range. Valid options: 30m, 1d, 7d")
+		mucks.JsonError(w, problem)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	response, err := h.fetchGolfMetricsTimeSeries(ctx, TimeRange(timeRange))
+	if err != nil {
+		problem := mucks.NewServerError(500)
+		problem.Detail = "Failed to fetch golf metrics timeseries: " + err.Error()
+		mucks.JsonError(w, problem)
+		return
+	}
+
+	mucks.JsonOk(w, response)
+}
+
+// The golf_hub stream instruments (MoonBase#1187 phase 4). Counters carry
+// label splits (resumed, kind, command, event, reason), so scalars sum
+// across them; the OTel collector exports the up-down session counter as
+// stream_sessions_active_gauge.
+func (h *MetricsHandler) fetchGolfMetrics(ctx context.Context) (*GolfMetrics, error) {
+	metrics := &GolfMetrics{
+		Timestamp: time.Now().UTC(),
+	}
+
+	scalars := []struct {
+		query string
+		field *float64
+	}{
+		{`sum(stream_sessions_active_gauge)`, &metrics.Sessions.Active},
+		{`sum(stream_sessions_total)`, &metrics.Sessions.StartedTotal},
+		{`sum(stream_sessions_total{resumed="true"})`, &metrics.Sessions.ResumedTotal},
+		{`sum(stream_admissions_refused_total)`, &metrics.Sessions.RefusedTotal},
+		{`sum(stream_disconnects_total)`, &metrics.Sessions.DisconnectsTotal},
+		{`sum(stream_seats_expired_total)`, &metrics.Sessions.SeatsExpiredTotal},
+		{`sum(rate(stream_commands_total[5m]))`, &metrics.Activity.CommandsPerSec},
+		{`sum(rate(stream_events_total[5m]))`, &metrics.Activity.EventsPerSec},
+		{`sum(rate(stream_rejections_total[5m]))`, &metrics.Activity.RejectionsPerSec},
+	}
+	for _, s := range scalars {
+		resp, err := h.promClient.Query(ctx, s.query)
+		if err == nil && len(resp.Data.Result) > 0 {
+			if val, err := extractFloatValue(&resp.Data.Result[0]); err == nil {
+				*s.field = val
+			}
+		}
+	}
+
+	return metrics, nil
+}
+
+func (h *MetricsHandler) fetchGolfMetricsTimeSeries(ctx context.Context, timeRange TimeRange) (*TimeSeriesResponse, error) {
+	duration, step := GetTimeRangeConfig(timeRange)
+	endTime := time.Now().UTC()
+	startTime := endTime.Add(-duration)
+
+	response := &TimeSeriesResponse{
+		TimeRange: string(timeRange),
+		StartTime: startTime,
+		EndTime:   endTime,
+		Step:      step,
+		Series:    []TimeSeries{},
+	}
+
+	queries := map[string]string{
+		"sessions_active": `sum(stream_sessions_active_gauge)`,
+		"session_starts":  `sum(increase(stream_sessions_total[5m]))`,
+		"command_rate":    `sum(rate(stream_commands_total[5m]))`,
+		"event_rate":      `sum(rate(stream_events_total[5m]))`,
+		"rejection_rate":  `sum(rate(stream_rejections_total[5m]))`,
+		"disconnect_rate": `sum(rate(stream_disconnects_total[5m]))`,
+	}
+
+	for metricName, query := range queries {
+		resp, err := h.promClient.QueryRange(ctx, query, startTime, endTime, step)
+		if err != nil {
+			continue
+		}
+
+		for _, result := range resp.Data.Result {
+			ts, err := extractTimeSeries(&result)
+			if err != nil {
+				continue
+			}
+			ts.MetricName = metricName
+			response.Series = append(response.Series, ts)
+		}
+	}
+
+	return response, nil
+}

--- a/domains/platform/apis/prom_proxy/handlers_test.go
+++ b/domains/platform/apis/prom_proxy/handlers_test.go
@@ -459,3 +459,61 @@ var _ interface {
 	Query(ctx context.Context, query string) (*QueryResponse, error)
 	QueryRange(ctx context.Context, query string, start, end time.Time, step string) (*QueryResponse, error)
 } = (*mockPrometheusClient)(nil)
+func TestMetricsHandler_GetGolfMetrics_Success(t *testing.T) {
+	mockClient := &mockPrometheusClient{
+		queryResponse: &QueryResponse{
+			Status: "success",
+			Data: struct {
+				ResultType string   `json:"resultType"`
+				Result     []Result `json:"result"`
+			}{
+				ResultType: "vector",
+				Result: []Result{
+					{
+						Metric: map[string]string{},
+						Value:  []interface{}{1609459200.0, "3"},
+					},
+				},
+			},
+		},
+		queryError: nil,
+	}
+
+	handler := &MetricsHandler{promClient: mockClient}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/scalar/golf", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetGolfMetrics(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response GolfMetrics
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Every scalar rides the same mocked query result.
+	assert.Equal(t, float64(3), response.Sessions.Active)
+	assert.Equal(t, float64(3), response.Sessions.StartedTotal)
+	assert.Equal(t, float64(3), response.Activity.CommandsPerSec)
+	assert.WithinDuration(t, time.Now(), response.Timestamp, 5*time.Second)
+}
+
+func TestMetricsHandler_GetGolfMetricsTimeSeries_InvalidRange(t *testing.T) {
+	handler := &MetricsHandler{}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/timeseries/golf/invalid", nil)
+	req.SetPathValue("range", "invalid")
+	w := httptest.NewRecorder()
+
+	handler.GetGolfMetricsTimeSeries(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(400), response["status"])
+	assert.Contains(t, response["detail"], "Invalid time range")
+}

--- a/domains/platform/apis/prom_proxy/main.go
+++ b/domains/platform/apis/prom_proxy/main.go
@@ -41,12 +41,14 @@ func main() {
 	router.HandleFunc("GET /metrics/v1/scalar/portrait", metricsHandler.GetPortraitMetrics)
 	router.HandleFunc("GET /metrics/v1/scalar/containers", metricsHandler.GetContainerMetrics)
 	router.HandleFunc("GET /metrics/v1/scalar/summary", metricsHandler.GetSummaryMetrics)
+	router.HandleFunc("GET /metrics/v1/scalar/golf", metricsHandler.GetGolfMetrics)
 
 	// Timeseries endpoints - historical data with time ranges
 	router.HandleFunc("GET /metrics/v1/timeseries/system/{range}", metricsHandler.GetSystemMetricsTimeSeries)
 	router.HandleFunc("GET /metrics/v1/timeseries/portrait/{range}", metricsHandler.GetPortraitMetricsTimeSeries)
 	router.HandleFunc("GET /metrics/v1/timeseries/containers/{range}", metricsHandler.GetContainerMetricsTimeSeries)
 	router.HandleFunc("GET /metrics/v1/timeseries/microgpt/{range}", metricsHandler.GetMicrogptMetricsTimeSeries)
+	router.HandleFunc("GET /metrics/v1/timeseries/golf/{range}", metricsHandler.GetGolfMetricsTimeSeries)
 
 	// MicroGPT endpoints
 	router.HandleFunc("GET /metrics/v1/scalar/microgpt", metricsHandler.GetMicrogptMetrics)

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -155,3 +155,23 @@ type MicrogptInferenceMetrics struct {
 	AvgDurationMs        float64 `json:"avg_duration_ms"`
 	ConversationTotal    float64 `json:"conversation_total"`
 }
+type GolfMetrics struct {
+	Timestamp time.Time           `json:"timestamp"`
+	Sessions  GolfSessionMetrics  `json:"sessions"`
+	Activity  GolfActivityMetrics `json:"activity"`
+}
+
+type GolfSessionMetrics struct {
+	Active            float64 `json:"active"`
+	StartedTotal      float64 `json:"started_total"`
+	ResumedTotal      float64 `json:"resumed_total"`
+	RefusedTotal      float64 `json:"refused_total"`
+	DisconnectsTotal  float64 `json:"disconnects_total"`
+	SeatsExpiredTotal float64 `json:"seats_expired_total"`
+}
+
+type GolfActivityMetrics struct {
+	CommandsPerSec   float64 `json:"commands_per_sec"`
+	EventsPerSec     float64 `json:"events_per_sec"`
+	RejectionsPerSec float64 `json:"rejections_per_sec"`
+}


### PR DESCRIPTION
Prod-soak finding on #1187 phase 4: the `stream_*` instruments reach prometheus via otelcol, but the dashboard's `/metrics/v1/*` API had no golf route, so they were unreachable from the UI.

Adds `GET /metrics/v1/scalar/golf` (live sessions, started/resumed/refused/disconnect/expired counters, command/event/rejection rates) and `GET /metrics/v1/timeseries/golf/{range}`, following the portrait/microgpt handler shape. Counters carry label splits so scalars `sum()` across them; the collector exports the up-down session counter as `stream_sessions_active_gauge`. Both existing Caddy matchers are wildcarded (`/metrics/v1/scalar/*`, `/metrics/v1/timeseries/*`), so no deploy config changes.

Package tests pass locally (`go test` on the package file set); handler + invalid-range tests added for the new routes.