### PR TITLE
golf: GameState serde with a versioned schema (#1194 step 0)

### DIFF
--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -87,6 +87,25 @@ cc_library(
     ],
 )
 
+# Phase-0 slice of the persistence integration suite (#1194): serialized
+# engine states must survive the step-2 storage target (jsonb normalizes
+# keys and spacing, and refuses escaped NULs). Real postgres via
+# GOLF_HUB_TEST_DB_URL; skips otherwise.
+cc_test(
+    name = "game_state_jsonb_test",
+    size = "small",
+    srcs = ["game_state_jsonb_test.cc"],
+    env_inherit = ["GOLF_HUB_TEST_DB_URL"],
+    deps = [
+        "//domains/games/libs/cards",
+        "//domains/games/libs/cards/golf:game_state",
+        "//domains/games/libs/cards/golf:game_state_serde",
+        "//domains/games/libs/cards/golf:player",
+        "//domains/platform/libs/pg",
+        "@googletest//:gtest_main",
+    ],
+)
+
 # Runs against a real postgres when GOLF_HUB_TEST_DB_URL is set (the SQL
 # is the risky code — no in-memory double); skips otherwise.
 cc_test(

--- a/domains/games/apis/golf_hub/game_state_jsonb_test.cc
+++ b/domains/games/apis/golf_hub/game_state_jsonb_test.cc
@@ -1,0 +1,135 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "domains/games/libs/cards/card.h"
+#include "domains/games/libs/cards/golf/game_state.h"
+#include "domains/games/libs/cards/golf/game_state_serde.h"
+#include "domains/games/libs/cards/golf/player.h"
+#include "domains/platform/libs/pg/pg.h"
+
+namespace {
+
+using cards::Card;
+
+// Phase-0 slice of the persistence integration suite (#1194): serialized
+// engine states must survive the storage target step 2 will write them
+// to, and jsonb is not a byte-preserving container — it re-orders keys
+// (length-then-bytes, not alphabetical), re-spaces the text, and refuses
+// escaped NULs outright. Real postgres via GOLF_HUB_TEST_DB_URL (the
+// vault suite's pattern); skips otherwise.
+class GameStateJsonbTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* url = std::getenv("GOLF_HUB_TEST_DB_URL");
+    if (url == nullptr || *url == '\0') {
+      GTEST_SKIP() << "GOLF_HUB_TEST_DB_URL unset";
+    }
+    db_ = std::make_unique<pg::Client>(url);
+    // TEMP table: session-scoped on the client's one connection, gone
+    // when the test's connection closes — no migration entanglement.
+    ASSERT_TRUE(db_->Exec("CREATE TEMP TABLE IF NOT EXISTS game_state_probe (state jsonb)").ok());
+    ASSERT_TRUE(db_->Exec("TRUNCATE game_state_probe").ok());
+  }
+
+  // INSERT the serialized state into the jsonb column and return
+  // postgres's own text rendering of what it stored.
+  std::optional<std::string> StoreAndFetch(const std::string& serialized) {
+    auto inserted =
+        db_->Exec("INSERT INTO game_state_probe (state) VALUES ($1::jsonb)", {serialized});
+    if (!inserted.ok()) {
+      ADD_FAILURE() << "insert failed: " << inserted.status();
+      return std::nullopt;
+    }
+    auto fetched = db_->Exec("SELECT state::text FROM game_state_probe");
+    if (!fetched.ok() || fetched->rows() != 1) {
+      ADD_FAILURE() << "fetch failed: " << fetched.status();
+      return std::nullopt;
+    }
+    return fetched->Get(0, 0);
+  }
+
+  std::unique_ptr<pg::Client> db_;
+};
+
+std::deque<Card> pristineDeck() {
+  std::deque<Card> deck;
+  for (int i = 0; i < 52; ++i) deck.emplace_back(i);
+  return deck;
+}
+
+// A mid-game state with every kind of content populated: peek history,
+// hidden reveal, a swapped hand, a grown discard pile.
+golf::GameState playedState() {
+  std::optional<golf::GameState> state;
+  auto dealt = golf::dealGolfGame("g", {"alice", "bob"}, pristineDeck());
+  EXPECT_TRUE(dealt.ok()) << dealt.status();
+  state.emplace(*std::move(dealt));
+  for (const int player : {0, 1}) {
+    for (const golf::Position position : {golf::Position::TopLeft, golf::Position::BottomRight}) {
+      auto next = state->peekOwnCard(player, position);
+      EXPECT_TRUE(next.ok()) << next.status();
+      state.emplace(*std::move(next));
+    }
+  }
+  auto hidden = state->hideCards(0);
+  EXPECT_TRUE(hidden.ok()) << hidden.status();
+  state.emplace(*std::move(hidden));
+  auto drawn = state->peekAtDrawPile(0);
+  EXPECT_TRUE(drawn.ok()) << drawn.status();
+  state.emplace(*std::move(drawn));
+  auto swapped = state->swapForDrawPile(0, golf::Position::TopLeft);
+  EXPECT_TRUE(swapped.ok()) << swapped.status();
+  return *std::move(swapped);
+}
+
+TEST_F(GameStateJsonbTest, StoredStateSurvivesJsonbNormalization) {
+  const golf::GameState state = playedState();
+  const std::string serialized = golf::serializeGameState(state);
+
+  const auto stored = StoreAndFetch(serialized);
+  ASSERT_TRUE(stored.has_value());
+  // jsonb re-renders the text: byte identity is an app-side property
+  // only, and nothing downstream may compare stored states by bytes.
+  EXPECT_NE(*stored, serialized);
+
+  const auto restored = golf::deserializeGameState(*stored);
+  ASSERT_TRUE(restored.ok()) << restored.status();
+  // Canonical re-serialization is state equality (ids are storage-owned
+  // and excluded by schema).
+  EXPECT_EQ(golf::serializeGameState(*restored), serialized);
+}
+
+TEST_F(GameStateJsonbTest, NameWithNulByteStillInserts) {
+  // Without serialize-side replacement this INSERT fails with
+  // "unsupported Unicode escape sequence" — the reason the policy
+  // exists. The sanitized name must then survive the round trip.
+  const golf::Player mangled{std::string("a\0b", 3), Card(0), Card(1), Card(2), Card(3)};
+  const golf::GameState state{{Card(4)}, {Card(5)}, {mangled, mangled}, false, 0, -1, false,
+                              "g",       "v"};
+  const std::string serialized = golf::serializeGameState(state);
+
+  const auto stored = StoreAndFetch(serialized);
+  ASSERT_TRUE(stored.has_value());
+  const auto restored = golf::deserializeGameState(*stored);
+  ASSERT_TRUE(restored.ok()) << restored.status();
+  EXPECT_EQ(golf::serializeGameState(*restored), serialized);
+}
+
+TEST_F(GameStateJsonbTest, StoredStateIsQueryable) {
+  // The reason step 2 wants jsonb rather than text: operators reach into
+  // the stored state without deserializing it.
+  ASSERT_TRUE(StoreAndFetch(golf::serializeGameState(playedState())).has_value());
+  auto version = db_->Exec("SELECT state->>'v' FROM game_state_probe");
+  ASSERT_TRUE(version.ok()) << version.status();
+  EXPECT_EQ(version->Get(0, 0).value_or(""), "1");
+  auto seats = db_->Exec("SELECT jsonb_array_length(state->'players') FROM game_state_probe");
+  ASSERT_TRUE(seats.ok()) << seats.status();
+  EXPECT_EQ(seats->Get(0, 0).value_or(""), "2");
+}
+
+}  // namespace

