### PR TITLE
deploy: pin images to a commit SHA

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -12,6 +12,22 @@ permissions:
   contents: read
 
 jobs:
+  test-deploy:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/muchq/moonbase/ci-base:latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory /__w/MoonBase/MoonBase
+
+      # Runs deploy.sh end to end against a fake host — no ssh, docker, or
+      # network. Nothing else in CI executes this script.
+      - name: Test deploy.sh
+        run: ./scripts/test-deploy
+
   format-check:
     runs-on: ubuntu-latest
     container:

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -4,6 +4,9 @@ This directory contains the consolidated deployment configuration for multiple s
 
 ## Services Deployed
 
+`deploy.sh --services` lists these from `compose.yaml`, which is the source of
+truth for what's deployable.
+
 - **api.muchq.com** - API backend services
   - [`games_ws_backend`](../../domains/games/apis/games_ws_backend) (port 8080)
   - [`portrait`](../../domains/graphics/apis/portrait) (port 8081)
@@ -12,6 +15,8 @@ This directory contains the consolidated deployment configuration for multiple s
   - [`mithril`](../../domains/games/apis/mithril) (port 8083)
   - [`posterize`](../../domains/graphics/apis/posterize) (port 8084)
   - [`mcpserver`](../../domains/games/apis/mcpserver) (port 8086)
+  - [`microgpt-serve`](../../domains/ai/apis/microgpt_serve) (port 8087)
+  - [`one_d4`](../../domains/games/apis/one_d4) (port 8088)
 
 - **r3dr.net** - URL shortener service
   - [`r3dr`](../../domains/r3dr/apis/r3dr) (port 8085)
@@ -65,7 +70,7 @@ To deploy the latest commit on `main`:
 It shows the commit you're about to deploy and asks to confirm:
 
 ```
-Deploying 1694f01  posterize: accept common image formats and preserve them on output (#1207)
+Deploying all services at 1694f01  posterize: accept common image formats and preserve them on output (#1207)
 Replacing 891973a  server_pal: bundle webpki roots into the OTLP client (#1205)
 Proceed? [y/N]
 ```

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -140,18 +140,24 @@ container, not to everything the script touches.
 ```
 
 ```
