### PR TITLE
prom_proxy: surface container restarts and crash loops

### DIFF
--- a/domains/platform/apis/prom_proxy/handlers.go
+++ b/domains/platform/apis/prom_proxy/handlers.go
@@ -326,7 +326,9 @@ func (h *MetricsHandler) fetchContainerMetrics(ctx context.Context) (*ContainerM
 		}
 	}
 
-	// Fetch metrics for each container
+	// Fetch metrics for each container, including the restart churn that is a
+	// crash-looping service's only trace — it dies before serving anything, so
+	// its app metrics stay flat and look exactly like an idle service.
 	for _, name := range containerNames {
 		stats := ContainerStats{Name: name}
 
@@ -387,10 +389,43 @@ func (h *MetricsHandler) fetchContainerMetrics(ctx context.Context) (*ContainerM
 			}
 		}
 
+		// Restarts. cAdvisor exposes no restart counter, so count the steps in
+		// the container's start time: each restart re-stamps it.
+		restartQuery := fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[1h])`, name)
+		restartResp, err := h.promClient.Query(ctx, restartQuery)
+		if err == nil && len(restartResp.Data.Result) > 0 {
+			if val, err := extractFloatValue(&restartResp.Data.Result[0]); err == nil {
+				stats.RestartsLastHour = val
+			}
+		}
+
+		// How long the current run has lasted.
+		uptimeQuery := fmt.Sprintf(`time()-container_start_time_seconds{name="%s"}`, name)
+		uptimeResp, err := h.promClient.Query(ctx, uptimeQuery)
+		if err == nil && len(uptimeResp.Data.Result) > 0 {
+			if val, err := extractFloatValue(&uptimeResp.Data.Result[0]); err == nil {
+				stats.UptimeSeconds = val
+			}
+		}
+
+		stats.CrashLooping = isCrashLooping(stats.RestartsLastHour, stats.UptimeSeconds)
+
 		metrics.Containers = append(metrics.Containers, stats)
 	}
 
 	return metrics, nil
+}
+
+// A container is crash-looping when it keeps restarting and never stays up:
+// repeated restarts alone could be one bad hour it recovered from, and a young
+// container alone is just a fresh deploy. Together they mean it can't start.
+const (
+	crashLoopMinRestarts = 3
+	crashLoopMaxUptime   = 300 // seconds
+)
+
+func isCrashLooping(restartsLastHour, uptimeSeconds float64) bool {
+	return restartsLastHour >= crashLoopMinRestarts && uptimeSeconds < crashLoopMaxUptime
 }
 
 func (h *MetricsHandler) fetchContainerMetricsTimeSeries(ctx context.Context, timeRange TimeRange) (*TimeSeriesResponse, error) {
@@ -414,6 +449,9 @@ func (h *MetricsHandler) fetchContainerMetricsTimeSeries(ctx context.Context, ti
 		"memory_usage_percent": `(container_memory_usage_bytes/container_spec_memory_limit_bytes)*100`,
 		"network_rx":          `rate(container_network_receive_bytes_total[5m])`,
 		"network_tx":          `rate(container_network_transmit_bytes_total[5m])`,
+		// The history a point-in-time check can't give: restarts over the
+		// window, so a crash loop that resolved overnight is still visible.
+		"restarts": `changes(container_start_time_seconds[5m])`,
 	}
 
 	// Execute each query as a range query

--- a/domains/platform/apis/prom_proxy/handlers_test.go
+++ b/domains/platform/apis/prom_proxy/handlers_test.go
@@ -303,3 +303,71 @@ func scalarResponse(value string) *QueryResponse {
 		},
 	}
 }
+
+func TestIsCrashLooping(t *testing.T) {
+	tests := []struct {
+		name     string
+		restarts float64
+		uptime   float64
+		want     bool
+	}{
+		// The shape of the OTEL crash-loop: restarting constantly, never up
+		// long enough to serve a request, so its app metrics stay flat.
+		{"restarting and never up", 47, 8, true},
+		{"at the threshold", crashLoopMinRestarts, crashLoopMaxUptime - 1, true},
+		// A fresh deploy is young but stable; a rough hour it recovered from
+		// has the restarts without the youth. Neither is a crash loop now.
+		{"just deployed", 1, 5, false},
+		{"recovered after a bad patch", 12, crashLoopMaxUptime + 1, false},
+		{"healthy and long lived", 0, 86400, false},
+		// Prometheus returns nothing for a container it has never seen, which
+		// arrives here as zeroes; absence must not read as failure.
+		{"no data", 0, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCrashLooping(tt.restarts, tt.uptime))
+		})
+	}
+}
+
+func TestFetchContainerMetrics_SurfacesCrashLoop(t *testing.T) {
+	mock := &mockPrometheusClient{queryResponses: map[string]*QueryResponse{
+		`count by (name) (container_last_seen)`: {
+			Status: "success",
+			Data: struct {
+				ResultType string   `json:"resultType"`
+				Result     []Result `json:"result"`
+			}{
+				ResultType: "vector",
+				Result: []Result{
+					{Metric: map[string]string{"name": "posterize"}, Value: []interface{}{1609459200.0, "1"}},
+					{Metric: map[string]string{"name": "golf_hub"}, Value: []interface{}{1609459200.0, "1"}},
+				},
+			},
+		},
+		`changes(container_start_time_seconds{name="posterize"}[1h])`: scalarResponse("47"),
+		`time()-container_start_time_seconds{name="posterize"}`:       scalarResponse("8"),
+		`changes(container_start_time_seconds{name="golf_hub"}[1h])`:  scalarResponse("0"),
+		`time()-container_start_time_seconds{name="golf_hub"}`:        scalarResponse("86400"),
+	}}
+	handler := NewMetricsHandler(mock)
+
+	metrics, err := handler.fetchContainerMetrics(context.Background())
+	require.NoError(t, err)
+	require.Len(t, metrics.Containers, 2)
+
+	byName := map[string]ContainerStats{}
+	for _, c := range metrics.Containers {
+		byName[c.Name] = c
+	}
+
+	// Crash-looping: restarting constantly, never up long enough to serve.
+	assert.Equal(t, 47.0, byName["posterize"].RestartsLastHour)
+	assert.Equal(t, 8.0, byName["posterize"].UptimeSeconds)
+	assert.True(t, byName["posterize"].CrashLooping)
+
+	// A healthy neighbour must not be tarred by it.
+	assert.Equal(t, 0.0, byName["golf_hub"].RestartsLastHour)
+	assert.False(t, byName["golf_hub"].CrashLooping)
+}

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -107,6 +107,12 @@ type ContainerStats struct {
 	MemoryUsagePercent  float64 `json:"memory_usage_percent"`
 	NetworkRxBytes      float64 `json:"network_rx_bytes_per_sec"`
 	NetworkTxBytes      float64 `json:"network_tx_bytes_per_sec"`
+	// Restart churn and how long the current run has lasted. A container that
+	// dies on startup emits no app metrics at all, so these are the only
+	// signal that separates "crash-looping" from "idle" on a service page.
+	RestartsLastHour float64 `json:"restarts_last_hour"`
+	UptimeSeconds    float64 `json:"uptime_seconds"`
+	CrashLooping     bool    `json:"crash_looping"`
 }
 
 type ServiceCatalogEntry struct {

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -367,6 +367,8 @@ func TestMetricsHandler_GetHostMetricsTimeSeries(t *testing.T) {
 	// the merged payload can't collide.
 	assert.True(t, names["cpu_utilization"])
 	assert.True(t, names["container_cpu_usage"])
+	// Restart history is what makes a crash loop visible after the fact.
+	assert.True(t, names["container_restarts"])
 	assert.Equal(t, 5, hostSeries)
-	assert.Equal(t, 6, containerSeries)
+	assert.Equal(t, 7, containerSeries)
 }


### PR DESCRIPTION
Backend half of #1208 §1 — makes a crash-looping container visible on the metrics pages.

## Why

A service that dies during startup never serves a request, so its `http_server_*` series stay flat. On a dashboard built entirely from app-emitted metrics (#1199), that is **indistinguishable from an idle-but-healthy service** — no error, no gap, just quiet. That's exactly how the recent OTEL crash-loop (#1201 → #1205/#1206) stayed invisible, while cAdvisor was recording the restarts the entire time and nothing exposed them.

## What

Three fields on the existing per-container stats in the host payload, plus a series:

- `restarts_last_hour` — cAdvisor has no restart counter, so count the steps in the container's start time: `changes(container_start_time_seconds{name="X"}[1h])`. Each restart re-stamps it.
- `uptime_seconds` — `time()-container_start_time_seconds{name="X"}`
- `crash_looping` — derived, so the UI doesn't reimplement the rule
- a `restarts` timeseries (`changes(container_start_time_seconds[5m])`), which is the piece a point-in-time check can't give: a loop that started and resolved at 3am is still visible in the morning.

**The crash-loop rule needs both signals.** Repeated restarts alone can be a bad hour a service recovered from; a young container alone is just a fresh deploy. Together — ≥3 restarts in the last hour *and* under 5 minutes of uptime — they mean it can't stay up. Thresholds are named constants next to the predicate.

## Complements `deploy.sh --status` (#1210), doesn't duplicate it

The two see different things, and neither subsumes the other:

- **Only the docker socket** (`--status`) has the **exit code** and Docker's `RestartCount` — `Restarting (101)` names the Rust panic outright. cAdvisor exposes neither.
- **Only Prometheus** (here) has **history** — restarts over a window, and what happened while nobody was watching. A CLI can only ever report *now*.

So the CLI is what you run during a deploy, and this is what tells you a service has been flapping since 3am.

## Tests

- `TestIsCrashLooping` — table over the boundary cases: restarting-and-never-up, exactly at the threshold, just-deployed (young but stable), recovered-after-a-bad-patch (restarts but stable), healthy, and no-data. The last matters because Prometheus returns nothing for a container it has never seen, which arrives as zeroes — absence must not read as failure.
- `TestFetchContainerMetrics_SurfacesCrashLoop` — drives the real fetch through the mock's per-query map: a crash-looping container reports 47 restarts / 8s uptime / `crash_looping: true`, while a healthy neighbour in the same payload stays clean.
- Updated the host-timeseries test, which pinned the container series count at 6 and now asserts the `container_restarts` series exists.

`go test` and `go vet` clean on the package. Note `bazel test` couldn't run here — loading the package fetches `container_structure_test`, which the sandbox proxy 403s — so CI is the first bazel run.

## Next

The UI side (rendering this on the service-page health strip and the Containers tab) belongs in `muchq/muchq.github.io` alongside #235. Version-per-container is the other half of #1208 §4 and depends on #1210's `:sha` pinning landing first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_