### PR TITLE
posterize: accept common image formats and preserve them on output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1154,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fd-lock"
 version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1665,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "governor"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,11 +2145,25 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
+ "tiff",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -3158,11 +3194,14 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "base64 0.22.1",
+ "http-body-util",
  "image",
  "imagine",
  "serde",
+ "serde_json",
  "server_pal",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3397,6 +3436,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -4414,6 +4459,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5110,6 +5169,12 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "widestring"

--- a/domains/graphics/apis/posterize/BUILD.bazel
+++ b/domains/graphics/apis/posterize/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@crates//:defs.bzl", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("@crates//:defs.bzl", "all_crate_deps", "crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 load("//bazel/rules:oci.bzl", "linux_amd64_oci_binary")
 
 rust_binary(
@@ -15,6 +15,17 @@ rust_binary(
         "//domains/graphics/libs/imagine_rust:imagine_lib",
         "//domains/platform/libs/server_pal",
     ] + all_crate_deps(),
+)
+
+rust_test(
+    name = "test_posterize",
+    size = "small",
+    crate = ":posterize",
+    deps = crate_deps([
+        "http-body-util",
+        "serde_json",
+        "tower",
+    ]),
 )
 
 linux_amd64_oci_binary(bin_name = "posterize")

--- a/domains/graphics/apis/posterize/Cargo.toml
+++ b/domains/graphics/apis/posterize/Cargo.toml
@@ -8,10 +8,15 @@ readme.workspace = true
 [dependencies]
 axum = { workspace = true }
 base64 = { workspace = true }
