### PR TITLE
prom_proxy: per-container endpoints and running version

### DIFF
--- a/domains/platform/apis/prom_proxy/BUILD.bazel
+++ b/domains/platform/apis/prom_proxy/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel/rules:oci.bzl", "linux_oci_go")
 go_library(
     name = "prom_proxy_lib",
     srcs = [
+        "container_handlers.go",
         "handlers.go",
         "models.go",
         "prometheus_client.go",
@@ -24,6 +25,7 @@ go_test(
     name = "prom_proxy_test",
     size = "small",
     srcs = [
+        "container_handlers_test.go",
         "handlers_test.go",
         "models_test.go",
         "prometheus_client_test.go",

--- a/domains/platform/apis/prom_proxy/container_handlers.go
+++ b/domains/platform/apis/prom_proxy/container_handlers.go
@@ -1,0 +1,152 @@
+package prom_proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/muchq/moonbase/domains/platform/libs/mucks"
+)
+
+// imageTag pulls the tag off an image reference: ghcr.io/muchq/mithril:abc123
+// -> abc123. Deploys pin images per commit, so that tag is the running
+// revision. Returns "" for an untagged reference; the colon check is anchored
+// past the last slash so a registry port (host:5000/img) isn't read as a tag.
+func imageTag(image string) string {
+	colon := strings.LastIndex(image, ":")
+	if colon < 0 || colon < strings.LastIndex(image, "/") {
+		return ""
+	}
+	return image[colon+1:]
+}
+
+// Compose names containers <project>-<service>-<index>, e.g. ubuntu-golf_hub-1.
+// Strip both ends so a container can be addressed by the service it backs.
+func containerDisplayName(name string) string {
+	trimmed := strings.TrimPrefix(name, "ubuntu-")
+	if i := strings.LastIndex(trimmed, "-"); i > 0 {
+		if suffix := trimmed[i+1:]; suffix != "" && strings.Trim(suffix, "0123456789") == "" {
+			trimmed = trimmed[:i]
+		}
+	}
+	return trimmed
+}
+
+// matchesContainer accepts either the raw cAdvisor name or the service name, so
+// callers don't have to know the compose naming convention.
+func matchesContainer(containerName, requested string) bool {
+	return containerName == requested || containerDisplayName(containerName) == requested
+}
+
+// GetContainers lists every container with its health. Unlike the service
+// catalog this isn't registry-driven — infrastructure containers (caddy,
+// postgres, prometheus) emit no app metrics at all, and they're exactly the
+// ones with no other surface.
+func (h *MetricsHandler) GetContainers(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	metrics, err := h.fetchContainerMetrics(ctx)
+	if err != nil {
+		mucks.JsonError(w, mucks.NewServerError(500))
+		return
+	}
+	mucks.JsonOk(w, metrics)
+}
+
+// GetContainerDetail returns one container, addressed by container or service
+// name. Unknown -> 404, matching the service endpoints.
+func (h *MetricsHandler) GetContainerDetail(w http.ResponseWriter, r *http.Request) {
+	requested := r.PathValue("name")
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	metrics, err := h.fetchContainerMetrics(ctx)
+	if err != nil {
+		mucks.JsonError(w, mucks.NewServerError(500))
+		return
+	}
+	for i := range metrics.Containers {
+		if matchesContainer(metrics.Containers[i].Name, requested) {
+			mucks.JsonOk(w, metrics.Containers[i])
+			return
+		}
+	}
+	mucks.JsonError(w, mucks.NewNotFound())
+}
+
+// GetContainerTimeSeries returns one container's series over the range. The
+// restarts series is the point: a crash loop that started and resolved
+// overnight leaves no trace in a point-in-time view.
+func (h *MetricsHandler) GetContainerTimeSeries(w http.ResponseWriter, r *http.Request) {
+	requested := r.PathValue("name")
+	rangeParam := r.PathValue("range")
+	if !ValidTimeRange(rangeParam) {
+		mucks.JsonError(w, mucks.NewBadRequest("Invalid time range. Valid options: 30m, 1d, 7d"))
+		return
+	}
+	timeRange := TimeRange(rangeParam)
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	// Resolve to the real container name so the label filter matches whether
+	// the caller addressed it by service or by container.
+	metrics, err := h.fetchContainerMetrics(ctx)
+	if err != nil {
+		mucks.JsonError(w, mucks.NewServerError(500))
+		return
+	}
+	name := ""
+	for i := range metrics.Containers {
+		if matchesContainer(metrics.Containers[i].Name, requested) {
+			name = metrics.Containers[i].Name
+			break
+		}
+	}
+	if name == "" {
+		mucks.JsonError(w, mucks.NewNotFound())
+		return
+	}
+
+	duration, step := GetTimeRangeConfig(timeRange)
+	endTime := time.Now().UTC()
+	startTime := endTime.Add(-duration)
+
+	response := &TimeSeriesResponse{
+		TimeRange: string(timeRange),
+		StartTime: startTime,
+		EndTime:   endTime,
+		Step:      step,
+		Series:    []TimeSeries{},
+	}
+
+	queries := map[string]string{
+		"cpu_usage":      fmt.Sprintf(`rate(container_cpu_usage_seconds_total{name="%s"}[5m])*100`, name),
+		"memory_usage":   fmt.Sprintf(`container_memory_usage_bytes{name="%s"}`, name),
+		"network_rx":     fmt.Sprintf(`rate(container_network_receive_bytes_total{name="%s"}[5m])`, name),
+		"network_tx":     fmt.Sprintf(`rate(container_network_transmit_bytes_total{name="%s"}[5m])`, name),
+		"restarts":       fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[5m])`, name),
+		"uptime_seconds": fmt.Sprintf(`time()-container_start_time_seconds{name="%s"}`, name),
+	}
+
+	for metricName, query := range queries {
+		resp, err := h.promClient.QueryRange(ctx, query, startTime, endTime, step)
+		if err != nil {
+			continue
+		}
+		for _, result := range resp.Data.Result {
+			ts, err := extractTimeSeries(&result)
+			if err != nil {
+				continue
+			}
+			ts.MetricName = metricName
+			response.Series = append(response.Series, ts)
+		}
+	}
+
+	mucks.JsonOk(w, response)
+}

--- a/domains/platform/apis/prom_proxy/container_handlers.go
+++ b/domains/platform/apis/prom_proxy/container_handlers.go
@@ -15,6 +15,13 @@ import (
 // revision. Returns "" for an untagged reference; the colon check is anchored
 // past the last slash so a registry port (host:5000/img) isn't read as a tag.
 func imageTag(image string) string {
+	// A digest reference (img@sha256:...) has no tag. Returning the hex would
+	// be worse than returning nothing: 64 hex chars in a "running version"
+	// field is indistinguishable from a commit SHA, so a wrong answer would
+	// look like a right one.
+	if strings.Contains(image[strings.LastIndex(image, "/")+1:], "@") {
+		return ""
+	}
 	colon := strings.LastIndex(image, ":")
 	if colon < 0 || colon < strings.LastIndex(image, "/") {
 		return ""
@@ -34,10 +41,22 @@ func containerDisplayName(name string) string {
 	return trimmed
 }
 
-// matchesContainer accepts either the raw cAdvisor name or the service name, so
-// callers don't have to know the compose naming convention.
-func matchesContainer(containerName, requested string) bool {
-	return containerName == requested || containerDisplayName(containerName) == requested
+// resolveContainer finds the ref a request addresses, by container name or by
+// service. An exact name always wins: otherwise a request for a container that
+// exists could be answered with a different one whose service happens to match.
+// refs are sorted, so a tie between replicas resolves the same way every time.
+func resolveContainer(refs []containerRef, requested string) (containerRef, bool) {
+	for _, ref := range refs {
+		if ref.name == requested {
+			return ref, true
+		}
+	}
+	for _, ref := range refs {
+		if ref.service == requested {
+			return ref, true
+		}
+	}
+	return containerRef{}, false
 }
 
 // GetContainers lists every container with its health. Unlike the service
@@ -50,8 +69,9 @@ func (h *MetricsHandler) GetContainers(w http.ResponseWriter, r *http.Request) {
 
 	metrics, err := h.fetchContainerMetrics(ctx)
 	if err != nil {
-		mucks.JsonError(w, mucks.NewServerError(500))
-		return
+		// Same resilience contract as the rest of the API: a failing scrape
+		// source yields an empty section with 200, never a 500.
+		metrics = &ContainerMetrics{Timestamp: time.Now().UTC(), Containers: []ContainerStats{}}
 	}
 	mucks.JsonOk(w, metrics)
 }
@@ -64,18 +84,24 @@ func (h *MetricsHandler) GetContainerDetail(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
-	metrics, err := h.fetchContainerMetrics(ctx)
+	refs, err := h.listContainers(ctx)
 	if err != nil {
-		mucks.JsonError(w, mucks.NewServerError(500))
+		// Unlike the listing, a single-resource lookup can't degrade to an
+		// empty answer: with the listing unavailable there's no way to tell a
+		// missing container from an unknown one.
+		problem := mucks.NewServerError(500)
+		problem.Detail = "Failed to list containers: " + err.Error()
+		mucks.JsonError(w, problem)
 		return
 	}
-	for i := range metrics.Containers {
-		if matchesContainer(metrics.Containers[i].Name, requested) {
-			mucks.JsonOk(w, metrics.Containers[i])
-			return
-		}
+	ref, found := resolveContainer(refs, requested)
+	if !found {
+		mucks.JsonError(w, mucks.NewNotFound())
+		return
 	}
-	mucks.JsonError(w, mucks.NewNotFound())
+
+	stats := h.containerStats(ctx, ref)
+	mucks.JsonOk(w, ContainerDetail{Timestamp: time.Now().UTC(), Container: stats})
 }
 
 // GetContainerTimeSeries returns one container's series over the range. The
@@ -94,23 +120,21 @@ func (h *MetricsHandler) GetContainerTimeSeries(w http.ResponseWriter, r *http.R
 	defer cancel()
 
 	// Resolve to the real container name so the label filter matches whether
-	// the caller addressed it by service or by container.
-	metrics, err := h.fetchContainerMetrics(ctx)
+	// the caller addressed it by service or by container. The listing alone is
+	// enough — fetching every container's stats here would discard all of them.
+	refs, err := h.listContainers(ctx)
 	if err != nil {
-		mucks.JsonError(w, mucks.NewServerError(500))
+		problem := mucks.NewServerError(500)
+		problem.Detail = "Failed to list containers: " + err.Error()
+		mucks.JsonError(w, problem)
 		return
 	}
-	name := ""
-	for i := range metrics.Containers {
-		if matchesContainer(metrics.Containers[i].Name, requested) {
-			name = metrics.Containers[i].Name
-			break
-		}
-	}
-	if name == "" {
+	ref, found := resolveContainer(refs, requested)
+	if !found {
 		mucks.JsonError(w, mucks.NewNotFound())
 		return
 	}
+	name := ref.name
 
 	duration, step := GetTimeRangeConfig(timeRange)
 	endTime := time.Now().UTC()
@@ -125,11 +149,16 @@ func (h *MetricsHandler) GetContainerTimeSeries(w http.ResponseWriter, r *http.R
 	}
 
 	queries := map[string]string{
-		"cpu_usage":      fmt.Sprintf(`rate(container_cpu_usage_seconds_total{name="%s"}[5m])*100`, name),
-		"memory_usage":   fmt.Sprintf(`container_memory_usage_bytes{name="%s"}`, name),
-		"network_rx":     fmt.Sprintf(`rate(container_network_receive_bytes_total{name="%s"}[5m])`, name),
-		"network_tx":     fmt.Sprintf(`rate(container_network_transmit_bytes_total{name="%s"}[5m])`, name),
-		"restarts":       fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[5m])`, name),
+		"cpu_usage":    fmt.Sprintf(`rate(container_cpu_usage_seconds_total{name="%s"}[5m])*100`, name),
+		"memory_usage": fmt.Sprintf(`container_memory_usage_bytes{name="%s"}`, name),
+		// sum() so a multi-interface container yields one series per metric
+		// rather than several sharing a metric_name.
+		"network_rx": fmt.Sprintf(`sum(rate(container_network_receive_bytes_total{name="%s"}[5m]))`, name),
+		"network_tx": fmt.Sprintf(`sum(rate(container_network_transmit_bytes_total{name="%s"}[5m]))`, name),
+		// Window tracks the step: at 7d the step is 1h, so a [5m] window would
+		// only ever inspect the last 5 minutes of each hour and drop most
+		// restarts — precisely the overnight crash loop this exists to show.
+		"restarts":       fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[%s])`, name, step),
 		"uptime_seconds": fmt.Sprintf(`time()-container_start_time_seconds{name="%s"}`, name),
 	}
 

--- a/domains/platform/apis/prom_proxy/container_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/container_handlers_test.go
@@ -2,8 +2,10 @@ package prom_proxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,16 +20,21 @@ func TestImageTag(t *testing.T) {
 		image string
 		want  string
 	}{
-		{"pinned image", "ghcr.io/muchq/mithril:abc123", "abc123"},
+		{"pinned image", "ghcr.io/muchq/mithril:" + strings.Repeat("a", 40), strings.Repeat("a", 40)},
 		{"latest", "ghcr.io/muchq/mithril:latest", "latest"},
-		{"third party with version", "caddy:2-alpine", "2-alpine"},
-		// Negative: nothing to report rather than something wrong.
+		{"third party with version", "postgres:18", "18"},
+		{"tag with dots", "otel/opentelemetry-collector-contrib:0.155.0", "0.155.0"},
+		// Negatives: report nothing rather than something wrong.
 		{"untagged", "ghcr.io/muchq/mithril", ""},
 		{"empty", "", ""},
+		{"trailing colon", "img:", ""},
 		// A registry port is a colon that is not a tag; reading it as one
 		// would report "5000" as the running revision.
 		{"registry port, no tag", "registry.local:5000/mithril", ""},
 		{"registry port with tag", "registry.local:5000/mithril:abc123", "abc123"},
+		// A digest is not a tag. 64 hex chars in a "version" field would be
+		// indistinguishable from a commit SHA — a wrong answer that looks right.
+		{"digest", "ghcr.io/muchq/mithril@sha256:" + strings.Repeat("e", 64), ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -44,12 +51,12 @@ func TestContainerDisplayName(t *testing.T) {
 	}{
 		{"compose naming", "ubuntu-golf_hub-1", "golf_hub"},
 		{"hyphenated service", "ubuntu-microgpt-serve-1", "microgpt-serve"},
-		// Double-digit replicas: a bare "-1" strip would turn this into
-		// "svc0" rather than "svc".
+		{"underscored service", "ubuntu-one_d4_postgres-1", "one_d4_postgres"},
+		{"infrastructure container", "ubuntu-cadvisor-1", "cadvisor"},
+		// A bare "-1" strip would turn this into "svc0".
 		{"double digit index", "ubuntu-svc-10", "svc"},
 		{"no project prefix", "mithril-1", "mithril"},
 		{"no index", "cadvisor", "cadvisor"},
-		// Negative: a trailing segment that isn't an index must survive.
 		{"non numeric suffix", "ubuntu-one_d4-postgres", "one_d4-postgres"},
 		{"empty", "", ""},
 	}
@@ -60,40 +67,76 @@ func TestContainerDisplayName(t *testing.T) {
 	}
 }
 
-func TestMatchesContainer(t *testing.T) {
-	assert.True(t, matchesContainer("ubuntu-mithril-1", "mithril"), "by service name")
-	assert.True(t, matchesContainer("ubuntu-mithril-1", "ubuntu-mithril-1"), "by container name")
-	assert.False(t, matchesContainer("ubuntu-mithril-1", "posterize"), "different service")
+func TestResolveContainer(t *testing.T) {
+	refs := []containerRef{
+		{name: "ubuntu-mithril-1", service: "mithril"},
+		{name: "ubuntu-one_d4-1", service: "one_d4"},
+		{name: "mithril", service: "something_else"},
+	}
+
+	got, found := resolveContainer(refs, "one_d4")
+	require.True(t, found)
+	assert.Equal(t, "ubuntu-one_d4-1", got.name, "by service")
+
+	// An exact container name must win over another container whose service
+	// happens to match, or a request resolves to the wrong container.
+	got, found = resolveContainer(refs, "mithril")
+	require.True(t, found)
+	assert.Equal(t, "mithril", got.name, "exact name beats service match")
+
+	_, found = resolveContainer(refs, "nope")
+	assert.False(t, found)
 	// Substring must not match, or "d4" would resolve to one_d4.
-	assert.False(t, matchesContainer("ubuntu-one_d4-1", "d4"), "substring")
+	_, found = resolveContainer(refs, "d4")
+	assert.False(t, found)
 }
 
-// ---------------------------------------------------------------- integration
+// ---------------------------------------------------------------- fixtures
+
+const listQuery = `max by (name, image, container_label_com_docker_compose_service) (container_last_seen)`
+
+// listResult builds one row of the container listing. lastSeen is the sample
+// timestamp, which is how duplicate rows for one name are ordered.
+func listResult(name, service, image string, lastSeen float64) Result {
+	return Result{
+		Metric: map[string]string{
+			"name":  name,
+			"image": image,
+			"container_label_com_docker_compose_service": service,
+		},
+		Value: []interface{}{1609459200.0, fmt.Sprintf("%g", lastSeen)},
+	}
+}
+
+func listResponse(results ...Result) *QueryResponse {
+	return &QueryResponse{
+		Status: "success",
+		Data: struct {
+			ResultType string   `json:"resultType"`
+			Result     []Result `json:"result"`
+		}{ResultType: "vector", Result: results},
+	}
+}
 
 // A host whose posterize is crash-looping on the current revision while
 // golf_hub is healthy — the shape of the incident these endpoints exist for.
+// caddy is listed but has no per-container samples, standing in for a
+// container cAdvisor isn't reporting on.
 func containerFixture() *mockPrometheusClient {
 	return &mockPrometheusClient{queryResponses: map[string]*QueryResponse{
-		`count by (name, image) (container_last_seen)`: {
-			Status: "success",
-			Data: struct {
-				ResultType string   `json:"resultType"`
-				Result     []Result `json:"result"`
-			}{
-				ResultType: "vector",
-				Result: []Result{
-					{Metric: map[string]string{"name": "ubuntu-posterize-1", "image": "ghcr.io/muchq/posterize:abc123"}, Value: []interface{}{1609459200.0, "1"}},
-					{Metric: map[string]string{"name": "ubuntu-golf_hub-1", "image": "ghcr.io/muchq/golf_hub:abc123"}, Value: []interface{}{1609459200.0, "1"}},
-					{Metric: map[string]string{"name": "caddy", "image": "caddy:2-alpine"}, Value: []interface{}{1609459200.0, "1"}},
-				},
-			},
-		},
+		listQuery: listResponse(
+			listResult("ubuntu-posterize-1", "posterize", "ghcr.io/muchq/posterize:abc123", 100),
+			listResult("ubuntu-golf_hub-1", "golf_hub", "ghcr.io/muchq/golf_hub:abc123", 100),
+			listResult("ubuntu-caddy-1", "caddy", "caddy:2-alpine", 100),
+		),
 		`changes(container_start_time_seconds{name="ubuntu-posterize-1"}[1h])`: scalarResponse("47"),
 		`time()-container_start_time_seconds{name="ubuntu-posterize-1"}`:       scalarResponse("8"),
 		`changes(container_start_time_seconds{name="ubuntu-golf_hub-1"}[1h])`:  scalarResponse("0"),
 		`time()-container_start_time_seconds{name="ubuntu-golf_hub-1"}`:        scalarResponse("86400"),
 	}}
 }
+
+// ---------------------------------------------------------------- listing
 
 func TestGetContainers(t *testing.T) {
 	handler := NewMetricsHandler(containerFixture())
@@ -113,20 +156,98 @@ func TestGetContainers(t *testing.T) {
 	posterize := byName["ubuntu-posterize-1"]
 	assert.True(t, posterize.CrashLooping)
 	assert.Equal(t, 47.0, posterize.RestartsLastHour)
+	assert.Equal(t, 8.0, posterize.UptimeSeconds)
+	assert.True(t, posterize.Reporting)
+	assert.Equal(t, "ghcr.io/muchq/posterize:abc123", posterize.Image)
 	assert.Equal(t, "abc123", posterize.Version, "running revision from the image tag")
+	assert.Equal(t, "posterize", posterize.Service, "clients link to the service page with this")
 
-	assert.False(t, byName["ubuntu-golf_hub-1"].CrashLooping, "healthy peer unaffected")
+	golfHub := byName["ubuntu-golf_hub-1"]
+	assert.False(t, golfHub.CrashLooping, "healthy peer unaffected")
+	assert.Equal(t, 86400.0, golfHub.UptimeSeconds)
+
 	// Infrastructure containers emit no app metrics, so this listing is the
 	// only place they appear at all.
-	assert.Equal(t, "2-alpine", byName["caddy"].Version)
+	caddy := byName["ubuntu-caddy-1"]
+	assert.Equal(t, "2-alpine", caddy.Version)
+	// No samples for it: it must read as "not reporting", never as healthy.
+	assert.False(t, caddy.Reporting)
+	assert.False(t, caddy.CrashLooping)
+	assert.Zero(t, caddy.UptimeSeconds)
 }
 
+// Grouping the listing by image lets one container yield two rows while a
+// replaced container is still inside Prometheus's lookback window. Without
+// dedup the dashboard shows it twice, and can report the old revision as the
+// running one — during a deploy, which is exactly when someone is watching.
+func TestGetContainers_DeduplicatesByName(t *testing.T) {
+	mock := containerFixture()
+	// Newest first, so "keep the last row" would pick the stale one — the
+	// order that makes this assertion discriminating.
+	mock.queryResponses[listQuery] = listResponse(
+		listResult("ubuntu-mithril-1", "mithril", "ghcr.io/muchq/mithril:NEWSHA", 200),
+		listResult("ubuntu-mithril-1", "mithril", "ghcr.io/muchq/mithril:OLDSHA", 100),
+	)
+	handler := NewMetricsHandler(mock)
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 1, "one container, not one per image")
+	assert.Equal(t, "NEWSHA", response.Containers[0].Version, "the newer sample is what's running")
+}
+
+// The compose project name is the directory compose runs from: `ubuntu` on the
+// deployed host, `local_docker` under local_deploy.sh. Parsing the name would
+// resolve one and 404 the other, so the service comes from the label.
+func TestGetContainers_ServiceFromComposeLabel(t *testing.T) {
+	mock := containerFixture()
+	mock.queryResponses[listQuery] = listResponse(
+		listResult("local_docker-mithril-1", "mithril", "ghcr.io/muchq/mithril:abc123", 100),
+	)
+	handler := NewMetricsHandler(mock)
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 1)
+	assert.Equal(t, "mithril", response.Containers[0].Service)
+}
+
+// Falls back to parsing when cAdvisor isn't storing container labels.
+func TestGetContainers_ServiceFallsBackToName(t *testing.T) {
+	mock := containerFixture()
+	mock.queryResponses[listQuery] = listResponse(
+		Result{
+			Metric: map[string]string{"name": "ubuntu-mithril-1", "image": "ghcr.io/muchq/mithril:abc123"},
+			Value:  []interface{}{1609459200.0, "100"},
+		},
+	)
+	handler := NewMetricsHandler(mock)
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 1)
+	assert.Equal(t, "mithril", response.Containers[0].Service)
+}
+
+// House contract: a failing scrape source yields an empty section with 200, so
+// the page shape stays stable. `reporting` is what keeps that unambiguous.
 func TestGetContainers_PrometheusDown(t *testing.T) {
 	handler := NewMetricsHandler(&mockPrometheusClient{queryError: assert.AnError})
 	w := httptest.NewRecorder()
 	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"containers":[]`, "empty slice, not null")
 }
