### PR TITLE
prom_proxy: last-seen age and OOM kills per container

### DIFF
--- a/domains/platform/apis/prom_proxy/container_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/container_handlers_test.go
@@ -469,3 +469,67 @@ func TestGetContainers_PartialDataIsNotAVerdict(t *testing.T) {
 	assert.False(t, response.Containers[0].CrashLooping, "no verdict without uptime")
 	assert.Equal(t, 47.0, response.Containers[0].RestartsLastHour, "what we did measure is still reported")
 }
+
+// cAdvisor keeps answering for a container after it stops — the series lingers
+// until retention drops it — so the age of the last_seen stamp is what
+// separates "running" from "gone", in the window where uptime has nothing to
+// say because there is no current run to measure.
+func TestGetContainers_LastSeenAge(t *testing.T) {
+	mock := containerFixture()
+	mock.queryResponses[listQuery] = listResponse(
+		listResult("ubuntu-mithril-1", "mithril", "ghcr.io/muchq/mithril:abc123", 100),
+	)
+	mock.queryResponses[`time()-container_last_seen{name="ubuntu-mithril-1"}`] = scalarResponse("240")
+
+	handler := NewMetricsHandler(mock)
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 1)
+	assert.Equal(t, 240.0, response.Containers[0].LastSeenAgoSeconds)
+}
+
+func TestGetContainers_OOMEvents(t *testing.T) {
+	mock := containerFixture()
+	mock.queryResponses[listQuery] = listResponse(
+		listResult("ubuntu-mithril-1", "mithril", "ghcr.io/muchq/mithril:abc123", 100),
+	)
+	mock.queryResponses[`time()-container_start_time_seconds{name="ubuntu-mithril-1"}`] = scalarResponse("3600")
+	mock.queryResponses[`increase(container_oom_events_total{name="ubuntu-mithril-1"}[1h])`] = scalarResponse("2")
+
+	handler := NewMetricsHandler(mock)
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 1)
+	assert.Equal(t, 2.0, response.Containers[0].OOMEventsLastHour)
+}
+
+// Some cAdvisor builds ship no OOM counter at all. Its absence leaves the field
+// zero, which reads identically to "no kills" — so it must not touch Reporting,
+// which is the field that does carry a verdict about visibility.
+func TestGetContainers_OOMCounterAbsentIsNotAVerdict(t *testing.T) {
+	mock := containerFixture()
+	mock.queryResponses[listQuery] = listResponse(
+		listResult("ubuntu-mithril-1", "mithril", "ghcr.io/muchq/mithril:abc123", 100),
+	)
+	mock.queryResponses[`time()-container_start_time_seconds{name="ubuntu-mithril-1"}`] = scalarResponse("3600")
+	// OOM query deliberately absent
+
+	handler := NewMetricsHandler(mock)
+	w := httptest.NewRecorder()
+	handler.GetContainers(w, httptest.NewRequest(http.MethodGet, "/metrics/v1/containers", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response ContainerMetrics
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Len(t, response.Containers, 1)
+	assert.Zero(t, response.Containers[0].OOMEventsLastHour)
+	assert.True(t, response.Containers[0].Reporting, "a missing OOM counter says nothing about visibility")
+}

--- a/domains/platform/apis/prom_proxy/handlers.go
+++ b/domains/platform/apis/prom_proxy/handlers.go
@@ -426,6 +426,21 @@ func (h *MetricsHandler) containerStats(ctx context.Context, ref containerRef) C
 	uptime, reporting := scalar(fmt.Sprintf(`time()-container_start_time_seconds{name="%s"}`, name))
 	stats.UptimeSeconds = uptime
 
+	// How stale cAdvisor's view of this container is. Unlike uptime, this keeps
+	// answering after a container stops — the series lingers until retention
+	// drops it — which is what lets a dead container stay on the page instead
+	// of vanishing from it.
+	if val, ok := scalar(fmt.Sprintf(`time()-container_last_seen{name="%s"}`, name)); ok {
+		stats.LastSeenAgoSeconds = val
+	}
+
+	// Only where cAdvisor ships the counter; a build without it leaves zero,
+	// which reads the same as no kills. Not part of the reporting signal for
+	// that reason.
+	if val, ok := scalar(fmt.Sprintf(`increase(container_oom_events_total{name="%s"}[1h])`, name)); ok {
+		stats.OOMEventsLastHour = val
+	}
+
 	// Uptime is the liveness signal: a running container always has one. Its
 	// absence means the query failed or cAdvisor has nothing, and claiming
 	// crash_looping=false there would report a container we can't see as

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -116,6 +116,18 @@ type ContainerStats struct {
 	RestartsLastHour float64 `json:"restarts_last_hour"`
 	UptimeSeconds    float64 `json:"uptime_seconds"`
 	CrashLooping     bool    `json:"crash_looping"`
+	// Seconds since cAdvisor last observed this container. A running container
+	// has its stamp refreshed every scrape, so this stays near zero; a stopped
+	// one keeps its series until retention drops it, with the age growing.
+	// That is what keeps "deployed but down" visible rather than silently
+	// absent — the container is still listed, just increasingly stale.
+	LastSeenAgoSeconds float64 `json:"last_seen_ago_seconds"`
+	// OOM kills in the last hour, where cAdvisor exposes the counter at all.
+	// Restart churn says a container is flapping; this says whether memory is
+	// why. Absent on cAdvisor builds without the metric, which leaves it zero
+	// — indistinguishable from no kills, so treat it as corroboration for a
+	// restart count rather than as evidence of its own.
+	OOMEventsLastHour float64 `json:"oom_events_last_hour"`
 	// The image the container is actually running, and its tag. Deploys pin
 	// every image to a commit SHA (MoonBase#1210), so the tag is the running
 	// revision — the fact, as opposed to what the host recorded it should be.


### PR DESCRIPTION
Completes the per-container health fields #1208 §1 asked for. The dashboard's Containers tab (muchq/muchq.github.io#242 §3) needs last-seen to tell a running container from one that is merely still inside Prometheus retention.

## `last_seen_ago_seconds`

The age of cAdvisor's stamp rather than the stamp itself, matching how uptime is already derived.

It answers where uptime cannot. Uptime measures the *current run*, so a stopped container has nothing to report — but its `container_last_seen` series lingers until retention drops it, with the age growing. That is what keeps "deployed but down" on the page instead of vanishing from it, which is the visibility #1208 asks for.

## `oom_events_last_hour`

Best-effort. Some cAdvisor builds ship no OOM counter, and its absence leaves zero — identical to no kills. So it deliberately stays out of the `reporting` signal and is corroboration for a restart count rather than evidence on its own: restart churn says a container is flapping, this says whether memory is why.

## Testing

Verified by mutation rather than assumed: dropping the `last_seen` assignment fails the new test. Three tests added, including one pinning that a missing OOM counter says nothing about visibility — the same "absence is not a verdict" rule `reporting` exists to enforce.

Run with the repo's own invocation, since the package shares a directory with `main`:

```
go test $(ls domains/platform/apis/prom_proxy/*.go | grep -v /main.go)
ok  	command-line-arguments	0.225s
```

Note: `bazel test //domains/platform/apis/prom_proxy:prom_proxy_test` could not run in this environment — fetching `container_structure_test` from `github.com/GoogleContainerTools` returns 403 through the egress proxy. That is an environment restriction, not a change in this PR, and I did not route around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQGhwNTP1M1vTaFAutxCsr)_