### PR TITLE
deploy: keep deploy.sh working on bash 3.2, and test it there

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -28,6 +28,35 @@ jobs:
       - name: Test deploy.sh
         run: ./scripts/test-deploy
 
+  # deploy.sh runs from a developer machine, and macOS ships bash 3.2 as
+  # /bin/bash — no associative arrays or case-conversion expansions. The Linux
+  # job above runs bash 5 and cannot reproduce that, so run the same suite on a
+  # mac against /bin/bash explicitly.
+  test-deploy-macos:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for deploy changes
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD -- deploy/ scripts/test-deploy)
+          if [ -n "$CHANGED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Explicitly /bin/bash: the runner may have a newer bash earlier in PATH,
+      # which would defeat the point of running here at all.
+      - name: Test deploy.sh under system bash
+        if: steps.filter.outputs.changed == 'true'
+        run: |
+          /bin/bash --version | head -1
+          /bin/bash scripts/test-deploy
+
   format-check:
     runs-on: ubuntu-latest
     container:

--- a/deploy/consolidated/deploy.sh
+++ b/deploy/consolidated/deploy.sh
@@ -62,10 +62,11 @@ service_table() {
   ' "$COMPOSE_FILE"
 }
 
-# golf_hub -> GOLF_HUB_SHA, microgpt-serve -> MICROGPT_SERVE_SHA
+# golf_hub -> GOLF_HUB_SHA, microgpt-serve -> MICROGPT_SERVE_SHA.
+# tr rather than ${name^^}: macOS still ships bash 3.2, which has neither
+# case-conversion expansions nor associative arrays.
 sha_var_for() {
-  local name=${1//-/_}
-  echo "${name^^}_SHA"
+  echo "$1" | tr 'a-z-' 'A-Z_' | sed 's/$/_SHA/'
 }
 
 describe() { # describe <sha> -> "subject", or a placeholder when not local
@@ -175,10 +176,8 @@ if [ "$SHOW_STATUS" -eq 1 ]; then
     exit 1
   fi
 
-  declare -A restarts=()
-  while IFS='|' read -r kind svc count; do
-    [ "$kind" = "R" ] && [ -n "$svc" ] && restarts[$svc]=$count
-  done <<< "$running"
+  # A lookup rather than an associative array, which bash 3.2 lacks.
+  restarts_for() { printf '%s\n' "$running" | sed -n "s/^R|$1|//p" | tail -1; }
 
   printf '%-18s  %-9s  %-8s  %s\n' "SERVICE" "VERSION" "RESTARTS" "STATE"
   drifted=0
@@ -209,7 +208,8 @@ if [ "$SHOW_STATUS" -eq 1 ]; then
       Up*) ;;
       *) unhealthy=$((unhealthy + 1)) ;;
     esac
-    printf '%-18s  %-9s  %-8s  %s%s\n' "$svc" "$shown" "${restarts[$svc]:-?}" "$state" "$note"
+    count=$(restarts_for "$svc")
+    printf '%-18s  %-9s  %-8s  %s%s\n' "$svc" "$shown" "${count:-?}" "$state" "$note"
   done <<< "$(printf '%s\n' "$running" | sort)"
 
   if [ "$drifted" -gt 0 ] || [ "$unhealthy" -gt 0 ]; then

--- a/scripts/test-deploy
+++ b/scripts/test-deploy
@@ -57,8 +57,9 @@ STUB
 #!/bin/bash
 args=()
 for a in "$@"; do [ "$a" = "-r" ] || args+=("$a"); done
-dest=${args[-1]}
-unset 'args[-1]'
+last=$((${#args[@]} - 1))   # not ${args[-1]}; bash 3.2 has no negative indices
+dest=${args[$last]}
+unset "args[$last]"
 path=${dest#*:}   # host:~/foo -> ~/foo
 path=${path#\~/}
 target="$FAKE_HOST/$path"
@@ -301,6 +302,16 @@ check "shows the restart count" grep -qE "posterize .*47" "$WORK/out.txt"
 check "surfaces the exit code from the state" grep -q "Restarting (101)" "$WORK/out.txt"
 check "calls out the crash loop" grep -q "crash loop" "$WORK/out.txt"
 check "reports a healthy peer as 0 restarts" grep -qE "golf_hub .*0 " "$WORK/out.txt"
+
+echo "portability"
+# deploy.sh runs from a developer machine, and macOS still ships bash 3.2 as
+# /bin/bash — no associative arrays, no case-conversion expansions, no negative
+# array indices. CI runs bash 5, so only a static check catches this.
+# Comments are stripped first so prose about these constructs doesn't trip it.
+bash4_only=$(sed 's/#.*//' "$REPO/deploy/consolidated/deploy.sh" |
+  grep -nE 'declare -A|\$\{[A-Za-z_][A-Za-z0-9_]*\^\^|\$\{[A-Za-z_][A-Za-z0-9_]*,,|\bmapfile\b|\breadarray\b|\[-1\]' || true)
+check "no bash 4+ only syntax" test -z "$bash4_only"
+[ -n "$bash4_only" ] && printf '%s\n' "$bash4_only" | sed 's/^/          /'
 
 echo "argument handling"
 deploy --service nope -y

--- a/scripts/test-deploy
+++ b/scripts/test-deploy
@@ -70,6 +70,16 @@ esac
 cp -r "${args[@]}" "$target" 2>/dev/null || true
 STUB
 
+  # The remote payload targets the Linux host, so it uses GNU `xargs -r`. The
+  # stub ssh runs that payload locally, and BSD xargs rejects -r — drop the
+  # flag rather than weaken the command that actually ships.
+  cat > "$STUBS/xargs" <<'STUB'
+#!/bin/bash
+args=()
+for a in "$@"; do [ "$a" = "-r" ] || args+=("$a"); done
+exec /usr/bin/xargs "${args[@]}"
+STUB
+
   # Only docker is really run; mkdir/cp/chown against absolute host paths
   # (/var/www, /etc/forgejo) are neutralised so a test can't touch this machine.
   cat > "$STUBS/sudo" <<'STUB'


### PR DESCRIPTION
Fixes `deploy.sh --status` and `--service` failing on macOS after #1210:

```
deploy/consolidated/deploy.sh: line 178: declare: -A: invalid option
```

## Cause

macOS still ships **bash 3.2** as `/bin/bash` (GPLv3 — frozen since 2007). #1210 introduced two bash 4+ constructs:

- `declare -A restarts` — associative arrays, bash 4.0+. Breaks `--status`.
- `${name^^}` in `sha_var_for` — case-conversion expansion, bash 4.0+. Breaks `--service`.

`--list`, `--services`, `--help`, and a **full deploy** all miss both paths, which is why it looked fine: the full-deploy path derives its variable list by grepping `compose.yaml` and never calls `sha_var_for`.

`sha_var_for` was originally `tr 'a-z-' 'A-Z_' | sed 's/$/_SHA/'`, which is portable. Review flagged it as convoluted and suggested `${name^^}`; I took the suggestion without checking what it requires. `deploy.sh` was the only script in the repo using bash 4 syntax — the rest of `scripts/` and `deploy/consolidated/` are portable.

## Fix

- `sha_var_for` back to `tr`/`sed`. Verified it still yields the right variable for all 10 services, including `microgpt-serve` → `MICROGPT_SERVE_SHA`.
- The restart-count array becomes a lookup over the captured output (`restarts_for`) — also less code than building and reading a map.
- `scripts/test-deploy` used `${args[-1]}` (negative index, bash 4.2+), so the harness itself wouldn't have run on macOS either. Now index arithmetic.

## Guarding it, two ways

**Static check** (Linux job): grep the comment-stripped script for `declare -A`, `${x^^}`/`${x,,}`, `mapfile`/`readarray`, negative indices. Verified it fires — reintroducing `declare -A` fails the suite and names the line:

```
portability
  FAIL  no bash 4+ only syntax
          180:  declare -A restarts=()
```

**Real execution** (new `test-deploy-macos` job): the static check only catches constructs I thought to list, so also run the suite on `macos-26` against `/bin/bash` — which catches whatever 3.2 actually rejects. That's the real contract, since deploy.sh runs from a developer machine and never in a container. `/bin/bash` is invoked explicitly because the runner may have a newer bash earlier in `PATH`, which would defeat the point. Gated on `deploy/` changes, matching the existing macOS jobs.

One harness change this required: the remote payload targets Linux and uses GNU `xargs -r`, which BSD `xargs` rejects. The stub `ssh` executes that payload locally, so the harness now stubs `xargs` to drop the flag — rather than weakening the command that actually ships to the host.

## Still unverified

`--status` against a real host. The stubs answer `docker ps`/`inspect`, so those format strings have never met real output — if `--status` misbehaves after this, that's where I'd look first.