-SERVICE             VERSION    STATE
-caddy               2-alpine   Up 3 hours
-golf_hub            7faca68    Up 3 hours
-mithril             1694f01    Up 12 minutes
-posterize           dac0383    Restarting (101) 8 seconds ago  <- .env says 7faca68
-prom_proxy          7faca68    Up 3 hours
+SERVICE             VERSION    RESTARTS  STATE
+caddy               2-alpine   0         Up 3 hours
+golf_hub            7faca68    0         Up 3 hours
+mithril             1694f01    0         Up 12 minutes
+posterize           7faca68    47        Restarting (101) 8 seconds ago
 ```
 
 This reads the containers themselves rather than the recorded pins, so it shows
-the *fact* rather than the intent. The two diverge when a deploy didn't recreate
-a container, and `--status` exits non-zero when they do — which is also how you
-confirm a deploy actually took effect. A full deploy re-converges the stack.
+the *fact* rather than the intent. It exits non-zero when a container is not up,
+or when its revision doesn't match the recorded pin — the latter meaning a
+deploy didn't recreate it, which is also how you confirm a deploy took effect.
+A full deploy re-converges the stack.
+
+`RESTARTS` is Docker's restart count, which resets when a container is
+recreated — so it reads as restarts *since that service was last deployed*. A
+climbing count next to a low uptime is a crash loop, and the exit code is in the
+state (`Restarting (101)` above is a Rust panic). Docker has no windowed rate;
+for restarts-over-time across the fleet, that's the dashboard's job (#1208).
 
 ## Rollback
 

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -56,28 +56,56 @@ After initialization, you may need to reboot the instance.
 
 ## Deploying
 
-To deploy or update services:
+To deploy the latest commit on `main`:
 
 ```bash
 ./deploy/consolidated/deploy.sh
 ```
 
-This will:
+It shows the commit you're about to deploy and asks to confirm:
+
+```
+Deploying 1694f01  posterize: accept common image formats and preserve them on output (#1207)
+Replacing 891973a  server_pal: bundle webpki roots into the OTLP client (#1205)
+Proceed? [y/N]
+```
+
+Every image is pinned to that commit's SHA (`compose.yaml` reads `DEPLOY_SHA`),
+so a deploy is reproducible and the running version is whatever you confirmed.
+Images are published per-commit by `publish.yml`, so a commit is only
+deployable once its build has finished — `deploy.sh` verifies the images exist
+before touching the host.
+
+To see what's available, with the deployed revision marked:
+
+```bash
+./deploy/consolidated/deploy.sh --list      # last 10 commits
+./deploy/consolidated/deploy.sh --list 25
+```
+
+```
+COMMIT     DATE        SUBJECT
+1694f01    2026-07-24  posterize: accept common image formats and preserve them on output (#1207)
+891973a    2026-07-24  server_pal: bundle webpki roots into the OTLP client (#1205)  <- deployed
+```
+
+Add `-y` to skip the confirmation. The deploy itself will:
 1. Copy deployment files to the host
 2. Copy r3dr static assets
 3. Copy observability configuration
-4. Pull latest Docker images
+4. Pull the images for that commit
 5. Restart all services
 
 ## Rollback
 
-Images are pushed with both a `latest` tag and the Git commit SHA (e.g. `abc1234`). To roll back, pin the service to a known-good commit in `compose.yaml`:
+Deploy an earlier commit — pick one with `--list`, then:
 
-```yaml
-image: ghcr.io/muchq/portrait:abc1234   # instead of :latest
+```bash
+./deploy/consolidated/deploy.sh --sha abc1234
 ```
 
-Then run `deploy.sh` again so the host pulls the pinned image.
+The whole stack moves together, so a rollback returns every service to a known
+state rather than leaving a hand-edited pin behind.
 
 ## Configuration Requirements
 

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -96,6 +96,32 @@ Add `-y` to skip the confirmation. The deploy itself will:
 4. Pull the images for that commit
 5. Restart all services
 
+### Deploying one service
+
+To ship a change without restarting the whole stack:
+
+```bash
+./deploy/consolidated/deploy.sh --services            # what can be deployed
+./deploy/consolidated/deploy.sh --service posterize
+```
+
+```
+SERVICE             DESCRIPTION
+games_ws_backend    Websocket backend for v1 games
+golf_hub            Golf v2 hub on smithy event streams (/games/v2/*)
+portrait            Ray-traced scene renderer
+...
+```
+
+Descriptions come from each service's `com.muchq.description` label in
+`compose.yaml`, so that file stays the source of truth (the labels also land on
+the containers).
+
+A targeted deploy pins **only** that service, recorded as its own variable
+(`POSTERIZE_SHA`) so the pin survives a reboot without dragging the rest of the
+stack to a new revision. A full deploy clears every per-service pin, so the
+stack converges back on a single revision.
+
 ## Rollback
 
 Deploy an earlier commit — pick one with `--list`, then:

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -133,6 +133,26 @@ Only the named container is recreated, but config files are still synced and
 Caddy is still reloaded, exactly as in a full deploy — "targeted" refers to the
 container, not to everything the script touches.
 
+### Checking what's actually running
+
+```bash
+./deploy/consolidated/deploy.sh --status
+```
+
+```
+SERVICE             VERSION    STATE
+caddy               2-alpine   Up 3 hours
+golf_hub            7faca68    Up 3 hours
+mithril             1694f01    Up 12 minutes
+posterize           dac0383    Restarting (101) 8 seconds ago  <- .env says 7faca68
+prom_proxy          7faca68    Up 3 hours
+```
+
+This reads the containers themselves rather than the recorded pins, so it shows
+the *fact* rather than the intent. The two diverge when a deploy didn't recreate
+a container, and `--status` exits non-zero when they do — which is also how you
+confirm a deploy actually took effect. A full deploy re-converges the stack.
+
 ## Rollback
 
 Deploy an earlier commit — pick one with `--list`, then:

--- a/deploy/consolidated/README.md
+++ b/deploy/consolidated/README.md
@@ -4,8 +4,9 @@ This directory contains the consolidated deployment configuration for multiple s
 
 ## Services Deployed
 
-`deploy.sh --services` lists these from `compose.yaml`, which is the source of
-truth for what's deployable.
+`deploy.sh --services` lists the application services below, read from
+`compose.yaml`. Caddy and the observability stack are deployed too but aren't
+individually targetable.
 
 - **api.muchq.com** - API backend services
   - [`games_ws_backend`](../../domains/games/apis/games_ws_backend) (port 8080)
@@ -95,11 +96,12 @@ COMMIT     DATE        SUBJECT
 ```
 
 Add `-y` to skip the confirmation. The deploy itself will:
-1. Copy deployment files to the host
-2. Copy r3dr static assets
-3. Copy observability configuration
-4. Pull the images for that commit
-5. Restart all services
+1. Verify every image exists at that commit, before touching the host
+2. Copy deployment files to the host
+3. Copy r3dr static assets
+4. Copy observability configuration
+5. Pull the images for that commit
+6. Restart the affected services
 
 ### Deploying one service
 
@@ -127,6 +129,10 @@ A targeted deploy pins **only** that service, recorded as its own variable
 stack to a new revision. A full deploy clears every per-service pin, so the
 stack converges back on a single revision.
 
+Only the named container is recreated, but config files are still synced and
+Caddy is still reloaded, exactly as in a full deploy — "targeted" refers to the
+container, not to everything the script touches.
+
 ## Rollback
 
 Deploy an earlier commit — pick one with `--list`, then:
@@ -135,8 +141,18 @@ Deploy an earlier commit — pick one with `--list`, then:
 ./deploy/consolidated/deploy.sh --sha abc1234
 ```
 
-The whole stack moves together, so a rollback returns every service to a known
-state rather than leaving a hand-edited pin behind.
+The whole stack moves together rather than leaving a hand-edited pin behind.
+
+Note this rolls back **images only**. Config — `compose.yaml`, the `Caddyfile`,
+`o11y/*`, and r3dr's static assets — is always copied from your working tree,
+so it stays at whatever you have checked out. Deploy from a clean checkout of
+`main`, and be aware that rolling images back past a config change (a new env
+var, a new route) leaves the newer config in front of an older binary.
+
+Rolling back further than the newest service is also rejected: the pre-flight
+check requires an image at that commit for every service, and a service that
+didn't exist yet has none. Use `--service` to roll back one service past that
+point.
 
 ## Configuration Requirements
 
@@ -149,6 +165,8 @@ Services require configuration files in their respective `/etc` directories on t
 - `/etc/mithril/` - Mithril service configuration
 - `/etc/posterize/` - Posterize service configuration
 - `/etc/mcpserver/` - MCP server configuration
+- `/etc/microgpt-serve/` - microgpt config, including the model in `model/`
+- `/etc/one_d4/` - one_d4 service configuration
 
 ## Network
 

--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -34,7 +34,7 @@ services:
           memory: 256M
 
   games_ws_backend:
-    image: ghcr.io/muchq/games_ws_backend:latest
+    image: ghcr.io/muchq/games_ws_backend:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8080:8080"
@@ -51,7 +51,7 @@ services:
   # The smithy event-stream golf service (/games/v2/*, MoonBase#1187);
   # serves the v2 beta while games_ws_backend keeps serving v1.
   golf_hub:
-    image: ghcr.io/muchq/golf_hub:latest
+    image: ghcr.io/muchq/golf_hub:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8089:8089"
@@ -63,7 +63,7 @@ services:
       TRUSTED_PROXY_CIDRS: *caddy_ip
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
       OTEL_SERVICE_NAME: golf_hub
-      OTEL_RESOURCE_ATTRIBUTES: service.name=golf_hub,service.version=latest
+      OTEL_RESOURCE_ATTRIBUTES: service.name=golf_hub,service.version=${DEPLOY_SHA:-latest}
     networks:
       - app_network
     deploy:
@@ -73,7 +73,7 @@ services:
           memory: 512M
 
   portrait:
-    image: ghcr.io/muchq/portrait:latest
+    image: ghcr.io/muchq/portrait:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8081:8081"
@@ -84,7 +84,7 @@ services:
       TRUSTED_PROXY_CIDRS: *caddy_ip
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
       OTEL_SERVICE_NAME: portrait
-      OTEL_RESOURCE_ATTRIBUTES: service.name=portrait,service.version=latest
+      OTEL_RESOURCE_ATTRIBUTES: service.name=portrait,service.version=${DEPLOY_SHA:-latest}
     volumes:
       - /etc/portrait:/etc/portrait
     networks:
@@ -96,7 +96,7 @@ services:
           memory: 512M
 
   prom_proxy:
-    image: ghcr.io/muchq/prom_proxy:latest
+    image: ghcr.io/muchq/prom_proxy:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8082:8082"
@@ -114,7 +114,7 @@ services:
           memory: 256M
 
   mithril:
-    image: ghcr.io/muchq/mithril:latest
+    image: ghcr.io/muchq/mithril:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8083:8083"
@@ -122,7 +122,7 @@ services:
       - PORT=8083
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=mithril
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=mithril,service.version=latest
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=mithril,service.version=${DEPLOY_SHA:-latest}
     volumes:
       - /etc/mithril:/etc/mithril
     networks:
@@ -134,7 +134,7 @@ services:
           memory: 512M
 
   posterize:
-    image: ghcr.io/muchq/posterize:latest
+    image: ghcr.io/muchq/posterize:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8084:8084"
@@ -142,7 +142,7 @@ services:
       - PORT=8084
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=posterize
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=posterize,service.version=latest
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=posterize,service.version=${DEPLOY_SHA:-latest}
     volumes:
       - /etc/posterize:/etc/posterize
     networks:
@@ -154,7 +154,7 @@ services:
           memory: 512M
 
   r3dr:
-    image: ghcr.io/muchq/r3dr:latest
+    image: ghcr.io/muchq/r3dr:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8085:8080"
@@ -169,7 +169,7 @@ services:
           memory: 256M
 
   mcpserver:
-    image: ghcr.io/muchq/mcpserver:latest
+    image: ghcr.io/muchq/mcpserver:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8086:8080"
@@ -210,7 +210,7 @@ services:
       start_period: 10s
 
   one_d4:
-    image: ghcr.io/muchq/one_d4:latest
+    image: ghcr.io/muchq/one_d4:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8088:8080"
@@ -237,7 +237,7 @@ services:
       start_period: 15s
 
   microgpt-serve:
-    image: ghcr.io/muchq/microgpt-serve:latest
+    image: ghcr.io/muchq/microgpt-serve:${DEPLOY_SHA:-latest}
     restart: always
     ports:
       - "8087:8087"
@@ -246,7 +246,7 @@ services:
       - MODEL_DIR=/etc/microgpt-serve/model
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=microgpt-serve
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=microgpt-serve,service.version=latest
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=microgpt-serve,service.version=${DEPLOY_SHA:-latest}
     volumes:
       - /etc/microgpt-serve:/etc/microgpt-serve
     networks:

--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -34,7 +34,9 @@ services:
           memory: 256M
 
   games_ws_backend:
-    image: ghcr.io/muchq/games_ws_backend:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/games_ws_backend:${GAMES_WS_BACKEND_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Websocket backend for v1 games"
     restart: always
     ports:
       - "8080:8080"
@@ -51,7 +53,9 @@ services:
   # The smithy event-stream golf service (/games/v2/*, MoonBase#1187);
   # serves the v2 beta while games_ws_backend keeps serving v1.
   golf_hub:
-    image: ghcr.io/muchq/golf_hub:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/golf_hub:${GOLF_HUB_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Golf v2 hub on smithy event streams (/games/v2/*)"
     restart: always
     ports:
       - "8089:8089"
@@ -63,7 +67,7 @@ services:
       TRUSTED_PROXY_CIDRS: *caddy_ip
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
       OTEL_SERVICE_NAME: golf_hub
-      OTEL_RESOURCE_ATTRIBUTES: service.name=golf_hub,service.version=${DEPLOY_SHA:-latest}
+      OTEL_RESOURCE_ATTRIBUTES: service.name=golf_hub,service.version=${GOLF_HUB_SHA:-${DEPLOY_SHA:-latest}}
     networks:
       - app_network
     deploy:
@@ -73,7 +77,9 @@ services:
           memory: 512M
 
   portrait:
-    image: ghcr.io/muchq/portrait:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/portrait:${PORTRAIT_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Ray-traced scene renderer"
     restart: always
     ports:
       - "8081:8081"
@@ -84,7 +90,7 @@ services:
       TRUSTED_PROXY_CIDRS: *caddy_ip
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
       OTEL_SERVICE_NAME: portrait
-      OTEL_RESOURCE_ATTRIBUTES: service.name=portrait,service.version=${DEPLOY_SHA:-latest}
+      OTEL_RESOURCE_ATTRIBUTES: service.name=portrait,service.version=${PORTRAIT_SHA:-${DEPLOY_SHA:-latest}}
     volumes:
       - /etc/portrait:/etc/portrait
     networks:
@@ -96,7 +102,9 @@ services:
           memory: 512M
 
   prom_proxy:
-    image: ghcr.io/muchq/prom_proxy:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/prom_proxy:${PROM_PROXY_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Metrics API behind the dashboard"
     restart: always
     ports:
       - "8082:8082"
@@ -114,7 +122,9 @@ services:
           memory: 256M
 
   mithril:
-    image: ghcr.io/muchq/mithril:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/mithril:${MITHRIL_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Word-ladder solver (wordchains)"
     restart: always
     ports:
       - "8083:8083"
@@ -122,7 +132,7 @@ services:
       - PORT=8083
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=mithril
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=mithril,service.version=${DEPLOY_SHA:-latest}
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=mithril,service.version=${MITHRIL_SHA:-${DEPLOY_SHA:-latest}}
     volumes:
       - /etc/mithril:/etc/mithril
     networks:
@@ -134,7 +144,9 @@ services:
           memory: 512M
 
   posterize:
-    image: ghcr.io/muchq/posterize:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/posterize:${POSTERIZE_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Image blur and edge detection"
     restart: always
     ports:
       - "8084:8084"
@@ -142,7 +154,7 @@ services:
       - PORT=8084
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=posterize
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=posterize,service.version=${DEPLOY_SHA:-latest}
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=posterize,service.version=${POSTERIZE_SHA:-${DEPLOY_SHA:-latest}}
     volumes:
       - /etc/posterize:/etc/posterize
     networks:
@@ -154,7 +166,9 @@ services:
           memory: 512M
 
   r3dr:
-    image: ghcr.io/muchq/r3dr:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/r3dr:${R3DR_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "URL shortener"
     restart: always
     ports:
       - "8085:8080"
@@ -169,7 +183,9 @@ services:
           memory: 256M
 
   mcpserver:
-    image: ghcr.io/muchq/mcpserver:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/mcpserver:${MCPSERVER_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Model Context Protocol server"
     restart: always
     ports:
       - "8086:8080"
@@ -210,7 +226,9 @@ services:
       start_period: 10s
 
   one_d4:
-    image: ghcr.io/muchq/one_d4:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/one_d4:${ONE_D4_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "Chess game indexer and analysis"
     restart: always
     ports:
       - "8088:8080"
@@ -237,7 +255,9 @@ services:
       start_period: 15s
 
   microgpt-serve:
-    image: ghcr.io/muchq/microgpt-serve:${DEPLOY_SHA:-latest}
+    image: ghcr.io/muchq/microgpt-serve:${MICROGPT_SERVE_SHA:-${DEPLOY_SHA:-latest}}
+    labels:
+      com.muchq.description: "microgpt text generation API"
     restart: always
     ports:
       - "8087:8087"
@@ -246,7 +266,7 @@ services:
       - MODEL_DIR=/etc/microgpt-serve/model
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=microgpt-serve
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=microgpt-serve,service.version=${DEPLOY_SHA:-latest}
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=microgpt-serve,service.version=${MICROGPT_SERVE_SHA:-${DEPLOY_SHA:-latest}}
     volumes:
       - /etc/microgpt-serve:/etc/microgpt-serve
     networks:

--- a/deploy/consolidated/deploy.sh
+++ b/deploy/consolidated/deploy.sh
@@ -1,36 +1,172 @@
 #!/bin/bash
 set -e
 
+HOST=ubuntu@consolidated.cmptr.info
+COMPOSE_FILE=deploy/consolidated/compose.yaml
+
+usage() {
+  cat <<'USAGE'
+Usage: deploy.sh [OPTIONS]
+
+Deploys the consolidated stack. Every image is pinned to a commit SHA, so what
+runs is reproducible and a rollback is just --sha.
+
+Options:
+  -l, --list [COUNT]   Show the last COUNT commits (default 10) and exit
+  -s, --sha SHA        Deploy a specific commit; default is the latest on main
+      --latest         Deploy the latest commit on main (the default)
+  -y, --yes            Skip the confirmation prompt
+  -h, --help           Show this help
+
+Images are published per-commit by .github/workflows/publish.yml, so a commit
+can only be deployed once its build has finished. The images are verified to
+exist before anything on the host is touched.
+USAGE
+}
+
+LIST_COUNT=""
+TARGET_REF=""
+ASSUME_YES=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -l | --list)
+      LIST_COUNT=10
+      case "${2:-}" in
+        [0-9]*)
+          LIST_COUNT=$2
+          shift
+          ;;
+      esac
+      shift
+      ;;
+    -s | --sha)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --sha needs a commit" >&2
+        exit 1
+      fi
+      TARGET_REF=$2
+      shift 2
+      ;;
+    --latest)
+      TARGET_REF=""
+      shift
+      ;;
+    -y | --yes)
+      ASSUME_YES=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Deploy targets are commits on main that CI has already published, so resolve
+# against the remote rather than whatever the local checkout happens to be on.
+git fetch --quiet origin main
+
+# Best-effort: the host records what it last deployed, which labels the table
+# and gives the confirmation prompt a before/after.
+deployed_sha=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$HOST" \
+  "grep -s '^DEPLOY_SHA=' ~/.env | cut -d= -f2" 2>/dev/null || true)
+
+describe() { # describe <sha> -> "subject", or a placeholder when not local
+  git log -1 --pretty=%s "$1" 2>/dev/null || echo "(unknown commit)"
+}
+
+if [ -n "$LIST_COUNT" ]; then
+  printf '%-9s  %-10s  %s\n' "COMMIT" "DATE" "SUBJECT"
+  git log --max-count="$LIST_COUNT" --date=short \
+    --pretty=tformat:'%h|%ad|%s' origin/main |
+    while IFS='|' read -r sha date subject; do
+      marker=""
+      case "$deployed_sha" in
+        "$sha"*) marker="  <- deployed" ;;
+      esac
+      printf '%-9s  %-10s  %s%s\n' "$sha" "$date" "$subject" "$marker"
+    done
+  exit 0
+fi
+
+if [ -n "$TARGET_REF" ]; then
+  DEPLOY_SHA=$(git rev-parse --verify "${TARGET_REF}^{commit}" 2>/dev/null) || {
+    echo "Error: '$TARGET_REF' is not a commit in this repo" >&2
+    exit 1
+  }
+else
+  DEPLOY_SHA=$(git rev-parse --verify "origin/main^{commit}")
+fi
+export DEPLOY_SHA
+short_sha=$(git rev-parse --short "$DEPLOY_SHA")
+
+echo "Deploying $short_sha  $(describe "$DEPLOY_SHA")"
+if [ -n "$deployed_sha" ] && [ "$deployed_sha" != "$DEPLOY_SHA" ]; then
+  echo "Replacing $(git rev-parse --short "$deployed_sha" 2>/dev/null || echo "$deployed_sha")  $(describe "$deployed_sha")"
+elif [ "$deployed_sha" = "$DEPLOY_SHA" ]; then
+  echo "(already the deployed revision)"
+fi
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  printf 'Proceed? [y/N] '
+  read -r reply
+  case "$reply" in
+    [yY] | [yY][eE][sS]) ;;
+    *)
+      echo "Aborted."
+      exit 1
+      ;;
+  esac
+fi
+
+# Fail before touching the host: a SHA whose publish build is still running (or
+# failed) has no images, and finding that out at `compose pull` would leave the
+# host half-updated.
+images=$(grep -o 'ghcr\.io/muchq/[a-z0-9_-]*' "$COMPOSE_FILE" | sort -u)
+echo "Verifying published images for $short_sha..."
+missing=$(ssh "$HOST" "for img in $images; do sudo docker manifest inspect \$img:$DEPLOY_SHA >/dev/null 2>&1 || echo \$img; done")
+if [ -n "$missing" ]; then
+  echo "Error: no image published at $short_sha for:" >&2
+  echo "$missing" | sed 's/^/  /' >&2
+  echo "Its publish build may still be running or may have failed." >&2
+  exit 1
+fi
+
 # Copy deployment files
 echo "Copying deployment files..."
-scp -r deploy/consolidated/compose.yaml deploy/consolidated/Caddyfile deploy/consolidated/docker-compose.observability.yml ubuntu@consolidated.cmptr.info:~/
+scp -r deploy/consolidated/compose.yaml deploy/consolidated/Caddyfile deploy/consolidated/docker-compose.observability.yml "$HOST":~/
 
 # Copy r3dr static assets
 echo "Copying r3dr static assets..."
-scp -r domains/r3dr/apps/r3dr_web/* ubuntu@consolidated.cmptr.info:~/r3dr-assets/
+scp -r domains/r3dr/apps/r3dr_web/* "$HOST":~/r3dr-assets/
 
 # Create observability directory structure and copy configs if they exist
 echo "Setting up observability configs..."
-ssh ubuntu@consolidated.cmptr.info "mkdir -p ~/o11y"
+ssh "$HOST" "mkdir -p ~/o11y"
 
 # Copy observability configs
 echo "Copying observability configuration files..."
-scp -r deploy/consolidated/o11y/* ubuntu@consolidated.cmptr.info:~/o11y/
+scp -r deploy/consolidated/o11y/* "$HOST":~/o11y/
 
 # Copy Forgejo configuration
 echo "Copying Forgejo configuration..."
-scp -r deploy/consolidated/forgejo/app.ini ubuntu@consolidated.cmptr.info:~/forgejo-app.ini
-
+scp -r deploy/consolidated/forgejo/app.ini "$HOST":~/forgejo-app.ini
 
 # Check if .env file exists locally and copy it
 if [ -f ".env" ]; then
   echo "Copying environment variables..."
-  scp .env ubuntu@consolidated.cmptr.info:~/
+  scp .env "$HOST":~/
 fi
 
 # Pull images and restart services
 echo "Pulling images and restarting services..."
-ssh ubuntu@consolidated.cmptr.info << EOF
+ssh "$HOST" << EOF
   # Export environment variables if .env exists
   if [ -f ".env" ]; then
     export \$(cat .env | grep -v '^#' | xargs)
@@ -59,8 +195,17 @@ ssh ubuntu@consolidated.cmptr.info << EOF
     sudo docker network create --subnet 172.28.0.0/16 --ip-range 172.28.1.0/24 --gateway 172.28.0.1 muchq_network
   fi
 
-  sudo docker compose -f compose.yaml -f docker-compose.observability.yml pull
-  sudo docker compose -f compose.yaml -f docker-compose.observability.yml up -d --remove-orphans
+  # Record the revision being deployed. compose.yaml reads DEPLOY_SHA to pin
+  # every image tag, so this file is what the stack comes back up on after an
+  # unattended \`compose up\` (a reboot, a manual restart).
+  touch ~/.env
+  grep -v '^DEPLOY_SHA=' ~/.env > ~/.env.tmp || true
+  echo "DEPLOY_SHA=${DEPLOY_SHA}" >> ~/.env.tmp
+  mv ~/.env.tmp ~/.env
+  export DEPLOY_SHA=${DEPLOY_SHA}
+
+  sudo -E docker compose -f compose.yaml -f docker-compose.observability.yml pull
+  sudo -E docker compose -f compose.yaml -f docker-compose.observability.yml up -d --remove-orphans
 
   # Reload Caddy configuration. Target the admin API on IPv4 explicitly: inside
   # the container \`localhost\` resolves to ::1 first, but Caddy's admin endpoint
@@ -68,5 +213,4 @@ ssh ubuntu@consolidated.cmptr.info << EOF
   sudo docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile --address 127.0.0.1:2019
 EOF
 
-echo "Deployment complete!"
-
+echo "Deployment complete! Running $short_sha"

--- a/deploy/consolidated/deploy.sh
+++ b/deploy/consolidated/deploy.sh
@@ -159,16 +159,32 @@ host_pin() { printf '%s\n' "$host_env" | sed -n "s/^$1=//p" | tail -1; }
 # What the host records is only the intent; the containers are the fact. They
 # diverge when a container wasn't recreated, so read them rather than infer.
 if [ "$SHOW_STATUS" -eq 1 ]; then
-  running=$(ssh -o BatchMode=yes -o ConnectTimeout=10 "$HOST" \
-    "sudo docker ps -a --filter label=com.docker.compose.service \
-       --format '{{.Label \"com.docker.compose.service\"}}|{{.Image}}|{{.Status}}'" 2>/dev/null)
+  # Two views in one connection: ps for the human status string (which already
+  # carries the exit code, e.g. "Restarting (101)"), inspect for the restart
+  # count, which ps can't report. RestartCount resets when a container is
+  # recreated, so it reads as restarts since the last deploy of that service.
+  running=$(ssh -o BatchMode=yes -o ConnectTimeout=10 "$HOST" "
+    sudo docker ps -a --filter label=com.docker.compose.service \
+      --format 'S|{{.Label \"com.docker.compose.service\"}}|{{.Image}}|{{.Status}}'
+    sudo docker ps -aq --filter label=com.docker.compose.service |
+      xargs -r sudo docker inspect \
+        --format 'R|{{index .Config.Labels \"com.docker.compose.service\"}}|{{.RestartCount}}'
+  " 2>/dev/null)
   if [ -z "$running" ]; then
     echo "Error: could not read container state from $HOST" >&2
     exit 1
   fi
-  printf '%-18s  %-9s  %s\n' "SERVICE" "VERSION" "STATE"
+
+  declare -A restarts=()
+  while IFS='|' read -r kind svc count; do
+    [ "$kind" = "R" ] && [ -n "$svc" ] && restarts[$svc]=$count
+  done <<< "$running"
+
+  printf '%-18s  %-9s  %-8s  %s\n' "SERVICE" "VERSION" "RESTARTS" "STATE"
   drifted=0
-  while IFS='|' read -r svc image state; do
+  unhealthy=0
+  while IFS='|' read -r kind svc image state; do
+    [ "$kind" = "S" ] || continue
     [ -n "$svc" ] || continue
     tag=${image##*:}
     shown=$tag
@@ -187,12 +203,25 @@ if [ "$SHOW_STATUS" -eq 1 ]; then
         fi
         ;;
     esac
-    printf '%-18s  %-9s  %s%s\n' "$svc" "$shown" "$state" "$note"
+    # Anything not "Up ..." is down, restarting, or crash-looping; the status
+    # string carries the exit code, and the restart count says how hard.
+    case "$state" in
+      Up*) ;;
+      *) unhealthy=$((unhealthy + 1)) ;;
+    esac
+    printf '%-18s  %-9s  %-8s  %s%s\n' "$svc" "$shown" "${restarts[$svc]:-?}" "$state" "$note"
   done <<< "$(printf '%s\n' "$running" | sort)"
-  if [ "$drifted" -gt 0 ]; then
+
+  if [ "$drifted" -gt 0 ] || [ "$unhealthy" -gt 0 ]; then
     echo
-    echo "$drifted container(s) are not running the recorded revision — a deploy" >&2
-    echo "may not have recreated them. A full deploy re-converges the stack." >&2
+    [ "$drifted" -gt 0 ] && {
+      echo "$drifted container(s) are not running the recorded revision — a deploy" >&2
+      echo "may not have recreated them. A full deploy re-converges the stack." >&2
+    }
+    [ "$unhealthy" -gt 0 ] && {
+      echo "$unhealthy container(s) are not up. A climbing restart count with a" >&2
+      echo "low uptime is a crash loop; the exit code is in the state above." >&2
+    }
     exit 1
   fi
   exit 0

--- a/deploy/consolidated/deploy.sh
+++ b/deploy/consolidated/deploy.sh
@@ -12,20 +12,49 @@ Deploys the consolidated stack. Every image is pinned to a commit SHA, so what
 runs is reproducible and a rollback is just --sha.
 
 Options:
-  -l, --list [COUNT]   Show the last COUNT commits (default 10) and exit
-  -s, --sha SHA        Deploy a specific commit; default is the latest on main
-      --latest         Deploy the latest commit on main (the default)
-  -y, --yes            Skip the confirmation prompt
-  -h, --help           Show this help
+  -l, --list [COUNT]     Show the last COUNT commits (default 10) and exit
+      --services         Show the deployable services and exit
+  -s, --sha SHA          Deploy a specific commit; default is the latest on main
+      --latest           Deploy the latest commit on main (the default)
+      --service NAME     Deploy only NAME, leaving the rest of the stack alone
+  -y, --yes              Skip the confirmation prompt
+  -h, --help             Show this help
 
 Images are published per-commit by .github/workflows/publish.yml, so a commit
 can only be deployed once its build has finished. The images are verified to
 exist before anything on the host is touched.
+
+A full deploy moves every service to one revision and clears any per-service
+pins. --service pins just that service, so a hotfix survives a reboot without
+dragging the rest of the stack along.
 USAGE
 }
 
+# Service name -> description, read from the compose file so it stays the one
+# source of truth (the labels also land on the containers).
+service_table() {
+  awk '
+    /^services:/ { in_services = 1; next }
+    /^[a-z]/     { in_services = 0 }
+    in_services && /^  [a-z0-9_-]+:$/ { svc = $1; sub(/:$/, "", svc); next }
+    in_services && /^      com\.muchq\.description:/ {
+      sub(/^ *com\.muchq\.description: */, "")
+      gsub(/^"|"$/, "")
+      if (svc != "") print svc "|" $0
+      svc = ""
+    }
+  ' "$COMPOSE_FILE"
+}
+
+service_names() { service_table | cut -d'|' -f1; }
+
+# golf_hub -> GOLF_HUB_SHA, microgpt-serve -> MICROGPT_SERVE_SHA
+sha_var_for() { echo "$1" | tr 'a-z-' 'A-Z_' | sed 's/$/_SHA/'; }
+
 LIST_COUNT=""
+LIST_SERVICES=0
 TARGET_REF=""
+TARGET_SERVICE=""
 ASSUME_YES=0
 
 while [ $# -gt 0 ]; do
@@ -40,6 +69,10 @@ while [ $# -gt 0 ]; do
       esac
       shift
       ;;
+    --services)
+      LIST_SERVICES=1
+      shift
+      ;;
     -s | --sha)
       if [ -z "${2:-}" ]; then
         echo "Error: --sha needs a commit" >&2
@@ -51,6 +84,14 @@ while [ $# -gt 0 ]; do
     --latest)
       TARGET_REF=""
       shift
+      ;;
+    --service)
+      if [ -z "${2:-}" ]; then
+        echo "Error: --service needs a service name" >&2
+        exit 1
+      fi
+      TARGET_SERVICE=$2
+      shift 2
       ;;
     -y | --yes)
       ASSUME_YES=1
@@ -68,14 +109,38 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$LIST_SERVICES" -eq 1 ]; then
+  printf '%-18s  %s\n' "SERVICE" "DESCRIPTION"
+  service_table | while IFS='|' read -r svc desc; do
+    printf '%-18s  %s\n' "$svc" "$desc"
+  done
+  exit 0
+fi
+
+if [ -n "$TARGET_SERVICE" ] && ! service_names | grep -qx "$TARGET_SERVICE"; then
+  echo "Error: unknown service '$TARGET_SERVICE'" >&2
+  echo "Run 'deploy.sh --services' to see what's deployable." >&2
+  exit 1
+fi
+
 # Deploy targets are commits on main that CI has already published, so resolve
 # against the remote rather than whatever the local checkout happens to be on.
 git fetch --quiet origin main
 
 # Best-effort: the host records what it last deployed, which labels the table
 # and gives the confirmation prompt a before/after.
+if [ -n "$TARGET_SERVICE" ]; then
+  deployed_var=$(sha_var_for "$TARGET_SERVICE")
+else
+  deployed_var=DEPLOY_SHA
+fi
 deployed_sha=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$HOST" \
-  "grep -s '^DEPLOY_SHA=' ~/.env | cut -d= -f2" 2>/dev/null || true)
+  "grep -s '^${deployed_var}=' ~/.env | cut -d= -f2" 2>/dev/null || true)
+# A service with no pin of its own is running the stack-wide revision.
+if [ -z "$deployed_sha" ] && [ -n "$TARGET_SERVICE" ]; then
+  deployed_sha=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$HOST" \
+    "grep -s '^DEPLOY_SHA=' ~/.env | cut -d= -f2" 2>/dev/null || true)
+fi
 
 describe() { # describe <sha> -> "subject", or a placeholder when not local
   git log -1 --pretty=%s "$1" 2>/dev/null || echo "(unknown commit)"
@@ -106,7 +171,11 @@ fi
 export DEPLOY_SHA
 short_sha=$(git rev-parse --short "$DEPLOY_SHA")
 
-echo "Deploying $short_sha  $(describe "$DEPLOY_SHA")"
+if [ -n "$TARGET_SERVICE" ]; then
+  echo "Deploying $TARGET_SERVICE at $short_sha  $(describe "$DEPLOY_SHA")"
+else
+  echo "Deploying all services at $short_sha  $(describe "$DEPLOY_SHA")"
+fi
 if [ -n "$deployed_sha" ] && [ "$deployed_sha" != "$DEPLOY_SHA" ]; then
   echo "Replacing $(git rev-parse --short "$deployed_sha" 2>/dev/null || echo "$deployed_sha")  $(describe "$deployed_sha")"
 elif [ "$deployed_sha" = "$DEPLOY_SHA" ]; then
@@ -128,7 +197,11 @@ fi
 # Fail before touching the host: a SHA whose publish build is still running (or
 # failed) has no images, and finding that out at `compose pull` would leave the
 # host half-updated.
-images=$(grep -o 'ghcr\.io/muchq/[a-z0-9_-]*' "$COMPOSE_FILE" | sort -u)
+if [ -n "$TARGET_SERVICE" ]; then
+  images="ghcr.io/muchq/$TARGET_SERVICE"
+else
+  images=$(grep -o 'ghcr\.io/muchq/[a-z0-9_-]*' "$COMPOSE_FILE" | sort -u)
+fi
 echo "Verifying published images for $short_sha..."
 missing=$(ssh "$HOST" "for img in $images; do sudo docker manifest inspect \$img:$DEPLOY_SHA >/dev/null 2>&1 || echo \$img; done")
 if [ -n "$missing" ]; then
@@ -136,6 +209,19 @@ if [ -n "$missing" ]; then
   echo "$missing" | sed 's/^/  /' >&2
   echo "Its publish build may still be running or may have failed." >&2
   exit 1
+fi
+
+# A full deploy converges the stack on one revision, so it also clears the
+# per-service pins; --service sets just its own.
+if [ -n "$TARGET_SERVICE" ]; then
+  stale_vars=$(sha_var_for "$TARGET_SERVICE")
+  env_line="$(sha_var_for "$TARGET_SERVICE")=$DEPLOY_SHA"
+  # Scoped to one service, so nothing here should reap the others.
+  up_flags=""
+else
+  stale_vars="DEPLOY_SHA $(service_names | while read -r s; do sha_var_for "$s"; done | tr '\n' ' ')"
+  env_line="DEPLOY_SHA=$DEPLOY_SHA"
+  up_flags="--remove-orphans"
 fi
 
 # Copy deployment files
@@ -195,17 +281,21 @@ ssh "$HOST" << EOF
     sudo docker network create --subnet 172.28.0.0/16 --ip-range 172.28.1.0/24 --gateway 172.28.0.1 muchq_network
   fi
 
-  # Record the revision being deployed. compose.yaml reads DEPLOY_SHA to pin
-  # every image tag, so this file is what the stack comes back up on after an
-  # unattended \`compose up\` (a reboot, a manual restart).
+  # Record the revision being deployed. compose.yaml reads these to pin image
+  # tags, so the file is what the stack comes back up on after an unattended
+  # \`compose up\` (a reboot, a manual restart).
   touch ~/.env
-  grep -v '^DEPLOY_SHA=' ~/.env > ~/.env.tmp || true
-  echo "DEPLOY_SHA=${DEPLOY_SHA}" >> ~/.env.tmp
+  cp ~/.env ~/.env.tmp
+  for var in ${stale_vars}; do
+    grep -v "^\${var}=" ~/.env.tmp > ~/.env.next || true
+    mv ~/.env.next ~/.env.tmp
+  done
+  echo "${env_line}" >> ~/.env.tmp
   mv ~/.env.tmp ~/.env
-  export DEPLOY_SHA=${DEPLOY_SHA}
+  export \$(cat ~/.env | grep -v '^#' | xargs)
 
-  sudo -E docker compose -f compose.yaml -f docker-compose.observability.yml pull
-  sudo -E docker compose -f compose.yaml -f docker-compose.observability.yml up -d --remove-orphans
+  sudo -E docker compose -f compose.yaml -f docker-compose.observability.yml pull ${TARGET_SERVICE}
+  sudo -E docker compose -f compose.yaml -f docker-compose.observability.yml up -d ${up_flags} ${TARGET_SERVICE}
 
   # Reload Caddy configuration. Target the admin API on IPv4 explicitly: inside
   # the container \`localhost\` resolves to ::1 first, but Caddy's admin endpoint
@@ -213,4 +303,8 @@ ssh "$HOST" << EOF
   sudo docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile --address 127.0.0.1:2019
 EOF
 
-echo "Deployment complete! Running $short_sha"
+if [ -n "$TARGET_SERVICE" ]; then
+  echo "Deployment complete! $TARGET_SERVICE running $short_sha"
+else
+  echo "Deployment complete! Running $short_sha"
+fi

--- a/deploy/consolidated/deploy.sh
+++ b/deploy/consolidated/deploy.sh
@@ -17,6 +17,7 @@ so what runs is reproducible and a rollback is just --sha.
 Options:
   -l, --list [COUNT]     Show the last COUNT commits (default 10) and exit
       --services         Show the deployable services and exit
+      --status           Show what each container is actually running, and exit
   -s, --sha SHA          Deploy a specific commit; default is the latest on main
       --latest           Deploy the latest commit on main (the default)
       --service NAME     Deploy only NAME, leaving the rest of the stack alone
@@ -73,6 +74,7 @@ describe() { # describe <sha> -> "subject", or a placeholder when not local
 
 LIST_COUNT=""
 LIST_SERVICES=0
+SHOW_STATUS=0
 TARGET_REF=""
 TARGET_SERVICE=""
 ASSUME_YES=0
@@ -91,6 +93,10 @@ while [ $# -gt 0 ]; do
       ;;
     --services)
       LIST_SERVICES=1
+      shift
+      ;;
+    --status)
+      SHOW_STATUS=1
       shift
       ;;
     -s | --sha)
@@ -146,13 +152,55 @@ if [ -n "$TARGET_SERVICE" ] && ! service_names | grep -qx "$TARGET_SERVICE"; the
   exit 1
 fi
 
-# Deploy targets are commits on main that CI has already published, so resolve
-# against the remote rather than whatever the local checkout happens to be on.
-git fetch --quiet origin main
-
 # One round trip; the host's .env is both the pin store and the secrets file.
 host_env=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$HOST" 'cat ~/.env' 2>/dev/null || true)
 host_pin() { printf '%s\n' "$host_env" | sed -n "s/^$1=//p" | tail -1; }
+
+# What the host records is only the intent; the containers are the fact. They
+# diverge when a container wasn't recreated, so read them rather than infer.
+if [ "$SHOW_STATUS" -eq 1 ]; then
+  running=$(ssh -o BatchMode=yes -o ConnectTimeout=10 "$HOST" \
+    "sudo docker ps -a --filter label=com.docker.compose.service \
+       --format '{{.Label \"com.docker.compose.service\"}}|{{.Image}}|{{.Status}}'" 2>/dev/null)
+  if [ -z "$running" ]; then
+    echo "Error: could not read container state from $HOST" >&2
+    exit 1
+  fi
+  printf '%-18s  %-9s  %s\n' "SERVICE" "VERSION" "STATE"
+  drifted=0
+  while IFS='|' read -r svc image state; do
+    [ -n "$svc" ] || continue
+    tag=${image##*:}
+    shown=$tag
+    case "$tag" in
+      # Show a revision the way --list does; leave third-party tags alone.
+      [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) shown=${tag:0:7} ;;
+    esac
+    note=""
+    case "$image" in
+      ghcr.io/muchq/*)
+        expected=$(host_pin "$(sha_var_for "$svc")")
+        [ -n "$expected" ] || expected=$(host_pin DEPLOY_SHA)
+        if [ -n "$expected" ] && [ "$tag" != "$expected" ]; then
+          note="  <- .env says ${expected:0:7}"
+          drifted=$((drifted + 1))
+        fi
+        ;;
+    esac
+    printf '%-18s  %-9s  %s%s\n' "$svc" "$shown" "$state" "$note"
+  done <<< "$(printf '%s\n' "$running" | sort)"
+  if [ "$drifted" -gt 0 ]; then
+    echo
+    echo "$drifted container(s) are not running the recorded revision — a deploy" >&2
+    echo "may not have recreated them. A full deploy re-converges the stack." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# Deploy targets are commits on main that CI has already published, so resolve
+# against the remote rather than whatever the local checkout happens to be on.
+git fetch --quiet origin main
 
 if [ -n "$TARGET_SERVICE" ]; then
   deployed_sha=$(host_pin "$(sha_var_for "$TARGET_SERVICE")")

--- a/deploy/consolidated/deploy.sh
+++ b/deploy/consolidated/deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Paths below are repo-relative; self-locate so this works from any directory.
+cd "$(dirname "$0")/../.." || exit 1
+
 HOST=ubuntu@consolidated.cmptr.info
 COMPOSE_FILE=deploy/consolidated/compose.yaml
 
@@ -8,8 +11,8 @@ usage() {
   cat <<'USAGE'
 Usage: deploy.sh [OPTIONS]
 
-Deploys the consolidated stack. Every image is pinned to a commit SHA, so what
-runs is reproducible and a rollback is just --sha.
+Deploys the consolidated stack. Every service image is pinned to a commit SHA,
+so what runs is reproducible and a rollback is just --sha.
 
 Options:
   -l, --list [COUNT]     Show the last COUNT commits (default 10) and exit
@@ -30,14 +33,26 @@ dragging the rest of the stack along.
 USAGE
 }
 
-# Service name -> description, read from the compose file so it stays the one
-# source of truth (the labels also land on the containers).
+# The services that carry a pinned image, from the image lines themselves so
+# this can't drift from what compose actually deploys.
+service_names() {
+  grep -o 'ghcr\.io/muchq/[a-z0-9_-]*' "$COMPOSE_FILE" | sed 's|.*/||' | sort -u
+}
+
+# Every pin variable compose.yaml reads, taken from the file that consumes
+# them. Load-bearing: these are the vars a deploy rewrites on the host.
+pin_vars() {
+  grep -o '\${[A-Z0-9_]*_SHA' "$COMPOSE_FILE" | tr -d '${' | sort -u
+}
+
+# Descriptions for --services. Display only — a missing or reformatted label
+# costs a row in the listing, it can't affect what gets deployed.
 service_table() {
   awk '
     /^services:/ { in_services = 1; next }
     /^[a-z]/     { in_services = 0 }
     in_services && /^  [a-z0-9_-]+:$/ { svc = $1; sub(/:$/, "", svc); next }
-    in_services && /^      com\.muchq\.description:/ {
+    in_services && /com\.muchq\.description:/ {
       sub(/^ *com\.muchq\.description: */, "")
       gsub(/^"|"$/, "")
       if (svc != "") print svc "|" $0
@@ -46,10 +61,15 @@ service_table() {
   ' "$COMPOSE_FILE"
 }
 
-service_names() { service_table | cut -d'|' -f1; }
-
 # golf_hub -> GOLF_HUB_SHA, microgpt-serve -> MICROGPT_SERVE_SHA
-sha_var_for() { echo "$1" | tr 'a-z-' 'A-Z_' | sed 's/$/_SHA/'; }
+sha_var_for() {
+  local name=${1//-/_}
+  echo "${name^^}_SHA"
+}
+
+describe() { # describe <sha> -> "subject", or a placeholder when not local
+  git log -1 --pretty=%s "$1" 2>/dev/null || echo "(unknown commit)"
+}
 
 LIST_COUNT=""
 LIST_SERVICES=0
@@ -114,6 +134,9 @@ if [ "$LIST_SERVICES" -eq 1 ]; then
   service_table | while IFS='|' read -r svc desc; do
     printf '%-18s  %s\n' "$svc" "$desc"
   done
+  if [ "$(service_table | wc -l)" -ne "$(service_names | wc -l)" ]; then
+    echo "(note: some services have no com.muchq.description label)" >&2
+  fi
   exit 0
 fi
 
@@ -127,24 +150,17 @@ fi
 # against the remote rather than whatever the local checkout happens to be on.
 git fetch --quiet origin main
 
-# Best-effort: the host records what it last deployed, which labels the table
-# and gives the confirmation prompt a before/after.
-if [ -n "$TARGET_SERVICE" ]; then
-  deployed_var=$(sha_var_for "$TARGET_SERVICE")
-else
-  deployed_var=DEPLOY_SHA
-fi
-deployed_sha=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$HOST" \
-  "grep -s '^${deployed_var}=' ~/.env | cut -d= -f2" 2>/dev/null || true)
-# A service with no pin of its own is running the stack-wide revision.
-if [ -z "$deployed_sha" ] && [ -n "$TARGET_SERVICE" ]; then
-  deployed_sha=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$HOST" \
-    "grep -s '^DEPLOY_SHA=' ~/.env | cut -d= -f2" 2>/dev/null || true)
-fi
+# One round trip; the host's .env is both the pin store and the secrets file.
+host_env=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$HOST" 'cat ~/.env' 2>/dev/null || true)
+host_pin() { printf '%s\n' "$host_env" | sed -n "s/^$1=//p" | tail -1; }
 
-describe() { # describe <sha> -> "subject", or a placeholder when not local
-  git log -1 --pretty=%s "$1" 2>/dev/null || echo "(unknown commit)"
-}
+if [ -n "$TARGET_SERVICE" ]; then
+  deployed_sha=$(host_pin "$(sha_var_for "$TARGET_SERVICE")")
+  # A service with no pin of its own is running the stack-wide revision.
+  [ -n "$deployed_sha" ] || deployed_sha=$(host_pin DEPLOY_SHA)
+else
+  deployed_sha=$(host_pin DEPLOY_SHA)
+fi
 
 if [ -n "$LIST_COUNT" ]; then
   printf '%-9s  %-10s  %s\n' "COMMIT" "DATE" "SUBJECT"
@@ -170,12 +186,9 @@ else
 fi
 export DEPLOY_SHA
 short_sha=$(git rev-parse --short "$DEPLOY_SHA")
+target_desc=${TARGET_SERVICE:-all services}
 
-if [ -n "$TARGET_SERVICE" ]; then
-  echo "Deploying $TARGET_SERVICE at $short_sha  $(describe "$DEPLOY_SHA")"
-else
-  echo "Deploying all services at $short_sha  $(describe "$DEPLOY_SHA")"
-fi
+echo "Deploying $target_desc at $short_sha  $(describe "$DEPLOY_SHA")"
 if [ -n "$deployed_sha" ] && [ "$deployed_sha" != "$DEPLOY_SHA" ]; then
   echo "Replacing $(git rev-parse --short "$deployed_sha" 2>/dev/null || echo "$deployed_sha")  $(describe "$deployed_sha")"
 elif [ "$deployed_sha" = "$DEPLOY_SHA" ]; then
@@ -184,7 +197,7 @@ fi
 
 if [ "$ASSUME_YES" -ne 1 ]; then
   printf 'Proceed? [y/N] '
-  read -r reply
+  read -r reply || reply=""
   case "$reply" in
     [yY] | [yY][eE][sS]) ;;
     *)
@@ -196,33 +209,49 @@ fi
 
 # Fail before touching the host: a SHA whose publish build is still running (or
 # failed) has no images, and finding that out at `compose pull` would leave the
-# host half-updated.
+# host half-updated. Space-separated — this list is expanded into a remote `for`
+# loop, where a newline would end the loop header instead of separating words.
 if [ -n "$TARGET_SERVICE" ]; then
   images="ghcr.io/muchq/$TARGET_SERVICE"
 else
-  images=$(grep -o 'ghcr\.io/muchq/[a-z0-9_-]*' "$COMPOSE_FILE" | sort -u)
+  images=$(grep -o 'ghcr\.io/muchq/[a-z0-9_-]*' "$COMPOSE_FILE" | sort -u | tr '\n' ' ')
 fi
 echo "Verifying published images for $short_sha..."
 missing=$(ssh "$HOST" "for img in $images; do sudo docker manifest inspect \$img:$DEPLOY_SHA >/dev/null 2>&1 || echo \$img; done")
 if [ -n "$missing" ]; then
   echo "Error: no image published at $short_sha for:" >&2
   echo "$missing" | sed 's/^/  /' >&2
-  echo "Its publish build may still be running or may have failed." >&2
+  echo "Either that commit's publish build is unfinished or failed, or the" >&2
+  echo "service did not exist yet at that commit." >&2
   exit 1
 fi
 
 # A full deploy converges the stack on one revision, so it also clears the
 # per-service pins; --service sets just its own.
+all_pin_vars=$(pin_vars | tr '\n' ' ')
 if [ -n "$TARGET_SERVICE" ]; then
-  stale_vars=$(sha_var_for "$TARGET_SERVICE")
-  env_line="$(sha_var_for "$TARGET_SERVICE")=$DEPLOY_SHA"
+  replaced_vars=$(sha_var_for "$TARGET_SERVICE")
+  env_line="$replaced_vars=$DEPLOY_SHA"
   # Scoped to one service, so nothing here should reap the others.
   up_flags=""
 else
-  stale_vars="DEPLOY_SHA $(service_names | while read -r s; do sha_var_for "$s"; done | tr '\n' ' ')"
+  replaced_vars=$all_pin_vars
   env_line="DEPLOY_SHA=$DEPLOY_SHA"
   up_flags="--remove-orphans"
 fi
+
+# The scp below replaces the host's ~/.env wholesale, and the local copy holds
+# secrets only — so carry over the pins this deploy isn't replacing. Without
+# this a --service run drops DEPLOY_SHA, and every other service would come
+# back on :latest at the next reboot.
+preserved_pins=""
+for var in $all_pin_vars; do
+  case " $replaced_vars " in
+    *" $var "*) continue ;;
+  esac
+  val=$(host_pin "$var")
+  [ -n "$val" ] && preserved_pins="$preserved_pins $var=$val"
+done
 
 # Copy deployment files
 echo "Copying deployment files..."
@@ -253,11 +282,6 @@ fi
 # Pull images and restart services
 echo "Pulling images and restarting services..."
 ssh "$HOST" << EOF
-  # Export environment variables if .env exists
-  if [ -f ".env" ]; then
-    export \$(cat .env | grep -v '^#' | xargs)
-  fi
-
   # Move r3dr static assets to web root
   sudo mkdir -p /var/www/r3dr
   sudo cp -r ~/r3dr-assets/* /var/www/r3dr/
@@ -282,16 +306,23 @@ ssh "$HOST" << EOF
   fi
 
   # Record the revision being deployed. compose.yaml reads these to pin image
-  # tags, so the file is what the stack comes back up on after an unattended
-  # \`compose up\` (a reboot, a manual restart).
+  # tags, so this file is what the stack comes back up on after an unattended
+  # \`compose up\` (a reboot, a manual restart). Rewritten after the scp above,
+  # which would otherwise have dropped the pins.
   touch ~/.env
   cp ~/.env ~/.env.tmp
-  for var in ${stale_vars}; do
+  for var in ${all_pin_vars}; do
     grep -v "^\${var}=" ~/.env.tmp > ~/.env.next || true
     mv ~/.env.next ~/.env.tmp
   done
+  for pin in ${preserved_pins}; do
+    echo "\$pin" >> ~/.env.tmp
+  done
   echo "${env_line}" >> ~/.env.tmp
   mv ~/.env.tmp ~/.env
+  chmod 600 ~/.env
+  # Export only after the rewrite: exporting the old file first would leave a
+  # replaced pin in the environment, where it outranks the .env file.
   export \$(cat ~/.env | grep -v '^#' | xargs)
 
   sudo -E docker compose -f compose.yaml -f docker-compose.observability.yml pull ${TARGET_SERVICE}
@@ -300,11 +331,7 @@ ssh "$HOST" << EOF
   # Reload Caddy configuration. Target the admin API on IPv4 explicitly: inside
   # the container \`localhost\` resolves to ::1 first, but Caddy's admin endpoint
   # listens only on 127.0.0.1:2019, so the default localhost reload is refused.
-  sudo docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile --address 127.0.0.1:2019
+  sudo -E docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile --address 127.0.0.1:2019
 EOF
 
-if [ -n "$TARGET_SERVICE" ]; then
-  echo "Deployment complete! $TARGET_SERVICE running $short_sha"
-else
-  echo "Deployment complete! Running $short_sha"
-fi
+echo "Deployment complete! $target_desc running $short_sha"

--- a/scripts/test-deploy
+++ b/scripts/test-deploy
@@ -1,0 +1,259 @@
+#!/bin/bash
+# Exercises deploy.sh end to end without a host, a docker daemon, or a network.
+#
+# The remote half of a deploy is just a string handed to ssh, so a stub `ssh`
+# that *executes* what it receives — against a throwaway HOME and a stub
+# `docker` — runs the real code path, including the heredoc. That's the half
+# local testing otherwise can't reach, and where the bugs have been.
+set -uo pipefail
+
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+STUBS=$WORK/bin
+TESTROOT=$WORK/repo
+ORIGIN=$WORK/origin.git
+HOSTDIR=$WORK/host
+DOCKER_LOG=$WORK/docker.log
+
+FAILURES=0
+pass() { echo "  ok    $1"; }
+fail() {
+  echo "  FAIL  $1"
+  FAILURES=$((FAILURES + 1))
+}
+check() { # check <description> <condition-as-args>
+  local desc=$1
+  shift
+  if "$@"; then pass "$desc"; else fail "$desc"; fi
+}
+host_env_has() { grep -qx "$1" "$HOSTDIR/.env"; }
+host_env_lacks() { ! grep -q "^$1=" "$HOSTDIR/.env"; }
+
+# ---------------------------------------------------------------- stubs
+
+make_stubs() {
+  mkdir -p "$STUBS"
+
+  # Runs the received command (or heredoc on stdin) against the fake host.
+  # `~` resolves through HOME, so the script's ~/.env manipulation lands there.
+  cat > "$STUBS/ssh" <<'STUB'
+#!/bin/bash
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) shift 2 ;;
+    -*) shift ;;
+    *) break ;;
+  esac
+done
+shift # host
+export HOME="$FAKE_HOST"
+cd "$FAKE_HOST" || exit 1
+if [ $# -gt 0 ]; then bash -c "$*"; else bash -s; fi
+STUB
+
+  cat > "$STUBS/scp" <<'STUB'
+#!/bin/bash
+args=()
+for a in "$@"; do [ "$a" = "-r" ] || args+=("$a"); done
+dest=${args[-1]}
+unset 'args[-1]'
+path=${dest#*:}   # host:~/foo -> ~/foo
+path=${path#\~/}
+target="$FAKE_HOST/$path"
+case "$dest" in
+  */) mkdir -p "$target" ;;
+  *) mkdir -p "$(dirname "$target")" ;;
+esac
+cp -r "${args[@]}" "$target" 2>/dev/null || true
+STUB
+
+  # Only docker is really run; mkdir/cp/chown against absolute host paths
+  # (/var/www, /etc/forgejo) are neutralised so a test can't touch this machine.
+  cat > "$STUBS/sudo" <<'STUB'
+#!/bin/bash
+[ "$1" = "-E" ] && shift
+case "$1" in
+  docker) exec "$@" ;;
+  *) exit 0 ;;
+esac
+STUB
+
+  # Records what compose would have been invoked with, including the pin
+  # variables visible in its environment — that's how a stale exported pin
+  # beating the .env file becomes observable.
+  cat > "$STUBS/docker" <<'STUB'
+#!/bin/bash
+case "$1 $2" in
+  "manifest inspect")
+    for missing in $FAKE_MISSING_IMAGES; do
+      case "$3" in "$missing":*) exit 1 ;; esac
+    done
+    exit 0
+    ;;
+  "network inspect")
+    # Report the expected subnet so the script doesn't tear the network down.
+    [ "$3" = "--format" ] || [ "$4" = "--format" ] && echo "172.28.0.0/16|172.28.1.0/24"
+    exit 0
+    ;;
+esac
+pins=$(env | grep -E '^([A-Z0-9_]+_SHA)=' | sort | tr '\n' ' ')
+echo "docker $* || env: $pins" >> "$DOCKER_LOG"
+exit 0
+STUB
+
+  chmod +x "$STUBS"/*
+}
+
+# ---------------------------------------------------------------- fixture
+
+# A throwaway repo so deploy.sh's real git calls work offline: it self-locates
+# to its ../.. and resolves targets against origin/main.
+make_repo() {
+  rm -rf "$TESTROOT" "$ORIGIN"
+  mkdir -p "$TESTROOT/deploy/consolidated/o11y" \
+    "$TESTROOT/deploy/consolidated/forgejo" \
+    "$TESTROOT/domains/r3dr/apps/r3dr_web"
+  cp "$REPO/deploy/consolidated/deploy.sh" "$TESTROOT/deploy/consolidated/"
+  cp "$REPO/deploy/consolidated/compose.yaml" "$TESTROOT/deploy/consolidated/"
+  cp "$REPO/deploy/consolidated/docker-compose.observability.yml" "$TESTROOT/deploy/consolidated/"
+  cp "$REPO/deploy/consolidated/o11y/"* "$TESTROOT/deploy/consolidated/o11y/"
+  echo "# caddy" > "$TESTROOT/deploy/consolidated/Caddyfile"
+  echo "[server]" > "$TESTROOT/deploy/consolidated/forgejo/app.ini"
+  echo "<html></html>" > "$TESTROOT/domains/r3dr/apps/r3dr_web/index.html"
+
+  git -C "$TESTROOT" init -q -b main
+  local g="git -C $TESTROOT -c user.email=t@example.com -c user.name=test"
+  $g add -A
+  $g commit -qm "older change (#1001)"
+  echo "x" > "$TESTROOT/domains/r3dr/apps/r3dr_web/v2.txt"
+  $g add -A
+  $g commit -qm "middle change (#1002)"
+  echo "y" >> "$TESTROOT/domains/r3dr/apps/r3dr_web/v2.txt"
+  $g add -A
+  $g commit -qm "newest change (#1003)"
+
+  git init -q --bare "$ORIGIN"
+  git -C "$TESTROOT" remote add origin "$ORIGIN"
+  git -C "$TESTROOT" push -q origin main
+  git -C "$TESTROOT" fetch -q origin main
+
+  # Untracked, like the real one (.gitignore'd) and holding secrets only. Its
+  # presence matters: deploy.sh copies it over the host's ~/.env, which is
+  # what made a targeted deploy drop the pins the host was relying on.
+  {
+    echo "ONE_D4_DB_PASSWORD=supersecret"
+    echo "ONE_D4_SENTRY_DSN=https://sentry.example"
+  } > "$TESTROOT/.env"
+}
+
+# Fake host carrying secrets plus whatever pins a scenario starts from.
+reset_host() {
+  rm -rf "$HOSTDIR"
+  mkdir -p "$HOSTDIR"
+  : > "$DOCKER_LOG"
+  {
+    echo "ONE_D4_DB_PASSWORD=supersecret"
+    echo "ONE_D4_SENTRY_DSN=https://sentry.example"
+    for line in "$@"; do echo "$line"; done
+  } > "$HOSTDIR/.env"
+  chmod 600 "$HOSTDIR/.env"
+}
+
+deploy() { # deploy <args...> -> exit code, output in $WORK/out.txt
+  # Run from the fixture so the script under test can't reach the real repo,
+  # whether or not it self-locates.
+  (
+    cd "$TESTROOT" || exit 1
+    PATH="$STUBS:$PATH" FAKE_HOST="$HOSTDIR" DOCKER_LOG="$DOCKER_LOG" \
+      FAKE_MISSING_IMAGES="${FAKE_MISSING_IMAGES:-}" \
+      bash deploy/consolidated/deploy.sh "$@"
+  ) > "$WORK/out.txt" 2>&1
+}
+
+# ---------------------------------------------------------------- cases
+
+make_stubs
+make_repo
+SHA=$(git -C "$TESTROOT" rev-parse origin/main)
+OLD_SHA=$(git -C "$TESTROOT" rev-parse "origin/main~2")
+
+echo "full deploy"
+reset_host "DEPLOY_SHA=previoussha"
+deploy -y
+rc=$?
+check "exits 0" test $rc -eq 0
+check "pins DEPLOY_SHA to the target commit" host_env_has "DEPLOY_SHA=$SHA"
+check "keeps secrets" host_env_has "ONE_D4_DB_PASSWORD=supersecret"
+check "pulls and ups every service" \
+  grep -q -- "up -d --remove-orphans" "$DOCKER_LOG"
+check "keeps .env at mode 600" \
+  test "$(stat -c '%a' "$HOSTDIR/.env" 2>/dev/null || stat -f '%Lp' "$HOSTDIR/.env")" = 600
+
+echo "targeted deploy"
+reset_host "DEPLOY_SHA=stackwidesha" "POSTERIZE_SHA=posterizepin"
+deploy --service mithril -y
+rc=$?
+check "exits 0" test $rc -eq 0
+check "pins the named service" host_env_has "MITHRIL_SHA=$SHA"
+# The regression: scp of the local .env drops the pins, so an unrestored
+# DEPLOY_SHA left every other service resolving to :latest after a reboot.
+check "preserves the stack-wide pin" host_env_has "DEPLOY_SHA=stackwidesha"
+check "preserves another service's pin" host_env_has "POSTERIZE_SHA=posterizepin"
+check "does not reap other services" \
+  bash -c '! grep -q -- "--remove-orphans" "$0"' "$DOCKER_LOG"
+
+echo "full deploy clears per-service pins"
+reset_host "DEPLOY_SHA=stackwidesha" "POSTERIZE_SHA=posterizepin"
+deploy -y
+check "removes the per-service pin from .env" host_env_lacks POSTERIZE_SHA
+# Guard the next check against passing vacuously: if the deploy died before
+# compose ran, an empty log would satisfy the absence assertion below.
+check "reaches compose" test -s "$DOCKER_LOG"
+# export cannot unset, so exporting .env before the rewrite left a cleared pin
+# in the environment, where compose prefers it over the file.
+check "cleared pin is absent from compose's environment" \
+  bash -c '! grep -q "POSTERIZE_SHA=posterizepin" "$0"' "$DOCKER_LOG"
+
+echo "unpublished commit"
+reset_host "DEPLOY_SHA=stackwidesha"
+FAKE_MISSING_IMAGES="ghcr.io/muchq/mithril" deploy -y
+rc=$?
+check "refuses to deploy" test $rc -ne 0
+check "names the missing image" grep -q "ghcr.io/muchq/mithril" "$WORK/out.txt"
+check "leaves the host untouched" host_env_has "DEPLOY_SHA=stackwidesha"
+check "runs no compose commands" test ! -s "$DOCKER_LOG"
+
+echo "rollback to an older commit"
+reset_host "DEPLOY_SHA=$SHA"
+deploy --sha "$OLD_SHA" -y
+check "pins to the older commit" host_env_has "DEPLOY_SHA=$OLD_SHA"
+
+echo "listings"
+reset_host "DEPLOY_SHA=$SHA"
+deploy --list 3
+check "lists the requested number of commits" \
+  test "$(tail -n +2 "$WORK/out.txt" | wc -l)" -eq 3
+check "shows PR numbers from commit subjects" grep -q "(#1003)" "$WORK/out.txt"
+check "marks the deployed commit" grep -q -- "<- deployed" "$WORK/out.txt"
+deploy --services
+check "lists every pinned service" \
+  test "$(tail -n +2 "$WORK/out.txt" | wc -l)" -eq \
+  "$(grep -c 'image: ghcr.io/muchq/' "$REPO/deploy/consolidated/compose.yaml")"
+
+echo "argument handling"
+deploy --service nope -y
+check "rejects an unknown service" test $? -ne 0
+deploy --sha definitelynotacommit -y
+check "rejects an unknown commit" test $? -ne 0
+deploy --bogus
+check "rejects an unknown flag" test $? -ne 0
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "all deploy.sh checks passed"
+else
+  echo "$FAILURES check(s) failed"
+fi
+exit $((FAILURES > 0))

--- a/scripts/test-deploy
+++ b/scripts/test-deploy
@@ -85,23 +85,38 @@ STUB
   # beating the .env file becomes observable.
   cat > "$STUBS/docker" <<'STUB'
 #!/bin/bash
-case "$1 $2" in
-  "manifest inspect")
+case "$1" in
+  manifest)
     for missing in $FAKE_MISSING_IMAGES; do
       case "$3" in "$missing":*) exit 1 ;; esac
     done
     exit 0
     ;;
-  "network inspect")
+  network)
     # Report the expected subnet so the script doesn't tear the network down.
-    [ "$3" = "--format" ] || [ "$4" = "--format" ] && echo "172.28.0.0/16|172.28.1.0/24"
+    echo "172.28.0.0/16|172.28.1.0/24"
     exit 0
     ;;
-  "ps -a")
-    printf '%s\n' "$FAKE_PS"
+  ps)
+    # -aq is asked for ids; the rest of the stub uses service names as ids.
+    case "$*" in
+      *-aq*) printf '%s\n' "$FAKE_PS" | sed 's/|.*//' ;;
+      *) printf '%s\n' "$FAKE_PS" | sed 's/^/S|/' ;;
+    esac
+    exit 0
+    ;;
+  inspect)
+    shift 3 # past `inspect --format <template>`
+    for svc in "$@"; do
+      count=$(printf '%s\n' "$FAKE_RESTARTS" | sed -n "s/^$svc|//p")
+      echo "R|$svc|${count:-0}"
+    done
     exit 0
     ;;
 esac