-image = { workspace = true }
+image = { workspace = true, features = ["gif", "bmp", "tiff", "webp", "ico"] }
 serde = { workspace = true, features = ["derive"] }
 server_pal = {workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 imagine = { workspace = true }
+
+[dev-dependencies]
+http-body-util = { workspace = true }
+serde_json = { workspace = true }
+tower = { workspace = true }

--- a/domains/graphics/apis/posterize/README.md
+++ b/domains/graphics/apis/posterize/README.md
@@ -2,12 +2,18 @@
 
 Image post-processing api
 
+## Supported formats
+
+Input images are auto-detected from their bytes. PNG, JPEG, GIF, BMP, TIFF,
+WebP, and ICO are accepted. The result is returned in the same format as the
+input where an encoder is available; WebP and ICO inputs are returned as PNG.
+
 ## Routes
 
 ### POST /imagine/v1/blur
 
-blur a png
+blur an image
 
 ### POST /imagine/v1/edges
 
-detect edges on a png
+detect edges on an image

--- a/domains/graphics/apis/posterize/src/images.rs
+++ b/domains/graphics/apis/posterize/src/images.rs
@@ -12,6 +12,10 @@ fn error_response(status_code: StatusCode, message: String) -> (StatusCode, Json
     (status_code, Json(ErrorResponse { error: message }))
 }
 
+fn bad_request(message: String) -> (StatusCode, Json<ErrorResponse>) {
+    error_response(StatusCode::BAD_REQUEST, message)
+}
+
 fn server_error() -> (StatusCode, Json<ErrorResponse>) {
     error_response(
         StatusCode::INTERNAL_SERVER_ERROR,
@@ -19,53 +23,116 @@ fn server_error() -> (StatusCode, Json<ErrorResponse>) {
     )
 }
 
-pub fn read_png_from_b64_string(
-    b64_png: &String,
-) -> Result<DynamicImage, (StatusCode, Json<ErrorResponse>)> {
-    general_purpose::STANDARD
-        .decode(b64_png)
-        .map_err(|_| {
-            error_response(
-                StatusCode::BAD_REQUEST,
-                "Invalid base64 encoding".to_string(),
-            )
-        })
-        .and_then(|image_bytes| {
-            image::load_from_memory(&image_bytes).map_err(|e| {
-                error_response(
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid image format: {}", e),
-                )
-            })
-        })
+/// Human-readable label for a format, reported back in API responses.
+pub fn format_label(format: ImageFormat) -> String {
+    match format {
+        ImageFormat::Png => "PNG",
+        ImageFormat::Jpeg => "JPEG",
+        ImageFormat::Gif => "GIF",
+        ImageFormat::WebP => "WEBP",
+        ImageFormat::Bmp => "BMP",
+        ImageFormat::Tiff => "TIFF",
+        ImageFormat::Ico => "ICO",
+        _ => "PNG",
+    }
+    .to_string()
 }
 
-pub fn write_png_to_b64_string(
-    png: &DynamicImage,
-) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
-    let mut png_bytes = Vec::new();
-    let mut cursor = Cursor::new(&mut png_bytes);
+/// Pick the format to encode the result in. We preserve the input format when
+/// we have a reliable encoder for it; formats we can decode but not re-encode
+/// dependably (e.g. WebP, ICO) round-trip out as PNG.
+fn output_format(input: ImageFormat) -> ImageFormat {
+    match input {
+        ImageFormat::Png
+        | ImageFormat::Jpeg
+        | ImageFormat::Gif
+        | ImageFormat::Bmp
+        | ImageFormat::Tiff => input,
+        _ => ImageFormat::Png,
+    }
+}
 
-    png.write_to(&mut cursor, ImageFormat::Png)
-        .map(|()| {
-            return png_bytes;
-        })
+/// Cap on memory a single decode may allocate. Guards against decompression
+/// bombs: a small payload (input is already limited to ~3.75 MiB decoded) can
+/// still declare enormous dimensions, and enabling TIFF/GIF/BMP widens that
+/// surface. 256 MiB comfortably fits any legitimately-sized image.
+const MAX_DECODE_ALLOC_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Decode a base64-encoded image, auto-detecting the format from its magic
+/// bytes. Returns the decoded image alongside the detected input format so the
+/// caller can preserve it on the way out.
+pub fn read_image_from_b64_string(
+    b64_image: &str,
+) -> Result<(DynamicImage, ImageFormat), (StatusCode, Json<ErrorResponse>)> {
+    let image_bytes = general_purpose::STANDARD
+        .decode(b64_image)
+        .map_err(|_| bad_request("Invalid base64 encoding".to_string()))?;
+
+    let format = image::guess_format(&image_bytes)
+        .map_err(|_| bad_request("Unsupported or unrecognized image format".to_string()))?;
+
+    let mut reader = image::ImageReader::new(Cursor::new(&image_bytes));
+    reader.set_format(format);
+    let mut limits = image::Limits::default();
+    limits.max_alloc = Some(MAX_DECODE_ALLOC_BYTES);
+    reader.limits(limits);
+
+    let image = reader
+        .decode()
+        .map_err(|e| bad_request(format!("Invalid image data: {}", e)))?;
+
+    Ok((image, format))
+}
+
+/// Convert an image to a color type the target format's encoder accepts.
+/// `DynamicImage::write_to` does not adapt color types for every encoder, so
+/// grayscale (Luma8) buffers produced by the edge/gray-blur pipeline must be
+/// widened for formats whose encoders only speak RGB(A).
+fn to_encodable(image: &DynamicImage, format: ImageFormat) -> DynamicImage {
+    match format {
+        // JPEG has no alpha channel; flatten to RGB.
+        ImageFormat::Jpeg => DynamicImage::ImageRgb8(image.to_rgb8()),
+        // The GIF encoder only accepts Rgb8/Rgba8 and performs no conversion of
+        // its own, so a Luma8 buffer would otherwise error out.
+        ImageFormat::Gif => DynamicImage::ImageRgba8(image.to_rgba8()),
+        // PNG, BMP, and TIFF encoders handle Luma8 and Rgba8 directly.
+        _ => image.clone(),
+    }
+}
+
+/// Encode an image back to a base64 string, preferring `format`. Returns the
+/// encoded string and the format actually used, which may differ from `format`
+/// when the input format has no reliable encoder.
+pub fn write_image_to_b64_string(
+    image: &DynamicImage,
+    format: ImageFormat,
+) -> Result<(String, ImageFormat), (StatusCode, Json<ErrorResponse>)> {
+    let out_format = output_format(format);
+    let mut image_bytes = Vec::new();
+    let mut cursor = Cursor::new(&mut image_bytes);
+
+    to_encodable(image, out_format)
+        .write_to(&mut cursor, out_format)
         .map_err(|e| {
-            event!(Level::INFO, "Failed to encode PNG: {}", e);
+            event!(
+                Level::INFO,
+                "Failed to encode {}: {}",
+                format_label(out_format),
+                e
+            );
             server_error()
-        })
-        .map(|bytes| {
-            return general_purpose::STANDARD.encode(bytes);
-        })
+        })?;
+
+    Ok((general_purpose::STANDARD.encode(&image_bytes), out_format))
 }
 
 pub async fn process_image(
-    input_png: DynamicImage,
+    input_image: DynamicImage,
     f: impl Fn(&DynamicImage) -> DynamicImage + Send + 'static,
 ) -> Result<DynamicImage, (StatusCode, Json<ErrorResponse>)> {
     tokio::time::timeout(
         Duration::from_secs(10),
-        tokio::task::spawn_blocking(move || f(&input_png)),
+        tokio::task::spawn_blocking(move || f(&input_image)),
     )
     .await
     .map_err(|_| {
@@ -75,4 +142,100 @@ pub async fn process_image(
         )
     })?
     .map_err(|_| server_error())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageFormat, RgbImage, RgbaImage};
+
+    /// Encode a small test image to a base64 string in the given format.
+    fn b64_image(format: ImageFormat) -> String {
+        let img = DynamicImage::ImageRgba8(RgbaImage::from_pixel(
+            8,
+            8,
+            image::Rgba([120, 80, 200, 255]),
+        ));
+        let mut bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut bytes);
+        // JPEG can't hold alpha; feed it RGB.
+        if format == ImageFormat::Jpeg {
+            DynamicImage::ImageRgb8(img.to_rgb8())
+                .write_to(&mut cursor, format)
+                .unwrap();
+        } else {
+            img.write_to(&mut cursor, format).unwrap();
+        }
+        general_purpose::STANDARD.encode(&bytes)
+    }
+
+    #[test]
+    fn reads_common_formats_and_reports_their_format() {
+        for format in [
+            ImageFormat::Png,
+            ImageFormat::Jpeg,
+            ImageFormat::Gif,
+            ImageFormat::Bmp,
+            ImageFormat::Tiff,
+        ] {
+            let (img, detected) = read_image_from_b64_string(&b64_image(format))
+                .unwrap_or_else(|_| panic!("failed to read {:?}", format));
+            assert_eq!(detected, format, "format detection for {:?}", format);
+            assert_eq!(img.width(), 8);
+            assert_eq!(img.height(), 8);
+        }
+    }
+
+    #[test]
+    fn round_trips_preserve_input_format() {
+        for format in [
+            ImageFormat::Png,
+            ImageFormat::Jpeg,
+            ImageFormat::Gif,
+            ImageFormat::Bmp,
+            ImageFormat::Tiff,
+        ] {
+            let (img, detected) = read_image_from_b64_string(&b64_image(format)).unwrap();
+            let (encoded, out_format) = write_image_to_b64_string(&img, detected).unwrap();
+            assert_eq!(out_format, format, "output format for {:?}", format);
+            // The encoded output must be decodable and detected as the same format.
+            let (_, re_detected) = read_image_from_b64_string(&encoded).unwrap();
+            assert_eq!(re_detected, format, "re-detected format for {:?}", format);
+        }
+    }
+
+    #[test]
+    fn jpeg_encodes_rgba_input_without_error() {
+        // The blur pipeline can hand back an RGBA image; encoding as JPEG must
+        // flatten the alpha channel rather than fail.
+        let rgba =
+            DynamicImage::ImageRgba8(RgbaImage::from_pixel(4, 4, image::Rgba([10, 20, 30, 128])));
+        let (encoded, out_format) = write_image_to_b64_string(&rgba, ImageFormat::Jpeg).unwrap();
+        assert_eq!(out_format, ImageFormat::Jpeg);
+        assert!(!encoded.is_empty());
+    }
+
+    #[test]
+    fn webp_input_falls_back_to_png_output() {
+        // WebP has no reliable encoder here, so a WebP round-trip should still
+        // succeed by emitting PNG.
+        let rgb = DynamicImage::ImageRgb8(RgbImage::from_pixel(4, 4, image::Rgb([1, 2, 3])));
+        let (encoded, out_format) = write_image_to_b64_string(&rgb, ImageFormat::WebP).unwrap();
+        assert_eq!(out_format, ImageFormat::Png);
+        let (_, detected) = read_image_from_b64_string(&encoded).unwrap();
+        assert_eq!(detected, ImageFormat::Png);
+    }
+
+    #[test]
+    fn rejects_invalid_base64() {
+        let err = read_image_from_b64_string("not base64!!!").unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rejects_non_image_bytes() {
+        let junk = general_purpose::STANDARD.encode("this is definitely not an image");
+        let err = read_image_from_b64_string(&junk).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
 }

--- a/domains/graphics/apis/posterize/src/images.rs
+++ b/domains/graphics/apis/posterize/src/images.rs
@@ -238,4 +238,35 @@ mod tests {
         let err = read_image_from_b64_string(&junk).unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
     }
+
+    #[test]
+    fn rejects_truncated_image() {
+        // A valid PNG signature makes `guess_format` succeed, but a truncated
+        // body makes the *decode* step fail — a different error path than the
+        // unrecognized-format case above.
+        let full = general_purpose::STANDARD
+            .decode(b64_image(ImageFormat::Png))
+            .unwrap();
+        let truncated = general_purpose::STANDARD.encode(&full[..16]);
+        let err = read_image_from_b64_string(&truncated).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        let err = read_image_from_b64_string("").unwrap_err();
+        // Empty base64 decodes to zero bytes, which `guess_format` can't
+        // identify.
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rejects_format_mismatched_bytes() {
+        // JPEG bytes labelled as anything still decode fine, but bytes whose
+        // magic doesn't match any enabled decoder are rejected. Here we hand a
+        // PDF-like header (`%PDF`) that `guess_format` does not recognize.
+        let not_an_image = general_purpose::STANDARD.encode(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3");
+        let err = read_image_from_b64_string(&not_an_image).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
 }

--- a/domains/graphics/apis/posterize/src/service.rs
+++ b/domains/graphics/apis/posterize/src/service.rs
@@ -1,4 +1,6 @@
-use crate::images::{process_image, read_png_from_b64_string, write_png_to_b64_string};
+use crate::images::{
+    format_label, process_image, read_image_from_b64_string, write_image_to_b64_string,
+};
 use crate::types::{BlurRequest, BlurResponse, EdgesRequest, EdgesResponse, ErrorResponse};
 use axum::Json;
 use axum::extract::Json as ExtractJson;
@@ -8,11 +10,11 @@ use imagine::{Radius, fast_blur, gray_gaussian_blur, sobel};
 pub async fn blur_post(
     ExtractJson(request): ExtractJson<BlurRequest>,
 ) -> Result<Json<BlurResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let input_png = read_png_from_b64_string(&request.b64_png)?;
+    let (input_image, input_format) = read_image_from_b64_string(&request.b64_png)?;
 
     let gray = request.gray;
     let sigma = request.sigma.unwrap_or(5.0);
-    let blurred = process_image(input_png, move |p| {
+    let blurred = process_image(input_image, move |p| {
         if gray {
             image::DynamicImage::ImageLuma8(gray_gaussian_blur(&p, Radius::Five, 3))
         } else {
@@ -21,11 +23,11 @@ pub async fn blur_post(
     })
     .await?;
 
-    let blurred_b64 = write_png_to_b64_string(&blurred)?;
+    let (blurred_b64, output_format) = write_image_to_b64_string(&blurred, input_format)?;
     let response = BlurResponse {
         width: blurred.width(),
         height: blurred.height(),
-        format: "PNG".to_string(),
+        format: format_label(output_format),
         size_bytes: blurred_b64.len(),
         image_data: blurred_b64,
     };
@@ -35,20 +37,144 @@ pub async fn blur_post(
 pub async fn edges_post(
     ExtractJson(request): ExtractJson<EdgesRequest>,
 ) -> Result<Json<EdgesResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let input_png = read_png_from_b64_string(&request.b64_png)?;
+    let (input_image, input_format) = read_image_from_b64_string(&request.b64_png)?;
 
-    let edges_img = process_image(input_png, move |p| {
+    let edges_img = process_image(input_image, move |p| {
         image::DynamicImage::ImageLuma8(sobel(&p.to_luma8()))
     })
     .await?;
 
-    let edges_b64 = write_png_to_b64_string(&edges_img)?;
+    let (edges_b64, output_format) = write_image_to_b64_string(&edges_img, input_format)?;
     let response = EdgesResponse {
         width: edges_img.width(),
         height: edges_img.height(),
-        format: "PNG".to_string(),
+        format: format_label(output_format),
         size_bytes: edges_b64.len(),
         image_data: edges_b64,
     };
     Ok(Json(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::post;
+    use base64::Engine;
+    use base64::engine::general_purpose;
+    use http_body_util::BodyExt;
+    use image::{DynamicImage, ImageFormat, RgbaImage};
+    use std::io::Cursor;
+    use tower::ServiceExt;
+
+    fn app() -> Router {
+        Router::new()
+            .route("/blur", post(blur_post))
+            .route("/edges", post(edges_post))
+    }
+
+    /// A small base64-encoded test image in the requested format.
+    fn b64_image(format: ImageFormat) -> String {
+        let img = DynamicImage::ImageRgba8(RgbaImage::from_pixel(
+            8,
+            8,
+            image::Rgba([120, 80, 200, 255]),
+        ));
+        let mut bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut bytes);
+        if format == ImageFormat::Jpeg {
+            DynamicImage::ImageRgb8(img.to_rgb8())
+                .write_to(&mut cursor, format)
+                .unwrap();
+        } else {
+            img.write_to(&mut cursor, format).unwrap();
+        }
+        general_purpose::STANDARD.encode(&bytes)
+    }
+
+    fn json_request(uri: &str, body: String) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap()
+    }
+
+    async fn response_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    const FORMAT_CASES: [(ImageFormat, &str); 5] = [
+        (ImageFormat::Png, "PNG"),
+        (ImageFormat::Jpeg, "JPEG"),
+        (ImageFormat::Gif, "GIF"),
+        (ImageFormat::Bmp, "BMP"),
+        (ImageFormat::Tiff, "TIFF"),
+    ];
+
+    #[tokio::test]
+    async fn blur_preserves_format_across_types() {
+        // Both the color (Rgba8) and grayscale (Luma8) blur paths must encode
+        // cleanly for every format; the Luma8 path in particular exercises the
+        // color-type widening in `to_encodable`.
+        for gray in [false, true] {
+            for (format, label) in FORMAT_CASES {
+                let body = format!(
+                    r#"{{"b64_png":"{}","gray":{},"sigma":3.0}}"#,
+                    b64_image(format),
+                    gray
+                );
+                let resp = app().oneshot(json_request("/blur", body)).await.unwrap();
+                assert_eq!(
+                    resp.status(),
+                    StatusCode::OK,
+                    "status for {:?} gray={}",
+                    format,
+                    gray
+                );
+                let json = response_json(resp).await;
+                assert_eq!(
+                    json["format"], label,
+                    "format for {:?} gray={}",
+                    format, gray
+                );
+                assert!(!json["image_data"].as_str().unwrap().is_empty());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn edges_preserves_format_across_types() {
+        // Edge detection always yields a Luma8 image, so re-encoding it as GIF
+        // (which the encoder can't do without widening) is the regression this
+        // guards against.
+        for (format, label) in FORMAT_CASES {
+            let body = format!(r#"{{"b64_png":"{}"}}"#, b64_image(format));
+            let resp = app().oneshot(json_request("/edges", body)).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "status for {:?}", format);
+            let json = response_json(resp).await;
+            assert_eq!(json["format"], label, "format for {:?}", format);
+        }
+    }
+
+    #[tokio::test]
+    async fn blur_rejects_non_image_payload() {
+        let junk = general_purpose::STANDARD.encode("not an image at all");
+        let body = format!(r#"{{"b64_png":"{}","gray":false,"sigma":3.0}}"#, junk);
+        let resp = app().oneshot(json_request("/blur", body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn blur_rejects_empty_payload() {
+        let body = r#"{"b64_png":"","gray":false,"sigma":3.0}"#.to_string();
+        let resp = app().oneshot(json_request("/blur", body)).await.unwrap();
+        // The `validate_image` deserializer rejects empty input before the
+        // handler runs, which axum surfaces as 422 Unprocessable Entity.
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
 }

--- a/domains/graphics/apis/posterize/src/service.rs
+++ b/domains/graphics/apis/posterize/src/service.rs
@@ -177,4 +177,51 @@ mod tests {
         // handler runs, which axum surfaces as 422 Unprocessable Entity.
         assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
+
+    #[tokio::test]
+    async fn blur_rejects_non_positive_sigma() {
+        for sigma in ["0.0", "-1.5"] {
+            let body = format!(
+                r#"{{"b64_png":"{}","gray":false,"sigma":{}}}"#,
+                b64_image(ImageFormat::Png),
+                sigma
+            );
+            let resp = app().oneshot(json_request("/blur", body)).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "sigma={}",
+                sigma
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn blur_rejects_missing_image_field() {
+        let body = r#"{"gray":false,"sigma":3.0}"#.to_string();
+        let resp = app().oneshot(json_request("/blur", body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn blur_rejects_malformed_json() {
+        let body = r#"{"b64_png": "#.to_string();
+        let resp = app().oneshot(json_request("/blur", body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn edges_rejects_invalid_base64() {
+        let body = r#"{"b64_png":"not valid base64 !!!"}"#.to_string();
+        let resp = app().oneshot(json_request("/edges", body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn edges_rejects_non_image_payload() {
+        let junk = general_purpose::STANDARD.encode("still not an image");
+        let body = format!(r#"{{"b64_png":"{}"}}"#, junk);
+        let resp = app().oneshot(json_request("/edges", body)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/domains/graphics/apis/posterize/src/types.rs
+++ b/domains/graphics/apis/posterize/src/types.rs
@@ -68,3 +68,62 @@ pub struct EdgesResponse {
 pub struct ErrorResponse {
     pub(crate) error: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blur_request_accepts_valid_payload() {
+        let json = r#"{"b64_png":"aGVsbG8=","gray":true,"sigma":4.0}"#;
+        let req: BlurRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.b64_png, "aGVsbG8=");
+        assert_eq!(req.sigma, Some(4.0));
+        assert!(req.gray);
+    }
+
+    #[test]
+    fn blur_request_allows_null_sigma() {
+        let json = r#"{"b64_png":"aGVsbG8=","gray":false,"sigma":null}"#;
+        let req: BlurRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.sigma, None);
+    }
+
+    #[test]
+    fn blur_request_rejects_empty_image() {
+        let json = r#"{"b64_png":"","gray":false,"sigma":1.0}"#;
+        assert!(serde_json::from_str::<BlurRequest>(json).is_err());
+    }
+
+    #[test]
+    fn blur_request_rejects_oversized_image() {
+        // One byte past the 5 MB base64 cap enforced by `validate_image`.
+        let big = "A".repeat(5_000_001);
+        let json = format!(r#"{{"b64_png":"{}","gray":false,"sigma":1.0}}"#, big);
+        assert!(serde_json::from_str::<BlurRequest>(&json).is_err());
+    }
+
+    #[test]
+    fn blur_request_rejects_non_positive_sigma() {
+        for sigma in ["0.0", "-2.5"] {
+            let json = format!(r#"{{"b64_png":"aGVsbG8=","gray":false,"sigma":{}}}"#, sigma);
+            assert!(
+                serde_json::from_str::<BlurRequest>(&json).is_err(),
+                "sigma={}",
+                sigma
+            );
+        }
+    }
+
+    #[test]
+    fn blur_request_requires_image_field() {
+        let json = r#"{"gray":false,"sigma":1.0}"#;
+        assert!(serde_json::from_str::<BlurRequest>(json).is_err());
+    }
+
+    #[test]
+    fn edges_request_rejects_empty_image() {
+        let json = r#"{"b64_png":""}"#;
+        assert!(serde_json::from_str::<EdgesRequest>(json).is_err());
+    }
+}

--- a/domains/graphics/apis/posterize/src/types.rs
+++ b/domains/graphics/apis/posterize/src/types.rs
@@ -1,19 +1,19 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
-fn validate_png<'de, D>(deserializer: D) -> Result<String, D::Error>
+fn validate_image<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let b64_png = String::deserialize(deserializer)?;
+    let b64_image = String::deserialize(deserializer)?;
 
-    if b64_png.is_empty() {
-        return Err(serde::de::Error::custom("png cannot be empty"));
+    if b64_image.is_empty() {
+        return Err(serde::de::Error::custom("image cannot be empty"));
     }
 
-    if b64_png.len() > 5_000_000 {
-        return Err(serde::de::Error::custom("b64 png must be at most 5MiB"));
+    if b64_image.len() > 5_000_000 {
+        return Err(serde::de::Error::custom("b64 image must be at most 5MiB"));
     }
-    Ok(b64_png)
+    Ok(b64_image)
 }
 
 fn validate_sigma<'de, D>(deserializer: D) -> Result<Option<f32>, D::Error>
@@ -33,7 +33,7 @@ where
 
 #[derive(Deserialize)]
 pub struct BlurRequest {
-    #[serde(deserialize_with = "validate_png")]
+    #[serde(deserialize_with = "validate_image")]
     pub(crate) b64_png: String,
     #[serde(deserialize_with = "validate_sigma")]
     pub(crate) sigma: Option<f32>,
@@ -51,7 +51,7 @@ pub struct BlurResponse {
 
 #[derive(Deserialize)]
 pub struct EdgesRequest {
-    #[serde(deserialize_with = "validate_png")]
+    #[serde(deserialize_with = "validate_image")]
     pub(crate) b64_png: String,
 }
 


### PR DESCRIPTION
## Summary

Posterize previously decoded only PNG/JPEG and always re-encoded the result as PNG (the response `format` was hardcoded to `"PNG"`). This extends it to the common image types and preserves the input format on output.

- **Decoders enabled:** `gif`, `bmp`, `tiff`, `webp`, `ico` added to the `image` crate features (PNG/JPEG already on).
- **Format detection:** input format is detected from magic bytes via `image::guess_format`; the result is re-encoded in that same format.
- **Encoder fallback:** WebP and ICO have no dependable encoder here, so they round-trip out as PNG. The response `format` field now reports whatever was actually produced.
- **Encoder edge cases** (`to_encodable`): JPEG has no alpha channel (flatten RGBA→RGB), and the GIF encoder rejects grayscale buffers without converting them (widen Luma8→RGBA). Both matter because the `/edges` and gray-`/blur` pipelines return `Luma8`.
- **Hardening:** a decode-time allocation cap (256 MiB) bounds the widened decompression-bomb surface.

The request field stays named `b64_png` for wire compatibility with the existing UI. A companion UI PR (muchq/muchq.github.io#…) consumes the returned `format` for correct download extension / clipboard handling and relaxes the uploader to accept the new types.

## Testing

`cargo test -p posterize` — 10 tests, all passing:
- per-format decode + detection, and format-preserving round-trips (PNG/JPEG/GIF/BMP/TIFF)
- the RGBA→RGB (JPEG) and Luma8→GIF encode paths via `/blur` (both `gray` modes) and `/edges` across all formats — this covers the case where GIF `/edges` would otherwise 500
- WebP→PNG fallback
- invalid-base64, non-image, and empty-input rejection

`cargo fmt -p posterize --check` clean. A `rust_test` target (`test_posterize`) is wired into `BUILD.bazel`, mirroring `microgpt_serve`.

## Review

An initial quality pass plus a small three-reviewer panel (correctness, API/compat, tests+build) ran over the diff. The panel caught a real bug — GIF input to `/edges` (or gray `/blur`) returned 500 because the GIF encoder can't take a `Luma8` buffer — which is fixed here and now covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX1aN5cBSm7rqmzLQMAoXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX1aN5cBSm7rqmzLQMAoXL)_