### PR TITLE
prom_proxy: catalog, host, and per-service metrics routes

### DIFF
--- a/domains/platform/apis/prom_proxy/BUILD.bazel
+++ b/domains/platform/apis/prom_proxy/BUILD.bazel
@@ -7,6 +7,8 @@ go_library(
         "handlers.go",
         "models.go",
         "prometheus_client.go",
+        "registry.go",
+        "service_handlers.go",
     ],
     importpath = "github.com/muchq/moonbase/domains/platform/apis/prom_proxy",
     visibility = ["//visibility:public"],
@@ -25,6 +27,7 @@ go_test(
         "handlers_test.go",
         "models_test.go",
         "prometheus_client_test.go",
+        "service_handlers_test.go",
     ],
     embed = [":prom_proxy_lib"],
     deps = [

--- a/domains/platform/apis/prom_proxy/main.go
+++ b/domains/platform/apis/prom_proxy/main.go
@@ -36,6 +36,15 @@ func main() {
 	// Health endpoint
 	router.HandleFunc("GET /health", metricsHandler.HealthHandler)
 
+	// Dashboard overhaul (#1199): catalog, merged host page, and generic
+	// per-service pages. The per-service scalar/timeseries routes below
+	// are legacy and retire once the UI cutover deploys.
+	router.HandleFunc("GET /metrics/v1/services", metricsHandler.GetServiceCatalog)
+	router.HandleFunc("GET /metrics/v1/host", metricsHandler.GetHostMetrics)
+	router.HandleFunc("GET /metrics/v1/host/timeseries/{range}", metricsHandler.GetHostMetricsTimeSeries)
+	router.HandleFunc("GET /metrics/v1/service/{name}", metricsHandler.GetServiceMetrics)
+	router.HandleFunc("GET /metrics/v1/service/{name}/timeseries/{range}", metricsHandler.GetServiceMetricsTimeSeries)
+
 	// Metrics endpoints - current point-in-time data
 	router.HandleFunc("GET /metrics/v1/scalar/system", metricsHandler.GetSystemMetrics)
 	router.HandleFunc("GET /metrics/v1/scalar/portrait", metricsHandler.GetPortraitMetrics)

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -176,3 +176,47 @@ type GolfActivityMetrics struct {
 	EventsPerSec     float64 `json:"events_per_sec"`
 	RejectionsPerSec float64 `json:"rejections_per_sec"`
 }
+
+type ServiceCatalogEntry struct {
+	Name      string `json:"name"`
+	HasCustom bool   `json:"has_custom"`
+}
+
+type ServiceCatalog struct {
+	Services []ServiceCatalogEntry `json:"services"`
+}
+
+type HostMetricsResponse struct {
+	Timestamp  time.Time        `json:"timestamp"`
+	System     *SystemMetrics   `json:"system"`
+	Containers []ContainerStats `json:"containers"`
+}
+
+type StandardMetrics struct {
+	RequestsTotal     float64 `json:"requests_total"`
+	RatePerSec        float64 `json:"rate_per_sec"`
+	SuccessCount5m    float64 `json:"success_count_5m"`
+	FailureCount5m    float64 `json:"failure_count_5m"`
+	ErrorRatePercent  float64 `json:"error_rate_percent"`
+	AvgDurationMicros float64 `json:"avg_duration_microseconds"`
+	P95DurationMicros float64 `json:"p95_duration_microseconds"`
+	ActiveRequests    float64 `json:"active_requests"`
+}
+
+type CustomMetricValue struct {
+	Label string  `json:"label"`
+	Value float64 `json:"value"`
+	Unit  string  `json:"unit"`
+}
+
+type CustomMetricGroup struct {
+	Title   string              `json:"title"`
+	Metrics []CustomMetricValue `json:"metrics"`
+}
+
+type ServiceMetricsResponse struct {
+	Timestamp time.Time           `json:"timestamp"`
+	Service   string              `json:"service"`
+	Standard  StandardMetrics     `json:"standard"`
+	Custom    []CustomMetricGroup `json:"custom"`
+}

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -1,0 +1,119 @@
+package prom_proxy
+
+import "fmt"
+
+// The service registry behind the dashboard overhaul (#1199): the catalog
+// endpoint, the standard http_server_* block, and each service's custom
+// metric descriptors all read from here — adding an emitter is one entry,
+// no new routes, handlers, or UI code.
+
+type customScalarDef struct {
+	Group string
+	Label string
+	Unit  string
+	Query string
+}
+
+type serviceEntry struct {
+	CustomScalars    []customScalarDef
+	CustomTimeseries map[string]string
+}
+
+// Catalog order doubles as the UI's tab order.
+var serviceOrder = []string{"golf_hub", "microgpt-serve", "portrait"}
+
+var serviceRegistry = map[string]serviceEntry{
+	"golf_hub": {
+		CustomScalars: []customScalarDef{
+			{"Sessions", "active", "sessions", `sum(stream_sessions_active_gauge)`},
+			{"Sessions", "started_total", "", `sum(stream_sessions_total)`},
+			{"Sessions", "resumed_total", "", `sum(stream_sessions_total{resumed="true"})`},
+			{"Sessions", "refused_total", "", `sum(stream_admissions_refused_total)`},
+			{"Sessions", "disconnects_total", "", `sum(stream_disconnects_total)`},
+			{"Sessions", "seats_expired_total", "", `sum(stream_seats_expired_total)`},
+			{"Activity", "commands_per_sec", "/s", `sum(rate(stream_commands_total[5m]))`},
+			{"Activity", "events_per_sec", "/s", `sum(rate(stream_events_total[5m]))`},
+			{"Activity", "rejections_per_sec", "/s", `sum(rate(stream_rejections_total[5m]))`},
+		},
+		CustomTimeseries: map[string]string{
+			"sessions_active": `sum(stream_sessions_active_gauge)`,
+			"session_starts":  `sum(increase(stream_sessions_total[5m]))`,
+			"command_rate":    `sum(rate(stream_commands_total[5m]))`,
+			"event_rate":      `sum(rate(stream_events_total[5m]))`,
+			"rejection_rate":  `sum(rate(stream_rejections_total[5m]))`,
+			"disconnect_rate": `sum(rate(stream_disconnects_total[5m]))`,
+		},
+	},
+	"microgpt-serve": {
+		CustomScalars: []customScalarDef{
+			{"Requests by endpoint", "generate_total", "", `sum(microgpt_requests_total{endpoint="generate"})`},
+			{"Requests by endpoint", "chat_total", "", `sum(microgpt_requests_total{endpoint="chat"})`},
+			{"Inference", "tokens_generated_total", "tokens", `sum(microgpt_tokens_generated_total)`},
+			{"Inference", "tokens_per_sec", "tokens/s", `sum(rate(microgpt_tokens_generated_total[5m]))`},
+			{"Inference", "avg_duration_ms", "ms", `sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`},
+			{"Inference", "conversations_total", "", `sum(microgpt_conversations_total)`},
+		},
+		CustomTimeseries: map[string]string{
+			"request_rate":      `sum(rate(microgpt_requests_total[5m]))`,
+			"tokens_per_second": `sum(rate(microgpt_tokens_generated_total[5m]))`,
+			"avg_duration_ms":   `sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`,
+		},
+	},
+	"portrait": {
+		CustomScalars: []customScalarDef{
+			{"Render cache", "hit_rate_percent", "%", `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`},
+			{"Render cache", "operations_per_sec", "/s", `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`},
+			{"Scene complexity", "avg_spheres_1h", "spheres", `avg_over_time(scene_sphere_count_gauge[1h])`},
+			{"Scene complexity", "avg_lights_1h", "lights", `avg_over_time(scene_light_count_gauge[1h])`},
+		},
+		CustomTimeseries: map[string]string{
+			"cache_hit_rate":        `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`,
+			"cache_operations_rate": `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`,
+			"scene_sphere_count":    `scene_sphere_count_gauge`,
+			"scene_light_count":     `scene_light_count_gauge`,
+		},
+	},
+}
+
+// The standard serving block: every emitter shares the aura/server_pal
+// http_server_* instruments labeled by service_name, so one parameterized
+// query set covers all of them. service is always a registry key, never
+// caller input.
+func standardScalarQueries(service string) []struct {
+	Query string
+	Field func(*StandardMetrics) *float64
+} {
+	s := fmt.Sprintf("%q", service)
+	return []struct {
+		Query string
+		Field func(*StandardMetrics) *float64
+	}{
+		{`sum(http_server_requests_total{service_name=` + s + `})`,
+			func(m *StandardMetrics) *float64 { return &m.RequestsTotal }},
+		{`sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`,
+			func(m *StandardMetrics) *float64 { return &m.RatePerSec }},
+		{`sum(increase(http_server_requests_success_total{service_name=` + s + `}[5m]))`,
+			func(m *StandardMetrics) *float64 { return &m.SuccessCount5m }},
+		{`sum(increase(http_server_requests_failure_total{service_name=` + s + `}[5m]))`,
+			func(m *StandardMetrics) *float64 { return &m.FailureCount5m }},
+		{`sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m]))/(sum(rate(http_server_requests_success_total{service_name=` + s + `}[5m]))+sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m])))*100`,
+			func(m *StandardMetrics) *float64 { return &m.ErrorRatePercent }},
+		{`sum(rate(http_server_request_duration_microseconds_sum{service_name=` + s + `}[5m]))/sum(rate(http_server_request_duration_microseconds_count{service_name=` + s + `}[5m]))`,
+			func(m *StandardMetrics) *float64 { return &m.AvgDurationMicros }},
+		{`histogram_quantile(0.95,sum by (le) (rate(http_server_request_duration_microseconds_bucket{service_name=` + s + `}[5m])))`,
+			func(m *StandardMetrics) *float64 { return &m.P95DurationMicros }},
+		{`sum(http_server_requests_active_gauge{service_name=` + s + `})`,
+			func(m *StandardMetrics) *float64 { return &m.ActiveRequests }},
+	}
+}
+
+func standardTimeseriesQueries(service string) map[string]string {
+	s := fmt.Sprintf("%q", service)
+	return map[string]string{
+		"request_rate":       `sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`,
+		"error_rate_percent": `sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m]))/(sum(rate(http_server_requests_success_total{service_name=` + s + `}[5m]))+sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m])))*100`,
+		"avg_duration_us":    `sum(rate(http_server_request_duration_microseconds_sum{service_name=` + s + `}[5m]))/sum(rate(http_server_request_duration_microseconds_count{service_name=` + s + `}[5m]))`,
+		"p95_duration_us":    `histogram_quantile(0.95,sum by (le) (rate(http_server_request_duration_microseconds_bucket{service_name=` + s + `}[5m])))`,
+		"active_requests":    `sum(http_server_requests_active_gauge{service_name=` + s + `})`,
+	}
+}

--- a/domains/platform/apis/prom_proxy/service_handlers.go
+++ b/domains/platform/apis/prom_proxy/service_handlers.go
@@ -1,0 +1,186 @@
+package prom_proxy
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/muchq/moonbase/domains/platform/libs/mucks"
+)
+
+// Handlers for the dashboard overhaul (#1199): the service catalog, the
+// merged host page, and the generic per-service pages driven by the
+// registry. The legacy per-service routes stay up until the UI cutover.
+
+func (h *MetricsHandler) GetServiceCatalog(w http.ResponseWriter, r *http.Request) {
+	catalog := ServiceCatalog{Services: []ServiceCatalogEntry{}}
+	for _, name := range serviceOrder {
+		entry := serviceRegistry[name]
+		catalog.Services = append(catalog.Services, ServiceCatalogEntry{
+			Name:      name,
+			HasCustom: len(entry.CustomScalars) > 0,
+		})
+	}
+	mucks.JsonOk(w, catalog)
+}
+
+func (h *MetricsHandler) GetHostMetrics(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	response := &HostMetricsResponse{
+		Timestamp:  time.Now().UTC(),
+		Containers: []ContainerStats{},
+	}
+	// Same resilience contract as the rest of the API: a failing scrape
+	// source yields zeroed/empty sections with 200, never a 500.
+	if system, err := h.fetchSystemMetrics(ctx); err == nil {
+		response.System = system
+	}
+	if containers, err := h.fetchContainerMetrics(ctx); err == nil {
+		response.Containers = containers.Containers
+	}
+
+	mucks.JsonOk(w, response)
+}
+
+func (h *MetricsHandler) GetHostMetricsTimeSeries(w http.ResponseWriter, r *http.Request) {
+	timeRange := r.PathValue("range")
+
+	if !ValidTimeRange(timeRange) {
+		problem := mucks.NewBadRequest("Invalid time range. Valid options: 30m, 1d, 7d")
+		mucks.JsonError(w, problem)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	response, err := h.fetchSystemMetricsTimeSeries(ctx, TimeRange(timeRange))
+	if err != nil {
+		problem := mucks.NewServerError(500)
+		problem.Detail = "Failed to fetch host metrics timeseries: " + err.Error()
+		mucks.JsonError(w, problem)
+		return
+	}
+
+	// Container series ride the same response, namespaced so they can't
+	// collide with the host series names.
+	if containers, err := h.fetchContainerMetricsTimeSeries(ctx, TimeRange(timeRange)); err == nil {
+		for _, ts := range containers.Series {
+			if !strings.HasPrefix(ts.MetricName, "container_") {
+				ts.MetricName = "container_" + ts.MetricName
+			}
+			response.Series = append(response.Series, ts)
+		}
+	}
+
+	mucks.JsonOk(w, response)
+}
+
+func (h *MetricsHandler) GetServiceMetrics(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	entry, known := serviceRegistry[name]
+	if !known {
+		mucks.JsonError(w, mucks.NewNotFound())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	response := &ServiceMetricsResponse{
+		Timestamp: time.Now().UTC(),
+		Service:   name,
+		Custom:    []CustomMetricGroup{},
+	}
+
+	for _, q := range standardScalarQueries(name) {
+		resp, err := h.promClient.Query(ctx, q.Query)
+		if err == nil && len(resp.Data.Result) > 0 {
+			if val, err := extractFloatValue(&resp.Data.Result[0]); err == nil {
+				*q.Field(&response.Standard) = val
+			}
+		}
+	}
+
+	// Groups keep registry order; a failed query leaves its descriptor in
+	// place with a zero value, so the page shape is stable under outages.
+	groupIndex := map[string]int{}
+	for _, def := range entry.CustomScalars {
+		value := 0.0
+		resp, err := h.promClient.Query(ctx, def.Query)
+		if err == nil && len(resp.Data.Result) > 0 {
+			if val, err := extractFloatValue(&resp.Data.Result[0]); err == nil {
+				value = val
+			}
+		}
+		i, seen := groupIndex[def.Group]
+		if !seen {
+			i = len(response.Custom)
+			groupIndex[def.Group] = i
+			response.Custom = append(response.Custom, CustomMetricGroup{Title: def.Group})
+		}
+		response.Custom[i].Metrics = append(response.Custom[i].Metrics, CustomMetricValue{
+			Label: def.Label,
+			Value: value,
+			Unit:  def.Unit,
+		})
+	}
+
+	mucks.JsonOk(w, response)
+}
+
+func (h *MetricsHandler) GetServiceMetricsTimeSeries(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	entry, known := serviceRegistry[name]
+	if !known {
+		mucks.JsonError(w, mucks.NewNotFound())
+		return
+	}
+
+	timeRange := r.PathValue("range")
+	if !ValidTimeRange(timeRange) {
+		problem := mucks.NewBadRequest("Invalid time range. Valid options: 30m, 1d, 7d")
+		mucks.JsonError(w, problem)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	duration, step := GetTimeRangeConfig(TimeRange(timeRange))
+	endTime := time.Now().UTC()
+	startTime := endTime.Add(-duration)
+
+	response := &TimeSeriesResponse{
+		TimeRange: timeRange,
+		StartTime: startTime,
+		EndTime:   endTime,
+		Step:      step,
+		Series:    []TimeSeries{},
+	}
+
+	queries := standardTimeseriesQueries(name)
+	for metricName, query := range entry.CustomTimeseries {
+		queries[metricName] = query
+	}
+
+	for metricName, query := range queries {
+		resp, err := h.promClient.QueryRange(ctx, query, startTime, endTime, step)
+		if err != nil {
+			continue
+		}
+		for _, result := range resp.Data.Result {
+			ts, err := extractTimeSeries(&result)
+			if err != nil {
+				continue
+			}
+			ts.MetricName = metricName
+			response.Series = append(response.Series, ts)
+		}
+	}
+
+	mucks.JsonOk(w, response)
+}

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -1,0 +1,337 @@
+package prom_proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rangeResponse(metricName string) *QueryResponse {
+	return &QueryResponse{
+		Status: "success",
+		Data: struct {
+			ResultType string   `json:"resultType"`
+			Result     []Result `json:"result"`
+		}{
+			ResultType: "matrix",
+			Result: []Result{
+				{
+					Metric: map[string]string{"__name__": metricName},
+					Values: [][]interface{}{
+						{1609459200.0, "25.5"},
+						{1609459230.0, "26.1"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRegistry_OrderAndEntriesAgree(t *testing.T) {
+	assert.Len(t, serviceOrder, len(serviceRegistry))
+	for _, name := range serviceOrder {
+		_, ok := serviceRegistry[name]
+		assert.True(t, ok, "serviceOrder entry %q missing from registry", name)
+	}
+}
+
+func TestMetricsHandler_GetServiceCatalog(t *testing.T) {
+	handler := &MetricsHandler{}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/services", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetServiceCatalog(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var catalog ServiceCatalog
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &catalog))
+
+	require.Len(t, catalog.Services, 3)
+	assert.Equal(t, "golf_hub", catalog.Services[0].Name)
+	assert.Equal(t, "microgpt-serve", catalog.Services[1].Name)
+	assert.Equal(t, "portrait", catalog.Services[2].Name)
+	for _, entry := range catalog.Services {
+		assert.True(t, entry.HasCustom, entry.Name)
+	}
+
+	// The wire field names are the UI contract.
+	assert.Contains(t, w.Body.String(), `"has_custom"`)
+}
+
+// A few standard queries pinned as literal strings, so a typo in the
+// shared instrument names can't hide behind the enumeration below.
+func TestStandardQueries_GoldenStrings(t *testing.T) {
+	queries := standardScalarQueries("golf_hub")
+	var all []string
+	for _, q := range queries {
+		all = append(all, q.Query)
+	}
+	assert.Contains(t, all, `sum(rate(http_server_requests_total{service_name="golf_hub"}[5m]))`)
+	assert.Contains(t, all,
+		`histogram_quantile(0.95,sum by (le) (rate(http_server_request_duration_microseconds_bucket{service_name="golf_hub"}[5m])))`)
+	assert.Contains(t, all, `sum(http_server_requests_active_gauge{service_name="golf_hub"})`)
+}
+
+func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T) {
+	// Distinct value per query: a query wired to the wrong standard field
+	// or custom descriptor fails loudly. One custom query is deliberately
+	// omitted from the mock — its descriptor must still appear, zeroed.
+	responses := map[string]*QueryResponse{}
+	standard := standardScalarQueries("golf_hub")
+	for i, q := range standard {
+		responses[q.Query] = golfScalarResponse(fmt.Sprintf("%d", 100+i))
+	}
+	entry := serviceRegistry["golf_hub"]
+	omitted := entry.CustomScalars[len(entry.CustomScalars)-1]
+	for i, def := range entry.CustomScalars {
+		if def == omitted {
+			continue
+		}
+		responses[def.Query] = golfScalarResponse(fmt.Sprintf("%d", 200+i))
+	}
+
+	handler := &MetricsHandler{promClient: &mockPrometheusClient{queryResponses: responses}}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub", nil)
+	req.SetPathValue("name", "golf_hub")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetrics(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response ServiceMetricsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "golf_hub", response.Service)
+	assert.WithinDuration(t, time.Now(), response.Timestamp, 5*time.Second)
+
+	// Standard fields in declaration order of standardScalarQueries.
+	assert.Equal(t, 100.0, response.Standard.RequestsTotal)
+	assert.Equal(t, 101.0, response.Standard.RatePerSec)
+	assert.Equal(t, 102.0, response.Standard.SuccessCount5m)
+	assert.Equal(t, 103.0, response.Standard.FailureCount5m)
+	assert.Equal(t, 104.0, response.Standard.ErrorRatePercent)
+	assert.Equal(t, 105.0, response.Standard.AvgDurationMicros)
+	assert.Equal(t, 106.0, response.Standard.P95DurationMicros)
+	assert.Equal(t, 107.0, response.Standard.ActiveRequests)
+
+	// Custom groups keep registry order and every descriptor is present.
+	require.Len(t, response.Custom, 2)
+	assert.Equal(t, "Sessions", response.Custom[0].Title)
+	assert.Equal(t, "Activity", response.Custom[1].Title)
+	assert.Len(t, response.Custom[0].Metrics, 6)
+	require.Len(t, response.Custom[1].Metrics, 3)
+
+	assert.Equal(t, CustomMetricValue{Label: "active", Value: 200.0, Unit: "sessions"},
+		response.Custom[0].Metrics[0])
+	assert.Equal(t, CustomMetricValue{Label: "commands_per_sec", Value: 206.0, Unit: "/s"},
+		response.Custom[1].Metrics[0])
+	// The omitted query's descriptor survives with a zero value.
+	last := response.Custom[1].Metrics[2]
+	assert.Equal(t, omitted.Label, last.Label)
+	assert.Equal(t, 0.0, last.Value)
+}
+
+func TestMetricsHandler_GetServiceMetrics_PrometheusError(t *testing.T) {
+	handler := &MetricsHandler{promClient: &mockPrometheusClient{queryError: assert.AnError}}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/portrait", nil)
+	req.SetPathValue("name", "portrait")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetrics(w, req)
+
+	// Outage contract: zeroed values behind a stable page shape, never 500.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response ServiceMetricsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, 0.0, response.Standard.RatePerSec)
+	require.Len(t, response.Custom, 2)
+	assert.Equal(t, "Render cache", response.Custom[0].Title)
+	assert.Equal(t, "Scene complexity", response.Custom[1].Title)
+	for _, group := range response.Custom {
+		for _, metric := range group.Metrics {
+			assert.Equal(t, 0.0, metric.Value, metric.Label)
+		}
+	}
+}
+
+func TestMetricsHandler_GetServiceMetrics_UnknownService(t *testing.T) {
+	handler := &MetricsHandler{}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/nonesuch", nil)
+	req.SetPathValue("name", "nonesuch")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetrics(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	// Unknown service outranks an invalid range on the timeseries route.
+	req = httptest.NewRequest("GET", "/metrics/v1/service/nonesuch/timeseries/bogus", nil)
+	req.SetPathValue("name", "nonesuch")
+	req.SetPathValue("range", "bogus")
+	w = httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestMetricsHandler_GetServiceMetricsTimeSeries_InvalidRange(t *testing.T) {
+	handler := &MetricsHandler{}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/bogus", nil)
+	req.SetPathValue("name", "golf_hub")
+	req.SetPathValue("range", "bogus")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Contains(t, response["detail"], "Invalid time range")
+}
+
+func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testing.T) {
+	handler := &MetricsHandler{
+		promClient: &mockPrometheusClient{queryRangeResponse: rangeResponse("series")},
+	}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/30m", nil)
+	req.SetPathValue("name", "golf_hub")
+	req.SetPathValue("range", "30m")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "30m", response.TimeRange)
+
+	names := map[string]bool{}
+	for _, series := range response.Series {
+		names[series.MetricName] = true
+	}
+	// The five standard series plus golf's six custom series.
+	expected := []string{
+		"request_rate", "error_rate_percent", "avg_duration_us", "p95_duration_us",
+		"active_requests",
+		"sessions_active", "session_starts", "command_rate", "event_rate",
+		"rejection_rate", "disconnect_rate",
+	}
+	assert.Len(t, names, len(expected))
+	for _, name := range expected {
+		assert.True(t, names[name], name)
+	}
+}
+
+func TestMetricsHandler_GetHostMetrics_Success(t *testing.T) {
+	// One constant scalar response everywhere: the container-list query
+	// yields a "caddy" row, and every follow-up scalar reads 42.5.
+	handler := &MetricsHandler{
+		promClient: &mockPrometheusClient{
+			queryResponse: &QueryResponse{
+				Status: "success",
+				Data: struct {
+					ResultType string   `json:"resultType"`
+					Result     []Result `json:"result"`
+				}{
+					ResultType: "vector",
+					Result: []Result{
+						{
+							Metric: map[string]string{"name": "caddy"},
+							Value:  []interface{}{1609459200.0, "42.5"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/host", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetHostMetrics(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response HostMetricsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotNil(t, response.System)
+	assert.Equal(t, 42.5, response.System.CPU.Utilization)
+	require.Len(t, response.Containers, 1)
+	assert.Equal(t, "caddy", response.Containers[0].Name)
+	assert.Equal(t, 42.5, response.Containers[0].CPUUsagePercent)
+	assert.WithinDuration(t, time.Now(), response.Timestamp, 5*time.Second)
+}
+
+func TestMetricsHandler_GetHostMetrics_PrometheusError(t *testing.T) {
+	handler := &MetricsHandler{promClient: &mockPrometheusClient{queryError: assert.AnError}}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/host", nil)
+	w := httptest.NewRecorder()
+
+	handler.GetHostMetrics(w, req)
+
+	// Zeroed system, empty containers, 200 — the host page renders.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response HostMetricsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.NotNil(t, response.System)
+	assert.Equal(t, 0.0, response.System.CPU.Utilization)
+	assert.Empty(t, response.Containers)
+}
+
+func TestMetricsHandler_GetHostMetricsTimeSeries(t *testing.T) {
+	req := httptest.NewRequest("GET", "/metrics/v1/host/timeseries/bogus", nil)
+	req.SetPathValue("range", "bogus")
+	w := httptest.NewRecorder()
+
+	handler := &MetricsHandler{}
+	handler.GetHostMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	handler = &MetricsHandler{
+		promClient: &mockPrometheusClient{queryRangeResponse: rangeResponse("series")},
+	}
+	req = httptest.NewRequest("GET", "/metrics/v1/host/timeseries/30m", nil)
+	req.SetPathValue("range", "30m")
+	w = httptest.NewRecorder()
+
+	handler.GetHostMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+	hostSeries, containerSeries := 0, 0
+	names := map[string]bool{}
+	for _, series := range response.Series {
+		names[series.MetricName] = true
+		if strings.HasPrefix(series.MetricName, "container_") {
+			containerSeries++
+		} else {
+			hostSeries++
+		}
+	}
+	// Host series keep their names; container series are namespaced so
+	// the merged payload can't collide.
+	assert.True(t, names["cpu_utilization"])
+	assert.True(t, names["container_cpu_usage"])
+	assert.Equal(t, 5, hostSeries)
+	assert.Equal(t, 6, containerSeries)
+}


### PR DESCRIPTION
Step 1 of #1199 (additive — the legacy per-service routes stay up until the UI cutover in muchq/muchq.github.io#235, then delete).

**Registry** (`registry.go`): one table drives everything — catalog entries, each service's custom scalar descriptors (`{group, label, unit, promql}`), and custom timeseries queries. golf_hub's `stream_*` set, microgpt's endpoint/inference set, and portrait's cache/scene set transcribe from the existing bespoke fetchers. Portrait's `trace_requests_*` metrics deliberately don't carry over to its custom block: they duplicate what the standard block now reports from the shared instruments.

**Routes**:
- `GET /metrics/v1/services` — catalog with `has_custom`, in tab order.
- `GET /metrics/v1/host` (+ `/timeseries/{range}`) — merges the system and container views; container series are namespaced `container_*` in the merged timeseries so names can't collide.
- `GET /metrics/v1/service/{name}` (+ `/timeseries/{range}`) — a standard `http_server_*` block parameterized by `service_name` (rate, success/failure + error rate, avg/p95 duration via `histogram_quantile`, active), plus registry-driven custom groups. Unknown service → 404. Failed queries leave descriptors in place with zero values, so the page shape is stable under a prometheus outage (same resilience contract as the existing endpoints).

**Tests** (12 new): registry/order agreement; catalog order + wire field names; golden strings for the standard queries (so instrument-name typos can't hide behind enumeration); a distinct-value-per-query mapping test across all standard fields and custom descriptors, including a deliberately omitted query proving descriptors survive zeroed; outage contract for service and host; unknown-service 404 precedence over invalid range; standard+custom series-name union on the timeseries route; host merge with container namespacing counts. Full package suite passes locally.