+# Records what compose would have been invoked with, including the pin
+# variables visible in its environment — that's how a stale exported pin
+# beating the .env file becomes observable.
 pins=$(env | grep -E '^([A-Z0-9_]+_SHA)=' | sort | tr '\n' ' ')
 echo "docker $* || env: $pins" >> "$DOCKER_LOG"
 exit 0
@@ -172,6 +187,7 @@ deploy() { # deploy <args...> -> exit code, output in $WORK/out.txt
     cd "$TESTROOT" || exit 1
     PATH="$STUBS:$PATH" FAKE_HOST="$HOSTDIR" DOCKER_LOG="$DOCKER_LOG" \
       FAKE_MISSING_IMAGES="${FAKE_MISSING_IMAGES:-}" FAKE_PS="${FAKE_PS:-}" \
+      FAKE_RESTARTS="${FAKE_RESTARTS:-}" \
       bash deploy/consolidated/deploy.sh "$@"
   ) > "$WORK/out.txt" 2>&1
 }
@@ -250,9 +266,12 @@ echo "status"
 reset_host "DEPLOY_SHA=$SHA" "POSTERIZE_SHA=posterizepin"
 FAKE_PS="golf_hub|ghcr.io/muchq/golf_hub:$SHA|Up 2 hours
 posterize|ghcr.io/muchq/posterize:posterizepin|Up 5 minutes