+
+// ---------------------------------------------------------------- detail
 
 func TestGetContainerDetail(t *testing.T) {
 	tests := []struct {
@@ -137,7 +258,7 @@ func TestGetContainerDetail(t *testing.T) {
 	}{
 		{"by service name", "posterize", http.StatusOK, "ubuntu-posterize-1"},
 		{"by container name", "ubuntu-posterize-1", http.StatusOK, "ubuntu-posterize-1"},
-		{"infrastructure container", "caddy", http.StatusOK, "caddy"},
+		{"infrastructure container", "caddy", http.StatusOK, "ubuntu-caddy-1"},
 		{"unknown", "nope", http.StatusNotFound, ""},
 		{"substring of a real one", "d4", http.StatusNotFound, ""},
 	}
@@ -153,12 +274,56 @@ func TestGetContainerDetail(t *testing.T) {
 			if tt.wantStatus != http.StatusOK {
 				return
 			}
-			var got ContainerStats
+			var got ContainerDetail
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
-			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantName, got.Container.Name)
+			assert.False(t, got.Timestamp.IsZero(), "point-in-time payloads carry a timestamp")
 		})
 	}
 }
+
+// The payload, not just the name: returning the right name attached to another
+// container's stats would otherwise pass.
+func TestGetContainerDetail_Payload(t *testing.T) {
+	handler := NewMetricsHandler(containerFixture())
+	req := httptest.NewRequest(http.MethodGet, "/metrics/v1/container/posterize", nil)
+	req.SetPathValue("name", "posterize")
+	w := httptest.NewRecorder()
+	handler.GetContainerDetail(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var got ContainerDetail
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.True(t, got.Container.CrashLooping)
+	assert.Equal(t, 47.0, got.Container.RestartsLastHour)
+	assert.Equal(t, 8.0, got.Container.UptimeSeconds)
+	assert.Equal(t, "abc123", got.Container.Version)
+	assert.Equal(t, "posterize", got.Container.Service)
+
+	// A healthy neighbour must not inherit any of that.
+	req = httptest.NewRequest(http.MethodGet, "/metrics/v1/container/caddy", nil)
+	req.SetPathValue("name", "caddy")
+	w = httptest.NewRecorder()
+	handler.GetContainerDetail(w, req)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.False(t, got.Container.CrashLooping)
+	assert.Equal(t, "2-alpine", got.Container.Version)
+	assert.Zero(t, got.Container.RestartsLastHour)
+}
+
+// A single-resource lookup can't degrade to an empty answer: without the
+// listing there's no way to tell a missing container from an unknown one, and
+// answering 404 would claim it doesn't exist.
+func TestGetContainerDetail_PrometheusDown(t *testing.T) {
+	handler := NewMetricsHandler(&mockPrometheusClient{queryError: assert.AnError})
+	req := httptest.NewRequest(http.MethodGet, "/metrics/v1/container/posterize", nil)
+	req.SetPathValue("name", "posterize")
+	w := httptest.NewRecorder()
+	handler.GetContainerDetail(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// ---------------------------------------------------------------- timeseries
 
 func TestGetContainerTimeSeries(t *testing.T) {
 	tests := []struct {
@@ -191,8 +356,116 @@ func TestGetContainerTimeSeries(t *testing.T) {
 				var response TimeSeriesResponse
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 				assert.Equal(t, tt.timeRange, response.TimeRange)
-				assert.NotNil(t, response.Series, "series is [] not null")
+			}
+			if tt.wantStatus != http.StatusOK {
+				assert.NotContains(t, w.Body.String(), `"series"`)
 			}
 		})
 	}
+}
+
+// Keyed on the exact queries the handler should issue, so building them from
+// the requested name instead of the resolved one — or dropping a series
+// entirely — fails here rather than shipping empty charts.
+func TestGetContainerTimeSeries_QueriesResolvedName(t *testing.T) {
+	name := "ubuntu-posterize-1"
+	mock := containerFixture()
+	mock.queryRangeResponses = map[string]*QueryResponse{
+		fmt.Sprintf(`rate(container_cpu_usage_seconds_total{name="%s"}[5m])*100`, name):       rangeResponse("x"),
+		fmt.Sprintf(`container_memory_usage_bytes{name="%s"}`, name):                          rangeResponse("x"),
+		fmt.Sprintf(`sum(rate(container_network_receive_bytes_total{name="%s"}[5m]))`, name):  rangeResponse("x"),
+		fmt.Sprintf(`sum(rate(container_network_transmit_bytes_total{name="%s"}[5m]))`, name): rangeResponse("x"),
+		// 1d -> step 5m, and the restart window must match the step.
+		fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[5m])`, name): rangeResponse("x"),
+		fmt.Sprintf(`time()-container_start_time_seconds{name="%s"}`, name):       rangeResponse("x"),
+	}
+	handler := NewMetricsHandler(mock)
+
+	// Addressed by service; every query must still use the container name.
+	req := httptest.NewRequest(http.MethodGet, "/metrics/v1/container/posterize/timeseries/1d", nil)
+	req.SetPathValue("name", "posterize")
+	req.SetPathValue("range", "1d")
+	w := httptest.NewRecorder()
+	handler.GetContainerTimeSeries(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+	assert.Empty(t, mock.misses, "every range query should have matched a fixture entry")
+	assert.Len(t, response.Series, 6)
+	names := map[string]bool{}
+	for _, s := range response.Series {
+		names[s.MetricName] = true
+		assert.NotEmpty(t, s.Values, "points actually flowed through")
+	}
+	assert.True(t, names["restarts"], "the series this endpoint exists for")
+	assert.True(t, names["uptime_seconds"])
+	assert.True(t, names["cpu_usage"])
+	assert.Equal(t, "5m", response.Step)
+	assert.True(t, response.EndTime.After(response.StartTime))
+}
+
+// At 7d the step is 1h, so a fixed [5m] window would inspect only the last 5
+// minutes of each hour and drop most restarts — the overnight crash loop this
+// endpoint is meant to reveal.
+func TestGetContainerTimeSeries_RestartWindowTracksStep(t *testing.T) {
+	name := "ubuntu-posterize-1"
+	mock := containerFixture()
+	mock.queryRangeResponses = map[string]*QueryResponse{
+		fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[1h])`, name): rangeResponse("x"),
+	}
+	handler := NewMetricsHandler(mock)
+	req := httptest.NewRequest(http.MethodGet, "/metrics/v1/container/posterize/timeseries/7d", nil)
+	req.SetPathValue("name", "posterize")
+	req.SetPathValue("range", "7d")
+	w := httptest.NewRecorder()
+	handler.GetContainerTimeSeries(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "1h", response.Step)
+	found := false
+	for _, s := range response.Series {
+		if s.MetricName == "restarts" {
+			found = true
+		}
+	}
+	assert.True(t, found, "restarts queried with a [1h] window at the 1h step")
+}
+
+func TestGetContainerTimeSeries_PrometheusDown(t *testing.T) {
+	handler := NewMetricsHandler(&mockPrometheusClient{queryError: assert.AnError})
+	req := httptest.NewRequest(http.MethodGet, "/metrics/v1/container/posterize/timeseries/1d", nil)
+	req.SetPathValue("name", "posterize")
+	req.SetPathValue("range", "1d")
+	w := httptest.NewRecorder()
+	handler.GetContainerTimeSeries(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// Partial failure is where the reporting guard earns its keep: restarts came
+// back but uptime didn't, so isCrashLooping(47, 0) would say "crash looping"
+// off a zero we never actually measured. Claiming either state from
+// half the data is worse than saying we don't know.
+func TestGetContainers_PartialDataIsNotAVerdict(t *testing.T) {
+	mock := containerFixture()
+	mock.queryResponses[listQuery] = listResponse(
+		listResult("ubuntu-mithril-1", "mithril", "ghcr.io/muchq/mithril:abc123", 100),
+	)
+	mock.queryResponses[`changes(container_start_time_seconds{name="ubuntu-mithril-1"}[1h])`] = scalarResponse("47")
+	// uptime deliberately absent
+
+	handler := NewMetricsHandler(mock)
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 1)
+	assert.False(t, response.Containers[0].Reporting)
+	assert.False(t, response.Containers[0].CrashLooping, "no verdict without uptime")
+	assert.Equal(t, 47.0, response.Containers[0].RestartsLastHour, "what we did measure is still reported")
 }

--- a/domains/platform/apis/prom_proxy/container_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/container_handlers_test.go
@@ -1,0 +1,198 @@
+package prom_proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------- unit
+
+func TestImageTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		want  string
+	}{
+		{"pinned image", "ghcr.io/muchq/mithril:abc123", "abc123"},
+		{"latest", "ghcr.io/muchq/mithril:latest", "latest"},
+		{"third party with version", "caddy:2-alpine", "2-alpine"},
+		// Negative: nothing to report rather than something wrong.
+		{"untagged", "ghcr.io/muchq/mithril", ""},
+		{"empty", "", ""},
+		// A registry port is a colon that is not a tag; reading it as one
+		// would report "5000" as the running revision.
+		{"registry port, no tag", "registry.local:5000/mithril", ""},
+		{"registry port with tag", "registry.local:5000/mithril:abc123", "abc123"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, imageTag(tt.image))
+		})
+	}
+}
+
+func TestContainerDisplayName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"compose naming", "ubuntu-golf_hub-1", "golf_hub"},
+		{"hyphenated service", "ubuntu-microgpt-serve-1", "microgpt-serve"},
+		// Double-digit replicas: a bare "-1" strip would turn this into
+		// "svc0" rather than "svc".
+		{"double digit index", "ubuntu-svc-10", "svc"},
+		{"no project prefix", "mithril-1", "mithril"},
+		{"no index", "cadvisor", "cadvisor"},
+		// Negative: a trailing segment that isn't an index must survive.
+		{"non numeric suffix", "ubuntu-one_d4-postgres", "one_d4-postgres"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, containerDisplayName(tt.in))
+		})
+	}
+}
+
+func TestMatchesContainer(t *testing.T) {
+	assert.True(t, matchesContainer("ubuntu-mithril-1", "mithril"), "by service name")
+	assert.True(t, matchesContainer("ubuntu-mithril-1", "ubuntu-mithril-1"), "by container name")
+	assert.False(t, matchesContainer("ubuntu-mithril-1", "posterize"), "different service")
+	// Substring must not match, or "d4" would resolve to one_d4.
+	assert.False(t, matchesContainer("ubuntu-one_d4-1", "d4"), "substring")
+}
+
+// ---------------------------------------------------------------- integration
+
+// A host whose posterize is crash-looping on the current revision while
+// golf_hub is healthy — the shape of the incident these endpoints exist for.
+func containerFixture() *mockPrometheusClient {
+	return &mockPrometheusClient{queryResponses: map[string]*QueryResponse{
+		`count by (name, image) (container_last_seen)`: {
+			Status: "success",
+			Data: struct {
+				ResultType string   `json:"resultType"`
+				Result     []Result `json:"result"`
+			}{
+				ResultType: "vector",
+				Result: []Result{
+					{Metric: map[string]string{"name": "ubuntu-posterize-1", "image": "ghcr.io/muchq/posterize:abc123"}, Value: []interface{}{1609459200.0, "1"}},
+					{Metric: map[string]string{"name": "ubuntu-golf_hub-1", "image": "ghcr.io/muchq/golf_hub:abc123"}, Value: []interface{}{1609459200.0, "1"}},
+					{Metric: map[string]string{"name": "caddy", "image": "caddy:2-alpine"}, Value: []interface{}{1609459200.0, "1"}},
+				},
+			},
+		},
+		`changes(container_start_time_seconds{name="ubuntu-posterize-1"}[1h])`: scalarResponse("47"),
+		`time()-container_start_time_seconds{name="ubuntu-posterize-1"}`:       scalarResponse("8"),
+		`changes(container_start_time_seconds{name="ubuntu-golf_hub-1"}[1h])`:  scalarResponse("0"),
+		`time()-container_start_time_seconds{name="ubuntu-golf_hub-1"}`:        scalarResponse("86400"),
+	}}
+}
+
+func TestGetContainers(t *testing.T) {
+	handler := NewMetricsHandler(containerFixture())
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 3)
+
+	byName := map[string]ContainerStats{}
+	for _, c := range response.Containers {
+		byName[c.Name] = c
+	}
+
+	posterize := byName["ubuntu-posterize-1"]
+	assert.True(t, posterize.CrashLooping)
+	assert.Equal(t, 47.0, posterize.RestartsLastHour)
+	assert.Equal(t, "abc123", posterize.Version, "running revision from the image tag")
+
+	assert.False(t, byName["ubuntu-golf_hub-1"].CrashLooping, "healthy peer unaffected")
+	// Infrastructure containers emit no app metrics, so this listing is the
+	// only place they appear at all.
+	assert.Equal(t, "2-alpine", byName["caddy"].Version)
+}
+
+func TestGetContainers_PrometheusDown(t *testing.T) {
+	handler := NewMetricsHandler(&mockPrometheusClient{queryError: assert.AnError})
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGetContainerDetail(t *testing.T) {
+	tests := []struct {
+		name       string
+		requested  string
+		wantStatus int
+		wantName   string
+	}{
+		{"by service name", "posterize", http.StatusOK, "ubuntu-posterize-1"},
+		{"by container name", "ubuntu-posterize-1", http.StatusOK, "ubuntu-posterize-1"},
+		{"infrastructure container", "caddy", http.StatusOK, "caddy"},
+		{"unknown", "nope", http.StatusNotFound, ""},
+		{"substring of a real one", "d4", http.StatusNotFound, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewMetricsHandler(containerFixture())
+			req := httptest.NewRequest(http.MethodGet, "/metrics/v1/container/"+tt.requested, nil)
+			req.SetPathValue("name", tt.requested)
+			w := httptest.NewRecorder()
+			handler.GetContainerDetail(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code)
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+			var got ContainerStats
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+			assert.Equal(t, tt.wantName, got.Name)
+		})
+	}
+}
+
+func TestGetContainerTimeSeries(t *testing.T) {
+	tests := []struct {
+		name       string
+		requested  string
+		timeRange  string
+		wantStatus int
+	}{
+		{"by service name", "posterize", "1d", http.StatusOK},
+		{"by container name", "ubuntu-posterize-1", "30m", http.StatusOK},
+		{"unknown container", "nope", "1d", http.StatusNotFound},
+		{"invalid range", "posterize", "99y", http.StatusBadRequest},
+		// Range is validated before the container is resolved, so a request
+		// that is wrong twice reports the range rather than a 404.
+		{"unknown container and invalid range", "nope", "99y", http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := containerFixture()
+			mock.queryRangeResponse = &QueryResponse{}
+			handler := NewMetricsHandler(mock)
+			req := httptest.NewRequest(http.MethodGet, "/metrics/v1/container/"+tt.requested+"/timeseries/"+tt.timeRange, nil)
+			req.SetPathValue("name", tt.requested)
+			req.SetPathValue("range", tt.timeRange)
+			w := httptest.NewRecorder()
+			handler.GetContainerTimeSeries(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			if tt.wantStatus == http.StatusOK {
+				var response TimeSeriesResponse
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+				assert.Equal(t, tt.timeRange, response.TimeRange)
+				assert.NotNil(t, response.Series, "series is [] not null")
+			}
+		})
+	}
+}

