### PR TITLE
Add mutation-check, and notes on tests that can't fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The repository is organized into **domains**, each containing its own libraries,
 
 - [**Build & IDE Instructions**](docs/BUILD_AND_IDE.md): How to build the project and set up your development environment.
 - [**Importing Projects**](docs/IMPORTING.md): Guidelines for adding new projects to MoonBase.
+- [**Testing Notes**](docs/TESTING.md): Checking that tests can actually fail, and the traps that only show up in CI or on another platform.
 
 
 <p align="center">

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,71 @@
+# Testing notes
+
+Conventions worth knowing beyond "write tests". Most of this exists because
+something got through.
+
+## Check that tests can fail
+
+A green suite proves the tests ran. It does not prove they would catch
+anything, and the difference is easy to miss because both look identical.
+
+The recurring shape is an assertion that holds for the right reason *and* for
+a wrong one:
+
+- A zero that means "healthy" and also "the query failed".
+- A name that is correct whether or not the payload beside it belongs to the
+  same object.
+- A response asserted only by status code, leaving the body unprotected.
+- A mock that ignores an argument, so a caller can pass the wrong value — or
+  build no request at all — and every assertion still passes.
+
+`scripts/mutation-check` breaks the code on purpose and reports which
+mutations the suite failed to notice. A surviving mutation is a bug the tests
+would ship.
+
+```bash
+scripts/mutation-check -f path/to/file.go -t 'go test ./...' \
+  's/count >= threshold/count > threshold/' \
+  's/x = ready \&\& check(y)/x = check(y)/'
+```
+
+It refuses to run against an already-red suite (every mutation would look
+caught) and reports an expression that matched nothing as `SKIPPED` rather
+than as a survivor, so a typo isn't mistaken for a finding. The file is
+restored afterwards, including on Ctrl-C.
+
+Mutate the *behaviour*, not the syntax. A change that fails to compile is
+caught by the compiler and says nothing about the tests. Aim at decisions:
+boundaries, guards, which variable feeds a call, an omitted field.
+
+Worth doing when a test protects something whose failure is silent — a health
+signal, a version, a permission, an error path — and when reviewing tests
+someone else wrote. Not worth doing on everything.
+
+Two real examples from `prom_proxy`:
+
+- The Prometheus mock returned a canned response for *range* queries without
+  looking at the query string. A handler could build its queries from the
+  wrong variable and produce empty charts in production; seven mutations
+  survived until the mock was keyed on the query.
+- A dedup test listed its fixture rows newest-last, so "keep the newest row"
+  and "keep the last row" gave the same answer. It passed against an
+  implementation that had no dedup logic at all.
+
+## Bazel `srcs` are explicit
+
+`BUILD.bazel` lists sources by name rather than globbing, and CI runs bazel
+directly with no gazelle step (`scripts/diff-build`). A new file that isn't
+added to the relevant `srcs` will not compile under bazel, and its tests will
+not run — while `go test ./...` locally passes, because it never reads
+`BUILD.bazel`. Run `bazel run //:gazelle` after adding files.
+
+## Some things only break on the other platform
+
+`deploy.sh` runs from a developer machine, and macOS ships bash 3.2 as
+`/bin/bash` — no associative arrays, no `${x^^}`, no negative array indices.
+Linux CI runs bash 5 and cannot reproduce any of it. `scripts/test-deploy`
+therefore does both: a static check for bash-4-only constructs, and a
+`test-deploy-macos` CI job that runs the suite against the real `/bin/bash`.
+
+The general point: when correctness depends on the environment, a test that
+only ever runs in one environment is evidence about that environment.