-caddy|caddy:2-alpine|Up 2 hours" deploy --status
+caddy|caddy:2-alpine|Up 2 hours" \
+  FAKE_RESTARTS="golf_hub|0
+posterize|0
+caddy|0" deploy --status
 rc=$?
-check "exits 0 when everything matches" test $rc -eq 0
+check "exits 0 when everything is healthy and matching" test $rc -eq 0
 check "reports the running revision" grep -q "golf_hub .*${SHA:0:7}" "$WORK/out.txt"
 check "honours a per-service pin" grep -q "posterize .*posterizepin" "$WORK/out.txt"
 check "includes third-party containers" grep -q "caddy .*2-alpine" "$WORK/out.txt"
@@ -261,11 +280,27 @@ check "includes third-party containers" grep -q "caddy .*2-alpine" "$WORK/out.tx
 # the new one — the divergence --status exists to surface.
 reset_host "DEPLOY_SHA=$SHA"
 FAKE_PS="golf_hub|ghcr.io/muchq/golf_hub:$SHA|Up 2 hours
-mithril|ghcr.io/muchq/mithril:$OLD_SHA|Up 3 days" deploy --status
+mithril|ghcr.io/muchq/mithril:$OLD_SHA|Up 3 days" \
+  FAKE_RESTARTS="golf_hub|0
+mithril|0" deploy --status
 rc=$?
 check "fails when a container drifted from .env" test $rc -ne 0
 check "names the drifted service" grep -q "mithril" "$WORK/out.txt"
 check "shows what .env expected" grep -q "\.env says ${SHA:0:7}" "$WORK/out.txt"