--- a/domains/platform/apis/prom_proxy/handlers.go
+++ b/domains/platform/apis/prom_proxy/handlers.go
@@ -313,16 +313,18 @@ func (h *MetricsHandler) fetchContainerMetrics(ctx context.Context) (*ContainerM
 	}
 
 	// Get list of containers
-	containerQuery := `count by (name) (container_last_seen)`
+	containerQuery := `count by (name, image) (container_last_seen)`
 	containerResp, err := h.promClient.Query(ctx, containerQuery)
 	if err != nil {
 		return nil, err
 	}
 
 	containerNames := []string{}
+	images := map[string]string{}
 	for _, result := range containerResp.Data.Result {
 		if name, exists := result.Metric["name"]; exists && name != "" {
 			containerNames = append(containerNames, name)
+			images[name] = result.Metric["image"]
 		}
 	}
 
@@ -409,6 +411,8 @@ func (h *MetricsHandler) fetchContainerMetrics(ctx context.Context) (*ContainerM
 		}
 
 		stats.CrashLooping = isCrashLooping(stats.RestartsLastHour, stats.UptimeSeconds)
+		stats.Image = images[name]
+		stats.Version = imageTag(stats.Image)
 
 		metrics.Containers = append(metrics.Containers, stats)
 	}

--- a/domains/platform/apis/prom_proxy/handlers.go
+++ b/domains/platform/apis/prom_proxy/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -15,18 +16,18 @@ func extractFloatValue(result *Result) (float64, error) {
 	if len(result.Value) < 2 {
 		return 0, fmt.Errorf("invalid prometheus result format")
 	}
-	
+
 	valueStr, ok := result.Value[1].(string)
 	if !ok {
 		return 0, fmt.Errorf("value is not a string")
 	}
-	
+
 	// Handle NaN, +Inf, -Inf values gracefully
 	switch valueStr {
 	case "NaN", "+Inf", "-Inf":
 		return 0, nil // Return 0 for invalid mathematical results
 	}
-	
+
 	return strconv.ParseFloat(valueStr, 64)
 }
 
