### PR TITLE
Metrics: caddy routing fix, wordchains on the dashboard, server_pal to micros, scene-metrics fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,8 +2508,6 @@ dependencies = [
  "http-body-util",
  "microgpt",
  "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "serde",
  "serde_json",
  "server_pal",
@@ -4079,6 +4077,8 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "tokio",
  "tower",
  "tower-http",

--- a/deploy/consolidated/Caddyfile
+++ b/deploy/consolidated/Caddyfile
@@ -29,14 +29,9 @@ api.muchq.com {
 		path /microgpt/v1/chat
 	}
 
-	@get_timeseries {
-		method GET
-		path /metrics/v1/timeseries/*
-	}
-
 	@get_metrics {
 		method GET
-		path /metrics/v1/scalar/*
+		path /metrics/v1/*
 	}
 
 	@get_1d4_health {
@@ -102,7 +97,6 @@ api.muchq.com {
 	reverse_proxy @post_golf_v2_session golf_hub:8089
 	reverse_proxy @ws_golf_v2 golf_hub:8089
 	reverse_proxy @post_portrait portrait:8081
-	reverse_proxy @get_timeseries prom_proxy:8082
 	reverse_proxy @get_metrics prom_proxy:8082
 	reverse_proxy @post_mithril mithril:8083
 	reverse_proxy @post_posterize_blur posterize:8084

--- a/deploy/consolidated/Caddyfile.local
+++ b/deploy/consolidated/Caddyfile.local
@@ -19,14 +19,9 @@
 		path /imagine/v1/edges
 	}
 
-	@get_timeseries {
-		method GET
-		path /metrics/v1/timeseries/*
-	}
-
 	@get_metrics {
 		method GET
-		path /metrics/v1/scalar/*
+		path /metrics/v1/*
 	}
 
 	@ws_thoughts {
@@ -72,6 +67,7 @@
 	reverse_proxy @post_golf_v2_session localhost:8089
 	reverse_proxy @ws_golf_v2 localhost:8089
 	reverse_proxy @post_portrait localhost:8081
+	reverse_proxy @get_metrics localhost:8082
 	reverse_proxy @post_mithril localhost:8083
 	reverse_proxy @post_posterize_blur localhost:8084
 	reverse_proxy @post_posterize_edges localhost:8084

--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -120,6 +120,9 @@ services:
       - "8083:8083"
     environment:
       - PORT=8083
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
+      - OTEL_SERVICE_NAME=mithril
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=mithril,service.version=latest
     volumes:
       - /etc/mithril:/etc/mithril
     networks:

--- a/domains/ai/apis/microgpt_serve/Cargo.toml
+++ b/domains/ai/apis/microgpt_serve/Cargo.toml
@@ -14,8 +14,6 @@ path = "src/main.rs"
 axum = { workspace = true }
 microgpt = { path = "../../libs/microgpt" }
 opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
-opentelemetry-otlp = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 server_pal = { workspace = true }

--- a/domains/ai/apis/microgpt_serve/src/main.rs
+++ b/domains/ai/apis/microgpt_serve/src/main.rs
@@ -7,14 +7,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::routing::post;
 use microgpt::model::ModelMeta;
 use microgpt::{InferenceGpt, Tokenizer};
-use opentelemetry_otlp::{MetricExporter, WithExportConfig};
-use opentelemetry_sdk::Resource;
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use server_pal::{RateLimit, listen_addr_pal, router_builder, serve};
 use tracing::{Level, event};
 
@@ -27,44 +23,13 @@ pub struct AppState {
     pub metrics: AppMetrics,
 }
 
-/// Initialise the global OTel meter provider if OTEL_EXPORTER_OTLP_ENDPOINT is
-/// set.  Returns the provider so the caller can keep it alive for the lifetime
-/// of the process (dropping it shuts down the exporter).
-fn init_otel() -> Option<SdkMeterProvider> {
-    let endpoint = env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
-
-    let exporter = MetricExporter::builder()
-        .with_http()
-        .with_endpoint(format!("{}/v1/metrics", endpoint))
-        .with_timeout(Duration::from_secs(5))
-        .build()
-        .unwrap_or_else(|e| {
-            eprintln!("warning: failed to create OTLP metric exporter: {e}");
-            process::exit(1);
-        });
-
-    // Resource::builder() automatically picks up OTEL_SERVICE_NAME and
-    // OTEL_RESOURCE_ATTRIBUTES via the built-in EnvResourceDetector.
-    let resource = Resource::builder().build();
-
-    let reader = PeriodicReader::builder(exporter).build();
-    let provider = SdkMeterProvider::builder()
-        .with_reader(reader)
-        .with_resource(resource)
-        .build();
-
-    opentelemetry::global::set_meter_provider(provider.clone());
-    event!(Level::INFO, "OTel metrics initialised (endpoint: {})", endpoint);
-    Some(provider)
-}
-
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
 
     // Must be initialised before AppMetrics::new() so the global provider is
     // in place when OTel instruments are created.
-    let _otel_provider = init_otel();
+    let _otel_provider = server_pal::init_otel();
 
     let model_dir = env::var("MODEL_DIR")
         .map(PathBuf::from)

--- a/domains/games/apis/mithril/src/main.rs
+++ b/domains/games/apis/mithril/src/main.rs
@@ -61,6 +61,9 @@ async fn wordchain_post(
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
+    // Keeps the exporter alive for the process lifetime; without this the
+    // http_server_* instruments record into the no-op global meter.
+    let _otel_provider = server_pal::init_otel();
 
     let data_dir = "mithril.runfiles/_main/domains/games/apis/mithril/data";
     let path = format!("{}/words.txt", data_dir);

--- a/domains/graphics/apis/portrait/tracer_service.cc
+++ b/domains/graphics/apis/portrait/tracer_service.cc
@@ -37,8 +37,8 @@ absl::StatusOr<TraceResponse> TracerService::trace(TraceRequest& trace_request) 
     auto [scene, perspective, output] = trace_request;
 
     // Record scene complexity metrics
-    // Distributions, not gauges: RecordGauge is an up-down delta, so
-    // feeding it absolute counts accumulated a lifetime sum.
+    // Distributions, not gauges: RecordGauge is an up-down delta;
+    // absolute per-request counts belong in a histogram.
     metrics_.RecordDistribution("scene_sphere_count", static_cast<double>(scene.spheres.size()));
     metrics_.RecordDistribution("scene_light_count", static_cast<double>(scene.lights.size()));
 

--- a/domains/graphics/apis/portrait/tracer_service.cc
+++ b/domains/graphics/apis/portrait/tracer_service.cc
@@ -37,8 +37,10 @@ absl::StatusOr<TraceResponse> TracerService::trace(TraceRequest& trace_request) 
     auto [scene, perspective, output] = trace_request;
 
     // Record scene complexity metrics
-    metrics_.RecordGauge("scene_sphere_count", static_cast<double>(scene.spheres.size()));
-    metrics_.RecordGauge("scene_light_count", static_cast<double>(scene.lights.size()));
+    // Distributions, not gauges: RecordGauge is an up-down delta, so
+    // feeding it absolute counts accumulated a lifetime sum.
+    metrics_.RecordDistribution("scene_sphere_count", static_cast<double>(scene.spheres.size()));
+    metrics_.RecordDistribution("scene_light_count", static_cast<double>(scene.lights.size()));
 
     auto image = do_trace(scene, perspective, output);
     auto png_bytes = pngpp::imageToPng(image);

--- a/domains/platform/apis/prom_proxy/handlers.go
+++ b/domains/platform/apis/prom_proxy/handlers.go
@@ -431,8 +431,8 @@ func (h *MetricsHandler) fetchPortraitMetricsTimeSeries(ctx context.Context, tim
 		"request_duration_avg":   `rate(trace_request_duration_microseconds_sum[5m])/rate(trace_request_duration_microseconds_count[5m])`,
 		"cache_hit_rate":         `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`,
 		"cache_operations_rate":  `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`,
-		"scene_sphere_count":     `scene_sphere_count_gauge`,
-		"scene_light_count":      `scene_light_count_gauge`,
+		"scene_sphere_count":     `sum(rate(scene_sphere_count_sum[5m]))/sum(rate(scene_sphere_count_count[5m]))`,
+		"scene_light_count":      `sum(rate(scene_light_count_sum[5m]))/sum(rate(scene_light_count_count[5m]))`,
 		"request_success_count":  `increase(http_server_requests_success_total{service_name="portrait"}[5m])`,
 		"request_failure_count":  `increase(http_server_requests_failure_total{service_name="portrait"}[5m])`,
 	}
@@ -537,7 +537,7 @@ func (h *MetricsHandler) fetchPortraitMetrics(ctx context.Context) (*PortraitMet
 	}
 	
 	// Fetch scene complexity metrics
-	sphereCountQuery := `avg_over_time(scene_sphere_count_gauge[1h])`
+	sphereCountQuery := `sum(rate(scene_sphere_count_sum[1h]))/sum(rate(scene_sphere_count_count[1h]))`
 	sphereResp, err := h.promClient.Query(ctx, sphereCountQuery)
 	if err == nil && len(sphereResp.Data.Result) > 0 {
 		if val, err := extractFloatValue(&sphereResp.Data.Result[0]); err == nil {
@@ -545,7 +545,7 @@ func (h *MetricsHandler) fetchPortraitMetrics(ctx context.Context) (*PortraitMet
 		}
 	}
 	
-	lightCountQuery := `avg_over_time(scene_light_count_gauge[1h])`
+	lightCountQuery := `sum(rate(scene_light_count_sum[1h]))/sum(rate(scene_light_count_count[1h]))`
 	lightResp, err := h.promClient.Query(ctx, lightCountQuery)
 	if err == nil && len(lightResp.Data.Result) > 0 {
 		if val, err := extractFloatValue(&lightResp.Data.Result[0]); err == nil {

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -20,7 +20,7 @@ type serviceEntry struct {
 }
 
 // Catalog order doubles as the UI's tab order.
-var serviceOrder = []string{"golf_hub", "microgpt-serve", "portrait"}
+var serviceOrder = []string{"golf_hub", "microgpt-serve", "mithril", "portrait"}
 
 var serviceRegistry = map[string]serviceEntry{
 	"golf_hub": {
@@ -58,18 +58,20 @@ var serviceRegistry = map[string]serviceEntry{
 			"avg_duration_ms":   `sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`,
 		},
 	},
+	// Wordchains: server_pal's standard instruments only, no custom set.
+	"mithril": {},
 	"portrait": {
 		CustomScalars: []customScalarDef{
 			{"Render cache", "hit_rate_percent", "%", `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`},
 			{"Render cache", "operations_per_sec", "/s", `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`},
-			{"Scene complexity", "avg_spheres_1h", "spheres", `avg_over_time(scene_sphere_count_gauge[1h])`},
-			{"Scene complexity", "avg_lights_1h", "lights", `avg_over_time(scene_light_count_gauge[1h])`},
+			{"Scene complexity", "avg_spheres_1h", "spheres", `sum(rate(scene_sphere_count_sum[1h]))/sum(rate(scene_sphere_count_count[1h]))`},
+			{"Scene complexity", "avg_lights_1h", "lights", `sum(rate(scene_light_count_sum[1h]))/sum(rate(scene_light_count_count[1h]))`},
 		},
 		CustomTimeseries: map[string]string{
 			"cache_hit_rate":        `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`,
 			"cache_operations_rate": `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`,
-			"scene_sphere_count":    `scene_sphere_count_gauge`,
-			"scene_light_count":     `scene_light_count_gauge`,
+			"scene_sphere_count":    `sum(rate(scene_sphere_count_sum[5m]))/sum(rate(scene_sphere_count_count[5m]))`,
+			"scene_light_count":     `sum(rate(scene_light_count_sum[5m]))/sum(rate(scene_light_count_count[5m]))`,
 		},
 	},
 }

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -54,7 +54,6 @@ var serviceRegistry = map[string]serviceEntry{
 			{"Inference", "conversations_total", "", `sum(microgpt_conversations_total)`},
 		},
 		CustomTimeseries: map[string]string{
-			"request_rate":      `sum(rate(microgpt_requests_total[5m]))`,
 			"tokens_per_second": `sum(rate(microgpt_tokens_generated_total[5m]))`,
 			"avg_duration_ms":   `sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`,
 		},
@@ -107,6 +106,10 @@ func standardScalarQueries(service string) []struct {
 	}
 }
 
+// Keys are mirrored by STANDARD_SERIES in the UI's ServiceDashboard
+// (muchq.github.io); keep them in sync, and keep CustomTimeseries keys
+// from colliding with them — a colliding custom series is classified as
+// standard by the UI and silently never charts.
 func standardTimeseriesQueries(service string) map[string]string {
 	s := fmt.Sprintf("%q", service)
 	return map[string]string{

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -64,6 +64,8 @@ var serviceRegistry = map[string]serviceEntry{
 		CustomScalars: []customScalarDef{
 			{"Render cache", "hit_rate_percent", "%", `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`},
 			{"Render cache", "operations_per_sec", "/s", `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`},
+			// Windowed averages over RecordDistribution histograms:
+			// rate(sum)/rate(count) = mean per request in the window.
 			{"Scene complexity", "avg_spheres_1h", "spheres", `sum(rate(scene_sphere_count_sum[1h]))/sum(rate(scene_sphere_count_count[1h]))`},
 			{"Scene complexity", "avg_lights_1h", "lights", `sum(rate(scene_light_count_sum[1h]))/sum(rate(scene_light_count_count[1h]))`},
 		},

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -55,12 +55,13 @@ func TestMetricsHandler_GetServiceCatalog(t *testing.T) {
 	var catalog ServiceCatalog
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &catalog))
 
-	require.Len(t, catalog.Services, 3)
+	require.Len(t, catalog.Services, 4)
 	assert.Equal(t, "golf_hub", catalog.Services[0].Name)
 	assert.Equal(t, "microgpt-serve", catalog.Services[1].Name)
-	assert.Equal(t, "portrait", catalog.Services[2].Name)
+	assert.Equal(t, "mithril", catalog.Services[2].Name)
+	assert.Equal(t, "portrait", catalog.Services[3].Name)
 	for _, entry := range catalog.Services {
-		assert.True(t, entry.HasCustom, entry.Name)
+		assert.Equal(t, entry.Name != "mithril", entry.HasCustom, entry.Name)
 	}
 
 	// The wire field names are the UI contract.

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -55,13 +55,19 @@ func TestMetricsHandler_GetServiceCatalog(t *testing.T) {
 	var catalog ServiceCatalog
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &catalog))
 
-	require.Len(t, catalog.Services, 4)
-	assert.Equal(t, "golf_hub", catalog.Services[0].Name)
-	assert.Equal(t, "microgpt-serve", catalog.Services[1].Name)
-	assert.Equal(t, "mithril", catalog.Services[2].Name)
-	assert.Equal(t, "portrait", catalog.Services[3].Name)
-	for _, entry := range catalog.Services {
-		assert.Equal(t, entry.Name != "mithril", entry.HasCustom, entry.Name)
+	wantCustom := []struct {
+		name      string
+		hasCustom bool
+	}{
+		{"golf_hub", true},
+		{"microgpt-serve", true},
+		{"mithril", false},
+		{"portrait", true},
+	}
+	require.Len(t, catalog.Services, len(wantCustom))
+	for i, want := range wantCustom {
+		assert.Equal(t, want.name, catalog.Services[i].Name)
+		assert.Equal(t, want.hasCustom, catalog.Services[i].HasCustom, want.name)
 	}
 
 	// The wire field names are the UI contract.
@@ -140,6 +146,33 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 	last := response.Custom[1].Metrics[2]
 	assert.Equal(t, omitted.Label, last.Label)
 	assert.Equal(t, 0.0, last.Value)
+}
+
+func TestMetricsHandler_GetServiceMetrics_NoCustomServiceKeepsEmptyArray(t *testing.T) {
+	mockClient := &mockPrometheusClient{
+		queryResponses: map[string]*QueryResponse{
+			`sum(rate(http_server_requests_total{service_name="mithril"}[5m]))`: golfScalarResponse("2.5"),
+		},
+	}
+
+	handler := &MetricsHandler{promClient: mockClient}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/mithril", nil)
+	req.SetPathValue("name", "mithril")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetrics(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// The UI iterates custom unconditionally: the wire value must be [],
+	// never null. Assert on the raw body — unmarshalling erases the
+	// distinction.
+	assert.Contains(t, w.Body.String(), `"custom":[]`)
+
+	var response ServiceMetricsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, 2.5, response.Standard.RatePerSec)
 }
 
 func TestMetricsHandler_GetServiceMetrics_PrometheusError(t *testing.T) {

--- a/domains/platform/libs/futility/otel/metrics.cc
+++ b/domains/platform/libs/futility/otel/metrics.cc
@@ -67,6 +67,27 @@ void MetricsRecorder::RecordLatency(const std::string& metric_name,
   }
 }
 
+void MetricsRecorder::RecordDistribution(const std::string& metric_name, double value,
+                                         const std::map<std::string, std::string>& attributes) {
+  if (!meter_) return;
+
+  auto* histogram = FindOrCreate(histograms_, metric_name,
+                                 [&] { return meter_->CreateUInt64Histogram(metric_name); });
+  if (histogram != nullptr) {
+    auto context = opentelemetry::context::Context{};
+    if (attributes.empty()) {
+      histogram->Record(static_cast<uint64_t>(value), context);
+    } else {
+      // Convert attributes to OpenTelemetry format
+      std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
+                                                                attributes.end());
+      auto kv_iterable = opentelemetry::common::KeyValueIterableView<
+          std::vector<std::pair<std::string, std::string>>>(attr_vec);
+      histogram->Record(static_cast<uint64_t>(value), kv_iterable, context);
+    }
+  }
+}
+
 void MetricsRecorder::RecordGauge(const std::string& metric_name, double value,
                                   const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;

--- a/domains/platform/libs/futility/otel/metrics.cc
+++ b/domains/platform/libs/futility/otel/metrics.cc
@@ -1,10 +1,32 @@
 #include "domains/platform/libs/futility/otel/metrics.h"
 
+#include <cmath>
+
 #include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/metrics/provider.h"
 
 namespace futility::otel {
+
+namespace {
+
+// Every instrument records the same way: bare when there are no
+// attributes, through a KeyValueIterableView otherwise. `record` is
+// called with the label arguments to forward to Add/Record.
+template <typename Record>
+void RecordWithAttributes(const std::map<std::string, std::string>& attributes, Record&& record) {
+  auto context = opentelemetry::context::Context{};
+  if (attributes.empty()) {
+    record(context);
+  } else {
+    std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(), attributes.end());
+    auto kv_iterable = opentelemetry::common::KeyValueIterableView<
+        std::vector<std::pair<std::string, std::string>>>(attr_vec);
+    record(kv_iterable, context);
+  }
+}
+
+}  // namespace
 
 MetricsRecorder::MetricsRecorder(const std::string& service_name) {
   auto provider = opentelemetry::v1::metrics::Provider::GetMeterProvider();
@@ -30,17 +52,9 @@ void MetricsRecorder::RecordCounter(const std::string& metric_name, int64_t valu
   auto* counter = FindOrCreate(counters_, metric_name,
                                [&] { return meter_->CreateUInt64Counter(metric_name); });
   if (counter != nullptr) {
-    auto context = opentelemetry::context::Context{};
-    if (attributes.empty()) {
-      counter->Add(static_cast<uint64_t>(value), context);
-    } else {
-      // Convert attributes to OpenTelemetry format
-      std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
-                                                                attributes.end());
-      auto kv_iterable = opentelemetry::common::KeyValueIterableView<
-          std::vector<std::pair<std::string, std::string>>>(attr_vec);
-      counter->Add(static_cast<uint64_t>(value), kv_iterable, context);
-    }
+    RecordWithAttributes(attributes, [&](auto&&... labels) {
+      counter->Add(static_cast<uint64_t>(value), std::forward<decltype(labels)>(labels)...);
+    });
   }
 }
 
@@ -49,42 +63,32 @@ void MetricsRecorder::RecordLatency(const std::string& metric_name,
                                     const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;
 
-  auto* histogram = FindOrCreate(histograms_, metric_name, [&] {
-    return meter_->CreateUInt64Histogram(metric_name + "_microseconds");
-  });
+  // Cache key is the instrument name, so a latency "x" (instrument
+  // x_microseconds) can never alias a distribution "x".
+  const std::string instrument_name = metric_name + "_microseconds";
+  auto* histogram = FindOrCreate(histograms_, instrument_name,
+                                 [&] { return meter_->CreateUInt64Histogram(instrument_name); });
   if (histogram != nullptr) {
-    auto context = opentelemetry::context::Context{};
-    if (attributes.empty()) {
-      histogram->Record(static_cast<uint64_t>(duration.count()), context);
-    } else {
-      // Convert attributes to OpenTelemetry format
-      std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
-                                                                attributes.end());
-      auto kv_iterable = opentelemetry::common::KeyValueIterableView<
-          std::vector<std::pair<std::string, std::string>>>(attr_vec);
-      histogram->Record(static_cast<uint64_t>(duration.count()), kv_iterable, context);
-    }
+    RecordWithAttributes(attributes, [&](auto&&... labels) {
+      histogram->Record(static_cast<uint64_t>(duration.count()),
+                        std::forward<decltype(labels)>(labels)...);
+    });
   }
 }
 
 void MetricsRecorder::RecordDistribution(const std::string& metric_name, double value,
                                          const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;
+  // The uint64 cast is UB for negative or non-finite input; observations
+  // are non-negative quantities by contract, so drop anything else.
+  if (!std::isfinite(value) || value < 0.0) return;
 
   auto* histogram = FindOrCreate(histograms_, metric_name,
                                  [&] { return meter_->CreateUInt64Histogram(metric_name); });
   if (histogram != nullptr) {
-    auto context = opentelemetry::context::Context{};
-    if (attributes.empty()) {
-      histogram->Record(static_cast<uint64_t>(value), context);
-    } else {
-      // Convert attributes to OpenTelemetry format
-      std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
-                                                                attributes.end());
-      auto kv_iterable = opentelemetry::common::KeyValueIterableView<
-          std::vector<std::pair<std::string, std::string>>>(attr_vec);
-      histogram->Record(static_cast<uint64_t>(value), kv_iterable, context);
-    }
+    RecordWithAttributes(attributes, [&](auto&&... labels) {
+      histogram->Record(static_cast<uint64_t>(value), std::forward<decltype(labels)>(labels)...);
+    });
   }
 }
 
@@ -96,17 +100,9 @@ void MetricsRecorder::RecordGauge(const std::string& metric_name, double value,
     return meter_->CreateInt64UpDownCounter(metric_name + "_gauge");
   });
   if (gauge != nullptr) {
-    auto context = opentelemetry::context::Context{};
-    if (attributes.empty()) {
-      gauge->Add(static_cast<int64_t>(value), context);
-    } else {
-      // Convert attributes to OpenTelemetry format
-      std::vector<std::pair<std::string, std::string>> attr_vec(attributes.begin(),
-                                                                attributes.end());
-      auto kv_iterable = opentelemetry::common::KeyValueIterableView<
-          std::vector<std::pair<std::string, std::string>>>(attr_vec);
-      gauge->Add(static_cast<int64_t>(value), kv_iterable, context);
-    }
+    RecordWithAttributes(attributes, [&](auto&&... labels) {
+      gauge->Add(static_cast<int64_t>(value), std::forward<decltype(labels)>(labels)...);
+    });
   }
 }
 

--- a/domains/platform/libs/futility/otel/metrics.h
+++ b/domains/platform/libs/futility/otel/metrics.h
@@ -77,6 +77,19 @@ class MetricsRecorder {
   void RecordLatency(const std::string& metric_name, std::chrono::microseconds duration,
                      const std::map<std::string, std::string>& attributes = {});
 
+  /// @brief Records one observation of a per-event quantity.
+  ///
+  /// Use for distributions of request-scoped values (payload sizes, scene
+  /// complexity). The histogram keeps the name as given; query the
+  /// windowed average as rate(<name>_sum)/rate(<name>_count). Not for
+  /// point-in-time levels — that is RecordGauge's delta form.
+  ///
+  /// @param metric_name The metric name (e.g., "scene_sphere_count").
+  /// @param value The observed value.
+  /// @param attributes Optional key-value labels for the metric.
+  void RecordDistribution(const std::string& metric_name, double value,
+                          const std::map<std::string, std::string>& attributes = {});
+
   /// @brief Records a gauge metric (point-in-time value).
   ///
   /// Use for current state: active connections, queue depth, memory usage, etc.

--- a/domains/platform/libs/server_pal/Cargo.toml
+++ b/domains/platform/libs/server_pal/Cargo.toml
@@ -8,6 +8,8 @@ readme.workspace = true
 [dependencies]
 axum = { workspace = true }
 opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
 tower_governor = { workspace = true }
 tower-http = { workspace = true, features = ["full"] }

--- a/domains/platform/libs/server_pal/src/lib.rs
+++ b/domains/platform/libs/server_pal/src/lib.rs
@@ -8,7 +8,7 @@ use axum::middleware::Next;
 use axum::response::Response;
 use axum::routing::{MethodRouter, get};
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Histogram};
+use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
 use tokio::net::TcpListener;
 use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
@@ -23,23 +23,45 @@ use tower_http::validate_request::ValidateRequestHeaderLayer;
 
 const DEFAULT_PORT: u16 = 8080;
 
+static HTTP_REQUESTS: OnceLock<Counter<u64>> = OnceLock::new();
 static HTTP_SUCCESS: OnceLock<Counter<u64>> = OnceLock::new();
 static HTTP_FAILURE: OnceLock<Counter<u64>> = OnceLock::new();
+static HTTP_ACTIVE: OnceLock<UpDownCounter<i64>> = OnceLock::new();
 static HTTP_DURATION: OnceLock<Histogram<f64>> = OnceLock::new();
 
+// Instrument names mirror the C++ aura/futility http_server_* family
+// (requests, success/failure, active gauge, microseconds histogram), so
+// prom_proxy's standard service block reads every language the same way.
 async fn http_metrics_middleware(req: Request, next: Next) -> Response {
     let start = std::time::Instant::now();
     let method = req.method().as_str().to_string();
     let service_name = env::var("OTEL_SERVICE_NAME").unwrap_or_default();
-
-    let resp = next.run(req).await;
-
-    let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
-    let status = resp.status().as_u16();
     let attrs = [
         KeyValue::new("http_method", method),
         KeyValue::new("service_name", service_name),
     ];
+
+    HTTP_REQUESTS
+        .get_or_init(|| {
+            opentelemetry::global::meter("http_server")
+                .u64_counter("http_server_requests")
+                .with_description("HTTP requests received")
+                .build()
+        })
+        .add(1, &attrs);
+    let active = HTTP_ACTIVE.get_or_init(|| {
+        opentelemetry::global::meter("http_server")
+            .i64_up_down_counter("http_server_requests_active_gauge")
+            .with_description("HTTP requests currently in flight")
+            .build()
+    });
+    active.add(1, &attrs);
+
+    let resp = next.run(req).await;
+
+    active.add(-1, &attrs);
+    let duration_us = start.elapsed().as_micros() as f64;
+    let status = resp.status().as_u16();
 
     if status < 400 {
         HTTP_SUCCESS
@@ -64,12 +86,11 @@ async fn http_metrics_middleware(req: Request, next: Next) -> Response {
     HTTP_DURATION
         .get_or_init(|| {
             opentelemetry::global::meter("http_server")
-                .f64_histogram("http_server_request_duration_ms")
-                .with_description("HTTP request duration in milliseconds")
-                .with_unit("ms")
+                .f64_histogram("http_server_request_duration_microseconds")
+                .with_description("HTTP request duration in microseconds")
                 .build()
         })
-        .record(duration_ms, &attrs);
+        .record(duration_us, &attrs);
 
     resp
 }

--- a/domains/platform/libs/server_pal/src/lib.rs
+++ b/domains/platform/libs/server_pal/src/lib.rs
@@ -9,6 +9,9 @@ use axum::response::Response;
 use axum::routing::{MethodRouter, get};
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
+use opentelemetry_otlp::{MetricExporter, WithExportConfig};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use tokio::net::TcpListener;
 use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
@@ -29,6 +32,81 @@ static HTTP_FAILURE: OnceLock<Counter<u64>> = OnceLock::new();
 static HTTP_ACTIVE: OnceLock<UpDownCounter<i64>> = OnceLock::new();
 static HTTP_DURATION: OnceLock<Histogram<f64>> = OnceLock::new();
 
+/// Initialise the global OTel meter provider when
+/// OTEL_EXPORTER_OTLP_ENDPOINT is set; a no-op None otherwise. Callers
+/// keep the returned provider alive for the process lifetime — dropping
+/// it shuts down the exporter. Shared by every server_pal service so the
+/// http_server_* instruments actually export.
+pub fn init_otel() -> Option<SdkMeterProvider> {
+    let endpoint = env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
+
+    let exporter = match MetricExporter::builder()
+        .with_http()
+        .with_endpoint(format!("{}/v1/metrics", endpoint))
+        .with_timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(exporter) => exporter,
+        Err(e) => {
+            eprintln!("warning: failed to create OTLP metric exporter: {e}; metrics disabled");
+            return None;
+        }
+    };
+
+    // Resource::builder() picks up OTEL_SERVICE_NAME and
+    // OTEL_RESOURCE_ATTRIBUTES via the built-in EnvResourceDetector.
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter).build())
+        .with_resource(Resource::builder().build())
+        .build();
+
+    opentelemetry::global::set_meter_provider(provider.clone());
+    eprintln!("OTel metrics initialised (endpoint: {endpoint})");
+    Some(provider)
+}
+
+fn http_counter(
+    cell: &'static OnceLock<Counter<u64>>,
+    name: &'static str,
+    desc: &'static str,
+) -> &'static Counter<u64> {
+    cell.get_or_init(|| {
+        opentelemetry::global::meter("http_server")
+            .u64_counter(name)
+            .with_description(desc)
+            .build()
+    })
+}
+
+/// In-flight gauge as a drop guard: a manual decrement after the await
+/// never runs when the request future is cancelled (client disconnect),
+/// and the gauge would drift upward forever.
+struct ActiveRequest {
+    attrs: [KeyValue; 2],
+}
+
+impl ActiveRequest {
+    fn start(attrs: [KeyValue; 2]) -> Self {
+        Self::counter().add(1, &attrs);
+        Self { attrs }
+    }
+
+    fn counter() -> &'static UpDownCounter<i64> {
+        HTTP_ACTIVE.get_or_init(|| {
+            opentelemetry::global::meter("http_server")
+                .i64_up_down_counter("http_server_requests_active_gauge")
+                .with_description("HTTP requests currently in flight")
+                .build()
+        })
+    }
+}
+
+impl Drop for ActiveRequest {
+    fn drop(&mut self) {
+        Self::counter().add(-1, &self.attrs);
+    }
+}
+
 // Instrument names mirror the C++ aura/futility http_server_* family
 // (requests, success/failure, active gauge, microseconds histogram), so
 // prom_proxy's standard service block reads every language the same way.
@@ -41,46 +119,28 @@ async fn http_metrics_middleware(req: Request, next: Next) -> Response {
         KeyValue::new("service_name", service_name),
     ];
 
-    HTTP_REQUESTS
-        .get_or_init(|| {
-            opentelemetry::global::meter("http_server")
-                .u64_counter("http_server_requests")
-                .with_description("HTTP requests received")
-                .build()
-        })
-        .add(1, &attrs);
-    let active = HTTP_ACTIVE.get_or_init(|| {
-        opentelemetry::global::meter("http_server")
-            .i64_up_down_counter("http_server_requests_active_gauge")
-            .with_description("HTTP requests currently in flight")
-            .build()
-    });
-    active.add(1, &attrs);
+    http_counter(&HTTP_REQUESTS, "http_server_requests", "HTTP requests received").add(1, &attrs);
+    let _active = ActiveRequest::start(attrs.clone());
 
     let resp = next.run(req).await;
 
-    active.add(-1, &attrs);
     let duration_us = start.elapsed().as_micros() as f64;
     let status = resp.status().as_u16();
 
     if status < 400 {
-        HTTP_SUCCESS
-            .get_or_init(|| {
-                opentelemetry::global::meter("http_server")
-                    .u64_counter("http_server_requests_success")
-                    .with_description("HTTP requests completed successfully (2xx–3xx)")
-                    .build()
-            })
-            .add(1, &attrs);
+        http_counter(
+            &HTTP_SUCCESS,
+            "http_server_requests_success",
+            "HTTP requests completed successfully (2xx–3xx)",
+        )
+        .add(1, &attrs);
     } else {
-        HTTP_FAILURE
-            .get_or_init(|| {
-                opentelemetry::global::meter("http_server")
-                    .u64_counter("http_server_requests_failure")
-                    .with_description("HTTP requests that returned 4xx or 5xx")
-                    .build()
-            })
-            .add(1, &attrs);
+        http_counter(
+            &HTTP_FAILURE,
+            "http_server_requests_failure",
+            "HTTP requests that returned 4xx or 5xx",
+        )
+        .add(1, &attrs);
     }
 
     HTTP_DURATION


### PR DESCRIPTION
Four related fixes from the prod soak of the dashboard overhaul (#1199), plus a review-panel round. Left unmerged for your review.

**1. Caddy routes the whole metrics API (the empty-dashboard fix).** The overhaul routes (`/metrics/v1/services`, `/host`, `/host/timeseries/*`, `/service/*`) fell outside the `scalar/*`/`timeseries/*` matchers, so Caddy never forwarded them — no catalog, no tabs, no host data. One GET matcher over `/metrics/v1/*` makes my earlier "wildcarded" claim true. The local Caddyfile's metrics matchers were defined but never proxied — now wired.

**2. Wordchains on the dashboard — for real.** compose OTEL env + a registry entry (`has_custom: false`), and the panel caught that this alone would have shipped a permanently-zero tab: server_pal only *records* against the global meter, and mithril never installed a provider. `init_otel` is hoisted from microgpt_serve into server_pal (one exporter path for every consumer); mithril calls it, microgpt's local copy deletes.

**3. server_pal grows the full standard family, in microseconds.** `http_server_requests`, `http_server_requests_active_gauge`, `http_server_request_duration_microseconds` — byte-matching the C++ aura names so one query set reads every language. Panel hardening: the in-flight gauge is now a drop guard — the manual decrement after the await never ran when a client disconnected mid-request, so the gauge drifted upward forever. (Panic path verified safe: CatchPanicLayer sits inside the metrics middleware and converts panics to 500s before they'd unwind past it.)

**4. Portrait scene complexity was a lifetime cumulative sum.** `RecordGauge` is an up-down delta fed absolute per-request counts. New `RecordDistribution` histogram in futility; portrait's call sites switch; registry queries become windowed `rate(_sum)/rate(_count)` averages — and the panel caught that the *legacy* portrait routes still queried the retired `_gauge` series, which would have gone blank during the transition; they're updated too. Also from the panel: `RecordLatency` keys its instrument cache by full instrument name (a latency "x" could silently alias a distribution "x"), `RecordDistribution` rejects negative/non-finite input before the uint64 cast, and futility's four copies of the attrs-conversion dance collapse into one helper.

Tests: Go suite green (catalog expectation table; new raw-body test pinning the `"custom":[]`-not-`null` wire contract for no-custom services); `cargo check` clean for server_pal + all three consumers; `cargo test -p server_pal` green (both tests exercise the new middleware). Also: microgpt's colliding `request_rate` custom key dropped; standard-series contract cross-referenced Go-side.

After merge: `deploy.sh`. Companion UI PR: muchq/muchq.github.io#238.