+
+# The shape of the incident this all came from: right revision, but the
+# container can't stay up. A climbing restart count is the tell.
+reset_host "DEPLOY_SHA=$SHA"
+FAKE_PS="golf_hub|ghcr.io/muchq/golf_hub:$SHA|Up 2 hours
+posterize|ghcr.io/muchq/posterize:$SHA|Restarting (101) 8 seconds ago" \
+  FAKE_RESTARTS="golf_hub|0
+posterize|47" deploy --status
+rc=$?
+check "fails when a container is not up" test $rc -ne 0
+check "shows the restart count" grep -qE "posterize .*47" "$WORK/out.txt"
+check "surfaces the exit code from the state" grep -q "Restarting (101)" "$WORK/out.txt"
+check "calls out the crash loop" grep -q "crash loop" "$WORK/out.txt"
+check "reports a healthy peer as 0 restarts" grep -qE "golf_hub .*0 " "$WORK/out.txt"
 
 echo "argument handling"
 deploy --service nope -y

--- a/scripts/test-deploy
+++ b/scripts/test-deploy
@@ -97,6 +97,10 @@ case "$1 $2" in
     [ "$3" = "--format" ] || [ "$4" = "--format" ] && echo "172.28.0.0/16|172.28.1.0/24"
     exit 0
     ;;