@@ -36,33 +37,33 @@ func extractTimeSeries(result *Result) (TimeSeries, error) {
 		Labels: result.Metric,
 		Values: make([]DataPoint, 0, len(result.Values)),
 	}
-	
+
 	// Set metric name from __name__ label or construct from labels
 	if name, exists := result.Metric["__name__"]; exists {
 		ts.MetricName = name
 	} else {
 		ts.MetricName = "unnamed_metric"
 	}
-	
+
 	// Process each timestamp-value pair
 	for _, valueArray := range result.Values {
 		if len(valueArray) != 2 {
 			continue
 		}
-		
+
 		// Extract timestamp
 		timestampFloat, ok := valueArray[0].(float64)
 		if !ok {
 			continue
 		}
 		timestamp := time.Unix(int64(timestampFloat), 0)
-		
+
 		// Extract value
 		valueStr, ok := valueArray[1].(string)
 		if !ok {
 			continue
 		}
-		
+
 		// Handle NaN, +Inf, -Inf values gracefully
 		var value float64
 		switch valueStr {
@@ -75,13 +76,13 @@ func extractTimeSeries(result *Result) (TimeSeries, error) {
 				continue
 			}
 		}
-		
+
 		ts.Values = append(ts.Values, DataPoint{
 			Timestamp: timestamp,
 			Value:     value,
 		})
 	}