--- a/scripts/mutation-check
+++ b/scripts/mutation-check
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Break the code on purpose and check the tests notice.
+#
+# A green suite proves the tests ran, not that they'd catch anything. Tests
+# routinely assert on values that are correct and also the default — a zero
+# that means "healthy" and also "the query failed", a name that's right whether
+# or not the payload beside it is. Those pass against a broken implementation.
+#
+# This applies each mutation, runs the tests, and reports the ones that did NOT
+# fail. A surviving mutation is a bug the suite would ship.
+set -uo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: mutation-check -f FILE -t TEST_CMD MUTATION [MUTATION...]
+
+Applies each MUTATION (a sed expression) to FILE, runs TEST_CMD, and reports
+which mutations survived — i.e. which real bugs the tests fail to catch.
+
+Options:
+  -f, --file FILE     File to mutate; restored afterwards, including on Ctrl-C
+  -t, --test CMD      Test command; must pass before mutating
+  -h, --help          Show this help
+
+Examples:
+  # Does the suite notice if a boundary is wrong?
+  scripts/mutation-check -f domains/platform/apis/prom_proxy/handlers.go \
+    -t 'go test $(ls domains/platform/apis/prom_proxy/*.go | grep -v /main.go)' \
+    's/restartsLastHour >= crashLoopMinRestarts/restartsLastHour > crashLoopMinRestarts/' \
+    's/stats.CrashLooping = reporting \&\& isCrashLooping/stats.CrashLooping = isCrashLooping/'
+
+  # Shell works too — the file just has to be text and the command a test run.
+  scripts/mutation-check -f deploy/consolidated/deploy.sh -t ./scripts/test-deploy \
+    's/--remove-orphans//'
+
+Mutate the behaviour, not the syntax: a change that won't compile is caught by
+the compiler and tells you nothing about the tests. Aim at the decisions —
+boundaries, guards, which variable feeds a call, an omitted field.
+USAGE
+}
+
+FILE=""
+TEST_CMD=""
+MUTATIONS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -f | --file)
+      FILE=${2:-}
+      shift 2
+      ;;
+    -t | --test)
+      TEST_CMD=${2:-}
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      MUTATIONS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$FILE" ] || [ -z "$TEST_CMD" ] || [ ${#MUTATIONS[@]} -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+if [ ! -f "$FILE" ]; then
+  echo "Error: no such file: $FILE" >&2
+  exit 1
+fi
+
+BACKUP=$(mktemp)
+cp "$FILE" "$BACKUP"
+restore() { cp "$BACKUP" "$FILE"; }
+# Restore on interrupt too: leaving a mutated source behind would be worse
+# than the bug being looked for.
+trap 'restore; rm -f "$BACKUP"; exit 130' INT TERM
+trap 'restore; rm -f "$BACKUP"' EXIT
+
+# Baseline. Without this a suite that's already red makes every mutation look
+# caught, which is the most flattering possible wrong answer.
+echo "baseline..."
+if ! eval "$TEST_CMD" > /dev/null 2>&1; then
+  echo "Error: tests fail before any mutation — fix that first, or every" >&2
+  echo "mutation will look caught." >&2
+  exit 1
+fi
+echo "  ok, suite is green"
+echo
+
+SURVIVED=0
+for mutation in "${MUTATIONS[@]}"; do
+  restore
+  sed -i.bak "$mutation" "$FILE" 2>/dev/null
+  rm -f "$FILE.bak"
+
+  # A sed that matched nothing leaves the code intact, so the suite passes and
+  # the mutation looks like a survivor. That's a broken experiment, not a
+  # finding — say so instead of reporting a false bug.
+  if cmp -s "$FILE" "$BACKUP"; then
+    echo "  SKIPPED  $mutation"
+    echo "           (matched nothing — check the expression)"
+    continue
+  fi
+
+  if eval "$TEST_CMD" > /dev/null 2>&1; then
+    echo "  SURVIVED $mutation"
+    SURVIVED=$((SURVIVED + 1))
+  else
+    echo "  killed   $mutation"
+  fi
+done
+
+restore
+echo
+if [ "$SURVIVED" -gt 0 ]; then
+  echo "$SURVIVED mutation(s) survived: the tests would ship those bugs."
+  echo "Add an assertion that fails on each, then re-run."
+  exit 1
+fi
+echo "all mutations killed"


### PR DESCRIPTION
Persists a practice that earned its keep twice while reviewing #1218, so it doesn't live only in a review thread.

## The problem it addresses

A green suite proves the tests ran. It does not prove they'd catch anything — and the two are indistinguishable from the outside. Reviewing the container endpoints turned up seven assertions that passed against a **broken** implementation:

- The Prometheus mock returned a canned response for range queries without looking at the query string, so a handler could build its queries from the wrong variable — producing silently empty charts in production — and every assertion still passed.
- Handler tests asserted a status code and one field, leaving the rest of the payload unprotected: returning one container's stats under another's name passed.
- A dedup fixture listed its rows newest-last, so "keep the newest" and "keep the last" gave the same answer. It passed against an implementation with no dedup logic at all.

That last one was mine, in the fix for the first two. Which is the point: this isn't a thing you do once.

## `scripts/mutation-check`

Applies each mutation, runs the tests, reports which survived.

```
$ scripts/mutation-check -f domains/platform/apis/prom_proxy/handlers.go \
    -t 'go test $(ls domains/platform/apis/prom_proxy/*.go | grep -v /main.go)' \
    's/stats.CrashLooping = reporting && isCrashLooping/stats.CrashLooping = isCrashLooping/' \
    's/service := result.Metric\["container_label_com_docker_compose_service"\]/service := ""/'
baseline...
  ok, suite is green

  killed   s/stats.CrashLooping = reporting && isCrashLooping/...
  killed   s/service := result.Metric["container_label_com_docker_compose_service"]/service := ""/

all mutations killed
```

Two guards make the result trustworthy rather than flattering:

- **It refuses to run against an already-red suite.** Otherwise every mutation looks caught — the most flattering possible wrong answer.
- **An expression that matched nothing reports `SKIPPED`, not survived.** A typo'd sed leaves the code intact, the suite passes, and it would otherwise look exactly like a real finding.

The file is restored afterwards, including on Ctrl-C. Language-agnostic — it takes a file, a test command, and sed expressions, so it works on the Go packages and on `deploy.sh` via `scripts/test-deploy`.

Not wired into CI: mutations are line-specific and would rot. This is a tool you reach for when a test guards something whose failure is silent — a health signal, a version, an error path — or when reviewing tests someone else wrote.

## `docs/TESTING.md`

Writes down the why, with the two real cases, plus the other two traps from this week that have the same shape — *a check that can't observe the thing it's supposed to*:

- **Bazel `srcs` are explicit lists** and CI runs bazel with no gazelle step, so a new file compiles locally via `go test` and not in CI. That's how #1218 shipped a build where none of the new tests could run.
- **macOS ships bash 3.2**, so Linux CI proves nothing about `deploy.sh` running on a developer machine — which is why `scripts/test-deploy` has both a static check and a `test-deploy-macos` job.

Linked from the README's Getting Started alongside the existing docs.

## Verified

Ran the tool against the real prom_proxy suite: kills the three genuine mutations, reports the no-op expression as `SKIPPED`, and leaves the file byte-identical. Confirmed the `SURVIVED` path fires (exit 1) on a mutation nothing asserts, and that the baseline guard refuses a red suite. `bash -n` clean; every factual claim in the doc checked against the files it describes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_