+  "ps -a")
+    printf '%s\n' "$FAKE_PS"
+    exit 0
+    ;;
 esac
 pins=$(env | grep -E '^([A-Z0-9_]+_SHA)=' | sort | tr '\n' ' ')
 echo "docker $* || env: $pins" >> "$DOCKER_LOG"
@@ -167,7 +171,7 @@ deploy() { # deploy <args...> -> exit code, output in $WORK/out.txt
   (
     cd "$TESTROOT" || exit 1
     PATH="$STUBS:$PATH" FAKE_HOST="$HOSTDIR" DOCKER_LOG="$DOCKER_LOG" \
-      FAKE_MISSING_IMAGES="${FAKE_MISSING_IMAGES:-}" \
+      FAKE_MISSING_IMAGES="${FAKE_MISSING_IMAGES:-}" FAKE_PS="${FAKE_PS:-}" \
       bash deploy/consolidated/deploy.sh "$@"
   ) > "$WORK/out.txt" 2>&1
 }
@@ -241,6 +245,27 @@ deploy --services
 check "lists every pinned service" \
   test "$(tail -n +2 "$WORK/out.txt" | wc -l)" -eq \
   "$(grep -c 'image: ghcr.io/muchq/' "$REPO/deploy/consolidated/compose.yaml")"