-	
+
 	return ts, nil
 }
 
@@ -103,8 +104,8 @@ func NewMetricsHandler(promClient PrometheusQuerier) *MetricsHandler {
 
 func (h *MetricsHandler) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	response := map[string]string{
-		"status": "healthy",
-		"service": "prometheus-proxy",
+		"status":    "healthy",
+		"service":   "prometheus-proxy",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 	}
 	mucks.JsonOk(w, response)
@@ -117,7 +118,7 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 		Disk:      []DiskMetrics{},
 		Network:   []NetworkMetrics{},
 	}
-	
+
 	// Fetch CPU utilization
 	cpuQuery := `100-avg(rate(system_cpu_time_seconds_total{state="idle"}[5m]))*100`
 	cpuResp, err := h.promClient.Query(ctx, cpuQuery)
@@ -126,7 +127,7 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 			metrics.CPU.Utilization = val
 		}
 	}
-	
+
 	// Fetch CPU by core
 	cpuCoreQuery := `rate(system_cpu_time_seconds_total[5m])*100`
 	cpuCoreResp, err := h.promClient.Query(ctx, cpuCoreQuery)
@@ -139,7 +140,7 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 			}
 		}
 	}
-	
+
 	// Fetch memory metrics
 	memoryUsedQuery := `system_memory_usage_bytes{state="used"}`
 	memUsedResp, err := h.promClient.Query(ctx, memoryUsedQuery)
@@ -148,7 +149,7 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 			metrics.Memory.Used = val
 		}
 	}
-	
+
 	memoryFreeQuery := `system_memory_usage_bytes{state="free"}`
 	memFreeResp, err := h.promClient.Query(ctx, memoryFreeQuery)
 	if err == nil && len(memFreeResp.Data.Result) > 0 {
@@ -156,7 +157,7 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 			metrics.Memory.Free = val
 		}
 	}
-	
+
 	memoryCachedQuery := `system_memory_usage_bytes{state="cached"}`
 	memCachedResp, err := h.promClient.Query(ctx, memoryCachedQuery)
 	if err == nil && len(memCachedResp.Data.Result) > 0 {
@@ -164,25 +165,25 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 			metrics.Memory.Cached = val
 		}
 	}
-	
+
 	// Calculate total and utilization
 	metrics.Memory.Total = metrics.Memory.Used + metrics.Memory.Free + metrics.Memory.Cached
 	if metrics.Memory.Total > 0 {
 		metrics.Memory.Utilization = (metrics.Memory.Used / metrics.Memory.Total) * 100
 	}