--- a/domains/games/libs/cards/golf/BUILD.bazel
+++ b/domains/games/libs/cards/golf/BUILD.bazel
@@ -75,5 +75,6 @@ cc_test(
         ":player",
         "//domains/games/libs/cards",
         "@googletest//:gtest_main",
+        "@nlohmann_json//:json",
     ],
 )

--- a/domains/games/libs/cards/golf/BUILD.bazel
+++ b/domains/games/libs/cards/golf/BUILD.bazel
@@ -45,3 +45,35 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+# Versioned serde of the engine's full truth (#1194 step 0): what the
+# games table stores in step 2. Server-side only — redaction stays in
+# the hub's per-viewer views.
+cc_library(
+    name = "game_state_serde",
+    srcs = ["game_state_serde.cc"],
+    hdrs = ["game_state_serde.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":game_state",
+        ":player",
+        "//domains/games/libs/cards",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@nlohmann_json//:json",
+    ],
+)
+
+cc_test(
+    name = "game_state_serde_test",
+    size = "small",
+    srcs = ["game_state_serde_test.cc"],
+    deps = [
+        ":game_state",
+        ":game_state_serde",
+        ":player",
+        "//domains/games/libs/cards",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/domains/games/libs/cards/golf/game_state_serde.cc
+++ b/domains/games/libs/cards/golf/game_state_serde.cc
@@ -25,11 +25,28 @@ json cardsToJson(const Cards& cards) {
   return codes;
 }
 
+// A NUL byte is valid JSON (escapes to \u0000) but postgres jsonb — the
+// step-2 storage column — rejects it, so a NUL in a player-supplied name
+// gets the same treatment as invalid UTF-8: U+FFFD, and the write path
+// outlives the weirdest name.
+std::optional<std::string> sanitizedName(const std::optional<std::string>& name) {
+  if (!name.has_value()) return std::nullopt;
+  std::string safe;
+  for (const char c : *name) {
+    if (c == '\0') {
+      safe += "\xEF\xBF\xBD";  // U+FFFD
+    } else {
+      safe += c;
+    }
+  }
+  return safe;
+}
+
 json playerToJson(const Player& player) {
   json peeked = json::array();
   for (const Position position : player.getPeeked()) peeked.push_back(indexOfPosition(position));
   return json{
-      {"name", player.getName()},
+      {"name", sanitizedName(player.getName())},
       {"cards", cardsToJson(player.allCards())},
       {"peeked", std::move(peeked)},
       {"donePeeking", player.hasCompletedPeeks()},

--- a/domains/games/libs/cards/golf/game_state_serde.cc
+++ b/domains/games/libs/cards/golf/game_state_serde.cc
@@ -1,0 +1,186 @@
+#include "domains/games/libs/cards/golf/game_state_serde.h"
+
+#include <deque>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "domains/games/libs/cards/card.h"
+#include "domains/games/libs/cards/golf/player.h"
+
+namespace golf {
+namespace {
+
+using nlohmann::json;
+
+constexpr int kSchemaVersion = 1;
+
+json cardsToJson(const std::deque<Card>& pile) {
+  json codes = json::array();
+  for (const Card& card : pile) codes.push_back(card.intValue());
+  return codes;
+}
+
+json playerToJson(const Player& player) {
+  json hand = json::array();
+  for (const Card& card : player.allCards()) hand.push_back(card.intValue());
+  json peeked = json::array();
+  for (const Position position : player.getPeeked()) peeked.push_back(indexOfPosition(position));
+  return json{
+      {"name", player.getName().has_value() ? json(*player.getName()) : json(nullptr)},
+      {"cards", std::move(hand)},
+      {"peeked", std::move(peeked)},
+      {"donePeeking", player.hasCompletedPeeks()},
+  };
+}
+
+// Field accessors that turn shape errors into invalid-argument statuses;
+// every read goes through one of these so no malformed byte can throw.
+
+absl::StatusOr<int> readInt(const json& object, const char* key) {
+  if (!object.contains(key) || !object[key].is_number_integer()) {
+    return absl::InvalidArgumentError(absl::StrCat("expected integer field '", key, "'"));
+  }
+  return object[key].get<int>();
+}
+
+absl::StatusOr<bool> readBool(const json& object, const char* key) {
+  if (!object.contains(key) || !object[key].is_boolean()) {
+    return absl::InvalidArgumentError(absl::StrCat("expected boolean field '", key, "'"));
+  }
+  return object[key].get<bool>();
+}
+
+absl::StatusOr<std::string> readString(const json& object, const char* key) {
+  if (!object.contains(key) || !object[key].is_string()) {
+    return absl::InvalidArgumentError(absl::StrCat("expected string field '", key, "'"));
+  }
+  return object[key].get<std::string>();
+}
+
+absl::StatusOr<std::deque<Card>> readPile(const json& object, const char* key) {
+  if (!object.contains(key) || !object[key].is_array()) {
+    return absl::InvalidArgumentError(absl::StrCat("expected array field '", key, "'"));
+  }
+  std::deque<Card> pile;
+  for (const json& code : object[key]) {
+    if (!code.is_number_integer() || code.get<int>() < 0 || code.get<int>() > 51) {
+      return absl::InvalidArgumentError(absl::StrCat("card code out of range in '", key, "'"));
+    }
+    pile.emplace_back(code.get<int>());
+  }
+  return pile;
+}
+
+absl::StatusOr<Player> readPlayer(const json& object) {
+  if (!object.is_object()) return absl::InvalidArgumentError("expected player object");
+
+  std::optional<std::string> name;
+  if (!object.contains("name") || (!object["name"].is_null() && !object["name"].is_string())) {
+    return absl::InvalidArgumentError("expected string-or-null field 'name'");
+  }
+  if (object["name"].is_string()) name = object["name"].get<std::string>();
+
+  auto hand = readPile(object, "cards");
+  if (!hand.ok()) return hand.status();
+  if (hand->size() != 4) return absl::InvalidArgumentError("a hand is exactly four cards");
+
+  if (!object.contains("peeked") || !object["peeked"].is_array()) {
+    return absl::InvalidArgumentError("expected array field 'peeked'");
+  }
+  std::vector<Position> peeked;
+  for (const json& index : object["peeked"]) {
+    const std::optional<Position> position =
+        index.is_number_integer() ? positionFromIndex(index.get<int>()) : std::nullopt;
+    if (!position.has_value()) {
+      return absl::InvalidArgumentError("peek position out of range");
+    }
+    peeked.push_back(*position);
+  }
+
+  auto done_peeking = readBool(object, "donePeeking");
+  if (!done_peeking.ok()) return done_peeking.status();
+
+  return Player{std::move(name), (*hand)[0],        (*hand)[1],   (*hand)[2],
+                (*hand)[3],      std::move(peeked), *done_peeking};
+}
+
+}  // namespace
+
+std::string serializeGameState(const GameState& state) {
+  json players = json::array();
+  for (const Player& player : state.getPlayers()) players.push_back(playerToJson(player));
+  const json serialized{
+      {"v", kSchemaVersion},
+      {"gameId", state.getGameId()},
+      {"versionId", state.getVersionId()},
+      {"drawPile", cardsToJson(state.getDrawPile())},
+      {"discardPile", cardsToJson(state.getDiscardPile())},
+      {"peekedAtDrawPile", state.getPeekedAtDrawPile()},
+      {"whoseTurn", state.getWhoseTurn()},
+      {"whoKnocked", state.getWhoKnocked()},
+      {"peeksHidden", state.getPeeksHidden()},
+      {"players", std::move(players)},
+  };
+  return serialized.dump();
+}
+
+absl::StatusOr<GameState> deserializeGameState(const std::string& serialized) {
+  const json parsed = json::parse(serialized, /*cb=*/nullptr, /*allow_exceptions=*/false);
+  if (parsed.is_discarded() || !parsed.is_object()) {
+    return absl::InvalidArgumentError("not a JSON object");
+  }
+
+  auto version = readInt(parsed, "v");
+  if (!version.ok()) return version.status();
+  if (*version != kSchemaVersion) {
+    return absl::InvalidArgumentError(absl::StrCat("unknown schema version ", *version));
+  }
+
+  auto game_id = readString(parsed, "gameId");
+  if (!game_id.ok()) return game_id.status();
+  auto version_id = readString(parsed, "versionId");
+  if (!version_id.ok()) return version_id.status();
+  auto draw_pile = readPile(parsed, "drawPile");
+  if (!draw_pile.ok()) return draw_pile.status();
+  auto discard_pile = readPile(parsed, "discardPile");
+  if (!discard_pile.ok()) return discard_pile.status();
+  auto peeked_at_draw_pile = readBool(parsed, "peekedAtDrawPile");
+  if (!peeked_at_draw_pile.ok()) return peeked_at_draw_pile.status();
+  auto whose_turn = readInt(parsed, "whoseTurn");
+  if (!whose_turn.ok()) return whose_turn.status();
+  auto who_knocked = readInt(parsed, "whoKnocked");
+  if (!who_knocked.ok()) return who_knocked.status();
+  auto peeks_hidden = readBool(parsed, "peeksHidden");
+  if (!peeks_hidden.ok()) return peeks_hidden.status();
+
+  if (!parsed.contains("players") || !parsed["players"].is_array()) {
+    return absl::InvalidArgumentError("expected array field 'players'");
+  }
+  std::vector<Player> players;
+  for (const json& entry : parsed["players"]) {
+    auto player = readPlayer(entry);
+    if (!player.ok()) return player.status();
+    players.push_back(*std::move(player));
+  }
+
+  // The engine indexes seats by these; an out-of-range value from a
+  // corrupted row must fail here, not in a .at() later.
+  const int seats = static_cast<int>(players.size());
+  if (*whose_turn < 0 || *whose_turn >= seats) {
+    return absl::InvalidArgumentError("whoseTurn out of range");
+  }
+  if (*who_knocked < -1 || *who_knocked >= seats) {
+    return absl::InvalidArgumentError("whoKnocked out of range");
+  }
+
+  return GameState{*std::move(draw_pile), *std::move(discard_pile),
+                   std::move(players),    *peeked_at_draw_pile,
+                   *whose_turn,           *who_knocked,
+                   *peeks_hidden,         *std::move(game_id),
+                   *std::move(version_id)};
+}
+
+}  // namespace golf

--- a/domains/games/libs/cards/golf/game_state_serde.cc
+++ b/domains/games/libs/cards/golf/game_state_serde.cc
@@ -1,5 +1,6 @@
 #include "domains/games/libs/cards/golf/game_state_serde.h"
 
+#include <cstdint>
 #include <deque>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -17,33 +18,39 @@ using nlohmann::json;
 
 constexpr int kSchemaVersion = 1;
 
-json cardsToJson(const std::deque<Card>& pile) {
+template <typename Cards>
+json cardsToJson(const Cards& cards) {
   json codes = json::array();
-  for (const Card& card : pile) codes.push_back(card.intValue());
+  for (const Card& card : cards) codes.push_back(card.intValue());
   return codes;
 }
 
 json playerToJson(const Player& player) {
-  json hand = json::array();
-  for (const Card& card : player.allCards()) hand.push_back(card.intValue());
   json peeked = json::array();
   for (const Position position : player.getPeeked()) peeked.push_back(indexOfPosition(position));
   return json{
-      {"name", player.getName().has_value() ? json(*player.getName()) : json(nullptr)},
-      {"cards", std::move(hand)},
+      {"name", player.getName()},
+      {"cards", cardsToJson(player.allCards())},
       {"peeked", std::move(peeked)},
       {"donePeeking", player.hasCompletedPeeks()},
   };
 }
 
-// Field accessors that turn shape errors into invalid-argument statuses;
-// every read goes through one of these so no malformed byte can throw.
+// Field accessors that turn shape errors into invalid-argument statuses.
+// The rule the no-throw guarantee rests on: no get<>() runs before an
+// is_*() check of the same value. Integers read as int64 and range-check
+// before narrowing — get<int>() alone is a static_cast, so an attacker's
+// 2^32+1 would otherwise wrap to 1 and walk through every gate below.
 
-absl::StatusOr<int> readInt(const json& object, const char* key) {
+absl::StatusOr<int> readIntInRange(const json& object, const char* key, int64_t lo, int64_t hi) {
   if (!object.contains(key) || !object[key].is_number_integer()) {
     return absl::InvalidArgumentError(absl::StrCat("expected integer field '", key, "'"));
   }
-  return object[key].get<int>();
+  const int64_t value = object[key].get<int64_t>();
+  if (value < lo || value > hi) {
+    return absl::InvalidArgumentError(absl::StrCat("field '", key, "' out of range"));
+  }
+  return static_cast<int>(value);
 }
 
 absl::StatusOr<bool> readBool(const json& object, const char* key) {
@@ -53,25 +60,18 @@ absl::StatusOr<bool> readBool(const json& object, const char* key) {
   return object[key].get<bool>();
 }
 
-absl::StatusOr<std::string> readString(const json& object, const char* key) {
-  if (!object.contains(key) || !object[key].is_string()) {
-    return absl::InvalidArgumentError(absl::StrCat("expected string field '", key, "'"));
-  }
-  return object[key].get<std::string>();
-}
-
-absl::StatusOr<std::deque<Card>> readPile(const json& object, const char* key) {
+absl::StatusOr<std::deque<Card>> readCardCodes(const json& object, const char* key) {
   if (!object.contains(key) || !object[key].is_array()) {
     return absl::InvalidArgumentError(absl::StrCat("expected array field '", key, "'"));
   }
-  std::deque<Card> pile;
+  std::deque<Card> cards;
   for (const json& code : object[key]) {
-    if (!code.is_number_integer() || code.get<int>() < 0 || code.get<int>() > 51) {
+    if (!code.is_number_integer() || code.get<int64_t>() < 0 || code.get<int64_t>() > 51) {
       return absl::InvalidArgumentError(absl::StrCat("card code out of range in '", key, "'"));
     }
-    pile.emplace_back(code.get<int>());
+    cards.emplace_back(static_cast<int>(code.get<int64_t>()));
   }
-  return pile;
+  return cards;
 }
 
 absl::StatusOr<Player> readPlayer(const json& object) {
@@ -83,7 +83,7 @@ absl::StatusOr<Player> readPlayer(const json& object) {
   }
   if (object["name"].is_string()) name = object["name"].get<std::string>();
 
-  auto hand = readPile(object, "cards");
+  auto hand = readCardCodes(object, "cards");
   if (!hand.ok()) return hand.status();
   if (hand->size() != 4) return absl::InvalidArgumentError("a hand is exactly four cards");
 
@@ -93,7 +93,8 @@ absl::StatusOr<Player> readPlayer(const json& object) {
   std::vector<Position> peeked;
   for (const json& index : object["peeked"]) {
     const std::optional<Position> position =
-        index.is_number_integer() ? positionFromIndex(index.get<int>()) : std::nullopt;
+        index.is_number_integer() ? positionFromIndex(static_cast<int>(index.get<int64_t>()))
+                                  : std::nullopt;
     if (!position.has_value()) {
       return absl::InvalidArgumentError("peek position out of range");
     }
@@ -114,8 +115,6 @@ std::string serializeGameState(const GameState& state) {
   for (const Player& player : state.getPlayers()) players.push_back(playerToJson(player));
   const json serialized{
       {"v", kSchemaVersion},
-      {"gameId", state.getGameId()},
-      {"versionId", state.getVersionId()},
       {"drawPile", cardsToJson(state.getDrawPile())},
       {"discardPile", cardsToJson(state.getDiscardPile())},
       {"peekedAtDrawPile", state.getPeekedAtDrawPile()},
@@ -124,7 +123,11 @@ std::string serializeGameState(const GameState& state) {
       {"peeksHidden", state.getPeeksHidden()},
       {"players", std::move(players)},
   };
-  return serialized.dump();
+  // Player names are player-supplied; strict dump() would throw on a name
+  // that is not valid UTF-8. Replacement (U+FFFD) keeps the write path
+  // alive and stays deterministic.
+  return serialized.dump(/*indent=*/-1, /*indent_char=*/' ', /*ensure_ascii=*/false,
+                         json::error_handler_t::replace);
 }
 
 absl::StatusOr<GameState> deserializeGameState(const std::string& serialized) {
@@ -133,26 +136,18 @@ absl::StatusOr<GameState> deserializeGameState(const std::string& serialized) {
     return absl::InvalidArgumentError("not a JSON object");
   }
 
-  auto version = readInt(parsed, "v");
-  if (!version.ok()) return version.status();
-  if (*version != kSchemaVersion) {
-    return absl::InvalidArgumentError(absl::StrCat("unknown schema version ", *version));
+  auto version = readIntInRange(parsed, "v", kSchemaVersion, kSchemaVersion);
+  if (!version.ok()) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("unknown schema version: ", version.status().message()));
   }
 
-  auto game_id = readString(parsed, "gameId");
-  if (!game_id.ok()) return game_id.status();
-  auto version_id = readString(parsed, "versionId");
-  if (!version_id.ok()) return version_id.status();
-  auto draw_pile = readPile(parsed, "drawPile");
+  auto draw_pile = readCardCodes(parsed, "drawPile");
   if (!draw_pile.ok()) return draw_pile.status();
-  auto discard_pile = readPile(parsed, "discardPile");
+  auto discard_pile = readCardCodes(parsed, "discardPile");
   if (!discard_pile.ok()) return discard_pile.status();
   auto peeked_at_draw_pile = readBool(parsed, "peekedAtDrawPile");
   if (!peeked_at_draw_pile.ok()) return peeked_at_draw_pile.status();
-  auto whose_turn = readInt(parsed, "whoseTurn");
-  if (!whose_turn.ok()) return whose_turn.status();
-  auto who_knocked = readInt(parsed, "whoKnocked");
-  if (!who_knocked.ok()) return who_knocked.status();
   auto peeks_hidden = readBool(parsed, "peeksHidden");
   if (!peeks_hidden.ok()) return peeks_hidden.status();
 
@@ -165,22 +160,24 @@ absl::StatusOr<GameState> deserializeGameState(const std::string& serialized) {
     if (!player.ok()) return player.status();
     players.push_back(*std::move(player));
   }
+  // The engine's turn arithmetic divides by the roster size, and seat
+  // fields index into it; both need the roster known before they read.
+  if (players.empty()) return absl::InvalidArgumentError("no players");
+  const int64_t seats = static_cast<int64_t>(players.size());
+  auto whose_turn = readIntInRange(parsed, "whoseTurn", 0, seats - 1);
+  if (!whose_turn.ok()) return whose_turn.status();
+  auto who_knocked = readIntInRange(parsed, "whoKnocked", -1, seats - 1);
+  if (!who_knocked.ok()) return who_knocked.status();
 
-  // The engine indexes seats by these; an out-of-range value from a
-  // corrupted row must fail here, not in a .at() later.
-  const int seats = static_cast<int>(players.size());
-  if (*whose_turn < 0 || *whose_turn >= seats) {
-    return absl::InvalidArgumentError("whoseTurn out of range");
-  }
-  if (*who_knocked < -1 || *who_knocked >= seats) {
-    return absl::InvalidArgumentError("whoKnocked out of range");
-  }
-
-  return GameState{*std::move(draw_pile), *std::move(discard_pile),
-                   std::move(players),    *peeked_at_draw_pile,
-                   *whose_turn,           *who_knocked,
-                   *peeks_hidden,         *std::move(game_id),
-                   *std::move(version_id)};
+  return GameState{*std::move(draw_pile),
+                   *std::move(discard_pile),
+                   std::move(players),
+                   /*_peekedAtDrawPile=*/*peeked_at_draw_pile,
+                   /*_whoseTurn=*/*whose_turn,
+                   /*_whoKnocked=*/*who_knocked,
+                   /*_peeksHidden=*/*peeks_hidden,
+                   /*_gameId=*/"",
+                   /*_version_id=*/""};
 }
 
 }  // namespace golf

--- a/domains/games/libs/cards/golf/game_state_serde.h
+++ b/domains/games/libs/cards/golf/game_state_serde.h
@@ -1,0 +1,33 @@
+#ifndef CPP_CARDS_GOLF_GAME_STATE_SERDE_H
+#define CPP_CARDS_GOLF_GAME_STATE_SERDE_H
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "domains/games/libs/cards/golf/game_state.h"
+
+namespace golf {
+
+/// Serde for the engine's full truth (#1194 step 0): deck order and
+/// unrevealed cards included, so serialized states are server-side only —
+/// per-viewer redaction stays in the hub's ViewLocked. The wire is
+/// versioned JSON; deserialize rejects unknown versions and any value the
+/// engine would index out of range, because the bytes arrive from a
+/// database row, not from code we trust. Serialization is deterministic:
+/// re-serializing a deserialized state reproduces the bytes.
+///
+/// Schema v1 — cards are Card::intValue() codes (0..51), piles list front
+/// to back, hands are [topLeft, topRight, bottomLeft, bottomRight], peeks
+/// are indexOfPosition codes (0..3), a null name is an abandoned seat:
+///   {"v":1, "gameId":str, "versionId":str,
+///    "drawPile":[int...], "discardPile":[int...],
+///    "peekedAtDrawPile":bool, "whoseTurn":int, "whoKnocked":int,
+///    "peeksHidden":bool,
+///    "players":[{"name":str|null, "cards":[int,int,int,int],
+///                "peeked":[int...], "donePeeking":bool}...]}
+[[nodiscard]] std::string serializeGameState(const GameState& state);
+[[nodiscard]] absl::StatusOr<GameState> deserializeGameState(const std::string& serialized);
+
+}  // namespace golf
+
+#endif

--- a/domains/games/libs/cards/golf/game_state_serde.h
+++ b/domains/games/libs/cards/golf/game_state_serde.h
@@ -13,18 +13,32 @@ namespace golf {
 /// per-viewer redaction stays in the hub's ViewLocked. The wire is
 /// versioned JSON; deserialize rejects unknown versions and any value the
 /// engine would index out of range, because the bytes arrive from a
-/// database row, not from code we trust. Serialization is deterministic:
-/// re-serializing a deserialized state reproduces the bytes.
+/// database row, not from code we trust.
 ///
-/// Schema v1 — cards are Card::intValue() codes (0..51), piles list front
-/// to back, hands are [topLeft, topRight, bottomLeft, bottomRight], peeks
-/// are indexOfPosition codes (0..3), a null name is an abandoned seat:
-///   {"v":1, "gameId":str, "versionId":str,
-///    "drawPile":[int...], "discardPile":[int...],
+/// Schema v1 — engine truth only. Identity and optimistic concurrency
+/// belong to the storage row (#1194 step 2's game_id and version
+/// columns), so gameId/versionId are not in the bytes: deserialize
+/// returns them empty, and the storage layer rehydrates via
+/// withIdAndVersion. Cards are Card::intValue() codes (0..51), piles
+/// list front to back, hands are [topLeft, topRight, bottomLeft,
+/// bottomRight], peeks are indexOfPosition codes (0..3), a null name is
+/// an abandoned seat:
+///   {"v":1, "drawPile":[int...], "discardPile":[int...],
 ///    "peekedAtDrawPile":bool, "whoseTurn":int, "whoKnocked":int,
 ///    "peeksHidden":bool,
 ///    "players":[{"name":str|null, "cards":[int,int,int,int],
 ///                "peeked":[int...], "donePeeking":bool}...]}
+///
+/// The listing above is logical; the emitted bytes order keys
+/// alphabetically (nlohmann's sorted-map default), which is what makes
+/// serialization deterministic — re-serializing a deserialized state
+/// reproduces the bytes, and the frozen-payload test pins the exact
+/// layout. Two deliberate lenient edges: unknown fields are ignored (and
+/// dropped on re-serialize), and game legality (card uniqueness, peek
+/// caps) stays the engine's business — serde polices only what it would
+/// otherwise let the engine index out of range. A player name that is
+/// not valid UTF-8 serializes with U+FFFD replacement rather than
+/// failing the write path.
 [[nodiscard]] std::string serializeGameState(const GameState& state);
 [[nodiscard]] absl::StatusOr<GameState> deserializeGameState(const std::string& serialized);
 

--- a/domains/games/libs/cards/golf/game_state_serde.h
+++ b/domains/games/libs/cards/golf/game_state_serde.h
@@ -37,7 +37,8 @@ namespace golf {
 /// dropped on re-serialize), and game legality (card uniqueness, peek
 /// caps) stays the engine's business — serde polices only what it would
 /// otherwise let the engine index out of range. A player name that is
-/// not valid UTF-8 serializes with U+FFFD replacement rather than
+/// not valid UTF-8 — or that contains a NUL byte, which postgres jsonb
+/// refuses to store — serializes with U+FFFD replacement rather than
 /// failing the write path.
 [[nodiscard]] std::string serializeGameState(const GameState& state);
 [[nodiscard]] absl::StatusOr<GameState> deserializeGameState(const std::string& serialized);

--- a/domains/games/libs/cards/golf/game_state_serde_test.cc
+++ b/domains/games/libs/cards/golf/game_state_serde_test.cc
@@ -1,0 +1,186 @@
+#include "domains/games/libs/cards/golf/game_state_serde.h"
+
+#include <gtest/gtest.h>
+
+#include <deque>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "domains/games/libs/cards/card.h"
+#include "domains/games/libs/cards/golf/game_state.h"
+#include "domains/games/libs/cards/golf/player.h"
+
+using namespace cards;
+using namespace golf;
+
+namespace {
+
+// Card(i) inverts intValue(), so 0..51 is the full deck in a fixed order —
+// the same determinism trick the hub's NoShuffleDealer relies on.
+std::deque<Card> pristineDeck() {
+  std::deque<Card> deck;
+  for (int i = 0; i < 52; ++i) deck.emplace_back(i);
+  return deck;
+}
+
+void expectStatesEqual(const GameState& a, const GameState& b) {
+  EXPECT_EQ(a.getDrawPile(), b.getDrawPile());
+  EXPECT_EQ(a.getDiscardPile(), b.getDiscardPile());
+  EXPECT_EQ(a.getPlayers(), b.getPlayers());
+  EXPECT_EQ(a.getPeekedAtDrawPile(), b.getPeekedAtDrawPile());
+  EXPECT_EQ(a.getWhoseTurn(), b.getWhoseTurn());
+  EXPECT_EQ(a.getWhoKnocked(), b.getWhoKnocked());
+  EXPECT_EQ(a.getPeeksHidden(), b.getPeeksHidden());
+  EXPECT_EQ(a.getGameId(), b.getGameId());
+  EXPECT_EQ(a.getVersionId(), b.getVersionId());
+}
+
+// Serialize -> deserialize -> compare, and serialize again: the second
+// pass must be byte-identical, so stored states re-serialize stably.
+void expectRoundTrips(const GameState& state) {
+  const std::string serialized = serializeGameState(state);
+  const auto restored = deserializeGameState(serialized);
+  ASSERT_TRUE(restored.ok()) << restored.status();
+  expectStatesEqual(state, *restored);
+  EXPECT_EQ(serializeGameState(*restored), serialized);
+}
+
+TEST(GameStateSerde, RoundTripsAFreshDeal) {
+  const auto dealt = dealGolfGame("g-fresh", {"alice", "bob", "cara"}, pristineDeck());
+  ASSERT_TRUE(dealt.ok()) << dealt.status();
+  expectRoundTrips(*dealt);
+}
+
+TEST(GameStateSerde, RoundTripsEveryStateOfADeterministicGame) {
+  // GameState is immutable (const members, no assignment), so the walk
+  // re-emplaces into an optional at every transition.
+  std::optional<GameState> state;
+  auto dealt = dealGolfGame("g-full", {"alice", "bob"}, pristineDeck());
+  ASSERT_TRUE(dealt.ok()) << dealt.status();
+  state.emplace(*std::move(dealt));
+  expectRoundTrips(*state);
+
+  const auto advance = [&state](absl::StatusOr<GameState> next) {
+    ASSERT_TRUE(next.ok()) << next.status();
+    state.emplace(*std::move(next));
+    expectRoundTrips(*state);
+  };
+
+  // The opening reveal: both players peek two of their own cards, then
+  // one hide ends the countdown for the table.
+  for (const int player : {0, 1}) {
+    for (const Position position : {Position::TopLeft, Position::BottomRight}) {
+      advance(state->peekOwnCard(player, position));
+    }
+  }
+  advance(state->hideCards(0));
+
+  // Turn play, every mechanic once. Draw-pile moves are draw-then-decide:
+  // peekAtDrawPile is the draw, then the swap either keeps or declines it.
+  advance(state->peekAtDrawPile(0));
+  advance(state->swapForDrawPile(0, Position::TopLeft));
+  advance(state->swapForDiscardPile(1, Position::BottomLeft));
+  advance(state->peekAtDrawPile(0));
+  advance(state->swapDrawForDiscardPile(0));
+  advance(state->knock(1));
+  advance(state->peekAtDrawPile(0));
+  advance(state->swapForDrawPile(0, Position::TopRight));
+  ASSERT_TRUE(state->isOver());
+}
+
+TEST(GameStateSerde, RoundTripsAnAbandonedSeatAndEmptyPiles) {
+  // A nameless seat is a real engine state (abandoned mid-game), and an
+  // empty draw pile is the game-over-by-exhaustion shape.
+  const Player abandoned{Card(Suit::Clubs, Rank::Two), Card(Suit::Diamonds, Rank::Three),
+                         Card(Suit::Hearts, Rank::Four), Card(Suit::Spades, Rank::Five)};
+  const Player named{"dana",
+                     Card(Suit::Clubs, Rank::Six),
+                     Card(Suit::Diamonds, Rank::Seven),
+                     Card(Suit::Hearts, Rank::Eight),
+                     Card(Suit::Spades, Rank::Nine),
+                     {Position::TopLeft, Position::BottomRight},
+                     true};
+  const GameState state{{}, {}, {abandoned, named}, false, 1, 0, true, "g-ragged", "v-9"};
+  expectRoundTrips(state);
+}
+
+TEST(GameStateSerde, RejectsUnknownSchemaVersion) {
+  const auto dealt = dealGolfGame("g", {"a", "b"}, pristineDeck());
+  ASSERT_TRUE(dealt.ok());
+  std::string serialized = serializeGameState(*dealt);
+  const auto bumped = serialized.replace(serialized.find("\"v\":1"), 5, "\"v\":2");
+  const auto restored = deserializeGameState(bumped);
+  ASSERT_FALSE(restored.ok());
+  EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST(GameStateSerde, RejectsMalformedInput) {
+  // None of these may crash, and all must read as invalid-argument: the
+  // bytes come from a database row, not from code we trust.
+  const std::vector<std::string> bad = {
+      "",                 // not JSON
+      "not json at all",  // not JSON
+      "[]",               // wrong top-level shape
+      R"({"v":1})",       // missing everything else
+      R"({"v":"1"})",     // version of the wrong type
+  };
+  for (const std::string& input : bad) {
+    const auto restored = deserializeGameState(input);
+    ASSERT_FALSE(restored.ok()) << "accepted: " << input;
+    EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument) << input;
+  }
+}
+
+TEST(GameStateSerde, RejectsOutOfRangeValues) {
+  const auto dealt = dealGolfGame("g", {"a", "b"}, pristineDeck());
+  ASSERT_TRUE(dealt.ok());
+  const std::string serialized = serializeGameState(*dealt);
+
+  struct Break {
+    std::string find;
+    std::string replace;
+  };
+  // Each corruption targets a range the engine indexes by: card codes
+  // must stay 0..51, peek positions 0..3, seats within the roster.
+  const std::vector<Break> breaks = {
+      {"\"drawPile\":[", "\"drawPile\":[52,"},
+      {"\"drawPile\":[", "\"drawPile\":[-1,"},
+      {"\"whoseTurn\":0", "\"whoseTurn\":7"},
+      {"\"whoKnocked\":-1", "\"whoKnocked\":-3"},
+  };
+  for (const auto& corruption : breaks) {
+    std::string corrupted = serialized;
+    const auto at = corrupted.find(corruption.find);
+    ASSERT_NE(at, std::string::npos) << corruption.find;
+    corrupted.replace(at, corruption.find.size(), corruption.replace);
+    const auto restored = deserializeGameState(corrupted);
+    ASSERT_FALSE(restored.ok()) << "accepted: " << corruption.replace;
+    EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+  }
+
+  // A peek position outside 0..3 in a hand-built payload.
+  std::string bad_peek = serialized;
+  const auto players_at = bad_peek.find("\"peeked\":[]");
+  ASSERT_NE(players_at, std::string::npos);
+  bad_peek.replace(players_at, 11, "\"peeked\":[4]");
+  const auto restored = deserializeGameState(bad_peek);
+  ASSERT_FALSE(restored.ok());
+  EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST(GameStateSerde, RejectsWrongHandSize) {
+  const auto dealt = dealGolfGame("g", {"a", "b"}, pristineDeck());
+  ASSERT_TRUE(dealt.ok());
+  std::string serialized = serializeGameState(*dealt);
+  // A hand is exactly four cards; drop one.
+  const auto at = serialized.find("\"cards\":[");
+  ASSERT_NE(at, std::string::npos);
+  const auto comma = serialized.find(',', at + 9);
+  serialized.erase(at + 9, comma - (at + 9) + 1);
+  const auto restored = deserializeGameState(serialized);
+  ASSERT_FALSE(restored.ok());
+  EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+}  // namespace

--- a/domains/games/libs/cards/golf/game_state_serde_test.cc
+++ b/domains/games/libs/cards/golf/game_state_serde_test.cc
@@ -295,4 +295,21 @@ TEST(GameStateSerde, SerializesANameThatIsNotValidUtf8) {
   EXPECT_EQ(serializeGameState(*restored), serialized);
 }
 
+// A NUL byte is valid JSON but postgres jsonb (the step-2 storage
+// column) refuses to store escaped NULs, so serialize replaces it
+// like invalid UTF-8 — the bytes must never contain the escape.
+TEST(GameStateSerde, SerializesANameContainingNulWithoutTheEscape) {
+  const std::string nul_name("a\0b", 3);
+  const Player mangled{nul_name, Card(0), Card(1), Card(2), Card(3)};
+  const GameState state{{Card(4)}, {Card(5)}, {mangled, mangled}, false, 0, -1, false, "g", "v"};
+  const std::string serialized = serializeGameState(state);
+  EXPECT_EQ(serialized.find("\\u0000"), std::string::npos);
+  const auto restored = deserializeGameState(serialized);
+  ASSERT_TRUE(restored.ok()) << restored.status();
+  EXPECT_EQ(restored->getPlayer(0).getName().value_or(""),
+            "a\xEF\xBF\xBD"
+            "b");
+  EXPECT_EQ(serializeGameState(*restored), serialized);
+}
+
 }  // namespace

--- a/domains/games/libs/cards/golf/game_state_serde_test.cc
+++ b/domains/games/libs/cards/golf/game_state_serde_test.cc
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <deque>
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
 #include <vector>
@@ -13,6 +14,7 @@
 
 using namespace cards;
 using namespace golf;
+using nlohmann::json;
 
 namespace {
 
@@ -24,6 +26,22 @@ std::deque<Card> pristineDeck() {
   return deck;
 }
 
+// A known-good serialized game as an editable payload; negative tests
+// corrupt exactly the field they name and nothing else.
+json dealtPayload() {
+  const auto dealt = dealGolfGame("g", {"a", "b"}, pristineDeck());
+  EXPECT_TRUE(dealt.ok()) << dealt.status();
+  return json::parse(serializeGameState(*dealt));
+}
+
+void expectRejected(const json& payload) {
+  const auto restored = deserializeGameState(payload.dump());
+  ASSERT_FALSE(restored.ok()) << "accepted: " << payload.dump();
+  EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+// Engine truth only: identity is the storage row's business, so the
+// serde returns it empty and the comparison excludes it.
 void expectStatesEqual(const GameState& a, const GameState& b) {
   EXPECT_EQ(a.getDrawPile(), b.getDrawPile());
   EXPECT_EQ(a.getDiscardPile(), b.getDiscardPile());
@@ -32,8 +50,6 @@ void expectStatesEqual(const GameState& a, const GameState& b) {
   EXPECT_EQ(a.getWhoseTurn(), b.getWhoseTurn());
   EXPECT_EQ(a.getWhoKnocked(), b.getWhoKnocked());
   EXPECT_EQ(a.getPeeksHidden(), b.getPeeksHidden());
-  EXPECT_EQ(a.getGameId(), b.getGameId());
-  EXPECT_EQ(a.getVersionId(), b.getVersionId());
 }
 
 // Serialize -> deserialize -> compare, and serialize again: the second
@@ -43,6 +59,8 @@ void expectRoundTrips(const GameState& state) {
   const auto restored = deserializeGameState(serialized);
   ASSERT_TRUE(restored.ok()) << restored.status();
   expectStatesEqual(state, *restored);
+  EXPECT_TRUE(restored->getGameId().empty());
+  EXPECT_TRUE(restored->getVersionId().empty());
   EXPECT_EQ(serializeGameState(*restored), serialized);
 }
 
@@ -71,21 +89,21 @@ TEST(GameStateSerde, RoundTripsEveryStateOfADeterministicGame) {
   // one hide ends the countdown for the table.
   for (const int player : {0, 1}) {
     for (const Position position : {Position::TopLeft, Position::BottomRight}) {
-      advance(state->peekOwnCard(player, position));
+      ASSERT_NO_FATAL_FAILURE(advance(state->peekOwnCard(player, position)));
     }
   }
-  advance(state->hideCards(0));
+  ASSERT_NO_FATAL_FAILURE(advance(state->hideCards(0)));
 
   // Turn play, every mechanic once. Draw-pile moves are draw-then-decide:
   // peekAtDrawPile is the draw, then the swap either keeps or declines it.
-  advance(state->peekAtDrawPile(0));
-  advance(state->swapForDrawPile(0, Position::TopLeft));
-  advance(state->swapForDiscardPile(1, Position::BottomLeft));
-  advance(state->peekAtDrawPile(0));
-  advance(state->swapDrawForDiscardPile(0));
-  advance(state->knock(1));
-  advance(state->peekAtDrawPile(0));
-  advance(state->swapForDrawPile(0, Position::TopRight));
+  ASSERT_NO_FATAL_FAILURE(advance(state->peekAtDrawPile(0)));
+  ASSERT_NO_FATAL_FAILURE(advance(state->swapForDrawPile(0, Position::TopLeft)));
+  ASSERT_NO_FATAL_FAILURE(advance(state->swapForDiscardPile(1, Position::BottomLeft)));
+  ASSERT_NO_FATAL_FAILURE(advance(state->peekAtDrawPile(0)));
+  ASSERT_NO_FATAL_FAILURE(advance(state->swapDrawForDiscardPile(0)));
+  ASSERT_NO_FATAL_FAILURE(advance(state->knock(1)));
+  ASSERT_NO_FATAL_FAILURE(advance(state->peekAtDrawPile(0)));
+  ASSERT_NO_FATAL_FAILURE(advance(state->swapForDrawPile(0, Position::TopRight)));
   ASSERT_TRUE(state->isOver());
 }
 
@@ -105,25 +123,49 @@ TEST(GameStateSerde, RoundTripsAnAbandonedSeatAndEmptyPiles) {
   expectRoundTrips(state);
 }
 
+// The frozen shape of a stored row. Everything else in this suite
+// generates its bytes with the code under test, so only this test can
+// catch a simultaneous serialize+deserialize change that would orphan —
+// or worse, silently permute — rows already written. Do not regenerate
+// this literal from the code; schema changes mean a version bump.
+TEST(GameStateSerde, ParsesAFrozenV1Payload) {
+  constexpr char kRow[] =
+      R"({"discardPile":[43],"drawPile":[0,1],"peekedAtDrawPile":false,"peeksHidden":true,)"
+      R"("players":[{"cards":[51,50,49,48],"donePeeking":true,"name":"a","peeked":[]},)"
+      R"({"cards":[47,46,45,44],"donePeeking":true,"name":null,"peeked":[2]}],)"
+      R"("v":1,"whoKnocked":1,"whoseTurn":1})";
+  const auto restored = deserializeGameState(kRow);
+  ASSERT_TRUE(restored.ok()) << restored.status();
+  // Hand order is [tl, tr, bl, br]; a permutation here would round-trip
+  // green everywhere else while scrambling every stored hand.
+  EXPECT_EQ(restored->getPlayer(0).cardAt(Position::TopLeft), Card(51));
+  EXPECT_EQ(restored->getPlayer(0).cardAt(Position::BottomRight), Card(48));
+  EXPECT_EQ(restored->getDrawPile(), (std::deque<Card>{Card(0), Card(1)}));
+  EXPECT_EQ(restored->getPlayer(1).getPeeked(), (std::vector<Position>{Position::BottomLeft}));
+  EXPECT_FALSE(restored->getPlayer(1).getName().has_value());
+  EXPECT_TRUE(restored->getGameId().empty());
+  // Byte-for-byte re-serialization pins field names, sorted key order,
+  // and compact formatting all at once.
+  EXPECT_EQ(serializeGameState(*restored), kRow);
+}
+
 TEST(GameStateSerde, RejectsUnknownSchemaVersion) {
-  const auto dealt = dealGolfGame("g", {"a", "b"}, pristineDeck());
-  ASSERT_TRUE(dealt.ok());
-  std::string serialized = serializeGameState(*dealt);
-  const auto bumped = serialized.replace(serialized.find("\"v\":1"), 5, "\"v\":2");
-  const auto restored = deserializeGameState(bumped);
-  ASSERT_FALSE(restored.ok());
-  EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+  json payload = dealtPayload();
+  payload["v"] = 2;
+  expectRejected(payload);
 }
 
 TEST(GameStateSerde, RejectsMalformedInput) {
-  // None of these may crash, and all must read as invalid-argument: the
-  // bytes come from a database row, not from code we trust.
+  // Raw bytes on purpose — this is the one test where the string layer
+  // itself is under test. All must read as invalid-argument, none may
+  // crash: the bytes come from a database row, not from code we trust.
   const std::vector<std::string> bad = {
       "",                 // not JSON
       "not json at all",  // not JSON
       "[]",               // wrong top-level shape
       R"({"v":1})",       // missing everything else
       R"({"v":"1"})",     // version of the wrong type
+      R"({"v":1.0})",     // floats are not versions
   };
   for (const std::string& input : bad) {
     const auto restored = deserializeGameState(input);
@@ -132,55 +174,125 @@ TEST(GameStateSerde, RejectsMalformedInput) {
   }
 }
 
-TEST(GameStateSerde, RejectsOutOfRangeValues) {
-  const auto dealt = dealGolfGame("g", {"a", "b"}, pristineDeck());
-  ASSERT_TRUE(dealt.ok());
-  const std::string serialized = serializeGameState(*dealt);
+// get<int>() alone is a static_cast: 2^32+1 would wrap to 1 and pass the
+// version gate, and 2^32 would wrap to card 0. The reads must reject
+// before narrowing.
+TEST(GameStateSerde, RejectsIntegersThatWouldWrapToValidValues) {
+  json payload = dealtPayload();
+  payload["v"] = int64_t{4294967297};
+  expectRejected(payload);
 
-  struct Break {
-    std::string find;
-    std::string replace;
-  };
-  // Each corruption targets a range the engine indexes by: card codes
-  // must stay 0..51, peek positions 0..3, seats within the roster.
-  const std::vector<Break> breaks = {
-      {"\"drawPile\":[", "\"drawPile\":[52,"},
-      {"\"drawPile\":[", "\"drawPile\":[-1,"},
-      {"\"whoseTurn\":0", "\"whoseTurn\":7"},
-      {"\"whoKnocked\":-1", "\"whoKnocked\":-3"},
-  };
-  for (const auto& corruption : breaks) {
-    std::string corrupted = serialized;
-    const auto at = corrupted.find(corruption.find);
-    ASSERT_NE(at, std::string::npos) << corruption.find;
-    corrupted.replace(at, corruption.find.size(), corruption.replace);
-    const auto restored = deserializeGameState(corrupted);
-    ASSERT_FALSE(restored.ok()) << "accepted: " << corruption.replace;
-    EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+  payload = dealtPayload();
+  payload["drawPile"][0] = int64_t{4294967296};
+  expectRejected(payload);
+
+  payload = dealtPayload();
+  payload["whoseTurn"] = int64_t{4294967296};
+  expectRejected(payload);
+}
+
+TEST(GameStateSerde, RejectsEachFieldMissingOrMistyped) {
+  const json good = dealtPayload();
+  for (const auto& [key, value] : good.items()) {
+    json without = good;
+    without.erase(key);
+    ASSERT_NO_FATAL_FAILURE(expectRejected(without)) << "missing " << key;
+    json mistyped = good;
+    mistyped[key] = json::object();
+    ASSERT_NO_FATAL_FAILURE(expectRejected(mistyped)) << "mistyped " << key;
   }
+  for (const auto& [key, value] : good["players"][0].items()) {
+    json without = good;
+    without["players"][0].erase(key);
+    ASSERT_NO_FATAL_FAILURE(expectRejected(without)) << "missing player " << key;
+    json mistyped = good;
+    mistyped["players"][0][key] = json::object();
+    ASSERT_NO_FATAL_FAILURE(expectRejected(mistyped)) << "mistyped player " << key;
+  }
+  json bare_player = good;
+  bare_player["players"][0] = 5;
+  expectRejected(bare_player);
+}
 
-  // A peek position outside 0..3 in a hand-built payload.
-  std::string bad_peek = serialized;
-  const auto players_at = bad_peek.find("\"peeked\":[]");
-  ASSERT_NE(players_at, std::string::npos);
-  bad_peek.replace(players_at, 11, "\"peeked\":[4]");
-  const auto restored = deserializeGameState(bad_peek);
-  ASSERT_FALSE(restored.ok());
-  EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+TEST(GameStateSerde, RejectsOutOfRangeValues) {
+  json payload = dealtPayload();
+  payload["drawPile"][0] = 52;
+  expectRejected(payload);
+
+  payload = dealtPayload();
+  payload["drawPile"][0] = -1;
+  expectRejected(payload);
+
+  payload = dealtPayload();
+  payload["players"][0]["peeked"] = json::array({4});
+  expectRejected(payload);
+}
+
+// The exact reject boundary: a two-seat game admits seats 0 and 1, so 2
+// must fail — a loose value here would let an off-by-one in the range
+// check send players.at() out of bounds in the engine.
+TEST(GameStateSerde, RejectsSeatIndexAtTheBoundary) {
+  json payload = dealtPayload();
+  payload["whoseTurn"] = 2;
+  expectRejected(payload);
+
+  payload = dealtPayload();
+  payload["whoKnocked"] = 2;
+  expectRejected(payload);
+
+  payload = dealtPayload();
+  payload["whoKnocked"] = -2;
+  expectRejected(payload);
+
+  // An empty roster has no seat 0, and the engine's turn arithmetic
+  // divides by the roster size.
+  payload = dealtPayload();
+  payload["players"] = json::array();
+  payload["whoseTurn"] = 0;
+  expectRejected(payload);
 }
 
 TEST(GameStateSerde, RejectsWrongHandSize) {
-  const auto dealt = dealGolfGame("g", {"a", "b"}, pristineDeck());
-  ASSERT_TRUE(dealt.ok());
-  std::string serialized = serializeGameState(*dealt);
-  // A hand is exactly four cards; drop one.
-  const auto at = serialized.find("\"cards\":[");
-  ASSERT_NE(at, std::string::npos);
-  const auto comma = serialized.find(',', at + 9);
-  serialized.erase(at + 9, comma - (at + 9) + 1);
+  json payload = dealtPayload();
+  payload["players"][0]["cards"] = json::array({1, 2, 3});
+  expectRejected(payload);
+
+  payload = dealtPayload();
+  payload["players"][0]["cards"] = json::array({1, 2, 3, 4, 5});
+  expectRejected(payload);
+}
+
+// Pinned leniency, not oversight: serde polices only what the engine
+// would index out of range; game legality (card uniqueness, peek caps)
+// stays the engine's business, and unknown fields are tolerated on read
+// so a rolled-back binary can load rows a newer one annotated — at the
+// cost that re-serializing drops the extras.
+TEST(GameStateSerde, ToleratesEngineLegalityAndUnknownFieldsByDesign) {
+  json payload = dealtPayload();
+  payload["players"][0]["cards"] = payload["players"][1]["cards"];  // duplicate cards
+  EXPECT_TRUE(deserializeGameState(payload.dump()).ok());
+
+  payload = dealtPayload();
+  payload["players"][0]["peeked"] = json::array({0, 0, 1, 2});  // beyond the engine's peek cap
+  EXPECT_TRUE(deserializeGameState(payload.dump()).ok());
+
+  payload = dealtPayload();
+  payload["annotation"] = "from-the-future";
+  const auto restored = deserializeGameState(payload.dump());
+  ASSERT_TRUE(restored.ok());
+  EXPECT_EQ(serializeGameState(*restored), dealtPayload().dump());
+}
+
+// Names are player-supplied; a byte sequence that is not UTF-8 must not
+// take down the write path. Replacement changes the name's bytes, and
+// the replaced form round-trips stably.
+TEST(GameStateSerde, SerializesANameThatIsNotValidUtf8) {
+  const Player mangled{std::string("bad\xff"), Card(0), Card(1), Card(2), Card(3)};
+  const GameState state{{Card(4)}, {Card(5)}, {mangled, mangled}, false, 0, -1, false, "g", "v"};
+  const std::string serialized = serializeGameState(state);
   const auto restored = deserializeGameState(serialized);
-  ASSERT_FALSE(restored.ok());
-  EXPECT_EQ(restored.status().code(), absl::StatusCode::kInvalidArgument);
+  ASSERT_TRUE(restored.ok()) << restored.status();
+  EXPECT_EQ(serializeGameState(*restored), serialized);
 }
 
 }  // namespace


### PR DESCRIPTION
Step 0 of the persistence plan in #1194: explicit serde for the engine's `GameState`, the piece both the games-table write-through (step 2) and LISTEN/NOTIFY fan-out (step 3) will read and write. Lands alone, constrains nothing about storage shape, and forces the schema-versioning decision now.

## What's here

`domains/games/libs/cards/golf/game_state_serde.{h,cc}` — two functions next to the engine:

- `serializeGameState(state)` → deterministic JSON of the **full engine truth**: deck order, unrevealed cards, peeks, knock state. Server-side only by design — per-viewer redaction stays exactly where it is, in the hub's `ViewLocked`. A player-supplied name that isn't valid UTF-8 serializes with U+FFFD replacement rather than throwing out of the write path.
- `deserializeGameState(bytes)` → `absl::StatusOr<GameState>`, strict: unknown schema versions are rejected, and so is anything the engine would index out of range (card codes outside 0..51, peek positions outside 0..3, `whoseTurn`/`whoKnocked` outside the roster, empty rosters, hands that aren't exactly four cards). Integer reads compare in int64 before narrowing, so an over-range value can't wrap into a "valid" one and slip a gate. The bytes will arrive from a database row, not from code we trust.

**Identity stays out of the bytes.** Schema v1 is engine truth only — `gameId`/`versionId` are not serialized, because step 2's table owns identity and optimistic concurrency as the `game_id` and `version` columns, and a copy inside the blob is either write-both-and-hope or silent divergence (`version_id` is a dead `""` field from the deleted v1 store besides). Deserialize returns them empty; the storage layer rehydrates via the engine's existing `withIdAndVersion`.

Schema v1 reuses encodings the engine already owns rather than inventing new ones: cards are `Card::intValue()` codes (the `Card(int)` constructor inverts them), hands are `[tl, tr, bl, br]`, peeks are `indexOfPosition` codes. The `"v":1` envelope is the versioning seam. Two deliberate lenient edges, both pinned by tests: unknown fields are tolerated on read (and dropped on re-serialize), and game legality (card uniqueness, peek caps) stays the engine's business.

Re-serializing a deserialized state reproduces the bytes exactly (nlohmann's sorted-key order, documented in the header), so stored states are stable across load/store cycles.

## Tests

Round-trips are verified at every transition of a deterministic two-player game (the `Card(i)` pristine deck, same determinism trick as the hub's `NoShuffleDealer`): opening peeks and the reveal countdown, both draw mechanics (take and decline), a discard take, a knock, and the final turn to game over. Plus a fresh three-player deal and an abandoned (nameless) seat with empty piles.

A **frozen v1 payload** test pins the exact bytes, key order, and hand order of a stored row — everything else in the suite generates its bytes with the code under test, so only this one catches a simultaneous serialize+deserialize change that would orphan (or silently permute) rows already written.

Rejection coverage: every field missing or mistyped at both levels, exact seat-index boundaries and the empty roster, wrap-to-valid int64 values, out-of-range cards/peeks, wrong hand sizes, malformed raw bytes, unknown schema versions — none may crash, all must read as invalid-argument.

No behavior change for anything running today: nothing consumes the new library yet. Step 2 wires it to the `games` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdYxwwdR5oFwZzTpf6Bra9