+
+echo "status"
+reset_host "DEPLOY_SHA=$SHA" "POSTERIZE_SHA=posterizepin"
+FAKE_PS="golf_hub|ghcr.io/muchq/golf_hub:$SHA|Up 2 hours
+posterize|ghcr.io/muchq/posterize:posterizepin|Up 5 minutes
+caddy|caddy:2-alpine|Up 2 hours" deploy --status
+rc=$?
+check "exits 0 when everything matches" test $rc -eq 0
+check "reports the running revision" grep -q "golf_hub .*${SHA:0:7}" "$WORK/out.txt"
+check "honours a per-service pin" grep -q "posterize .*posterizepin" "$WORK/out.txt"
+check "includes third-party containers" grep -q "caddy .*2-alpine" "$WORK/out.txt"
+
+# A container the deploy didn't recreate keeps its old image while .env claims
+# the new one — the divergence --status exists to surface.
+reset_host "DEPLOY_SHA=$SHA"
+FAKE_PS="golf_hub|ghcr.io/muchq/golf_hub:$SHA|Up 2 hours
+mithril|ghcr.io/muchq/mithril:$OLD_SHA|Up 3 days" deploy --status
+rc=$?
+check "fails when a container drifted from .env" test $rc -ne 0
+check "names the drifted service" grep -q "mithril" "$WORK/out.txt"
+check "shows what .env expected" grep -q "\.env says ${SHA:0:7}" "$WORK/out.txt"
 
 echo "argument handling"
 deploy --service nope -y