-	
+
 	// Fetch disk metrics
 	diskUsageQuery := `system_filesystem_usage_bytes`
 	diskResp, err := h.promClient.Query(ctx, diskUsageQuery)
 	if err == nil {
 		deviceMap := make(map[string]*DiskMetrics)
-		
+
 		for _, result := range diskResp.Data.Result {
 			if device, exists := result.Metric["device"]; exists {
 				if _, exists := deviceMap[device]; !exists {
 					deviceMap[device] = &DiskMetrics{Device: device}
 				}
-				
+
 				if val, err := extractFloatValue(&result); err == nil {
 					if state, exists := result.Metric["state"]; exists {
 						switch state {
@@ -195,7 +196,7 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 				}
 			}
 		}
-		
+
 		// Convert map to slice and calculate utilization
 		for _, disk := range deviceMap {
 			disk.Total += disk.Used
@@ -205,13 +206,13 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 			metrics.Disk = append(metrics.Disk, *disk)
 		}
 	}
-	
+
 	// Fetch disk I/O rates
 	diskIOQuery := `rate(system_disk_io_bytes_total[5m])`
 	diskIOResp, err := h.promClient.Query(ctx, diskIOQuery)
 	if err == nil {
 		deviceIOMap := make(map[string]float64)
-		
+
 		for _, result := range diskIOResp.Data.Result {
 			if device, exists := result.Metric["device"]; exists {
 				if val, err := extractFloatValue(&result); err == nil {
@@ -219,7 +220,7 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 				}
 			}
 		}
-		
+
 		// Update disk metrics with I/O rates
 		for i := range metrics.Disk {
 			if ioRate, exists := deviceIOMap[metrics.Disk[i].Device]; exists {
@@ -227,19 +228,19 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 			}
 		}
 	}
-	
+
 	// Fetch network metrics
 	networkIOQuery := `rate(system_network_io_bytes_total[5m])`
 	netIOResp, err := h.promClient.Query(ctx, networkIOQuery)
 	if err == nil {
 		interfaceMap := make(map[string]*NetworkMetrics)
-		
+
 		for _, result := range netIOResp.Data.Result {
 			if iface, exists := result.Metric["device"]; exists {
 				if _, exists := interfaceMap[iface]; !exists {
 					interfaceMap[iface] = &NetworkMetrics{Interface: iface}
 				}
-				
+
 				if val, err := extractFloatValue(&result); err == nil {
 					if direction, exists := result.Metric["direction"]; exists {
 						switch direction {
@@ -252,13 +253,13 @@ func (h *MetricsHandler) fetchSystemMetrics(ctx context.Context) (*SystemMetrics
 				}
 			}
 		}
-		
+
 		// Convert map to slice
 		for _, netMetric := range interfaceMap {
 			metrics.Network = append(metrics.Network, *netMetric)
 		}
 	}
-	
+
 	return metrics, nil
 }
 
@@ -266,7 +267,7 @@ func (h *MetricsHandler) fetchSystemMetricsTimeSeries(ctx context.Context, timeR
 	duration, step := GetTimeRangeConfig(timeRange)
 	endTime := time.Now().UTC()
 	startTime := endTime.Add(-duration)
-	
+
 	response := &TimeSeriesResponse{
 		TimeRange: string(timeRange),
 		StartTime: startTime,
@@ -274,7 +275,7 @@ func (h *MetricsHandler) fetchSystemMetricsTimeSeries(ctx context.Context, timeR
 		Step:      step,
 		Series:    []TimeSeries{},
 	}
-	
+
 	// Define key system metrics queries
 	queries := map[string]string{
 		"cpu_utilization":    `100-avg(rate(system_cpu_time_seconds_total{state="idle"}[5m]))*100`,
@@ -283,7 +284,7 @@ func (h *MetricsHandler) fetchSystemMetricsTimeSeries(ctx context.Context, timeR
 		"network_rx_rate":    `rate(system_network_io_bytes_total{direction="receive"}[5m])`,
 		"network_tx_rate":    `rate(system_network_io_bytes_total{direction="transmit"}[5m])`,
 	}
-	
+
 	// Execute each query as a range query
 	for metricName, query := range queries {
 		resp, err := h.promClient.QueryRange(ctx, query, startTime, endTime, step)
@@ -291,7 +292,7 @@ func (h *MetricsHandler) fetchSystemMetricsTimeSeries(ctx context.Context, timeR
 			// Log error but continue with other metrics
 			continue
 		}
-		
+
 		// Process results and add to response
 		for _, result := range resp.Data.Result {
 			ts, err := extractTimeSeries(&result)
@@ -302,121 +303,151 @@ func (h *MetricsHandler) fetchSystemMetricsTimeSeries(ctx context.Context, timeR
 			response.Series = append(response.Series, ts)
 		}
 	}
-	
+
 	return response, nil
 }
 
-func (h *MetricsHandler) fetchContainerMetrics(ctx context.Context) (*ContainerMetrics, error) {
-	metrics := &ContainerMetrics{
-		Timestamp:  time.Now().UTC(),
-		Containers: []ContainerStats{},
-	}
+// containerRef is one row of the container listing: the cAdvisor name, the
+// compose service behind it, and the image it is running.
+type containerRef struct {
+	name    string
+	service string
+	image   string
+}
 
-	// Get list of containers
-	containerQuery := `count by (name, image) (container_last_seen)`
-	containerResp, err := h.promClient.Query(ctx, containerQuery)
+// listContainers is a single query, so callers that only need to resolve a
+// name don't pay for the whole per-container fan-out.
+//
+// max() rather than count() so the value is the last-seen timestamp. Grouping
+// by image means one container can yield two rows: for a few minutes after a
+// redeploy the replaced container is still inside Prometheus's lookback
+// window alongside its replacement. Keeping the newer sample per name is what
+// stops the dashboard reporting the previous revision as the running one,
+// right when someone is watching a deploy.
+func (h *MetricsHandler) listContainers(ctx context.Context) ([]containerRef, error) {
+	const query = `max by (name, image, container_label_com_docker_compose_service) (container_last_seen)`
+	resp, err := h.promClient.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
-	containerNames := []string{}
-	images := map[string]string{}
-	for _, result := range containerResp.Data.Result {
-		if name, exists := result.Metric["name"]; exists && name != "" {
-			containerNames = append(containerNames, name)
-			images[name] = result.Metric["image"]
+	newest := map[string]float64{}
+	byName := map[string]containerRef{}
+	for i := range resp.Data.Result {
+		result := &resp.Data.Result[i]
+		name := result.Metric["name"]
+		if name == "" {
+			continue
 		}
+		lastSeen, err := extractFloatValue(result)
+		if err != nil {
+			lastSeen = 0
+		}
+		if prev, seen := newest[name]; seen && lastSeen <= prev {
+			continue
+		}
+		newest[name] = lastSeen
+
+		// Compose stamps the service on the container; the label is exact
+		// where parsing the name is a guess about the project prefix, which
+		// differs between the deployed host and local_deploy.sh.
+		service := result.Metric["container_label_com_docker_compose_service"]
+		if service == "" {
+			service = containerDisplayName(name)
+		}
+		byName[name] = containerRef{name: name, service: service, image: result.Metric["image"]}
 	}
 
-	// Fetch metrics for each container, including the restart churn that is a
-	// crash-looping service's only trace — it dies before serving anything, so
-	// its app metrics stay flat and look exactly like an idle service.
-	for _, name := range containerNames {
-		stats := ContainerStats{Name: name}
+	// Sorted so first-match resolution is deterministic rather than dependent
+	// on Prometheus's vector order.
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
 
-		// CPU usage (percentage)
-		cpuQuery := fmt.Sprintf(`rate(container_cpu_usage_seconds_total{name="%s"}[5m])*100`, name)
-		cpuResp, err := h.promClient.Query(ctx, cpuQuery)
-		if err == nil && len(cpuResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&cpuResp.Data.Result[0]); err == nil {
-				stats.CPUUsagePercent = val
-			}
+	refs := make([]containerRef, 0, len(names))
+	for _, name := range names {
+		refs = append(refs, byName[name])
+	}
+	return refs, nil
+}
+
+// containerStats runs the per-container queries for one container, so a
+// single-container request doesn't fan out across the whole stack.
+func (h *MetricsHandler) containerStats(ctx context.Context, ref containerRef) ContainerStats {
+	stats := ContainerStats{
+		Name:    ref.name,
+		Service: ref.service,
+		Image:   ref.image,
+		Version: imageTag(ref.image),
+	}
+	name := ref.name
+
+	scalar := func(query string) (float64, bool) {
+		resp, err := h.promClient.Query(ctx, query)
+		if err != nil || len(resp.Data.Result) == 0 {
+			return 0, false
 		}
-
-		// CPU throttling
-		throttleQuery := fmt.Sprintf(`rate(container_cpu_cfs_throttled_seconds_total{name="%s"}[5m])`, name)
-		throttleResp, err := h.promClient.Query(ctx, throttleQuery)
-		if err == nil && len(throttleResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&throttleResp.Data.Result[0]); err == nil {
-				stats.CPUThrottledSeconds = val
-			}
+		val, err := extractFloatValue(&resp.Data.Result[0])
+		if err != nil {
+			return 0, false
 		}
-
-		// Memory usage
-		memQuery := fmt.Sprintf(`container_memory_usage_bytes{name="%s"}`, name)
-		memResp, err := h.promClient.Query(ctx, memQuery)
-		if err == nil && len(memResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&memResp.Data.Result[0]); err == nil {
-				stats.MemoryUsageBytes = val
-			}
-		}
-
-		// Memory limit
-		memLimitQuery := fmt.Sprintf(`container_spec_memory_limit_bytes{name="%s"}`, name)
-		memLimitResp, err := h.promClient.Query(ctx, memLimitQuery)
-		if err == nil && len(memLimitResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&memLimitResp.Data.Result[0]); err == nil {
-				stats.MemoryLimitBytes = val
-				if stats.MemoryUsageBytes > 0 && val > 0 {
-					stats.MemoryUsagePercent = (stats.MemoryUsageBytes / val) * 100
-				}
-			}
-		}
-
-		// Network RX
-		netRxQuery := fmt.Sprintf(`rate(container_network_receive_bytes_total{name="%s"}[5m])`, name)
-		netRxResp, err := h.promClient.Query(ctx, netRxQuery)
-		if err == nil && len(netRxResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&netRxResp.Data.Result[0]); err == nil {
-				stats.NetworkRxBytes = val
-			}
-		}
-
-		// Network TX
-		netTxQuery := fmt.Sprintf(`rate(container_network_transmit_bytes_total{name="%s"}[5m])`, name)
-		netTxResp, err := h.promClient.Query(ctx, netTxQuery)
-		if err == nil && len(netTxResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&netTxResp.Data.Result[0]); err == nil {
-				stats.NetworkTxBytes = val
-			}
-		}
-
-		// Restarts. cAdvisor exposes no restart counter, so count the steps in
-		// the container's start time: each restart re-stamps it.
-		restartQuery := fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[1h])`, name)
-		restartResp, err := h.promClient.Query(ctx, restartQuery)
-		if err == nil && len(restartResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&restartResp.Data.Result[0]); err == nil {
-				stats.RestartsLastHour = val
-			}
-		}
-
-		// How long the current run has lasted.
-		uptimeQuery := fmt.Sprintf(`time()-container_start_time_seconds{name="%s"}`, name)
-		uptimeResp, err := h.promClient.Query(ctx, uptimeQuery)
-		if err == nil && len(uptimeResp.Data.Result) > 0 {
-			if val, err := extractFloatValue(&uptimeResp.Data.Result[0]); err == nil {
-				stats.UptimeSeconds = val
-			}
-		}
-
-		stats.CrashLooping = isCrashLooping(stats.RestartsLastHour, stats.UptimeSeconds)
-		stats.Image = images[name]
-		stats.Version = imageTag(stats.Image)
-
-		metrics.Containers = append(metrics.Containers, stats)
+		return val, true
 	}
 
+	if val, ok := scalar(fmt.Sprintf(`rate(container_cpu_usage_seconds_total{name="%s"}[5m])*100`, name)); ok {
+		stats.CPUUsagePercent = val
+	}
+	if val, ok := scalar(fmt.Sprintf(`rate(container_cpu_cfs_throttled_seconds_total{name="%s"}[5m])`, name)); ok {
+		stats.CPUThrottledSeconds = val
+	}
+	if val, ok := scalar(fmt.Sprintf(`container_memory_usage_bytes{name="%s"}`, name)); ok {
+		stats.MemoryUsageBytes = val
+	}
+	if val, ok := scalar(fmt.Sprintf(`container_spec_memory_limit_bytes{name="%s"}`, name)); ok {
+		stats.MemoryLimitBytes = val
+		if stats.MemoryUsageBytes > 0 && val > 0 {
+			stats.MemoryUsagePercent = (stats.MemoryUsageBytes / val) * 100
+		}
+	}
+	if val, ok := scalar(fmt.Sprintf(`sum(rate(container_network_receive_bytes_total{name="%s"}[5m]))`, name)); ok {
+		stats.NetworkRxBytes = val
+	}
+	if val, ok := scalar(fmt.Sprintf(`sum(rate(container_network_transmit_bytes_total{name="%s"}[5m]))`, name)); ok {
+		stats.NetworkTxBytes = val
+	}
+
+	// cAdvisor exposes no restart counter, so count the steps in the
+	// container's start time: each restart re-stamps it.
+	if val, ok := scalar(fmt.Sprintf(`changes(container_start_time_seconds{name="%s"}[1h])`, name)); ok {
+		stats.RestartsLastHour = val
+	}
+	uptime, reporting := scalar(fmt.Sprintf(`time()-container_start_time_seconds{name="%s"}`, name))
+	stats.UptimeSeconds = uptime
+
+	// Uptime is the liveness signal: a running container always has one. Its
+	// absence means the query failed or cAdvisor has nothing, and claiming
+	// crash_looping=false there would report a container we can't see as
+	// healthy — the exact false negative these fields exist to prevent.
+	stats.Reporting = reporting
+	stats.CrashLooping = reporting && isCrashLooping(stats.RestartsLastHour, stats.UptimeSeconds)
+	return stats
+}
+
+func (h *MetricsHandler) fetchContainerMetrics(ctx context.Context) (*ContainerMetrics, error) {
+	refs, err := h.listContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := &ContainerMetrics{
+		Timestamp:  time.Now().UTC(),
+		Containers: []ContainerStats{},
+	}
+	for _, ref := range refs {
+		metrics.Containers = append(metrics.Containers, h.containerStats(ctx, ref))
+	}
 	return metrics, nil
 }
 
@@ -447,15 +478,15 @@ func (h *MetricsHandler) fetchContainerMetricsTimeSeries(ctx context.Context, ti
 
 	// Define key container metrics queries
 	queries := map[string]string{
-		"cpu_usage":           `rate(container_cpu_usage_seconds_total[5m])*100`,
-		"cpu_throttled":       `rate(container_cpu_cfs_throttled_seconds_total[5m])`,
-		"memory_usage":        `container_memory_usage_bytes`,
+		"cpu_usage":            `rate(container_cpu_usage_seconds_total[5m])*100`,
+		"cpu_throttled":        `rate(container_cpu_cfs_throttled_seconds_total[5m])`,
+		"memory_usage":         `container_memory_usage_bytes`,
 		"memory_usage_percent": `(container_memory_usage_bytes/container_spec_memory_limit_bytes)*100`,
-		"network_rx":          `rate(container_network_receive_bytes_total[5m])`,
-		"network_tx":          `rate(container_network_transmit_bytes_total[5m])`,
+		"network_rx":           `rate(container_network_receive_bytes_total[5m])`,
+		"network_tx":           `rate(container_network_transmit_bytes_total[5m])`,
 		// The history a point-in-time check can't give: restarts over the
 		// window, so a crash loop that resolved overnight is still visible.
-		"restarts": `changes(container_start_time_seconds[5m])`,
+		"restarts": fmt.Sprintf(`changes(container_start_time_seconds[%s])`, step),
 	}
 
 	// Execute each query as a range query

--- a/domains/platform/apis/prom_proxy/handlers_test.go
+++ b/domains/platform/apis/prom_proxy/handlers_test.go
@@ -255,6 +255,12 @@ type mockPrometheusClient struct {
 	// returns an empty result, so a mis-wired query reads as zero instead
 	// of borrowing another query's value.
 	queryResponses map[string]*QueryResponse
+	// Same for range queries. Without this a handler can build the wrong
+	// query — or none at all — and every assertion still passes.
+	queryRangeResponses map[string]*QueryResponse
+	// Queries with no fixture entry, so a test can prove nothing was
+	// silently answered with an empty result.
+	misses []string
 }
 
 func (m *mockPrometheusClient) Query(ctx context.Context, query string) (*QueryResponse, error) {
@@ -262,12 +268,20 @@ func (m *mockPrometheusClient) Query(ctx context.Context, query string) (*QueryR
 		if resp, ok := m.queryResponses[query]; ok {
 			return resp, nil
 		}
+		m.misses = append(m.misses, query)
 		return &QueryResponse{}, nil
 	}
 	return m.queryResponse, m.queryError
 }
 
 func (m *mockPrometheusClient) QueryRange(ctx context.Context, query string, start, end time.Time, step string) (*QueryResponse, error) {
+	if m.queryRangeResponses != nil {
+		if resp, ok := m.queryRangeResponses[query]; ok {
+			return resp, nil
+		}
+		m.misses = append(m.misses, query)
+		return &QueryResponse{}, nil
+	}
 	return m.queryRangeResponse, m.queryRangeError
 }
 
@@ -333,7 +347,7 @@ func TestIsCrashLooping(t *testing.T) {
 
 func TestFetchContainerMetrics_SurfacesCrashLoop(t *testing.T) {
 	mock := &mockPrometheusClient{queryResponses: map[string]*QueryResponse{
-		`count by (name, image) (container_last_seen)`: {
+		`max by (name, image, container_label_com_docker_compose_service) (container_last_seen)`: {
 			Status: "success",
 			Data: struct {
 				ResultType string   `json:"resultType"`

--- a/domains/platform/apis/prom_proxy/handlers_test.go
+++ b/domains/platform/apis/prom_proxy/handlers_test.go
@@ -333,7 +333,7 @@ func TestIsCrashLooping(t *testing.T) {
 
 func TestFetchContainerMetrics_SurfacesCrashLoop(t *testing.T) {
 	mock := &mockPrometheusClient{queryResponses: map[string]*QueryResponse{
-		`count by (name) (container_last_seen)`: {
+		`count by (name, image) (container_last_seen)`: {
 			Status: "success",
 			Data: struct {
 				ResultType string   `json:"resultType"`

--- a/domains/platform/apis/prom_proxy/main.go
+++ b/domains/platform/apis/prom_proxy/main.go
@@ -41,6 +41,11 @@ func main() {
 	router.HandleFunc("GET /metrics/v1/services", metricsHandler.GetServiceCatalog)
 	router.HandleFunc("GET /metrics/v1/host", metricsHandler.GetHostMetrics)
 	router.HandleFunc("GET /metrics/v1/host/timeseries/{range}", metricsHandler.GetHostMetricsTimeSeries)
+	// Container endpoints (#1208): health for every container, including the
+	// infrastructure ones that emit no app metrics and so have no service page.
+	router.HandleFunc("GET /metrics/v1/containers", metricsHandler.GetContainers)
+	router.HandleFunc("GET /metrics/v1/container/{name}", metricsHandler.GetContainerDetail)
+	router.HandleFunc("GET /metrics/v1/container/{name}/timeseries/{range}", metricsHandler.GetContainerTimeSeries)
 	router.HandleFunc("GET /metrics/v1/service/{name}", metricsHandler.GetServiceMetrics)
 	router.HandleFunc("GET /metrics/v1/service/{name}/timeseries/{range}", metricsHandler.GetServiceMetricsTimeSeries)
 

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -113,6 +113,11 @@ type ContainerStats struct {
 	RestartsLastHour float64 `json:"restarts_last_hour"`
 	UptimeSeconds    float64 `json:"uptime_seconds"`
 	CrashLooping     bool    `json:"crash_looping"`
+	// The image the container is actually running, and its tag. Deploys pin
+	// every image to a commit SHA (MoonBase#1210), so the tag is the running
+	// revision — the fact, as opposed to what the host recorded it should be.
+	Image   string `json:"image"`
+	Version string `json:"version"`
 }
 
 type ServiceCatalogEntry struct {

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -7,15 +7,15 @@ type TimeRange string
 
 const (
 	Last30Minutes TimeRange = "30m"
-	LastDay       TimeRange = "1d" 
+	LastDay       TimeRange = "1d"
 	LastWeek      TimeRange = "7d"
 )
 
 // TimeSeries represents a single metric with timestamps
 type TimeSeries struct {
-	MetricName string      `json:"metric_name"`
+	MetricName string            `json:"metric_name"`
 	Labels     map[string]string `json:"labels,omitempty"`
-	Values     []DataPoint `json:"values"`
+	Values     []DataPoint       `json:"values"`
 }
 
 // DataPoint represents a single timestamped value
@@ -58,10 +58,10 @@ func ValidTimeRange(tr string) bool {
 }
 
 type SystemMetrics struct {
-	Timestamp time.Time      `json:"timestamp"`
-	CPU       CPUMetrics     `json:"cpu"`
-	Memory    MemoryMetrics  `json:"memory"`
-	Disk      []DiskMetrics  `json:"disk"`
+	Timestamp time.Time        `json:"timestamp"`
+	CPU       CPUMetrics       `json:"cpu"`
+	Memory    MemoryMetrics    `json:"memory"`
+	Disk      []DiskMetrics    `json:"disk"`
 	Network   []NetworkMetrics `json:"network"`
 }
 
@@ -94,12 +94,15 @@ type NetworkMetrics struct {
 }
 
 type ContainerMetrics struct {
-	Timestamp  time.Time             `json:"timestamp"`
-	Containers []ContainerStats      `json:"containers"`
+	Timestamp  time.Time        `json:"timestamp"`
+	Containers []ContainerStats `json:"containers"`
 }
 
 type ContainerStats struct {
-	Name                string  `json:"name"`
+	Name string `json:"name"`
+	// The compose service behind the container. Clients link a container to
+	// its service page with this rather than re-deriving it from the name.
+	Service             string  `json:"service"`
 	CPUUsagePercent     float64 `json:"cpu_usage_percent"`
 	CPUThrottledSeconds float64 `json:"cpu_throttled_seconds"`
 	MemoryUsageBytes    float64 `json:"memory_usage_bytes"`
@@ -118,6 +121,10 @@ type ContainerStats struct {
 	// revision — the fact, as opposed to what the host recorded it should be.
 	Image   string `json:"image"`
 	Version string `json:"version"`
+	// False when cAdvisor returned nothing for this container. Without it a
+	// failed or timed-out query leaves zeros, and zero restarts with zero
+	// uptime is indistinguishable from a healthy container.
+	Reporting bool `json:"reporting"`
 }
 
 type ServiceCatalogEntry struct {
@@ -162,4 +169,11 @@ type ServiceMetricsResponse struct {
 	Service   string              `json:"service"`
 	Standard  StandardMetrics     `json:"standard"`
 	Custom    []CustomMetricGroup `json:"custom"`
+}
+
+// ContainerDetail wraps a single container so the point-in-time endpoints all
+// carry a timestamp, like the host and service responses.
+type ContainerDetail struct {
+	Timestamp time.Time      `json:"timestamp"`
+	Container ContainerStats `json:"container"`
 }


### PR DESCRIPTION
Finishes the backend for the container half of #1208, so the UI can be built against a real API instead of working around its absence.

## What

**Endpoints**
- `GET /metrics/v1/containers` — every container with health
- `GET /metrics/v1/container/{name}` — one container
- `GET /metrics/v1/container/{name}/timeseries/{range}` — its series, including restarts

Addressable by **service name or container name** (`posterize` or `ubuntu-posterize-1`). The listing is deliberately *not* registry-driven: caddy, postgres, and prometheus emit no app metrics, so this is the only surface they appear on at all. Caddy already routes `/metrics/v1/*` (widened in #1201), so no deploy config change.

**Running version** (#1208 §4 read side) — cAdvisor labels its series with the image, and deploys pin images per commit (#1210), so the container listing yields the running revision with no extra round trip and no per-language work. It covers every container, not just the OTEL emitters.

## Why before the UI

The UI was going to fetch the **entire host payload** — every container's CPU/memory/network — just to read one container's health on a service page. That's a workaround for a missing endpoint, not a design.

## Review round

A review panel found a blocker and several correctness bugs, all fixed here.

**Blocker: the bazel build was broken.** `BUILD.bazel` uses explicit `srcs`, not globs, and `scripts/diff-build` never runs gazelle. `handlers.go` calls `imageTag` from the unlisted `container_handlers.go`, so the library couldn't compile — and none of the new tests would have run. Local `go test` never consults BUILD.bazel, which is exactly why it looked fine.

**The `ubuntu-` prefix is not a convention — it's the directory compose runs from.** `local_deploy.sh` runs from `local_docker/`, so containers there are `local_docker-mithril-1` and every `/container/{service}` request would 404. Now resolved from cAdvisor's `container_label_com_docker_compose_service`, with name-parsing as fallback. The resolved `service` is returned in the payload too, so clients link a container to its service page instead of re-deriving the heuristic in JavaScript.

**Missing data read as healthy.** Every per-container query is error-tolerant, so a failed or timed-out one left zeros — and zero restarts with zero uptime is indistinguishable from a healthy container. That is the exact false negative these endpoints exist to prevent, and it was reachable: the handlers share one 30s deadline. Uptime presence now gates the crash-loop flag and is reported as `reporting`, so absence is legible rather than silently benign.

**Duplicate rows during deploys.** Grouping the listing by image lets one container yield two rows while the replaced container is still inside Prometheus's lookback window — showing it twice, and able to report the *previous* revision as the running one, during a deploy. Now keyed on the newest sample per name.

**129 queries to return one container.** `/container/{name}` fetched every container and discarded 15/16; `/container/{name}/timeseries` burned the same 129 purely to translate a name, then threw all of it away. Both now resolve from the single listing query: **9** and **7** queries respectively.

Also: the restart window tracks the step (at 7d the step is 1h, so a fixed `[5m]` window inspects five minutes per hour and drops most restarts — precisely the overnight crash loop this is for); an exact container name beats a service match; digest references return no version rather than 64 hex chars that look like a commit SHA; network rates are summed so multi-interface containers yield one series per metric; and the listing degrades to an empty section rather than a 500, matching the rest of the API.

## Tests

51 passing. The review's mutation testing showed the first round's HTTP-layer tests were much weaker than they looked: **the mock ignored the query argument for range queries**, so a handler could build the wrong query — or none at all — and still pass. Seven mutations survived, including building queries from the *requested* name instead of the resolved one, which in production means silently empty charts.

The mock is now keyed on range queries like it already was on instant queries, and records unmatched queries so a test can assert nothing was silently answered with an empty result.

I re-ran mutation testing on the fixes, and **two of my own new tests were still hollow**:
- the dedup fixture listed the newest row last, so "keep the last row" passed too — reversed so it discriminates;
- the `reporting` guard only bites on *partial* failure (restarts present, uptime absent, where `isCrashLooping(47, 0)` would wrongly say yes) — the all-zeros case couldn't catch it.

Both fixed. All six mutations I checked are now killed: resolved-vs-requested name, dropped restarts series, fixed restart window, the reporting guard, newest-wins dedup, and the compose label.

Unit coverage is unchanged in spirit but broadened: digests, registry ports, tags with dots, underscored service names, double-digit replica indices, and exact-name-beats-service resolution.

`go vet` clean; new files gofmt-clean. `bazel test` still can't run in my sandbox (the proxy 403s `container_structure_test` during package load), so CI remains the first bazel run — which is precisely how the blocker above escaped the first round.

## Next

UI (muchq/muchq.github.io#242): service-page health strip, the host page's container list — currently rendering only `containers.slice(0, 4)` of ~14 — and a Containers tab. Work in progress is parked on `container-health-ui` there.