### PR DESCRIPTION
Emit side of #1208 (§4, running-version visibility), via **immutable `:sha` image tags** — plus the deploy ergonomics that pinning makes possible, and the first CI coverage this script has ever had.

## Why this shape

An earlier draft stamped the SHA into an OTEL resource attribute at deploy time. That was loose: it described the *asset checkout*, a separate fact from the image content, so it could drift from what was actually running.

Baking `org.opencontainers.image.revision` in via bazel `--stamp` is authoritative but cache-hostile. `STABLE_GIT_COMMIT` changes every commit, so every stamped action is invalidated every commit and **every image digest changes on every merge** even when the code is byte-identical — all images re-pushed each merge, every container recreated on every deploy. It also needs infra that doesn't exist here: a `workspace_status_command`, bazelrc wiring, a stamped label template in `oci.bzl`, and a cAdvisor label whitelist.

Pinning the tag gets the same guarantee with none of that:

- **Nothing touches bazel** — the build cache is unaffected, and an unchanged service still resolves to the same digest.
- **CI already publishes these tags** — `publish.yml` pushes `:<github.sha>` for every image (lines 54–61). No CI change at all.
- **The version can't lie** — the tag *selects* what runs rather than asserting something about it.
- Reproducible deploys and one-flag rollback fall out for free, and `:latest`'s mutable-tag ambiguity goes away.

## What changed

**compose.yaml**
- All 10 images → `ghcr.io/muchq/<svc>:${<SVC>_SHA:-${DEPLOY_SHA:-latest}}` — a stack-wide pin with a per-service override. `service.version` uses the same expression so the OTEL resource matches the image instead of reporting the constant `latest`. Falls back to `:latest` when everything is unset, so local runs (`local_deploy.sh` reuses this file) are unaffected.
- Each service gains a `com.muchq.description` label, so the compose file is the source of truth for what's deployable (and the descriptions land on the containers — handy for #1208's Containers tab).

**deploy.sh**
- Default deploys the latest commit on `origin/main` (resolved after a fetch, not local HEAD) and **confirms first**. Main is squash-merged, so the subject carries the PR number — no GitHub API needed:
  ```
  Deploying all services at 7faca68  server_pal: use reqwest's tls_certs_only for bundled roots (#1206)
  Replacing 1694f01  posterize: accept common image formats and preserve them on output (#1207)
  Proceed? [y/N]
  ```
- `--list [N]` — recent commits with the deployed one marked, for picking a rollback target.
- `--services` — what's deployable, with descriptions read from the compose labels.
- `--service NAME` — deploy one service without restarting the stack. Pins only that service so a hotfix survives a reboot; a full deploy clears every per-service pin so the stack reconverges.
- `--sha <sha>` for rollback, `--latest` as an explicit alias, `-y` to skip the prompt.
- **Pre-flight image check** — verifies the images exist at that SHA *before* copying anything.

**README** — documents the flow and replaces the old "hand-edit a pin into compose.yaml" rollback instructions.

## Review round — three defects found and fixed

A review pass caught three real bugs in the first version, all fixed in `75fe2ef`:

1. **Every full deploy aborted.** The pre-flight built a newline-separated image list and expanded it into a remote `for` loop, where a newline *ends the loop header* rather than separating words — the remote shell died with a syntax error before anything was copied. Only `--service` worked, because its list is a single word.
2. **`--service` destroyed the stack-wide pin.** The script scps the local `.env` (secrets only) over the host's, which drops every pin; a full deploy rewrote `DEPLOY_SHA` afterwards and looked fine, but a targeted deploy wrote only its own variable. The host was left with **no `DEPLOY_SHA`**, so the next reboot brought the other nine services up on `:latest` — the precise failure this PR exists to prevent, armed silently by the intended hotfix workflow.
3. **A cleared pin still won.** `.env` was exported *before* the rewrite, and `export` can't unset, so a pin the rewrite removed survived in the environment — where it outranks the `.env` file for compose. A full deploy could print one revision while compose ran another.

Also hardened: pin variables are derived from the compose lines that *read* them rather than from label parsing; `~/.env` keeps mode 600 instead of widening to 644; the script self-locates the repo root; and `read` handles EOF.

## CI coverage (`scripts/test-deploy`, new `test-deploy` job)

**All three bugs shipped CI-green, because nothing in CI ran this script.** Bug #1 in particular lived in the ssh path that local testing can't reach.

The remote half of a deploy is just a string handed to `ssh` — so a stub `ssh` that *executes* what it receives, against a throwaway `HOME` with stub `scp`/`sudo`/`docker` alongside, runs the real code path including the heredoc. No daemon, no network, no host; the fixture is a small git repo with its own `origin`, so the git calls work offline. It needs nothing but bash, and runs as a standalone job in about a second.

24 checks over: a full deploy pins every service and preserves secrets; a targeted deploy preserves the pins it isn't replacing; a full deploy clears per-service pins from both the file *and* compose's environment; an unpublished commit is refused before the host is touched; rollback, listings, and argument handling.

Validated against the pre-fix script — it fails 8 of them, precisely on the three defects, while the checks for behavior that was never broken still pass. One subtlety worth noting: the fixture carries an **untracked `.env`** like a real checkout, because bug #2 only fires when a local `.env` exists to be copied over the host's. Without that detail the biggest regression goes unseen — my first draft of the suite had exactly that hole.

## Known sharp edges (documented, not fixed)

- **Config doesn't roll back with images.** `compose.yaml`, the `Caddyfile`, `o11y/*`, and r3dr's assets are always copied from your working tree, so `--sha <old>` moves images but leaves current config in front of an older binary. Fixing it properly is awkward — an old commit's `compose.yaml` predates pinning and wouldn't honour `DEPLOY_SHA` at all. Called out in the README; deploy from a clean checkout of main.
- **Rollback reaches back only as far as the newest service.** The pre-flight requires an image at that commit for *every* service, and golf_hub only exists from 2026-07-21. The error says so and suggests `--service`.
- **The remote heredoc has no `set -e`** (pre-existing): a mid-deploy failure continues to the next step. Worth a follow-up.
- **First deploy recreates every container** — tag strings change for all 10, plus the one-time label addition. `caddy`, `one_d4_postgres`, and `forgejo` are untouched, so no database or forgejo data is at risk.

## Worth watching on the first deploy

Whether `compose up -d` recreates containers when the tag string changes but the resolved digest is identical. If it does, unchanged services restart on every deploy; the fix would be pinning by digest, which costs a sha→digest resolution step.