### PR TITLE
golf_hub: rooms and games write through to postgres (#1194 step 2)

### DIFF
--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -97,6 +97,8 @@ cc_library(
     srcs = ["pg_hub_store.cc"],
     hdrs = ["pg_hub_store.h"],
     deps = [
+        "//domains/games/libs/cards/golf:game_state",
+        "//domains/games/libs/cards/golf:game_state_serde",
         "//domains/platform/libs/pg",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
@@ -119,6 +121,9 @@ cc_test(
     deps = [
         ":pg_hub_store",
         ":pg_ticket_vault",
+        "//domains/games/libs/cards",
+        "//domains/games/libs/cards/golf:game_state",
+        "//domains/games/libs/cards/golf:game_state_serde",
         "//domains/platform/libs/pg",
         "@googletest//:gtest_main",
     ],
@@ -177,7 +182,6 @@ cc_library(
         "//domains/games/libs/cards:card_mapper",
         "//domains/games/libs/cards:dealer",
         "//domains/games/libs/cards/golf:game_state",
-        "//domains/games/libs/cards/golf:game_state_serde",
         "//domains/games/libs/cards/golf:player",
         "//domains/platform/libs/futility/otel:metrics",
         "@com_google_absl//absl/log",

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -87,6 +87,43 @@ cc_library(
     ],
 )
 
+# The rooms/members/games write-through (#1194 step 2): staged by the hub
+# under its lock, applied FIFO by one writer thread; boot restore reads
+# the snapshot back. Concrete postgres component, injected optionally —
+# no interface (the issue's design note), and nullptr keeps the
+# all-in-memory hub as the test mode.
+cc_library(
+    name = "pg_hub_store",
+    srcs = ["pg_hub_store.cc"],
+    hdrs = ["pg_hub_store.h"],
+    deps = [
+        "//domains/platform/libs/pg",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@nlohmann_json//:json",
+    ],
+)
+
+# Step-2 slice of the persistence integration suite (#1194): real
+# postgres via GOLF_HUB_TEST_DB_URL; skips otherwise.
+cc_test(
+    name = "pg_hub_store_test",
+    size = "small",
+    srcs = ["pg_hub_store_test.cc"],
+    env_inherit = ["GOLF_HUB_TEST_DB_URL"],
+    # One shared scratch database: concurrent DB tests truncate each
+    # other mid-flight.
+    tags = ["exclusive"],
+    deps = [
+        ":pg_hub_store",
+        ":pg_ticket_vault",
+        "//domains/platform/libs/pg",
+        "@googletest//:gtest_main",
+    ],
+)
+
 # Phase-0 slice of the persistence integration suite (#1194): serialized
 # engine states must survive the step-2 storage target (jsonb normalizes
 # keys and spacing, and refuses escaped NULs). Real postgres via
@@ -96,6 +133,9 @@ cc_test(
     size = "small",
     srcs = ["game_state_jsonb_test.cc"],
     env_inherit = ["GOLF_HUB_TEST_DB_URL"],
+    # One shared scratch database: concurrent DB tests truncate each
+    # other mid-flight.
+    tags = ["exclusive"],
     deps = [
         "//domains/games/libs/cards",
         "//domains/games/libs/cards/golf:game_state",
@@ -113,6 +153,9 @@ cc_test(
     size = "small",
     srcs = ["pg_ticket_vault_test.cc"],
     env_inherit = ["GOLF_HUB_TEST_DB_URL"],
+    # One shared scratch database: concurrent DB tests truncate each
+    # other mid-flight.
+    tags = ["exclusive"],
     deps = [
         ":pg_ticket_vault",
         "//domains/platform/libs/pg",
@@ -128,16 +171,52 @@ cc_library(
     deps = [
         ":golf_hub_smithy_server",
         ":id_generator",
+        ":pg_hub_store",
         ":ticket_vault",
         "//domains/games/libs/cards",
         "//domains/games/libs/cards:card_mapper",
         "//domains/games/libs/cards:dealer",
         "//domains/games/libs/cards/golf:game_state",
+        "//domains/games/libs/cards/golf:game_state_serde",
         "//domains/games/libs/cards/golf:player",
         "//domains/platform/libs/futility/otel:metrics",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/strings",
         "@smithy_cpp//runtime:eventstream",
         "@smithy_cpp//runtime:server",
+    ],
+)
+
+# The step-2 restart-survival e2e (#1194): same client flows, durable
+# hub, RestartHub between them. Real postgres via GOLF_HUB_TEST_DB_URL;
+# skips otherwise.
+cc_test(
+    name = "pg_hub_e2e_test",
+    size = "small",
+    srcs = [
+        "pg_hub_e2e_test.cc",
+        "stream_test_fixture.h",
+    ],
+    env_inherit = ["GOLF_HUB_TEST_DB_URL"],
+    # One shared scratch database: concurrent DB tests truncate each
+    # other mid-flight.
+    tags = ["exclusive"],
+    deps = [
+        ":golf_hub_smithy_client",
+        ":golf_hub_smithy_server",
+        ":hub_handler",
+        ":id_generator",
+        ":pg_hub_store",
+        ":pg_ticket_vault",
+        ":ticket_vault",
+        "//domains/games/libs/cards:dealer",
+        "//domains/platform/libs/futility/otel:metrics",
+        "//domains/platform/libs/pg",
+        "@googletest//:gtest_main",
+        "@smithy_cpp//runtime:client",
+        "@smithy_cpp//runtime:core",
+        "@smithy_cpp//runtime:http",
+        "@smithy_cpp//runtime:http_beast",
     ],
 )
 
@@ -175,6 +254,7 @@ cc_binary(
         ":golf_hub_smithy_server",
         ":hub_handler",
         ":id_generator",
+        ":pg_hub_store",
         ":pg_ticket_vault",
         ":ticket_vault",
         "//domains/games/libs/cards:dealer",

--- a/domains/games/apis/golf_hub/README.md
+++ b/domains/games/apis/golf_hub/README.md
@@ -41,12 +41,16 @@ lobby-safe summaries only.
 
 ## Scaffold notes / deferred
 
-- Credentials live in postgres when `GOLF_HUB_DB_URL` is set (#1194
-  step 1: `PgTicketVault`, hashed at rest, spend = single-row
-  `DELETE ... RETURNING`), so tickets and resume tokens survive deploys
-  and don't care which instance minted them. Unset falls back to the
-  in-memory `InMemoryTicketVault` — dev mode and the test harness.
-  Rooms, games, and fan-out are still in-process (later #1194 steps).
+- Persistence rides `GOLF_HUB_DB_URL` (#1194). Step 1: credentials in
+  postgres (`PgTicketVault`, hashed at rest, spend = single-row
+  `DELETE ... RETURNING`) — tickets and resume tokens survive deploys.
+  Step 2: rooms, membership stats, and live games write through
+  (`PgHubStore` — ops staged under the hub lock, applied FIFO by one
+  writer; games save serialized `GameState` with a version counter) and
+  restore at boot, so a deploy no longer kills games: players resume by
+  token into their seat. Memory stays authoritative single-instance;
+  fan-out is still process-local (step 3). Unset falls back to
+  all-in-memory — dev mode and the test harness.
 - Player ids are whimsical (`bouncy-coral-quokka-x9k2`, the Go
   generator's word lists) and double as display names. Room and game ids
   are 6-char uppercase codes for permalink compatibility.

--- a/domains/games/apis/golf_hub/golf_hub_main.cc
+++ b/domains/games/apis/golf_hub/golf_hub_main.cc
@@ -24,6 +24,7 @@
 #include "domains/games/apis/golf_hub/hub_handler.h"
 #include "domains/games/apis/golf_hub/id_generator.h"
 #include "domains/games/apis/golf_hub/migrations.h"
+#include "domains/games/apis/golf_hub/pg_hub_store.h"
 #include "domains/games/apis/golf_hub/pg_ticket_vault.h"
 #include "domains/games/apis/golf_hub/ticket_vault.h"
 #include "domains/games/libs/cards/dealer.h"
@@ -69,12 +70,16 @@ int main() {
   futility::otel::OtelConfig otel_config{.service_name = "golf_hub", .service_version = "1.0.0"};
   futility::otel::OtelProvider otel_provider(otel_config);
 
-  // Credentials go to postgres when GOLF_HUB_DB_URL is set (#1194 step 1:
-  // tickets survive restarts and instances); unset falls back to the
-  // in-memory vault — dev parity, same pattern as ALLOWED_ORIGINS below.
+  // Persistence when GOLF_HUB_DB_URL is set (#1194): credentials (step 1)
+  // and the rooms/games write-through + boot restore (step 2) — tickets,
+  // resume tokens, rooms, and live games survive deploys. Unset falls
+  // back to all-in-memory — dev parity, same pattern as ALLOWED_ORIGINS
+  // below. The vault and the store get their own connections so a slow
+  // write-through never queues behind a credential check.
   constexpr auto kTicketTtl = std::chrono::seconds(30);
   constexpr auto kResumeTtl = std::chrono::hours(24);
   std::shared_ptr<golf_hub::TicketVault> vault;
+  std::shared_ptr<golf_hub::PgHubStore> store;
   const char* db_url = std::getenv("GOLF_HUB_DB_URL");
   if (db_url != nullptr && *db_url != '\0') {
     auto db = std::make_shared<pg::Client>(db_url);
@@ -83,17 +88,18 @@ int main() {
       return 1;
     }
     vault = std::make_shared<golf_hub::PgTicketVault>(std::move(db), kTicketTtl, kResumeTtl);
-    LOG(INFO) << "Ticket vault: postgres";
+    store = std::make_shared<golf_hub::PgHubStore>(std::make_shared<pg::Client>(db_url));
+    LOG(INFO) << "Persistence: postgres (credentials + rooms/games write-through)";
   } else {
     vault = std::make_shared<golf_hub::InMemoryTicketVault>(kTicketTtl, kResumeTtl);
-    LOG(INFO) << "Ticket vault: in-memory (GOLF_HUB_DB_URL unset; restarts forget credentials)";
+    LOG(INFO) << "Persistence: in-memory (GOLF_HUB_DB_URL unset; restarts forget everything)";
   }
   // Stream-side instruments (sessions, commands, events) ride the same
   // meter the aura chain's unary instruments use.
   auto handler = std::make_shared<golf_hub::HubHandler>(
       vault, std::make_shared<cards::Dealer>(), std::make_shared<golf_hub::WhimsicalIdGenerator>(),
       /*grace_period=*/std::chrono::minutes(5),
-      std::make_shared<futility::otel::MetricsRecorder>("golf_hub"));
+      std::make_shared<futility::otel::MetricsRecorder>("golf_hub"), store);
 
   // Block shutdown signals before the transport spawns its thread pool.
   sigset_t shutdown_signals;

--- a/domains/games/apis/golf_hub/golf_hub_main.cc
+++ b/domains/games/apis/golf_hub/golf_hub_main.cc
@@ -100,6 +100,12 @@ int main() {
       vault, std::make_shared<cards::Dealer>(), std::make_shared<golf_hub::WhimsicalIdGenerator>(),
       /*grace_period=*/std::chrono::minutes(5),
       std::make_shared<futility::otel::MetricsRecorder>("golf_hub"), store);
+  // Same policy as the migration above: a database we can't read at boot
+  // is a reason to let the supervisor retry, not to serve amnesiac.
+  if (absl::Status restored = handler->RestoreFromStore(); !restored.ok()) {
+    LOG(ERROR) << "Failed to restore golf hub state: " << restored;
+    return 1;
+  }
 
   // Block shutdown signals before the transport spawns its thread pool.
   sigset_t shutdown_signals;

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -19,89 +19,9 @@ using moonbase::golf::GolfEvents;
 using moonbase::golf::GolfMove;
 using moonbase::golf::GolfUpdate;
 
-// Receives until an event of the wanted case arrives (skipping others),
-// failing after a few frames so a wrong stream can't hang the test.
-std::optional<GolfEvents> ReceiveCase(moonbase::golf::PlayClientStream& stream,
-                                      const std::string& wanted) {
-  for (int i = 0; i < 8; ++i) {
-    auto received = stream.Receive();
-    if (!received.ok() || !received->has_value()) return std::nullopt;
-    if (wanted == (*received)->case_name()) return **received;
-  }
-  return std::nullopt;
-}
-
-// Same, but tunnels into the golf envelope: returns the first GolfUpdate
-// of the wanted case, skipping room noise and other updates in between.
-std::optional<GolfUpdate> ReceiveGolf(moonbase::golf::PlayClientStream& stream,
-                                      const std::string& wanted) {
-  for (int i = 0; i < 16; ++i) {
-    auto received = stream.Receive();
-    if (!received.ok() || !received->has_value()) return std::nullopt;
-    const auto* envelope = (*received)->as_golf_or_null();
-    if (envelope == nullptr) continue;
-    if (wanted == envelope->update.case_name()) return envelope->update;
-  }
-  return std::nullopt;
-}
-
-GolfCommands Move(GolfMove move) {
-  moonbase::golf::GolfCommand command;
-  command.move = std::move(move);
-  return GolfCommands::FromGolf(std::move(command));
-}
-
 }  // namespace
 
-class GolfGameFixture : public GolfHubStreamFixture {
- protected:
-  // Room with alice and bob seated in a started game: the NoShuffleDealer
-  // deals alice four aces and bob four kings with Q♠ seeding the discard.
-  struct Table {
-    Seat alice;
-    Seat bob;
-    std::string room_id;
-    std::string game_id;
-  };
-
-  std::optional<Table> SeatedTable() {
-    auto alice = OpenSeat();
-    auto bob = OpenSeat();
-    if (!alice.has_value() || !bob.has_value()) return std::nullopt;
-    if (!ReceiveCase(alice->stream, "sessionReady").has_value()) return std::nullopt;
-    if (!ReceiveCase(bob->stream, "sessionReady").has_value()) return std::nullopt;
-
-    if (!alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok()) {
-      return std::nullopt;
-    }
-    auto created = ReceiveCase(alice->stream, "roomState");
-    if (!created.has_value()) return std::nullopt;
-    const std::string room_id = created->as_roomState_or_null()->roomId;
-    moonbase::golf::JoinRoom join_room;
-    join_room.roomId = room_id;
-    if (!bob->stream.Send(GolfCommands::FromJoinroom(join_room)).ok()) return std::nullopt;
-    if (!ReceiveCase(bob->stream, "roomState").has_value()) return std::nullopt;
-
-    if (!alice->stream.Send(Move(GolfMove::FromCreategame(moonbase::golf::CreateGame{}))).ok()) {
-      return std::nullopt;
-    }
-    auto joined = ReceiveGolf(alice->stream, "gameJoined");
-    if (!joined.has_value()) return std::nullopt;
-    const std::string game_id = joined->as_gameJoined_or_null()->view.gameId;
-
-    moonbase::golf::JoinGame join_game;
-    join_game.gameId = game_id;
-    if (!bob->stream.Send(Move(GolfMove::FromJoingame(join_game))).ok()) return std::nullopt;
-    if (!ReceiveGolf(bob->stream, "gameJoined").has_value()) return std::nullopt;
-
-    if (!alice->stream.Send(Move(GolfMove::FromStartgame(moonbase::golf::StartGame{}))).ok()) {
-      return std::nullopt;
-    }
-    if (!ReceiveGolf(alice->stream, "gameStarted").has_value()) return std::nullopt;
-    if (!ReceiveGolf(bob->stream, "gameStarted").has_value()) return std::nullopt;
-    return Table{std::move(*alice), std::move(*bob), room_id, game_id};
-  }
-};
+class GolfGameFixture : public GolfHubStreamFixture {};
 
 namespace {
 
@@ -649,6 +569,33 @@ TEST_F(CollidingIdsFixture, RoomCodeCollisionRollsAgain) {
   auto second = ReceiveCase(bob->stream, "roomState");
   ASSERT_TRUE(second.has_value());
   EXPECT_EQ(second->as_roomState_or_null()->roomId, "ROOM2X");
+}
+
+// A vault whose store is down: GetSession must fail closed with a
+// non-leaking error, never mint a credential nothing recorded.
+class FailingVault final : public TicketVault {
+ public:
+  absl::StatusOr<std::string> IssueTicket(const std::string&) override {
+    return absl::UnavailableError("vault down");
+  }
+  absl::StatusOr<std::string> IssueResumeToken(const std::string&) override {
+    return absl::UnavailableError("vault down");
+  }
+  bool PeekTicket(const std::string&) const override { return false; }
+  std::optional<std::string> SpendTicket(const std::string&) override { return std::nullopt; }
+  std::optional<std::string> ResolveResumeToken(const std::string&) const override {
+    return std::nullopt;
+  }
+};
+
+class FailingVaultFixture : public GolfHubStreamFixture {
+ protected:
+  std::shared_ptr<TicketVault> MakeVault() override { return std::make_shared<FailingVault>(); }
+};
+
+TEST_F(FailingVaultFixture, GetSessionFailsClosedWhenTheVaultIsDown) {
+  const auto session = client_->GetSession(moonbase::golf::GetSessionInput{});
+  ASSERT_FALSE(session.ok());
 }
 
 }  // namespace

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -5,9 +5,11 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "domains/games/libs/cards/card_mapper.h"
+#include "domains/games/libs/cards/golf/game_state_serde.h"
 #include "domains/games/libs/cards/golf/player.h"
 
 namespace golf_hub {
@@ -68,18 +70,101 @@ GolfEvents GolfUpdateEvent(GolfUpdate update) {
 
 HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards::Dealer> dealer,
                        std::shared_ptr<IdGenerator> ids, std::chrono::seconds grace_period,
-                       std::shared_ptr<futility::otel::MetricsRecorder> metrics)
+                       std::shared_ptr<futility::otel::MetricsRecorder> metrics,
+                       std::shared_ptr<PgHubStore> store)
     : vault_(std::move(vault)),
       dealer_(std::move(dealer)),
       ids_(std::move(ids)),
       metrics_(std::move(metrics)),
+      store_(std::move(store)),
       registry_([this, grace_period] {
         Registry::Options options;
         options.async_delivery = true;  // chains, not writer threads (ADR-0019)
         options.grace_period = grace_period;
         options.on_expired = [this](const std::string& id) { OnExpired(id); };
         return options;
-      }()) {}
+      }()) {
+  if (store_ != nullptr) RestoreFromStore();
+}
+
+void HubHandler::RestoreFromStore() {
+  auto snapshot = store_->LoadSnapshot();
+  if (!snapshot.ok()) {
+    // Boot with what we have (nothing): the service coming up empty is
+    // the pre-persistence status quo, not a reason to stay down.
+    LOG(ERROR) << "hub restore failed; starting empty: " << snapshot.status();
+    return;
+  }
+  const std::lock_guard<std::mutex> lock(mu_);
+  for (const std::string& room_id : snapshot->rooms) rooms_[room_id];
+  for (const PgHubStore::MemberRow& row : snapshot->members) {
+    // Sockets did not survive the restart: everyone restores
+    // disconnected and flips back on resume.
+    Member member;
+    member.connected = false;
+    member.games_played = row.games_played;
+    member.games_won = row.games_won;
+    member.total_score = row.total_score;
+    rooms_[row.room_id].members.emplace(row.player_id, member);
+    player_room_[row.player_id] = row.room_id;
+  }
+  int restored_games = 0;
+  for (const PgHubStore::GameRow& row : snapshot->games) {
+    GameEntry entry;
+    entry.roster = row.roster;
+    entry.version = row.version;
+    if (!row.state_json.empty()) {
+      auto state = golf::deserializeGameState(row.state_json);
+      if (!state.ok()) {
+        // The lobby survives; the unreadable game does not.
+        LOG(ERROR) << "dropping unreadable game " << row.room_id << "/" << row.game_id << ": "
+                   << state.status();
+        continue;
+      }
+      entry.state.emplace(*std::move(state));
+    }
+    for (const std::string& member_id : entry.roster) player_game_[member_id] = row.game_id;
+    rooms_[row.room_id].games.emplace(row.game_id, std::move(entry));
+    ++restored_games;
+  }
+  LOG(INFO) << "hub restored " << snapshot->rooms.size() << " rooms, " << snapshot->members.size()
+            << " members, " << restored_games << " games";
+}
+
+void HubHandler::Persist(Writes& writes) {
+  if (store_ != nullptr && !writes.empty()) store_->Enqueue(std::move(writes));
+  writes.clear();
+}
+
+void HubHandler::StageMemberLocked(const std::string& room_id, const std::string& player_id,
+                                   Writes& writes) const {
+  if (store_ == nullptr) return;
+  const auto room = rooms_.find(room_id);
+  if (room == rooms_.end()) return;
+  const auto member = room->second.members.find(player_id);
+  if (member == room->second.members.end()) return;
+  PgHubStore::MemberRow row;
+  row.room_id = room_id;
+  row.player_id = player_id;
+  row.connected = member->second.connected;
+  row.games_played = member->second.games_played;
+  row.games_won = member->second.games_won;
+  row.total_score = member->second.total_score;
+  writes.push_back(PgHubStore::UpsertMember{std::move(row)});
+}
+
+void HubHandler::StageGameLocked(const std::string& room_id, const std::string& game_id,
+                                 GameEntry& entry, Writes& writes) const {
+  if (store_ == nullptr) return;
+  ++entry.version;
+  PgHubStore::GameRow row;
+  row.room_id = room_id;
+  row.game_id = game_id;
+  row.roster = entry.roster;
+  if (entry.started()) row.state_json = golf::serializeGameState(*entry.state);
+  row.version = entry.version;
+  writes.push_back(PgHubStore::SaveGame{std::move(row)});
+}
 
 smithy::Outcome<moonbase::golf::GetSessionOutput> HubHandler::GetSession(
     const moonbase::golf::GetSessionInput& input,
@@ -129,14 +214,17 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
     Count("stream_admissions_refused", {{"reason", "seat_conflict"}});
     co_return smithy::Error::Modeled("SeatConflict", "player already has a live connection");
   }
-  const bool resumed = admission == Registry::Admission::kResumed;
-  Count("stream_sessions", {{"resumed", resumed ? "true" : "false"}});
+  Count("stream_sessions",
+        {{"resumed", admission == Registry::Admission::kResumed ? "true" : "false"}});
   TrackActive(+1);
 
+  // Membership decides the resync, not the registry: a player restored
+  // from the store (#1194 step 2) admits as new — their old process's
+  // registry died — but their room and game are right here.
   std::optional<std::string> room;
   Outbox resync;
-  if (resumed) {
-    SetConnected(player_id, true);
+  SetConnected(player_id, true);
+  {
     const std::lock_guard<std::mutex> lock(mu_);
     const auto room_it = player_room_.find(player_id);
     if (room_it != player_room_.end()) room = room_it->second;
@@ -147,6 +235,7 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
       resync.To(player_id, GolfUpdateEvent(GolfUpdate::FromGamejoined(std::move(joined))));
     }
   }
+  const bool resumed = admission == Registry::Admission::kResumed || room.has_value();
   moonbase::golf::SessionReady ready;
   ready.playerId = player_id;
   ready.resumed = resumed;
@@ -177,10 +266,12 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
       TrackActive(-1);
       Count("stream_disconnects", {{"kind", "clean"}});
       Outbox outbox;
+      Writes writes;
       {
         const std::lock_guard<std::mutex> lock(mu_);
-        LeaveEverywhere(player_id, outbox);
+        LeaveEverywhere(player_id, outbox, writes);
       }
+      Persist(writes);
       Deliver(outbox);
       co_return smithy::Unit{};
     }
@@ -193,6 +284,7 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
   if (command.as_createRoom_or_null() != nullptr) {
     std::string room_id;
     Outbox outbox;
+    Writes writes;
     {
       const std::lock_guard<std::mutex> lock(mu_);
       if (!player_room_.contains(player_id)) {
@@ -200,12 +292,15 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
         while (rooms_.contains(room_id)) room_id = ids_->RoomId();
         rooms_[room_id].members.emplace(player_id, Member{});
         player_room_[player_id] = room_id;
+        if (store_ != nullptr) writes.push_back(PgHubStore::UpsertRoom{room_id});
+        StageMemberLocked(room_id, player_id, writes);
         StageRoomStateLocked(room_id, outbox);
       }
     }
     if (room_id.empty()) {
       Reject(player_id, "already in a room");
     } else {
+      Persist(writes);
       Deliver(outbox);
     }
     return;
@@ -213,6 +308,7 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
 
   if (const auto* join = command.as_joinRoom_or_null()) {
     Outbox outbox;
+    Writes writes;
     bool joined = false;
     {
       const std::lock_guard<std::mutex> lock(mu_);
@@ -220,11 +316,13 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
       if (room != rooms_.end() && !player_room_.contains(player_id)) {
         room->second.members.emplace(player_id, Member{});
         player_room_[player_id] = join->roomId;
+        StageMemberLocked(join->roomId, player_id, writes);
         StageRoomStateLocked(join->roomId, outbox);
         joined = true;
       }
     }
     if (joined) {
+      Persist(writes);
       Deliver(outbox);
     } else {
       Reject(player_id, "room unavailable or already in a room");
@@ -234,6 +332,7 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
 
   if (command.as_leaveRoom_or_null() != nullptr) {
     Outbox outbox;
+    Writes writes;
     bool left = false;
     {
       const std::lock_guard<std::mutex> lock(mu_);
@@ -242,11 +341,12 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
         moonbase::golf::RoomLeft ack;
         ack.roomId = it->second;
         outbox.To(player_id, GolfEvents::FromRoomleft(std::move(ack)));
-        LeaveEverywhere(player_id, outbox);
+        LeaveEverywhere(player_id, outbox, writes);
         left = true;
       }
     }
     if (left) {
+      Persist(writes);
       Deliver(outbox);
     } else {
       Reject(player_id, "not in a room");
@@ -328,13 +428,15 @@ void HubHandler::HandleMove(const std::string& player_id, const GolfMove& move) 
   }
   if (move.as_leaveGame_or_null() != nullptr) {
     Outbox outbox;
+    Writes writes;
     bool in_game = false;
     {
       const std::lock_guard<std::mutex> lock(mu_);
       in_game = player_game_.contains(player_id);
-      if (in_game) LeaveGameLocked(player_id, outbox);
+      if (in_game) LeaveGameLocked(player_id, outbox, writes);
     }
     if (in_game) {
+      Persist(writes);
       Deliver(outbox);
     } else {
       Reject(player_id, "not in a game");
@@ -424,6 +526,7 @@ void HubHandler::HandleMove(const std::string& player_id, const GolfMove& move) 
 
 void HubHandler::CreateGameMove(const std::string& player_id) {
   Outbox outbox;
+  Writes writes;
   std::string reason;
   {
     const std::lock_guard<std::mutex> lock(mu_);
@@ -438,6 +541,7 @@ void HubHandler::CreateGameMove(const std::string& player_id) {
       GameEntry& entry = room->games[game_id];
       entry.roster.push_back(player_id);
       player_game_[player_id] = game_id;
+      StageGameLocked(player_room_.at(player_id), game_id, entry, writes);
 
       moonbase::golf::GameCreated announcement;
       announcement.gameId = game_id;
@@ -454,12 +558,14 @@ void HubHandler::CreateGameMove(const std::string& player_id) {
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
+    Persist(writes);
     Deliver(outbox);
   }
 }
 
 void HubHandler::JoinGameMove(const std::string& player_id, const std::string& game_id) {
   Outbox outbox;
+  Writes writes;
   std::string reason;
   {
     const std::lock_guard<std::mutex> lock(mu_);
@@ -479,6 +585,7 @@ void HubHandler::JoinGameMove(const std::string& player_id, const std::string& g
       } else {
         game->second.roster.push_back(player_id);
         player_game_[player_id] = game_id;
+        StageGameLocked(player_room_.at(player_id), game_id, game->second, writes);
 
         moonbase::golf::GameJoined joined;
         joined.view = ViewLocked(game_id, game->second, player_id);
@@ -496,12 +603,14 @@ void HubHandler::JoinGameMove(const std::string& player_id, const std::string& g
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
+    Persist(writes);
     Deliver(outbox);
   }
 }
 
 void HubHandler::StartGameMove(const std::string& player_id) {
   Outbox outbox;
+  Writes writes;
   std::string reason;
   {
     const std::lock_guard<std::mutex> lock(mu_);
@@ -520,6 +629,7 @@ void HubHandler::StartGameMove(const std::string& player_id) {
         reason = std::string(dealt.status().message());
       } else {
         ref->entry->state.emplace(std::move(*dealt));
+        StageGameLocked(ref->room_id, ref->game_id, *ref->entry, writes);
         for (const std::string& recipient : ref->entry->roster) {
           outbox.To(recipient,
                     GolfUpdateEvent(GolfUpdate::FromGamestarted(moonbase::golf::GameStarted{})));
@@ -532,12 +642,14 @@ void HubHandler::StartGameMove(const std::string& player_id) {
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
+    Persist(writes);
     Deliver(outbox);
   }
 }
 
 void HubHandler::EngineMove(const std::string& player_id, const MoveFn& move, MoveEffects effects) {
   Outbox outbox;
+  Writes writes;
   std::string reason;
   {
     const std::lock_guard<std::mutex> lock(mu_);
@@ -574,8 +686,9 @@ void HubHandler::EngineMove(const std::string& player_id, const MoveFn& move, Mo
 
           if (updated.isOver()) {
             // Finalize stages the definitive face-up views itself.
-            FinalizeGameLocked(ref->room_id, *ref->room, ref->game_id, outbox);
+            FinalizeGameLocked(ref->room_id, *ref->room, ref->game_id, outbox, writes);
           } else {
+            StageGameLocked(ref->room_id, ref->game_id, *ref->entry, writes);
             const bool countdown_started = !was_countdown && updated.revealCountdownActive();
             if (effects.peek_fanout && !countdown_started) {
               // A quiet peek: only the peeker's view changed.
@@ -603,18 +716,25 @@ void HubHandler::EngineMove(const std::string& player_id, const MoveFn& move, Mo
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
+    Persist(writes);
     Deliver(outbox);
   }
 }
 
 void HubHandler::SetConnected(const std::string& player_id, bool connected) {
-  const std::lock_guard<std::mutex> lock(mu_);
-  const auto it = player_room_.find(player_id);
-  if (it == player_room_.end()) return;
-  const auto room = rooms_.find(it->second);
-  if (room == rooms_.end()) return;
-  const auto member = room->second.members.find(player_id);
-  if (member != room->second.members.end()) member->second.connected = connected;
+  Writes writes;
+  {
+    const std::lock_guard<std::mutex> lock(mu_);
+    const auto it = player_room_.find(player_id);
+    if (it == player_room_.end()) return;
+    const auto room = rooms_.find(it->second);
+    if (room == rooms_.end()) return;
+    const auto member = room->second.members.find(player_id);
+    if (member == room->second.members.end()) return;
+    member->second.connected = connected;
+    StageMemberLocked(it->second, player_id, writes);
+  }
+  Persist(writes);
 }
 
 std::optional<std::string> HubHandler::CurrentRoom(const std::string& player_id) {
@@ -642,8 +762,8 @@ std::optional<HubHandler::GameRef> HubHandler::FindGameLocked(const std::string&
   return GameRef{room_it->second, &room->second, game_it->second, &game->second};
 }
 
-void HubHandler::LeaveEverywhere(const std::string& player_id, Outbox& outbox) {
-  LeaveGameLocked(player_id, outbox);
+void HubHandler::LeaveEverywhere(const std::string& player_id, Outbox& outbox, Writes& writes) {
+  LeaveGameLocked(player_id, outbox, writes);
 
   const auto it = player_room_.find(player_id);
   if (it == player_room_.end()) return;
@@ -654,12 +774,15 @@ void HubHandler::LeaveEverywhere(const std::string& player_id, Outbox& outbox) {
   room->second.members.erase(player_id);
   if (room->second.members.empty()) {
     rooms_.erase(room);
+    // One DeleteRoom; the row's cascade takes members and games with it.
+    if (store_ != nullptr) writes.push_back(PgHubStore::DeleteRoom{room_id});
     return;  // nobody left to tell
   }
+  if (store_ != nullptr) writes.push_back(PgHubStore::DeleteMember{room_id, player_id});
   StageRoomStateLocked(room_id, outbox);
 }
 
-void HubHandler::LeaveGameLocked(const std::string& player_id, Outbox& outbox) {
+void HubHandler::LeaveGameLocked(const std::string& player_id, Outbox& outbox, Writes& writes) {
   auto ref = FindGameLocked(player_id);
   player_game_.erase(player_id);
   if (!ref.has_value()) return;
@@ -674,7 +797,9 @@ void HubHandler::LeaveGameLocked(const std::string& player_id, Outbox& outbox) {
   if (!ref->entry->started()) {
     if (roster.empty()) {
       ref->room->games.erase(ref->game_id);
+      if (store_ != nullptr) writes.push_back(PgHubStore::DeleteGame{ref->room_id, ref->game_id});
     } else {
+      StageGameLocked(ref->room_id, ref->game_id, *ref->entry, writes);
       StageGameViewsLocked(ref->game_id, *ref->entry, outbox);
     }
     StageRoomStateLocked(ref->room_id, outbox);
@@ -689,8 +814,9 @@ void HubHandler::LeaveGameLocked(const std::string& player_id, Outbox& outbox) {
   }
   if (ref->entry->state->isOver()) {
     // Finalize stages the final views and the room's refreshed stats.
-    FinalizeGameLocked(ref->room_id, *ref->room, ref->game_id, outbox);
+    FinalizeGameLocked(ref->room_id, *ref->room, ref->game_id, outbox, writes);
   } else {
+    StageGameLocked(ref->room_id, ref->game_id, *ref->entry, writes);
     StageGameViewsLocked(ref->game_id, *ref->entry, outbox);
     StageRoomStateLocked(ref->room_id, outbox);
   }
@@ -717,10 +843,12 @@ void HubHandler::OnExpired(const std::string& player_id) {
   // slots and tell whoever remains. Runs on the registry's expiry thread.
   Count("stream_seats_expired");
   Outbox outbox;
+  Writes writes;
   {
     const std::lock_guard<std::mutex> lock(mu_);
-    LeaveEverywhere(player_id, outbox);
+    LeaveEverywhere(player_id, outbox, writes);
   }
+  Persist(writes);
   Deliver(outbox);
 }
 
@@ -862,7 +990,7 @@ void HubHandler::StageGameViewsLocked(const std::string& game_id, const GameEntr
 }
 
 void HubHandler::FinalizeGameLocked(const std::string& room_id, Room& room,
-                                    const std::string& game_id, Outbox& outbox) {
+                                    const std::string& game_id, Outbox& outbox, Writes& writes) {
   const auto game = room.games.find(game_id);
   if (game == room.games.end() || !game->second.started()) return;
   const golf::GameState& state = *game->second.state;
@@ -896,6 +1024,7 @@ void HubHandler::FinalizeGameLocked(const std::string& room_id, Room& room,
     if (std::find(winner_ids.begin(), winner_ids.end(), occupant) != winner_ids.end()) {
       member->second.games_won++;
     }
+    StageMemberLocked(room_id, occupant, writes);
   }
 
   // Final views (everything face up), then the result, then the room's
@@ -906,6 +1035,7 @@ void HubHandler::FinalizeGameLocked(const std::string& room_id, Room& room,
     player_game_.erase(recipient);
   }
   room.games.erase(game);
+  if (store_ != nullptr) writes.push_back(PgHubStore::DeleteGame{room_id, game_id});
   StageRoomStateLocked(room_id, outbox);
 }
 

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -9,7 +9,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "domains/games/libs/cards/card_mapper.h"
-#include "domains/games/libs/cards/golf/game_state_serde.h"
 #include "domains/games/libs/cards/golf/player.h"
 
 namespace golf_hub {
@@ -83,18 +82,12 @@ HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards
         options.grace_period = grace_period;
         options.on_expired = [this](const std::string& id) { OnExpired(id); };
         return options;
-      }()) {
-  if (store_ != nullptr) RestoreFromStore();
-}
+      }()) {}
 
-void HubHandler::RestoreFromStore() {
+absl::Status HubHandler::RestoreFromStore() {
+  if (store_ == nullptr) return absl::OkStatus();
   auto snapshot = store_->LoadSnapshot();
-  if (!snapshot.ok()) {
-    // Boot with what we have (nothing): the service coming up empty is
-    // the pre-persistence status quo, not a reason to stay down.
-    LOG(ERROR) << "hub restore failed; starting empty: " << snapshot.status();
-    return;
-  }
+  if (!snapshot.ok()) return snapshot.status();
   const std::lock_guard<std::mutex> lock(mu_);
   for (const std::string& room_id : snapshot->rooms) rooms_[room_id];
   for (const PgHubStore::MemberRow& row : snapshot->members) {
@@ -108,60 +101,50 @@ void HubHandler::RestoreFromStore() {
     rooms_[row.room_id].members.emplace(row.player_id, member);
     player_room_[row.player_id] = row.room_id;
   }
-  int restored_games = 0;
-  for (const PgHubStore::GameRow& row : snapshot->games) {
+  for (PgHubStore::GameRow& row : snapshot->games) {
     GameEntry entry;
     entry.roster = row.roster;
     entry.version = row.version;
-    if (!row.state_json.empty()) {
-      auto state = golf::deserializeGameState(row.state_json);
-      if (!state.ok()) {
-        // The lobby survives; the unreadable game does not.
-        LOG(ERROR) << "dropping unreadable game " << row.room_id << "/" << row.game_id << ": "
-                   << state.status();
-        continue;
-      }
-      entry.state.emplace(*std::move(state));
-    }
+    if (row.state.has_value()) entry.state.emplace(*std::move(row.state));
     for (const std::string& member_id : entry.roster) player_game_[member_id] = row.game_id;
     rooms_[row.room_id].games.emplace(row.game_id, std::move(entry));
-    ++restored_games;
   }
   LOG(INFO) << "hub restored " << snapshot->rooms.size() << " rooms, " << snapshot->members.size()
-            << " members, " << restored_games << " games";
+            << " members, " << snapshot->games.size() << " games";
+  return absl::OkStatus();
 }
 
-void HubHandler::Persist(Writes& writes) {
+void HubHandler::EnqueueWritesLocked(Writes& writes) {
   if (store_ != nullptr && !writes.empty()) store_->Enqueue(std::move(writes));
   writes.clear();
 }
 
+void HubHandler::StageLocked(Writes& writes, PgHubStore::Op op) const {
+  if (store_ != nullptr) writes.push_back(std::move(op));
+}
+
 void HubHandler::StageMemberLocked(const std::string& room_id, const std::string& player_id,
-                                   Writes& writes) const {
+                                   const Member& member, Writes& writes) const {
   if (store_ == nullptr) return;
-  const auto room = rooms_.find(room_id);
-  if (room == rooms_.end()) return;
-  const auto member = room->second.members.find(player_id);
-  if (member == room->second.members.end()) return;
   PgHubStore::MemberRow row;
   row.room_id = room_id;
   row.player_id = player_id;
-  row.connected = member->second.connected;
-  row.games_played = member->second.games_played;
-  row.games_won = member->second.games_won;
-  row.total_score = member->second.total_score;
+  row.connected = member.connected;
+  row.games_played = member.games_played;
+  row.games_won = member.games_won;
+  row.total_score = member.total_score;
   writes.push_back(PgHubStore::UpsertMember{std::move(row)});
 }
 
 void HubHandler::StageGameLocked(const std::string& room_id, const std::string& game_id,
-                                 GameEntry& entry, Writes& writes) const {
-  if (store_ == nullptr) return;
+                                 GameEntry& entry, Writes& writes) {
   ++entry.version;
+  if (store_ == nullptr) return;
   PgHubStore::GameRow row;
   row.room_id = room_id;
   row.game_id = game_id;
   row.roster = entry.roster;
-  if (entry.started()) row.state_json = golf::serializeGameState(*entry.state);
+  if (entry.started()) row.state.emplace(*entry.state);
   row.version = entry.version;
   writes.push_back(PgHubStore::SaveGame{std::move(row)});
 }
@@ -270,8 +253,8 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
       {
         const std::lock_guard<std::mutex> lock(mu_);
         LeaveEverywhere(player_id, outbox, writes);
+        EnqueueWritesLocked(writes);
       }
-      Persist(writes);
       Deliver(outbox);
       co_return smithy::Unit{};
     }
@@ -290,17 +273,17 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
       if (!player_room_.contains(player_id)) {
         room_id = ids_->RoomId();
         while (rooms_.contains(room_id)) room_id = ids_->RoomId();
-        rooms_[room_id].members.emplace(player_id, Member{});
+        const auto [member, inserted] = rooms_[room_id].members.emplace(player_id, Member{});
         player_room_[player_id] = room_id;
-        if (store_ != nullptr) writes.push_back(PgHubStore::UpsertRoom{room_id});
-        StageMemberLocked(room_id, player_id, writes);
+        StageLocked(writes, PgHubStore::UpsertRoom{room_id});
+        StageMemberLocked(room_id, player_id, member->second, writes);
         StageRoomStateLocked(room_id, outbox);
+        EnqueueWritesLocked(writes);
       }
     }
     if (room_id.empty()) {
       Reject(player_id, "already in a room");
     } else {
-      Persist(writes);
       Deliver(outbox);
     }
     return;
@@ -314,15 +297,15 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
       const std::lock_guard<std::mutex> lock(mu_);
       const auto room = rooms_.find(join->roomId);
       if (room != rooms_.end() && !player_room_.contains(player_id)) {
-        room->second.members.emplace(player_id, Member{});
+        const auto [member, inserted] = room->second.members.emplace(player_id, Member{});
         player_room_[player_id] = join->roomId;
-        StageMemberLocked(join->roomId, player_id, writes);
+        StageMemberLocked(join->roomId, player_id, member->second, writes);
         StageRoomStateLocked(join->roomId, outbox);
+        EnqueueWritesLocked(writes);
         joined = true;
       }
     }
     if (joined) {
-      Persist(writes);
       Deliver(outbox);
     } else {
       Reject(player_id, "room unavailable or already in a room");
@@ -342,11 +325,11 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
         ack.roomId = it->second;
         outbox.To(player_id, GolfEvents::FromRoomleft(std::move(ack)));
         LeaveEverywhere(player_id, outbox, writes);
+        EnqueueWritesLocked(writes);
         left = true;
       }
     }
     if (left) {
-      Persist(writes);
       Deliver(outbox);
     } else {
       Reject(player_id, "not in a room");
@@ -434,9 +417,9 @@ void HubHandler::HandleMove(const std::string& player_id, const GolfMove& move) 
       const std::lock_guard<std::mutex> lock(mu_);
       in_game = player_game_.contains(player_id);
       if (in_game) LeaveGameLocked(player_id, outbox, writes);
+      EnqueueWritesLocked(writes);
     }
     if (in_game) {
-      Persist(writes);
       Deliver(outbox);
     } else {
       Reject(player_id, "not in a game");
@@ -554,11 +537,11 @@ void HubHandler::CreateGameMove(const std::string& player_id) {
       outbox.To(player_id, GolfUpdateEvent(GolfUpdate::FromGamejoined(std::move(joined))));
       StageRoomStateLocked(player_room_.at(player_id), outbox);
     }
+    EnqueueWritesLocked(writes);
   }
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
-    Persist(writes);
     Deliver(outbox);
   }
 }
@@ -599,11 +582,11 @@ void HubHandler::JoinGameMove(const std::string& player_id, const std::string& g
         StageRoomStateLocked(player_room_.at(player_id), outbox);
       }
     }
+    EnqueueWritesLocked(writes);
   }
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
-    Persist(writes);
     Deliver(outbox);
   }
 }
@@ -638,11 +621,11 @@ void HubHandler::StartGameMove(const std::string& player_id) {
         StageRoomStateLocked(ref->room_id, outbox);
       }
     }
+    EnqueueWritesLocked(writes);
   }
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
-    Persist(writes);
     Deliver(outbox);
   }
 }
@@ -712,11 +695,11 @@ void HubHandler::EngineMove(const std::string& player_id, const MoveFn& move, Mo
         }
       }
     }
+    EnqueueWritesLocked(writes);
   }
   if (!reason.empty()) {
     Reject(player_id, std::move(reason));
   } else {
-    Persist(writes);
     Deliver(outbox);
   }
 }
@@ -732,9 +715,9 @@ void HubHandler::SetConnected(const std::string& player_id, bool connected) {
     const auto member = room->second.members.find(player_id);
     if (member == room->second.members.end()) return;
     member->second.connected = connected;
-    StageMemberLocked(it->second, player_id, writes);
+    StageMemberLocked(it->second, player_id, member->second, writes);
+    EnqueueWritesLocked(writes);
   }
-  Persist(writes);
 }
 
 std::optional<std::string> HubHandler::CurrentRoom(const std::string& player_id) {
@@ -775,10 +758,10 @@ void HubHandler::LeaveEverywhere(const std::string& player_id, Outbox& outbox, W
   if (room->second.members.empty()) {
     rooms_.erase(room);
     // One DeleteRoom; the row's cascade takes members and games with it.
-    if (store_ != nullptr) writes.push_back(PgHubStore::DeleteRoom{room_id});
+    StageLocked(writes, PgHubStore::DeleteRoom{room_id});
     return;  // nobody left to tell
   }
-  if (store_ != nullptr) writes.push_back(PgHubStore::DeleteMember{room_id, player_id});
+  StageLocked(writes, PgHubStore::DeleteMember{room_id, player_id});
   StageRoomStateLocked(room_id, outbox);
 }
 
@@ -797,7 +780,7 @@ void HubHandler::LeaveGameLocked(const std::string& player_id, Outbox& outbox, W
   if (!ref->entry->started()) {
     if (roster.empty()) {
       ref->room->games.erase(ref->game_id);
-      if (store_ != nullptr) writes.push_back(PgHubStore::DeleteGame{ref->room_id, ref->game_id});
+      StageLocked(writes, PgHubStore::DeleteGame{ref->room_id, ref->game_id});
     } else {
       StageGameLocked(ref->room_id, ref->game_id, *ref->entry, writes);
       StageGameViewsLocked(ref->game_id, *ref->entry, outbox);
@@ -847,8 +830,8 @@ void HubHandler::OnExpired(const std::string& player_id) {
   {
     const std::lock_guard<std::mutex> lock(mu_);
     LeaveEverywhere(player_id, outbox, writes);
+    EnqueueWritesLocked(writes);
   }
-  Persist(writes);
   Deliver(outbox);
 }
 
@@ -1024,7 +1007,7 @@ void HubHandler::FinalizeGameLocked(const std::string& room_id, Room& room,
     if (std::find(winner_ids.begin(), winner_ids.end(), occupant) != winner_ids.end()) {
       member->second.games_won++;
     }
-    StageMemberLocked(room_id, occupant, writes);
+    StageMemberLocked(room_id, occupant, member->second, writes);
   }
 
   // Final views (everything face up), then the result, then the room's
@@ -1035,7 +1018,7 @@ void HubHandler::FinalizeGameLocked(const std::string& room_id, Room& room,
     player_game_.erase(recipient);
   }
   room.games.erase(game);
-  if (store_ != nullptr) writes.push_back(PgHubStore::DeleteGame{room_id, game_id});
+  StageLocked(writes, PgHubStore::DeleteGame{room_id, game_id});
   StageRoomStateLocked(room_id, outbox);
 }
 

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "domains/games/apis/golf_hub/id_generator.h"
+#include "domains/games/apis/golf_hub/pg_hub_store.h"
 #include "domains/games/apis/golf_hub/ticket_vault.h"
 #include "domains/games/libs/cards/dealer.h"
 #include "domains/games/libs/cards/golf/game_state.h"
@@ -36,11 +37,16 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
  public:
   using Registry = smithy::server::SessionRegistry<moonbase::golf::GolfEvents>;
 
+  /// store non-null turns on the #1194 step-2 write-through: every
+  /// rooms/members/games mutation is staged under mu_ and applied by the
+  /// store's writer, and construction restores the previous process's
+  /// rooms, members (disconnected until they resume), and games.
   explicit HubHandler(std::shared_ptr<TicketVault> vault,
                       std::shared_ptr<cards::Dealer> dealer = std::make_shared<cards::Dealer>(),
                       std::shared_ptr<IdGenerator> ids = std::make_shared<WhimsicalIdGenerator>(),
                       std::chrono::seconds grace_period = std::chrono::minutes(5),
-                      std::shared_ptr<futility::otel::MetricsRecorder> metrics = nullptr);
+                      std::shared_ptr<futility::otel::MetricsRecorder> metrics = nullptr,
+                      std::shared_ptr<PgHubStore> store = nullptr);
 
   // Note: operation IO generates as <Op>Input/<Op>Output regardless of
   // the named shapes bound in the model, and moonbase.games shapes land
@@ -67,9 +73,13 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// A game is a pre-start roster until startGame swaps in engine state.
   /// Once started, roster membership mirrors the engine's seats — every
   /// join/leave updates both, or a seat would stop receiving views.
+  /// version counts saves (memory owns it in step 2): each staged
+  /// write-through increments it, and the store's conditional UPDATE
+  /// verifies the row followed.
   struct GameEntry {
     std::vector<std::string> roster;
     std::optional<golf::GameState> state;
+    int64_t version = 0;
     [[nodiscard]] bool started() const { return state.has_value(); }
   };
 
@@ -87,6 +97,11 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
       events.emplace_back(player_id, std::move(event));
     }
   };
+
+  /// Write-through ops staged under mu_ (like Outbox for events) and
+  /// handed to the store after unlock — staging order is the truth's
+  /// order, and the store's single writer preserves it.
+  using Writes = std::vector<PgHubStore::Op>;
 
   using MoveFn = std::function<absl::StatusOr<golf::GameState>(const golf::GameState&, int seat)>;
   /// What a successful engine move announces beyond the state views.
@@ -130,12 +145,24 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   std::optional<GameRef> FindGameLocked(const std::string& player_id);
   /// Removes the player from their game and room (deliberate leave, clean
   /// close, or grace expiry) and stages every notification that implies.
-  void LeaveEverywhere(const std::string& player_id, Outbox& outbox);
-  void LeaveGameLocked(const std::string& player_id, Outbox& outbox);
+  void LeaveEverywhere(const std::string& player_id, Outbox& outbox, Writes& writes);
+  void LeaveGameLocked(const std::string& player_id, Outbox& outbox, Writes& writes);
   void BroadcastRoom(const std::string& room_id);
   void Reject(const std::string& player_id, std::string reason);
   void OnExpired(const std::string& player_id);
   void Deliver(Outbox& outbox);
+  /// Hands staged write-through ops to the store; no-op without one.
+  void Persist(Writes& writes);
+
+  /// Write-through staging; callers hold mu_. StageGameLocked increments
+  /// the entry's version — call it once per mutation of the entry.
+  void StageMemberLocked(const std::string& room_id, const std::string& player_id,
+                         Writes& writes) const;
+  void StageGameLocked(const std::string& room_id, const std::string& game_id, GameEntry& entry,
+                       Writes& writes) const;
+  /// Boot-time restore of the previous process's rooms/members/games;
+  /// runs before the transport serves, everyone restored disconnected.
+  void RestoreFromStore();
 
   /// Builders; callers hold mu_.
   moonbase::golf::RoomState RoomStateLocked(const std::string& room_id, const Room& room) const;
@@ -145,12 +172,13 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   void StageGameViewsLocked(const std::string& game_id, const GameEntry& entry,
                             Outbox& outbox) const;
   void FinalizeGameLocked(const std::string& room_id, Room& room, const std::string& game_id,
-                          Outbox& outbox);
+                          Outbox& outbox, Writes& writes);
 
   const std::shared_ptr<TicketVault> vault_;
   const std::shared_ptr<cards::Dealer> dealer_;
   const std::shared_ptr<IdGenerator> ids_;
   const std::shared_ptr<futility::otel::MetricsRecorder> metrics_;
+  const std::shared_ptr<PgHubStore> store_;
   std::mutex mu_;
   std::unordered_map<std::string, Room> rooms_;
   std::unordered_map<std::string, std::string> player_room_;

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -39,8 +39,9 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
 
   /// store non-null turns on the #1194 step-2 write-through: every
   /// rooms/members/games mutation is staged under mu_ and applied by the
-  /// store's writer, and construction restores the previous process's
-  /// rooms, members (disconnected until they resume), and games.
+  /// store's writer. Call RestoreFromStore before serving to rebuild the
+  /// previous process's rooms, members, and games — whether its failure
+  /// is fatal is the caller's policy, next to the migration decision.
   explicit HubHandler(std::shared_ptr<TicketVault> vault,
                       std::shared_ptr<cards::Dealer> dealer = std::make_shared<cards::Dealer>(),
                       std::shared_ptr<IdGenerator> ids = std::make_shared<WhimsicalIdGenerator>(),
@@ -62,6 +63,13 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// For main's SIGTERM path: Drain, then transport Stop.
   Registry& registry() { return registry_; }
 
+  /// Boot-time restore of the store's snapshot: rooms, members (everyone
+  /// disconnected until they resume), and games. Call before the
+  /// transport serves; no-op without a store. Undecodable rows were
+  /// already dropped (loudly) by the store — an error here means the
+  /// snapshot itself couldn't be read.
+  absl::Status RestoreFromStore();
+
  private:
   struct Member {
     bool connected = true;
@@ -73,9 +81,9 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// A game is a pre-start roster until startGame swaps in engine state.
   /// Once started, roster membership mirrors the engine's seats — every
   /// join/leave updates both, or a seat would stop receiving views.
-  /// version counts saves (memory owns it in step 2): each staged
-  /// write-through increments it, and the store's conditional UPDATE
-  /// verifies the row followed.
+  /// version is the entry's revision: every mutation bumps it (store or
+  /// not — it's a domain property staging merely reads), and the store's
+  /// conditional UPDATE verifies each saved row followed its predecessor.
   struct GameEntry {
     std::vector<std::string> roster;
     std::optional<golf::GameState> state;
@@ -98,9 +106,11 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
     }
   };
 
-  /// Write-through ops staged under mu_ (like Outbox for events) and
-  /// handed to the store after unlock — staging order is the truth's
-  /// order, and the store's single writer preserves it.
+  /// Write-through ops staged under mu_ and — unlike the Outbox, whose
+  /// delivery can block and so waits for unlock — handed to the store
+  /// while still holding mu_ (Enqueue is a queue append, no I/O). That
+  /// asymmetry is load-bearing: it is what makes queue order the truth's
+  /// order when two mutations race.
   using Writes = std::vector<PgHubStore::Op>;
 
   using MoveFn = std::function<absl::StatusOr<golf::GameState>(const golf::GameState&, int seat)>;
@@ -151,18 +161,19 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   void Reject(const std::string& player_id, std::string reason);
   void OnExpired(const std::string& player_id);
   void Deliver(Outbox& outbox);
-  /// Hands staged write-through ops to the store; no-op without one.
-  void Persist(Writes& writes);
+  /// Hands staged ops to the store's writer queue. Callers hold mu_ (see
+  /// Writes above). Asynchronous — clients may be told before the row
+  /// lands. No-op without a store; always leaves writes empty.
+  void EnqueueWritesLocked(Writes& writes);
 
-  /// Write-through staging; callers hold mu_. StageGameLocked increments
-  /// the entry's version — call it once per mutation of the entry.
+  /// Write-through staging; callers hold mu_. StageGameLocked bumps the
+  /// entry's revision (with or without a store) — call it once per
+  /// mutation of the entry.
+  void StageLocked(Writes& writes, PgHubStore::Op op) const;
   void StageMemberLocked(const std::string& room_id, const std::string& player_id,
-                         Writes& writes) const;
+                         const Member& member, Writes& writes) const;
   void StageGameLocked(const std::string& room_id, const std::string& game_id, GameEntry& entry,
-                       Writes& writes) const;
-  /// Boot-time restore of the previous process's rooms/members/games;
-  /// runs before the transport serves, everyone restored disconnected.
-  void RestoreFromStore();
+                       Writes& writes);
 
   /// Builders; callers hold mu_.
   moonbase::golf::RoomState RoomStateLocked(const std::string& room_id, const Room& room) const;

--- a/domains/games/apis/golf_hub/migrations.cc
+++ b/domains/games/apis/golf_hub/migrations.cc
@@ -21,6 +21,32 @@ absl::Status RunMigrations(pg::Client& db) {
       ))sql",
       R"sql(CREATE INDEX IF NOT EXISTS idx_resume_tokens_expires_at
           ON resume_tokens (expires_at))sql",
+      // Rooms, membership, and games (#1194 step 2). game state is the
+      // serialized engine value (game_state_serde schema); version is the
+      // optimistic-concurrency counter the hub owns. Game codes are only
+      // unique within a room, hence the composite keys. Deleting a room
+      // cascades — the hub stages one DeleteRoom when the last member
+      // leaves.
+      R"sql(CREATE TABLE IF NOT EXISTS rooms (
+          room_id text PRIMARY KEY
+      ))sql",
+      R"sql(CREATE TABLE IF NOT EXISTS room_members (
+          room_id      text NOT NULL REFERENCES rooms (room_id) ON DELETE CASCADE,
+          player_id    text NOT NULL,
+          connected    boolean NOT NULL,
+          games_played integer NOT NULL,
+          games_won    integer NOT NULL,
+          total_score  integer NOT NULL,
+          PRIMARY KEY (room_id, player_id)
+      ))sql",
+      R"sql(CREATE TABLE IF NOT EXISTS games (
+          room_id text NOT NULL REFERENCES rooms (room_id) ON DELETE CASCADE,
+          game_id text NOT NULL,
+          roster  jsonb NOT NULL,
+          state   jsonb,
+          version bigint NOT NULL,
+          PRIMARY KEY (room_id, game_id)
+      ))sql",
   };
   for (const char* statement : kStatements) {
     if (auto result = db.Exec(statement); !result.ok()) return result.status();

--- a/domains/games/apis/golf_hub/migrations.h
+++ b/domains/games/apis/golf_hub/migrations.h
@@ -9,8 +9,7 @@ namespace golf_hub {
 /// The hub's schema, applied at startup before the server takes traffic
 /// (one_d4's Migration pattern: idempotent statements run in-service, no
 /// external tool). Every statement must stay safe to re-run; schema
-/// changes land as new statements appended here. Currently #1194 step 1:
-/// the two credential tables.
+/// changes land as new statements appended here.
 absl::Status RunMigrations(pg::Client& db);
 
 }  // namespace golf_hub

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "domains/games/apis/golf_hub/migrations.h"
 #include "domains/games/apis/golf_hub/pg_hub_store.h"
@@ -19,43 +20,9 @@
 #include "domains/platform/libs/pg/pg.h"
 
 namespace golf_hub {
-namespace {
 
 using moonbase::golf::GolfCommands;
-using moonbase::golf::GolfEvents;
 using moonbase::golf::GolfMove;
-using moonbase::golf::GolfUpdate;
-
-// Receive helpers, as in hub_e2e_test: skip frames until the wanted case.
-std::optional<GolfEvents> ReceiveCase(moonbase::golf::PlayClientStream& stream,
-                                      const std::string& wanted) {
-  for (int i = 0; i < 8; ++i) {
-    auto received = stream.Receive();
-    if (!received.ok() || !received->has_value()) return std::nullopt;
-    if (wanted == (*received)->case_name()) return **received;
-  }
-  return std::nullopt;
-}
-
-std::optional<GolfUpdate> ReceiveGolf(moonbase::golf::PlayClientStream& stream,
-                                      const std::string& wanted) {
-  for (int i = 0; i < 16; ++i) {
-    auto received = stream.Receive();
-    if (!received.ok() || !received->has_value()) return std::nullopt;
-    const auto* envelope = (*received)->as_golf_or_null();
-    if (envelope == nullptr) continue;
-    if (wanted == envelope->update.case_name()) return envelope->update;
-  }
-  return std::nullopt;
-}
-
-GolfCommands Move(GolfMove move) {
-  moonbase::golf::GolfCommand command;
-  command.move = std::move(move);
-  return GolfCommands::FromGolf(std::move(command));
-}
-
-}  // namespace
 
 class PgGolfHubFixture : public GolfHubStreamFixture {
  protected:
@@ -64,7 +31,7 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     if (url_ == nullptr || *url_ == '\0') {
       GTEST_SKIP() << "GOLF_HUB_TEST_DB_URL unset";
     }
-    auto db = pg::Client(url_);
+    pg::Client db(url_);
     ASSERT_TRUE(RunMigrations(db).ok());
     ASSERT_TRUE(db.Exec("TRUNCATE rooms CASCADE").ok());
     ASSERT_TRUE(db.Exec("TRUNCATE tickets, resume_tokens").ok());
@@ -80,108 +47,274 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     return std::make_shared<PgHubStore>(std::make_shared<pg::Client>(url_));
   }
 
+  // Simulates the process dying and a fresh instance booting over the
+  // same database. A crash closes nothing and says no goodbyes, so the
+  // old generation is parked as-is; only the store flushes, because the
+  // row truth must be complete before the successor reads it. The
+  // retired hub is NOT inert: TearDown's Close() runs its clean-close
+  // path and its store then writes the goodbyes a real crash never
+  // would — every DB assertion must come before TearDown.
+  void RestartHub() {
+    if (store_ != nullptr) store_->Flush();
+    retired_.push_back(
+        {std::move(server_), std::move(client_), std::move(handler_), std::move(store_)});
+    BuildHub();
+  }
+
+  // A store-side view of the rows, flushed first so staged writes are in.
+  PgHubStore::Snapshot Rows() {
+    store_->Flush();
+    auto snapshot = store_->LoadSnapshot();
+    EXPECT_TRUE(snapshot.ok()) << snapshot.status();
+    return snapshot.value_or(PgHubStore::Snapshot{});
+  }
+
   const char* url_ = nullptr;
+
+  struct Generation {
+    std::unique_ptr<moonbase::golf::GolfHubServer> server;
+    std::unique_ptr<moonbase::golf::GolfHubClient> client;
+    std::shared_ptr<HubHandler> handler;
+    std::shared_ptr<PgHubStore> store;
+  };
+  std::vector<Generation> retired_;
 };
 
 namespace {
 
 TEST_F(PgGolfHubFixture, LiveGameSurvivesARestart) {
-  // Alice and bob: room, game, started, opening peeks done, one real
-  // move played — a state with every kind of content.
-  auto alice = OpenSeat();
-  auto bob = OpenSeat();
-  ASSERT_TRUE(alice.has_value() && bob.has_value());
-  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
-  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
-
-  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
-  auto created = ReceiveCase(alice->stream, "roomState");
-  ASSERT_TRUE(created.has_value());
-  const std::string room_id = created->as_roomState_or_null()->roomId;
-  moonbase::golf::JoinRoom join_room;
-  join_room.roomId = room_id;
-  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join_room)).ok());
-  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
-
-  ASSERT_TRUE(
-      alice->stream.Send(Move(GolfMove::FromCreategame(moonbase::golf::CreateGame{}))).ok());
-  auto joined = ReceiveGolf(alice->stream, "gameJoined");
-  ASSERT_TRUE(joined.has_value());
-  const std::string game_id = joined->as_gameJoined_or_null()->view.gameId;
-  moonbase::golf::JoinGame join_game;
-  join_game.gameId = game_id;
-  ASSERT_TRUE(bob->stream.Send(Move(GolfMove::FromJoingame(join_game))).ok());
-  ASSERT_TRUE(ReceiveGolf(bob->stream, "gameJoined").has_value());
-  ASSERT_TRUE(alice->stream.Send(Move(GolfMove::FromStartgame(moonbase::golf::StartGame{}))).ok());
-  ASSERT_TRUE(ReceiveGolf(alice->stream, "gameStarted").has_value());
-  ASSERT_TRUE(ReceiveGolf(bob->stream, "gameStarted").has_value());
+  auto table = SeatedTable();
+  ASSERT_TRUE(table.has_value());
+  Seat& alice = table->alice;
+  Seat& bob = table->bob;
 
   // Opening reveal for both, one hide, then alice draws and discards —
   // deck order and the discard pile now matter.
-  for (auto* seat : {&*alice, &*bob}) {
+  for (auto* seat : {&alice, &bob}) {
     for (const int index : {0, 3}) {
       moonbase::golf::PeekCard peek;
       peek.cardIndex = index;
       ASSERT_TRUE(seat->stream.Send(Move(GolfMove::FromPeekcard(peek))).ok());
     }
   }
-  ASSERT_TRUE(alice->stream.Send(Move(GolfMove::FromHidecards(moonbase::golf::HideCards{}))).ok());
-  ASSERT_TRUE(alice->stream.Send(Move(GolfMove::FromDrawcard(moonbase::golf::DrawCard{}))).ok());
+  ASSERT_TRUE(alice.stream.Send(Move(GolfMove::FromHidecards(moonbase::golf::HideCards{}))).ok());
+  ASSERT_TRUE(alice.stream.Send(Move(GolfMove::FromDrawcard(moonbase::golf::DrawCard{}))).ok());
   ASSERT_TRUE(
-      alice->stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{}))).ok());
-  auto turn = ReceiveGolf(bob->stream, "turnChanged");
+      alice.stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{}))).ok());
+  // Drain both seats to the same sync point (undelivered frames keep the
+  // registry's delivery chain holding the stream through teardown),
+  // remembering bob's last full view before the turn handoff — the
+  // post-discard fanout, which the restored view must match.
+  std::optional<moonbase::golf::GameView> before;
+  for (int i = 0; i < 16; ++i) {
+    auto update = ReceiveGolf(bob.stream, "gameState");
+    if (!update.has_value()) break;
+    before.emplace(update->as_gameState_or_null()->view);
+    if (before->discardCount == 2) break;  // the post-discard fanout
+  }
+  ASSERT_TRUE(before.has_value());
+  ASSERT_EQ(before->discardCount, 2);
+  auto turn = ReceiveGolf(bob.stream, "turnChanged");
   ASSERT_TRUE(turn.has_value());
-  EXPECT_EQ(turn->as_turnChanged_or_null()->playerId, bob->player_id);
-  // Drain alice to the same sync point: undelivered frames keep the
-  // registry's delivery chain holding the stream, and the in-memory
-  // pair's inline teardown would wait on it forever.
-  ASSERT_TRUE(ReceiveGolf(alice->stream, "turnChanged").has_value());
+  EXPECT_EQ(turn->as_turnChanged_or_null()->playerId, bob.player_id);
+  ASSERT_TRUE(ReceiveGolf(alice.stream, "turnChanged").has_value());
 
-  const std::string alice_token = alice->resume_token;
-  const std::string bob_token = bob->resume_token;
-  const std::string alice_id = alice->player_id;
-  const std::string bob_id = bob->player_id;
+  const int64_t version_before = [&] {
+    auto rows = Rows();
+    EXPECT_EQ(rows.games.size(), 1u);
+    return rows.games.empty() ? 0 : rows.games[0].version;
+  }();
+  ASSERT_GT(version_before, 0);
 
   // The deploy: this process's hub dies, a fresh one boots from the
   // database. Resume tokens are rows (step 1), so the same identities
   // walk back in.
+  const std::string alice_token = alice.resume_token;
+  const std::string bob_token = bob.resume_token;
   RestartHub();
 
   auto alice_back = OpenSeat(alice_token);
   ASSERT_TRUE(alice_back.has_value());
-  EXPECT_EQ(alice_back->player_id, alice_id);
+  EXPECT_EQ(alice_back->player_id, alice.player_id);
   auto ready = ReceiveCase(alice_back->stream, "sessionReady");
   ASSERT_TRUE(ready.has_value());
   EXPECT_TRUE(ready->as_sessionReady_or_null()->resumed);
   ASSERT_TRUE(ready->as_sessionReady_or_null()->roomId.has_value());
-  EXPECT_EQ(*ready->as_sessionReady_or_null()->roomId, room_id);
-  auto resynced = ReceiveGolf(alice_back->stream, "gameJoined");
-  ASSERT_TRUE(resynced.has_value());
-  const auto& view = resynced->as_gameJoined_or_null()->view;
-  EXPECT_EQ(view.gameId, game_id);
-  EXPECT_EQ(view.phase, "playing");
-  EXPECT_EQ(view.currentPlayerId, bob_id);
+  EXPECT_EQ(*ready->as_sessionReady_or_null()->roomId, table->room_id);
+  ASSERT_TRUE(ReceiveGolf(alice_back->stream, "gameJoined").has_value());
 
   auto bob_back = OpenSeat(bob_token);
   ASSERT_TRUE(bob_back.has_value());
-  EXPECT_EQ(bob_back->player_id, bob_id);
+  EXPECT_EQ(bob_back->player_id, bob.player_id);
   ASSERT_TRUE(ReceiveCase(bob_back->stream, "sessionReady").has_value());
-  ASSERT_TRUE(ReceiveGolf(bob_back->stream, "gameJoined").has_value());
+  auto resynced = ReceiveGolf(bob_back->stream, "gameJoined");
+  ASSERT_TRUE(resynced.has_value());
 
-  // The restored game is live, not a diorama: bob's turn carries on and
-  // the move fans out to the restored alice.
+  // Not a diorama, and not a re-deal either: bob's restored view matches
+  // the one he had — same piles, same discard top, same revealed cards.
+  const auto& after = resynced->as_gameJoined_or_null()->view;
+  EXPECT_EQ(after.gameId, table->game_id);
+  EXPECT_EQ(after.phase, "playing");
+  EXPECT_EQ(after.currentPlayerId, bob.player_id);
+  EXPECT_EQ(after.drawPileCount, before->drawPileCount);
+  EXPECT_EQ(after.discardCount, before->discardCount);
+  ASSERT_TRUE(after.discardTop.has_value());
+  ASSERT_TRUE(before->discardTop.has_value());
+  EXPECT_EQ(after.discardTop->rank, before->discardTop->rank);
+  EXPECT_EQ(after.discardTop->suit, before->discardTop->suit);
+  for (std::size_t seat = 0; seat < after.players.size(); ++seat) {
+    EXPECT_EQ(after.players[seat].revealedIndexes, before->players[seat].revealedIndexes);
+    for (std::size_t slot = 0; slot < 4; ++slot) {
+      const auto& mine = after.players[seat].cards[slot].card;
+      const auto& theirs = before->players[seat].cards[slot].card;
+      ASSERT_EQ(mine.has_value(), theirs.has_value());
+      if (mine.has_value()) {
+        EXPECT_EQ(mine->rank, theirs->rank);
+        EXPECT_EQ(mine->suit, theirs->suit);
+      }
+    }
+  }
+
+  // The restored game is live: bob's turn carries on, the move fans out
+  // to the restored alice, and the save continues the version sequence —
+  // a reset-to-1 restore would be laundered by the repair path and never
+  // fail an assertion elsewhere.
   ASSERT_TRUE(bob_back->stream.Send(Move(GolfMove::FromDrawcard(moonbase::golf::DrawCard{}))).ok());
   ASSERT_TRUE(
       bob_back->stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{}))).ok());
   auto next_turn = ReceiveGolf(alice_back->stream, "turnChanged");
   ASSERT_TRUE(next_turn.has_value());
-  EXPECT_EQ(next_turn->as_turnChanged_or_null()->playerId, alice_id);
-  // Same drain discipline for bob's copy of his own move.
+  EXPECT_EQ(next_turn->as_turnChanged_or_null()->playerId, alice.player_id);
   ASSERT_TRUE(ReceiveGolf(bob_back->stream, "turnChanged").has_value());
+
+  auto rows = Rows();
+  ASSERT_EQ(rows.games.size(), 1u);
+  EXPECT_EQ(rows.games[0].version, version_before + 2);  // draw + discard
 }
 
-TEST_F(PgGolfHubFixture, StatsAndEmptyRoomsFollowTheTruth) {
-  // A room whose members all leave must vanish from the database too.
+TEST_F(PgGolfHubFixture, StatsSurviveARestart) {
+  auto table = SeatedTable();
+  ASSERT_TRUE(table.has_value());
+
+  // Quickest legal game: alice knocks unseen, bob takes his final turn.
+  ASSERT_TRUE(table->alice.stream.Send(Move(GolfMove::FromKnock(moonbase::golf::Knock{}))).ok());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "playerKnocked").has_value());
+  ASSERT_TRUE(
+      table->bob.stream.Send(Move(GolfMove::FromDrawcard(moonbase::golf::DrawCard{}))).ok());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "gameState").has_value());
+  ASSERT_TRUE(
+      table->bob.stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{})))
+          .ok());
+  ASSERT_TRUE(ReceiveGolf(table->alice.stream, "gameEnded").has_value());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "gameEnded").has_value());
+
+  const std::string alice_token = table->alice.resume_token;
+  RestartHub();
+
+  auto alice_back = OpenSeat(alice_token);
+  ASSERT_TRUE(alice_back.has_value());
+  ASSERT_TRUE(ReceiveCase(alice_back->stream, "sessionReady").has_value());
+  ASSERT_TRUE(
+      alice_back->stream.Send(GolfCommands::FromGetroomstate(moonbase::golf::GetRoomState{})).ok());
+  auto lobby = ReceiveCase(alice_back->stream, "roomState");
+  ASSERT_TRUE(lobby.has_value());
+  // Identical zero-scoring deals; the knocker takes the tie alone.
+  for (const auto& player : lobby->as_roomState_or_null()->players) {
+    EXPECT_EQ(player.gamesPlayed, 1);
+    EXPECT_EQ(player.totalScore, 0);
+    EXPECT_EQ(player.gamesWon, player.playerId == alice_back->player_id ? 1 : 0);
+  }
+}
+
+TEST_F(PgGolfHubFixture, PendingGameLifecycleWritesThrough) {
+  auto table = SeatedTable();
+  ASSERT_TRUE(table.has_value());
+  // A second, pending game beside the started one: bob leaves his seat in
+  // the started game first, creates a fresh lobby game, and its roster
+  // rides the row. (Leaving the started two-seat game ends it.)
+  ASSERT_TRUE(
+      table->bob.stream.Send(Move(GolfMove::FromLeavegame(moonbase::golf::LeaveGame{}))).ok());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "gameLeft").has_value());
+  ASSERT_TRUE(
+      table->bob.stream.Send(Move(GolfMove::FromCreategame(moonbase::golf::CreateGame{}))).ok());
+  auto created = ReceiveGolf(table->bob.stream, "gameJoined");
+  ASSERT_TRUE(created.has_value());
+  const std::string pending_id = created->as_gameJoined_or_null()->view.gameId;
+
+  {
+    auto rows = Rows();
+    ASSERT_EQ(rows.games.size(), 1u);  // the started game ended when bob left
+    EXPECT_EQ(rows.games[0].game_id, pending_id);
+    EXPECT_FALSE(rows.games[0].state.has_value());
+    EXPECT_EQ(rows.games[0].roster, (std::vector<std::string>{table->bob.player_id}));
+  }
+
+  // Abandoning the pending game deletes its row and nothing else.
+  ASSERT_TRUE(
+      table->bob.stream.Send(Move(GolfMove::FromLeavegame(moonbase::golf::LeaveGame{}))).ok());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "gameLeft").has_value());
+  auto rows = Rows();
+  EXPECT_TRUE(rows.games.empty());
+  EXPECT_EQ(rows.rooms.size(), 1u);
+  EXPECT_EQ(rows.members.size(), 2u);
+}
+
+TEST_F(PgGolfHubFixture, CorruptRowsLoseTheGameNotTheLobby) {
+  auto table = SeatedTable();
+  ASSERT_TRUE(table.has_value());
+  store_->Flush();
+
+  // A row whose state bytes stopped decoding (schema bump gone wrong,
+  // torn write, hand edit): the boot drops the game, keeps the lobby.
+  {
+    pg::Client db(url_);
+    ASSERT_TRUE(db.Exec("UPDATE games SET state = '{\"v\":99}'::jsonb").ok());
+  }
+  const std::string alice_token = table->alice.resume_token;
+  RestartHub();
+
+  auto alice_back = OpenSeat(alice_token);
+  ASSERT_TRUE(alice_back.has_value());
+  auto ready = ReceiveCase(alice_back->stream, "sessionReady");
+  ASSERT_TRUE(ready.has_value());
+  ASSERT_TRUE(ready->as_sessionReady_or_null()->roomId.has_value());
+  ASSERT_TRUE(
+      alice_back->stream.Send(GolfCommands::FromGetroomstate(moonbase::golf::GetRoomState{})).ok());
+  auto lobby = ReceiveCase(alice_back->stream, "roomState");
+  ASSERT_TRUE(lobby.has_value());
+  EXPECT_TRUE(lobby->as_roomState_or_null()->games.empty());
+  // Not wedged: the seat can start over.
+  ASSERT_TRUE(
+      alice_back->stream.Send(Move(GolfMove::FromCreategame(moonbase::golf::CreateGame{}))).ok());
+  ASSERT_TRUE(ReceiveGolf(alice_back->stream, "gameJoined").has_value());
+}
+
+TEST_F(PgGolfHubFixture, ConnectedFlagFollowsPresence) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+
+  {
+    auto rows = Rows();
+    ASSERT_EQ(rows.members.size(), 1u);
+    EXPECT_TRUE(rows.members[0].connected);
+  }
+
+  // Across a restart the row keeps its last written value; the member
+  // restores disconnected in memory and flips the row back on resume.
+  const std::string token = alice->resume_token;
+  RestartHub();
+  auto alice_back = OpenSeat(token);
+  ASSERT_TRUE(alice_back.has_value());
+  ASSERT_TRUE(ReceiveCase(alice_back->stream, "sessionReady").has_value());
+  auto rows = Rows();
+  ASSERT_EQ(rows.members.size(), 1u);
+  EXPECT_TRUE(rows.members[0].connected);
+}
+
+TEST_F(PgGolfHubFixture, EmptiedRoomVanishesFromTheDatabase) {
   auto alice = OpenSeat();
   ASSERT_TRUE(alice.has_value());
   ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
@@ -190,12 +323,10 @@ TEST_F(PgGolfHubFixture, StatsAndEmptyRoomsFollowTheTruth) {
   ASSERT_TRUE(alice->stream.Send(GolfCommands::FromLeaveroom(moonbase::golf::LeaveRoom{})).ok());
   ASSERT_TRUE(ReceiveCase(alice->stream, "roomLeft").has_value());
 
-  store_->Flush();
-  auto snapshot = store_->LoadSnapshot();
-  ASSERT_TRUE(snapshot.ok()) << snapshot.status();
-  EXPECT_TRUE(snapshot->rooms.empty());
-  EXPECT_TRUE(snapshot->members.empty());
-  EXPECT_TRUE(snapshot->games.empty());
+  auto rows = Rows();
+  EXPECT_TRUE(rows.rooms.empty());
+  EXPECT_TRUE(rows.members.empty());
+  EXPECT_TRUE(rows.games.empty());
 }
 
 }  // namespace

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -1,0 +1,202 @@
+// The step-2 restart-survival e2e (#1194): the same client flows as
+// hub_e2e_test, but over durable credentials (step 1) and the rooms/games
+// write-through — then the process "dies" (RestartHub) and a fresh hub
+// over the same database has to seat everyone back into their live game.
+// Real postgres via GOLF_HUB_TEST_DB_URL; skips otherwise.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "domains/games/apis/golf_hub/migrations.h"
+#include "domains/games/apis/golf_hub/pg_hub_store.h"
+#include "domains/games/apis/golf_hub/pg_ticket_vault.h"
+#include "domains/games/apis/golf_hub/stream_test_fixture.h"
+#include "domains/platform/libs/pg/pg.h"
+
+namespace golf_hub {
+namespace {
+
+using moonbase::golf::GolfCommands;
+using moonbase::golf::GolfEvents;
+using moonbase::golf::GolfMove;
+using moonbase::golf::GolfUpdate;
+
+// Receive helpers, as in hub_e2e_test: skip frames until the wanted case.
+std::optional<GolfEvents> ReceiveCase(moonbase::golf::PlayClientStream& stream,
+                                      const std::string& wanted) {
+  for (int i = 0; i < 8; ++i) {
+    auto received = stream.Receive();
+    if (!received.ok() || !received->has_value()) return std::nullopt;
+    if (wanted == (*received)->case_name()) return **received;
+  }
+  return std::nullopt;
+}
+
+std::optional<GolfUpdate> ReceiveGolf(moonbase::golf::PlayClientStream& stream,
+                                      const std::string& wanted) {
+  for (int i = 0; i < 16; ++i) {
+    auto received = stream.Receive();
+    if (!received.ok() || !received->has_value()) return std::nullopt;
+    const auto* envelope = (*received)->as_golf_or_null();
+    if (envelope == nullptr) continue;
+    if (wanted == envelope->update.case_name()) return envelope->update;
+  }
+  return std::nullopt;
+}
+
+GolfCommands Move(GolfMove move) {
+  moonbase::golf::GolfCommand command;
+  command.move = std::move(move);
+  return GolfCommands::FromGolf(std::move(command));
+}
+
+}  // namespace
+
+class PgGolfHubFixture : public GolfHubStreamFixture {
+ protected:
+  void SetUp() override {
+    url_ = std::getenv("GOLF_HUB_TEST_DB_URL");
+    if (url_ == nullptr || *url_ == '\0') {
+      GTEST_SKIP() << "GOLF_HUB_TEST_DB_URL unset";
+    }
+    auto db = pg::Client(url_);
+    ASSERT_TRUE(RunMigrations(db).ok());
+    ASSERT_TRUE(db.Exec("TRUNCATE rooms CASCADE").ok());
+    ASSERT_TRUE(db.Exec("TRUNCATE tickets, resume_tokens").ok());
+    GolfHubStreamFixture::SetUp();
+  }
+
+  std::shared_ptr<TicketVault> MakeVault() override {
+    return std::make_shared<PgTicketVault>(std::make_shared<pg::Client>(url_),
+                                           /*ticket_ttl=*/std::chrono::seconds(60),
+                                           /*resume_ttl=*/std::chrono::seconds(60));
+  }
+  std::shared_ptr<PgHubStore> MakeStore() override {
+    return std::make_shared<PgHubStore>(std::make_shared<pg::Client>(url_));
+  }
+
+  const char* url_ = nullptr;
+};
+
+namespace {
+
+TEST_F(PgGolfHubFixture, LiveGameSurvivesARestart) {
+  // Alice and bob: room, game, started, opening peeks done, one real
+  // move played — a state with every kind of content.
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
+  moonbase::golf::JoinRoom join_room;
+  join_room.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join_room)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+
+  ASSERT_TRUE(
+      alice->stream.Send(Move(GolfMove::FromCreategame(moonbase::golf::CreateGame{}))).ok());
+  auto joined = ReceiveGolf(alice->stream, "gameJoined");
+  ASSERT_TRUE(joined.has_value());
+  const std::string game_id = joined->as_gameJoined_or_null()->view.gameId;
+  moonbase::golf::JoinGame join_game;
+  join_game.gameId = game_id;
+  ASSERT_TRUE(bob->stream.Send(Move(GolfMove::FromJoingame(join_game))).ok());
+  ASSERT_TRUE(ReceiveGolf(bob->stream, "gameJoined").has_value());
+  ASSERT_TRUE(alice->stream.Send(Move(GolfMove::FromStartgame(moonbase::golf::StartGame{}))).ok());
+  ASSERT_TRUE(ReceiveGolf(alice->stream, "gameStarted").has_value());
+  ASSERT_TRUE(ReceiveGolf(bob->stream, "gameStarted").has_value());
+
+  // Opening reveal for both, one hide, then alice draws and discards —
+  // deck order and the discard pile now matter.
+  for (auto* seat : {&*alice, &*bob}) {
+    for (const int index : {0, 3}) {
+      moonbase::golf::PeekCard peek;
+      peek.cardIndex = index;
+      ASSERT_TRUE(seat->stream.Send(Move(GolfMove::FromPeekcard(peek))).ok());
+    }
+  }
+  ASSERT_TRUE(alice->stream.Send(Move(GolfMove::FromHidecards(moonbase::golf::HideCards{}))).ok());
+  ASSERT_TRUE(alice->stream.Send(Move(GolfMove::FromDrawcard(moonbase::golf::DrawCard{}))).ok());
+  ASSERT_TRUE(
+      alice->stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{}))).ok());
+  auto turn = ReceiveGolf(bob->stream, "turnChanged");
+  ASSERT_TRUE(turn.has_value());
+  EXPECT_EQ(turn->as_turnChanged_or_null()->playerId, bob->player_id);
+  // Drain alice to the same sync point: undelivered frames keep the
+  // registry's delivery chain holding the stream, and the in-memory
+  // pair's inline teardown would wait on it forever.
+  ASSERT_TRUE(ReceiveGolf(alice->stream, "turnChanged").has_value());
+
+  const std::string alice_token = alice->resume_token;
+  const std::string bob_token = bob->resume_token;
+  const std::string alice_id = alice->player_id;
+  const std::string bob_id = bob->player_id;
+
+  // The deploy: this process's hub dies, a fresh one boots from the
+  // database. Resume tokens are rows (step 1), so the same identities
+  // walk back in.
+  RestartHub();
+
+  auto alice_back = OpenSeat(alice_token);
+  ASSERT_TRUE(alice_back.has_value());
+  EXPECT_EQ(alice_back->player_id, alice_id);
+  auto ready = ReceiveCase(alice_back->stream, "sessionReady");
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_TRUE(ready->as_sessionReady_or_null()->resumed);
+  ASSERT_TRUE(ready->as_sessionReady_or_null()->roomId.has_value());
+  EXPECT_EQ(*ready->as_sessionReady_or_null()->roomId, room_id);
+  auto resynced = ReceiveGolf(alice_back->stream, "gameJoined");
+  ASSERT_TRUE(resynced.has_value());
+  const auto& view = resynced->as_gameJoined_or_null()->view;
+  EXPECT_EQ(view.gameId, game_id);
+  EXPECT_EQ(view.phase, "playing");
+  EXPECT_EQ(view.currentPlayerId, bob_id);
+
+  auto bob_back = OpenSeat(bob_token);
+  ASSERT_TRUE(bob_back.has_value());
+  EXPECT_EQ(bob_back->player_id, bob_id);
+  ASSERT_TRUE(ReceiveCase(bob_back->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveGolf(bob_back->stream, "gameJoined").has_value());
+
+  // The restored game is live, not a diorama: bob's turn carries on and
+  // the move fans out to the restored alice.
+  ASSERT_TRUE(bob_back->stream.Send(Move(GolfMove::FromDrawcard(moonbase::golf::DrawCard{}))).ok());
+  ASSERT_TRUE(
+      bob_back->stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{}))).ok());
+  auto next_turn = ReceiveGolf(alice_back->stream, "turnChanged");
+  ASSERT_TRUE(next_turn.has_value());
+  EXPECT_EQ(next_turn->as_turnChanged_or_null()->playerId, alice_id);
+  // Same drain discipline for bob's copy of his own move.
+  ASSERT_TRUE(ReceiveGolf(bob_back->stream, "turnChanged").has_value());
+}
+
+TEST_F(PgGolfHubFixture, StatsAndEmptyRoomsFollowTheTruth) {
+  // A room whose members all leave must vanish from the database too.
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromLeaveroom(moonbase::golf::LeaveRoom{})).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomLeft").has_value());
+
+  store_->Flush();
+  auto snapshot = store_->LoadSnapshot();
+  ASSERT_TRUE(snapshot.ok()) << snapshot.status();
+  EXPECT_TRUE(snapshot->rooms.empty());
+  EXPECT_TRUE(snapshot->members.empty());
+  EXPECT_TRUE(snapshot->games.empty());
+}
+
+}  // namespace
+}  // namespace golf_hub

--- a/domains/games/apis/golf_hub/pg_hub_store.cc
+++ b/domains/games/apis/golf_hub/pg_hub_store.cc
@@ -5,7 +5,7 @@
 
 #include "absl/log/log.h"
 #include "absl/status/status.h"
-#include "absl/strings/str_cat.h"
+#include "domains/games/libs/cards/golf/game_state_serde.h"
 
 namespace golf_hub {
 namespace {
@@ -24,8 +24,10 @@ constexpr char kUpsertMember[] = R"sql(
           games_won = EXCLUDED.games_won, total_score = EXCLUDED.total_score)sql";
 constexpr char kDeleteMember[] = "DELETE FROM room_members WHERE room_id = $1 AND player_id = $2";
 // The conditional save: an UPDATE lands only when the row holds the
-// previous version. Zero rows back means the DB diverged from the only
-// writer — Apply logs that and repairs last-writer-wins.
+// previous version, and the RETURNING is load-bearing — rows() is the
+// divergence probe. kRepairGame is the same write unconditioned; the
+// pair stays duplicated because sharing the prefix would cost the
+// RETURNING or need string assembly.
 constexpr char kSaveGame[] = R"sql(
     INSERT INTO games (room_id, game_id, roster, state, version)
     VALUES ($1, $2, $3::jsonb, NULLIF($4, '')::jsonb, $5::bigint)
@@ -41,9 +43,9 @@ constexpr char kRepairGame[] = R"sql(
 constexpr char kDeleteGame[] = "DELETE FROM games WHERE room_id = $1 AND game_id = $2";
 
 std::string RosterJson(const std::vector<std::string>& roster) {
-  json codes = json::array();
-  for (const std::string& player_id : roster) codes.push_back(player_id);
-  return codes.dump();
+  json names = json::array();
+  for (const std::string& player_id : roster) names.push_back(player_id);
+  return names.dump();
 }
 
 }  // namespace
@@ -91,53 +93,45 @@ void PgHubStore::WriterLoop() {
   }
 }
 
+std::optional<int> PgHubStore::ExecOrWarn(const char* what, const char* sql,
+                                          const std::vector<std::string>& params) {
+  auto result = db_->Exec(sql, params);
+  if (!result.ok()) {
+    LOG(WARNING) << "hub write-through " << what << " failed: " << result.status();
+    return std::nullopt;
+  }
+  return result->rows();
+}
+
 void PgHubStore::Apply(const Op& op) {
-  const auto warn = [](const char* what, const absl::Status& status) {
-    // Memory stays authoritative in step 2: a failed write is degraded
-    // durability, not a gameplay error.
-    LOG(WARNING) << "hub write-through " << what << " failed: " << status;
-  };
   if (const auto* upsert = std::get_if<UpsertRoom>(&op)) {
-    if (auto result = db_->Exec(kUpsertRoom, {upsert->room_id}); !result.ok()) {
-      warn("UpsertRoom", result.status());
-    }
+    ExecOrWarn("UpsertRoom", kUpsertRoom, {upsert->room_id});
   } else if (const auto* erase = std::get_if<DeleteRoom>(&op)) {
-    if (auto result = db_->Exec(kDeleteRoom, {erase->room_id}); !result.ok()) {
-      warn("DeleteRoom", result.status());
-    }
+    ExecOrWarn("DeleteRoom", kDeleteRoom, {erase->room_id});
   } else if (const auto* upsert = std::get_if<UpsertMember>(&op)) {
     const MemberRow& row = upsert->row;
-    if (auto result = db_->Exec(kUpsertMember,
-                                {row.room_id, row.player_id, row.connected ? "true" : "false",
-                                 std::to_string(row.games_played), std::to_string(row.games_won),
-                                 std::to_string(row.total_score)});
-        !result.ok()) {
-      warn("UpsertMember", result.status());
-    }
+    ExecOrWarn("UpsertMember", kUpsertMember,
+               {row.room_id, row.player_id, row.connected ? "true" : "false",
+                std::to_string(row.games_played), std::to_string(row.games_won),
+                std::to_string(row.total_score)});
   } else if (const auto* erase = std::get_if<DeleteMember>(&op)) {
-    if (auto result = db_->Exec(kDeleteMember, {erase->room_id, erase->player_id}); !result.ok()) {
-      warn("DeleteMember", result.status());
-    }
+    ExecOrWarn("DeleteMember", kDeleteMember, {erase->room_id, erase->player_id});
   } else if (const auto* save = std::get_if<SaveGame>(&op)) {
     const GameRow& row = save->row;
-    const std::vector<std::string> params = {row.room_id, row.game_id, RosterJson(row.roster),
-                                             row.state_json, std::to_string(row.version)};
-    auto result = db_->Exec(kSaveGame, params);
-    if (!result.ok()) {
-      warn("SaveGame", result.status());
-    } else if (result->rows() == 0) {
+    const std::vector<std::string> params = {
+        row.room_id, row.game_id, RosterJson(row.roster),
+        row.state.has_value() ? golf::serializeGameState(*row.state) : "",
+        std::to_string(row.version)};
+    // nullopt != 0, so a failed Exec skips the repair.
+    if (ExecOrWarn("SaveGame", kSaveGame, params) == 0) {
       // Single-writer invariant broken (or a retry raced its own first
       // execution). Loud, then last-writer-wins: memory is the truth.
       LOG(ERROR) << "game " << row.room_id << "/" << row.game_id << " version " << row.version
                  << " did not follow the stored row; repairing";
-      if (auto repair = db_->Exec(kRepairGame, params); !repair.ok()) {
-        warn("RepairGame", repair.status());
-      }
+      ExecOrWarn("RepairGame", kRepairGame, params);
     }
   } else if (const auto* erase = std::get_if<DeleteGame>(&op)) {
-    if (auto result = db_->Exec(kDeleteGame, {erase->room_id, erase->game_id}); !result.ok()) {
-      warn("DeleteGame", result.status());
-    }
+    ExecOrWarn("DeleteGame", kDeleteGame, {erase->room_id, erase->game_id});
   }
 }
 
@@ -171,21 +165,37 @@ absl::StatusOr<PgHubStore::Snapshot> PgHubStore::LoadSnapshot() {
     GameRow row;
     row.room_id = games->Get(i, 0).value_or("");
     row.game_id = games->Get(i, 1).value_or("");
+    row.version = std::atoll(games->Get(i, 4).value_or("0").c_str());
+
+    // Undecodable rows cost their game, not the boot — the same blast
+    // radius whichever column is bad.
     const json roster = json::parse(games->Get(i, 2).value_or("[]"), /*cb=*/nullptr,
                                     /*allow_exceptions=*/false);
-    if (!roster.is_array()) {
-      return absl::InternalError(
-          absl::StrCat("game ", row.room_id, "/", row.game_id, " roster is not an array"));
-    }
-    for (const json& entry : roster) {
-      if (!entry.is_string()) {
-        return absl::InternalError(
-            absl::StrCat("game ", row.room_id, "/", row.game_id, " roster entry is not a string"));
+    bool roster_ok = roster.is_array();
+    if (roster_ok) {
+      for (const json& entry : roster) {
+        if (!entry.is_string()) {
+          roster_ok = false;
+          break;
+        }
+        row.roster.push_back(entry.get<std::string>());
       }
-      row.roster.push_back(entry.get<std::string>());
     }
-    row.state_json = games->Get(i, 3).value_or("");
-    row.version = std::atoll(games->Get(i, 4).value_or("0").c_str());
+    if (!roster_ok) {
+      LOG(ERROR) << "dropping game " << row.room_id << "/" << row.game_id
+                 << ": roster is not an array of player ids";
+      continue;
+    }
+    const std::string state_json = games->Get(i, 3).value_or("");
+    if (!state_json.empty()) {
+      auto state = golf::deserializeGameState(state_json);
+      if (!state.ok()) {
+        LOG(ERROR) << "dropping game " << row.room_id << "/" << row.game_id
+                   << ": unreadable state: " << state.status();
+        continue;
+      }
+      row.state.emplace(*std::move(state));
+    }
     snapshot.games.push_back(std::move(row));
   }
   return snapshot;

--- a/domains/games/apis/golf_hub/pg_hub_store.cc
+++ b/domains/games/apis/golf_hub/pg_hub_store.cc
@@ -1,0 +1,194 @@
+#include "domains/games/apis/golf_hub/pg_hub_store.h"
+
+#include <nlohmann/json.hpp>
+#include <utility>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+
+namespace golf_hub {
+namespace {
+
+using nlohmann::json;
+
+constexpr char kUpsertRoom[] = R"sql(
+    INSERT INTO rooms (room_id) VALUES ($1)
+    ON CONFLICT (room_id) DO NOTHING)sql";
+constexpr char kDeleteRoom[] = "DELETE FROM rooms WHERE room_id = $1";
+constexpr char kUpsertMember[] = R"sql(
+    INSERT INTO room_members (room_id, player_id, connected, games_played, games_won, total_score)
+    VALUES ($1, $2, $3::boolean, $4::integer, $5::integer, $6::integer)
+    ON CONFLICT (room_id, player_id) DO UPDATE
+      SET connected = EXCLUDED.connected, games_played = EXCLUDED.games_played,
+          games_won = EXCLUDED.games_won, total_score = EXCLUDED.total_score)sql";
+constexpr char kDeleteMember[] = "DELETE FROM room_members WHERE room_id = $1 AND player_id = $2";
+// The conditional save: an UPDATE lands only when the row holds the
+// previous version. Zero rows back means the DB diverged from the only
+// writer — Apply logs that and repairs last-writer-wins.
+constexpr char kSaveGame[] = R"sql(
+    INSERT INTO games (room_id, game_id, roster, state, version)
+    VALUES ($1, $2, $3::jsonb, NULLIF($4, '')::jsonb, $5::bigint)
+    ON CONFLICT (room_id, game_id) DO UPDATE
+      SET roster = EXCLUDED.roster, state = EXCLUDED.state, version = EXCLUDED.version
+      WHERE games.version = EXCLUDED.version - 1
+    RETURNING version)sql";
+constexpr char kRepairGame[] = R"sql(
+    INSERT INTO games (room_id, game_id, roster, state, version)
+    VALUES ($1, $2, $3::jsonb, NULLIF($4, '')::jsonb, $5::bigint)
+    ON CONFLICT (room_id, game_id) DO UPDATE
+      SET roster = EXCLUDED.roster, state = EXCLUDED.state, version = EXCLUDED.version)sql";
+constexpr char kDeleteGame[] = "DELETE FROM games WHERE room_id = $1 AND game_id = $2";
+
+std::string RosterJson(const std::vector<std::string>& roster) {
+  json codes = json::array();
+  for (const std::string& player_id : roster) codes.push_back(player_id);
+  return codes.dump();
+}
+
+}  // namespace
+
+PgHubStore::PgHubStore(std::shared_ptr<pg::Client> db)
+    : db_(std::move(db)), writer_([this] { WriterLoop(); }) {}
+
+PgHubStore::~PgHubStore() {
+  {
+    const std::lock_guard<std::mutex> lock(mu_);
+    stopping_ = true;
+  }
+  cv_.notify_all();
+  writer_.join();
+}
+
+void PgHubStore::Enqueue(std::vector<Op> ops) {
+  if (ops.empty()) return;
+  {
+    const std::lock_guard<std::mutex> lock(mu_);
+    for (Op& op : ops) queue_.push_back(std::move(op));
+  }
+  cv_.notify_all();
+}
+
+void PgHubStore::Flush() {
+  std::unique_lock<std::mutex> lock(mu_);
+  cv_.wait(lock, [this] { return queue_.empty() && !busy_; });
+}
+
+void PgHubStore::WriterLoop() {
+  std::unique_lock<std::mutex> lock(mu_);
+  while (true) {
+    cv_.wait(lock, [this] { return !queue_.empty() || stopping_; });
+    // Drain before stopping: shutdown must not drop staged writes.
+    if (queue_.empty() && stopping_) return;
+    const Op op = std::move(queue_.front());
+    queue_.pop_front();
+    busy_ = true;
+    lock.unlock();
+    Apply(op);
+    lock.lock();
+    busy_ = false;
+    cv_.notify_all();
+  }
+}
+
+void PgHubStore::Apply(const Op& op) {
+  const auto warn = [](const char* what, const absl::Status& status) {
+    // Memory stays authoritative in step 2: a failed write is degraded
+    // durability, not a gameplay error.
+    LOG(WARNING) << "hub write-through " << what << " failed: " << status;
+  };
+  if (const auto* upsert = std::get_if<UpsertRoom>(&op)) {
+    if (auto result = db_->Exec(kUpsertRoom, {upsert->room_id}); !result.ok()) {
+      warn("UpsertRoom", result.status());
+    }
+  } else if (const auto* erase = std::get_if<DeleteRoom>(&op)) {
+    if (auto result = db_->Exec(kDeleteRoom, {erase->room_id}); !result.ok()) {
+      warn("DeleteRoom", result.status());
+    }
+  } else if (const auto* upsert = std::get_if<UpsertMember>(&op)) {
+    const MemberRow& row = upsert->row;
+    if (auto result = db_->Exec(kUpsertMember,
+                                {row.room_id, row.player_id, row.connected ? "true" : "false",
+                                 std::to_string(row.games_played), std::to_string(row.games_won),
+                                 std::to_string(row.total_score)});
+        !result.ok()) {
+      warn("UpsertMember", result.status());
+    }
+  } else if (const auto* erase = std::get_if<DeleteMember>(&op)) {
+    if (auto result = db_->Exec(kDeleteMember, {erase->room_id, erase->player_id}); !result.ok()) {
+      warn("DeleteMember", result.status());
+    }
+  } else if (const auto* save = std::get_if<SaveGame>(&op)) {
+    const GameRow& row = save->row;
+    const std::vector<std::string> params = {row.room_id, row.game_id, RosterJson(row.roster),
+                                             row.state_json, std::to_string(row.version)};
+    auto result = db_->Exec(kSaveGame, params);
+    if (!result.ok()) {
+      warn("SaveGame", result.status());
+    } else if (result->rows() == 0) {
+      // Single-writer invariant broken (or a retry raced its own first
+      // execution). Loud, then last-writer-wins: memory is the truth.
+      LOG(ERROR) << "game " << row.room_id << "/" << row.game_id << " version " << row.version
+                 << " did not follow the stored row; repairing";
+      if (auto repair = db_->Exec(kRepairGame, params); !repair.ok()) {
+        warn("RepairGame", repair.status());
+      }
+    }
+  } else if (const auto* erase = std::get_if<DeleteGame>(&op)) {
+    if (auto result = db_->Exec(kDeleteGame, {erase->room_id, erase->game_id}); !result.ok()) {
+      warn("DeleteGame", result.status());
+    }
+  }
+}
+
+absl::StatusOr<PgHubStore::Snapshot> PgHubStore::LoadSnapshot() {
+  Snapshot snapshot;
+  auto rooms = db_->Exec("SELECT room_id FROM rooms");
+  if (!rooms.ok()) return rooms.status();
+  for (int i = 0; i < rooms->rows(); ++i) {
+    snapshot.rooms.push_back(rooms->Get(i, 0).value_or(""));
+  }
+
+  auto members = db_->Exec(
+      "SELECT room_id, player_id, connected, games_played, games_won, total_score"
+      " FROM room_members");
+  if (!members.ok()) return members.status();
+  for (int i = 0; i < members->rows(); ++i) {
+    MemberRow row;
+    row.room_id = members->Get(i, 0).value_or("");
+    row.player_id = members->Get(i, 1).value_or("");
+    row.connected = members->Get(i, 2).value_or("f") == "t";
+    row.games_played = std::atoi(members->Get(i, 3).value_or("0").c_str());
+    row.games_won = std::atoi(members->Get(i, 4).value_or("0").c_str());
+    row.total_score = std::atoi(members->Get(i, 5).value_or("0").c_str());
+    snapshot.members.push_back(std::move(row));
+  }
+
+  auto games = db_->Exec(
+      "SELECT room_id, game_id, roster::text, COALESCE(state::text, ''), version FROM games");
+  if (!games.ok()) return games.status();
+  for (int i = 0; i < games->rows(); ++i) {
+    GameRow row;
+    row.room_id = games->Get(i, 0).value_or("");
+    row.game_id = games->Get(i, 1).value_or("");
+    const json roster = json::parse(games->Get(i, 2).value_or("[]"), /*cb=*/nullptr,
+                                    /*allow_exceptions=*/false);
+    if (!roster.is_array()) {
+      return absl::InternalError(
+          absl::StrCat("game ", row.room_id, "/", row.game_id, " roster is not an array"));
+    }
+    for (const json& entry : roster) {
+      if (!entry.is_string()) {
+        return absl::InternalError(
+            absl::StrCat("game ", row.room_id, "/", row.game_id, " roster entry is not a string"));
+      }
+      row.roster.push_back(entry.get<std::string>());
+    }
+    row.state_json = games->Get(i, 3).value_or("");
+    row.version = std::atoll(games->Get(i, 4).value_or("0").c_str());
+    snapshot.games.push_back(std::move(row));
+  }
+  return snapshot;
+}
+
+}  // namespace golf_hub

--- a/domains/games/apis/golf_hub/pg_hub_store.h
+++ b/domains/games/apis/golf_hub/pg_hub_store.h
@@ -1,0 +1,107 @@
+#ifndef DOMAINS_GAMES_APIS_GOLF_HUB_PG_HUB_STORE_H
+#define DOMAINS_GAMES_APIS_GOLF_HUB_PG_HUB_STORE_H
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <variant>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "domains/platform/libs/pg/pg.h"
+
+namespace golf_hub {
+
+/// The hub's rooms/members/games write-through (#1194 step 2). Not an
+/// interface — the issue's design note rejects a store seam ahead of the
+/// backend; this is the concrete postgres component, injected optionally
+/// (nullptr keeps the all-in-memory hub, which stays the test mode).
+///
+/// Memory is authoritative in step 2: the hub stages ops under its lock
+/// (so staging order is the truth's order) and a single writer thread
+/// applies them FIFO — no DB latency inside the hub's lock, and write
+/// failures degrade durability, never gameplay. Game saves are
+/// conditional on version-1; a miss means the DB diverged from the only
+/// writer, which is logged loudly and repaired last-writer-wins. Step 3
+/// flips authority to the database and this component grows into the
+/// issue's Apply(game_id, transition) repository.
+class PgHubStore {
+ public:
+  struct MemberRow {
+    std::string room_id;
+    std::string player_id;
+    bool connected = false;
+    int games_played = 0;
+    int games_won = 0;
+    int total_score = 0;
+  };
+  /// state_json empty = not started (NULL in the column).
+  struct GameRow {
+    std::string room_id;
+    std::string game_id;
+    std::vector<std::string> roster;
+    std::string state_json;
+    int64_t version = 0;
+  };
+  struct Snapshot {
+    std::vector<std::string> rooms;
+    std::vector<MemberRow> members;
+    std::vector<GameRow> games;
+  };
+
+  struct UpsertRoom {
+    std::string room_id;
+  };
+  struct DeleteRoom {
+    std::string room_id;
+  };
+  struct UpsertMember {
+    MemberRow row;
+  };
+  struct DeleteMember {
+    std::string room_id;
+    std::string player_id;
+  };
+  struct SaveGame {
+    GameRow row;
+  };
+  struct DeleteGame {
+    std::string room_id;
+    std::string game_id;
+  };
+  using Op = std::variant<UpsertRoom, DeleteRoom, UpsertMember, DeleteMember, SaveGame, DeleteGame>;
+
+  explicit PgHubStore(std::shared_ptr<pg::Client> db);
+  /// Drains the queue, then joins the writer.
+  ~PgHubStore();
+  PgHubStore(const PgHubStore&) = delete;
+  PgHubStore& operator=(const PgHubStore&) = delete;
+
+  /// Appends a batch atomically; batches apply in enqueue order.
+  void Enqueue(std::vector<Op> ops);
+  /// Blocks until everything enqueued so far has been applied.
+  void Flush();
+
+  /// The boot-time restore read. Synchronous; call before serving.
+  absl::StatusOr<Snapshot> LoadSnapshot();
+
+ private:
+  void WriterLoop();
+  void Apply(const Op& op);
+
+  const std::shared_ptr<pg::Client> db_;
+  std::mutex mu_;
+  std::condition_variable cv_;
+  std::deque<Op> queue_;
+  bool busy_ = false;
+  bool stopping_ = false;
+  std::thread writer_;
+};
+
+}  // namespace golf_hub
+
+#endif

--- a/domains/games/apis/golf_hub/pg_hub_store.h
+++ b/domains/games/apis/golf_hub/pg_hub_store.h
@@ -6,29 +6,37 @@
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <variant>
 #include <vector>
 
 #include "absl/status/statusor.h"
+#include "domains/games/libs/cards/golf/game_state.h"
 #include "domains/platform/libs/pg/pg.h"
 
 namespace golf_hub {
 
-/// The hub's rooms/members/games write-through (#1194 step 2). Not an
-/// interface — the issue's design note rejects a store seam ahead of the
-/// backend; this is the concrete postgres component, injected optionally
-/// (nullptr keeps the all-in-memory hub, which stays the test mode).
+/// The hub's rooms/members/games write-through (#1194 step 2): a durable-
+/// write outbox, not a repository — the load→transition→commit loop the
+/// issue's Apply(game_id, transition) seam will own still lives in the
+/// hub, and gets carved out (with this queue behind it) when step 3 flips
+/// authority to the database. Not an interface either — the issue's
+/// design note rejects a store seam ahead of the backend; this is the
+/// concrete postgres component, injected optionally (nullptr keeps the
+/// all-in-memory hub, which stays the test mode).
 ///
-/// Memory is authoritative in step 2: the hub stages ops under its lock
-/// (so staging order is the truth's order) and a single writer thread
-/// applies them FIFO — no DB latency inside the hub's lock, and write
-/// failures degrade durability, never gameplay. Game saves are
-/// conditional on version-1; a miss means the DB diverged from the only
-/// writer, which is logged loudly and repaired last-writer-wins. Step 3
-/// flips authority to the database and this component grows into the
-/// issue's Apply(game_id, transition) repository.
+/// Memory is authoritative in step 2. The hub stages ops and hands them
+/// over while still holding its lock — so queue order is the truth's
+/// order — and a single writer thread applies them FIFO, one statement
+/// each: no DB latency inside the hub's lock, no transactions (a batch
+/// can land partially), and a failed write degrades durability, never
+/// gameplay. This component owns the row encodings end to end: game
+/// state serializes through the step-0 serde on the writer thread and
+/// deserializes in LoadSnapshot. Game saves are conditional on
+/// version-1; a miss means the DB diverged from the only writer, which
+/// is logged loudly and repaired last-writer-wins.
 class PgHubStore {
  public:
   struct MemberRow {
@@ -39,12 +47,12 @@ class PgHubStore {
     int games_won = 0;
     int total_score = 0;
   };
-  /// state_json empty = not started (NULL in the column).
+  /// state disengaged = not started (NULL in the column).
   struct GameRow {
     std::string room_id;
     std::string game_id;
     std::vector<std::string> roster;
-    std::string state_json;
+    std::optional<golf::GameState> state;
     int64_t version = 0;
   };
   struct Snapshot {
@@ -81,17 +89,25 @@ class PgHubStore {
   PgHubStore(const PgHubStore&) = delete;
   PgHubStore& operator=(const PgHubStore&) = delete;
 
-  /// Appends a batch atomically; batches apply in enqueue order.
+  /// Appends ops to the writer's queue under one lock acquisition; the
+  /// writer applies them FIFO. Not a transaction.
   void Enqueue(std::vector<Op> ops);
   /// Blocks until everything enqueued so far has been applied.
   void Flush();
 
-  /// The boot-time restore read. Synchronous; call before serving.
+  /// The boot-time restore read. Synchronous; call before serving. A row
+  /// whose stored bytes don't decode is dropped with a loud log — one
+  /// bad game costs that game, not the boot.
   absl::StatusOr<Snapshot> LoadSnapshot();
 
  private:
   void WriterLoop();
   void Apply(const Op& op);
+  /// Runs one statement; returns its row count, or nullopt after a
+  /// logged failure (memory stays authoritative — degraded durability,
+  /// not a gameplay error).
+  std::optional<int> ExecOrWarn(const char* what, const char* sql,
+                                const std::vector<std::string>& params);
 
   const std::shared_ptr<pg::Client> db_;
   std::mutex mu_;

--- a/domains/games/apis/golf_hub/pg_hub_store_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_store_test.cc
@@ -1,0 +1,111 @@
+#include "domains/games/apis/golf_hub/pg_hub_store.h"
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "domains/games/apis/golf_hub/migrations.h"
+#include "domains/platform/libs/pg/pg.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+using golf_hub::PgHubStore;
+
+// Step-2 slice of the persistence integration suite (#1194): the
+// write-through ops against the real tables. GOLF_HUB_TEST_DB_URL gates
+// it like the rest of the suite.
+class PgHubStoreTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const char* url = std::getenv("GOLF_HUB_TEST_DB_URL");
+    if (url == nullptr || *url == '\0') {
+      GTEST_SKIP() << "GOLF_HUB_TEST_DB_URL unset";
+    }
+    db_ = std::make_shared<pg::Client>(url);
+    ASSERT_TRUE(golf_hub::RunMigrations(*db_).ok());
+    ASSERT_TRUE(db_->Exec("TRUNCATE rooms CASCADE").ok());
+    store_ = std::make_unique<PgHubStore>(db_);
+  }
+
+  std::shared_ptr<pg::Client> db_;
+  std::unique_ptr<PgHubStore> store_;
+};
+
+TEST_F(PgHubStoreTest, OpsRoundTripThroughSnapshot) {
+  PgHubStore::MemberRow alice{"R1", "alice", true, 2, 1, 9};
+  PgHubStore::MemberRow bob{"R1", "bob", false, 2, 0, 14};
+  PgHubStore::GameRow waiting{"R1", "G1", {"alice"}, "", 1};
+  PgHubStore::GameRow started{"R1", "G2", {"alice", "bob"}, R"({"note":"stand-in state"})", 1};
+  store_->Enqueue({PgHubStore::UpsertRoom{"R1"}, PgHubStore::UpsertMember{alice},
+                   PgHubStore::UpsertMember{bob}, PgHubStore::SaveGame{waiting},
+                   PgHubStore::SaveGame{started}});
+  store_->Flush();
+
+  auto snapshot = store_->LoadSnapshot();
+  ASSERT_TRUE(snapshot.ok()) << snapshot.status();
+  ASSERT_EQ(snapshot->rooms.size(), 1u);
+  EXPECT_EQ(snapshot->rooms[0], "R1");
+  ASSERT_EQ(snapshot->members.size(), 2u);
+  ASSERT_EQ(snapshot->games.size(), 2u);
+  for (const auto& game : snapshot->games) {
+    if (game.game_id == "G1") {
+      EXPECT_TRUE(game.state_json.empty());
+      EXPECT_EQ(game.roster, (std::vector<std::string>{"alice"}));
+    } else {
+      EXPECT_EQ(game.game_id, "G2");
+      EXPECT_FALSE(game.state_json.empty());
+      EXPECT_EQ(game.version, 1);
+    }
+  }
+
+  // Upserts converge on the latest value; deletes remove exactly their row.
+  alice.total_score = 12;
+  alice.connected = false;
+  store_->Enqueue({PgHubStore::UpsertMember{alice}, PgHubStore::DeleteMember{"R1", "bob"},
+                   PgHubStore::DeleteGame{"R1", "G1"}});
+  store_->Flush();
+  snapshot = store_->LoadSnapshot();
+  ASSERT_TRUE(snapshot.ok());
+  ASSERT_EQ(snapshot->members.size(), 1u);
+  EXPECT_EQ(snapshot->members[0].total_score, 12);
+  EXPECT_FALSE(snapshot->members[0].connected);
+  ASSERT_EQ(snapshot->games.size(), 1u);
+  EXPECT_EQ(snapshot->games[0].game_id, "G2");
+}
+
+TEST_F(PgHubStoreTest, ConditionalSaveAdvancesAndRepairsOnDivergence) {
+  store_->Enqueue({PgHubStore::UpsertRoom{"R1"},
+                   PgHubStore::SaveGame{{"R1", "G1", {"alice"}, "", 1}},
+                   PgHubStore::SaveGame{{"R1", "G1", {"alice"}, R"({"v":"two"})", 2}}});
+  store_->Flush();
+  auto snapshot = store_->LoadSnapshot();
+  ASSERT_TRUE(snapshot.ok());
+  ASSERT_EQ(snapshot->games.size(), 1u);
+  EXPECT_EQ(snapshot->games[0].version, 2);
+
+  // A save that skips a version means the DB diverged from the only
+  // writer: it must still land (last-writer-wins repair), loudly.
+  store_->Enqueue({PgHubStore::SaveGame{{"R1", "G1", {"alice"}, R"({"v":"five"})", 5}}});
+  store_->Flush();
+  snapshot = store_->LoadSnapshot();
+  ASSERT_TRUE(snapshot.ok());
+  ASSERT_EQ(snapshot->games.size(), 1u);
+  EXPECT_EQ(snapshot->games[0].version, 5);
+  EXPECT_NE(snapshot->games[0].state_json.find("five"), std::string::npos);
+}
+
+TEST_F(PgHubStoreTest, DeleteRoomCascades) {
+  store_->Enqueue(
+      {PgHubStore::UpsertRoom{"R1"}, PgHubStore::UpsertMember{{"R1", "alice", true, 0, 0, 0}},
+       PgHubStore::SaveGame{{"R1", "G1", {"alice"}, "", 1}}, PgHubStore::DeleteRoom{"R1"}});
+  store_->Flush();
+  auto snapshot = store_->LoadSnapshot();
+  ASSERT_TRUE(snapshot.ok());
+  EXPECT_TRUE(snapshot->rooms.empty());
+  EXPECT_TRUE(snapshot->members.empty());
+  EXPECT_TRUE(snapshot->games.empty());
+}
+
+}  // namespace

--- a/domains/games/apis/golf_hub/pg_hub_store_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_store_test.cc
@@ -1,17 +1,33 @@
 #include "domains/games/apis/golf_hub/pg_hub_store.h"
 
 #include <cstdlib>
+#include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "domains/games/apis/golf_hub/migrations.h"
+#include "domains/games/libs/cards/card.h"
+#include "domains/games/libs/cards/golf/game_state.h"
+#include "domains/games/libs/cards/golf/game_state_serde.h"
 #include "domains/platform/libs/pg/pg.h"
 #include "gtest/gtest.h"
 
 namespace {
 
 using golf_hub::PgHubStore;
+
+// A real engine state for the started-game rows — the store owns the
+// serde end to end now, so round-trip fidelity is asserted by canonical
+// re-serialization.
+golf::GameState DealtState() {
+  std::deque<cards::Card> deck;
+  for (int i = 0; i < 52; ++i) deck.emplace_back(i);
+  auto dealt = golf::dealGolfGame("G2", {"alice", "bob"}, std::move(deck));
+  EXPECT_TRUE(dealt.ok());
+  return *std::move(dealt);
+}
 
 // Step-2 slice of the persistence integration suite (#1194): the
 // write-through ops against the real tables. GOLF_HUB_TEST_DB_URL gates
@@ -36,8 +52,9 @@ class PgHubStoreTest : public ::testing::Test {
 TEST_F(PgHubStoreTest, OpsRoundTripThroughSnapshot) {
   PgHubStore::MemberRow alice{"R1", "alice", true, 2, 1, 9};
   PgHubStore::MemberRow bob{"R1", "bob", false, 2, 0, 14};
-  PgHubStore::GameRow waiting{"R1", "G1", {"alice"}, "", 1};
-  PgHubStore::GameRow started{"R1", "G2", {"alice", "bob"}, R"({"note":"stand-in state"})", 1};
+  const golf::GameState state = DealtState();
+  PgHubStore::GameRow waiting{"R1", "G1", {"alice"}, std::nullopt, 1};
+  PgHubStore::GameRow started{"R1", "G2", {"alice", "bob"}, state, 1};
   store_->Enqueue({PgHubStore::UpsertRoom{"R1"}, PgHubStore::UpsertMember{alice},
                    PgHubStore::UpsertMember{bob}, PgHubStore::SaveGame{waiting},
                    PgHubStore::SaveGame{started}});
@@ -51,11 +68,14 @@ TEST_F(PgHubStoreTest, OpsRoundTripThroughSnapshot) {
   ASSERT_EQ(snapshot->games.size(), 2u);
   for (const auto& game : snapshot->games) {
     if (game.game_id == "G1") {
-      EXPECT_TRUE(game.state_json.empty());
+      EXPECT_FALSE(game.state.has_value());
       EXPECT_EQ(game.roster, (std::vector<std::string>{"alice"}));
+      EXPECT_EQ(game.version, 1);
     } else {
       EXPECT_EQ(game.game_id, "G2");
-      EXPECT_FALSE(game.state_json.empty());
+      ASSERT_TRUE(game.state.has_value());
+      // Canonical re-serialization is state equality.
+      EXPECT_EQ(golf::serializeGameState(*game.state), golf::serializeGameState(state));
       EXPECT_EQ(game.version, 1);
     }
   }
@@ -77,8 +97,8 @@ TEST_F(PgHubStoreTest, OpsRoundTripThroughSnapshot) {
 
 TEST_F(PgHubStoreTest, ConditionalSaveAdvancesAndRepairsOnDivergence) {
   store_->Enqueue({PgHubStore::UpsertRoom{"R1"},
-                   PgHubStore::SaveGame{{"R1", "G1", {"alice"}, "", 1}},
-                   PgHubStore::SaveGame{{"R1", "G1", {"alice"}, R"({"v":"two"})", 2}}});
+                   PgHubStore::SaveGame{{"R1", "G1", {"alice"}, std::nullopt, 1}},
+                   PgHubStore::SaveGame{{"R1", "G1", {"alice", "bob"}, std::nullopt, 2}}});
   store_->Flush();
   auto snapshot = store_->LoadSnapshot();
   ASSERT_TRUE(snapshot.ok());
@@ -87,19 +107,20 @@ TEST_F(PgHubStoreTest, ConditionalSaveAdvancesAndRepairsOnDivergence) {
 
   // A save that skips a version means the DB diverged from the only
   // writer: it must still land (last-writer-wins repair), loudly.
-  store_->Enqueue({PgHubStore::SaveGame{{"R1", "G1", {"alice"}, R"({"v":"five"})", 5}}});
+  store_->Enqueue({PgHubStore::SaveGame{{"R1", "G1", {"alice", "carol"}, std::nullopt, 5}}});
   store_->Flush();
   snapshot = store_->LoadSnapshot();
   ASSERT_TRUE(snapshot.ok());
   ASSERT_EQ(snapshot->games.size(), 1u);
   EXPECT_EQ(snapshot->games[0].version, 5);
-  EXPECT_NE(snapshot->games[0].state_json.find("five"), std::string::npos);
+  EXPECT_EQ(snapshot->games[0].roster, (std::vector<std::string>{"alice", "carol"}));
 }
 
 TEST_F(PgHubStoreTest, DeleteRoomCascades) {
-  store_->Enqueue(
-      {PgHubStore::UpsertRoom{"R1"}, PgHubStore::UpsertMember{{"R1", "alice", true, 0, 0, 0}},
-       PgHubStore::SaveGame{{"R1", "G1", {"alice"}, "", 1}}, PgHubStore::DeleteRoom{"R1"}});
+  store_->Enqueue({PgHubStore::UpsertRoom{"R1"},
+                   PgHubStore::UpsertMember{{"R1", "alice", true, 0, 0, 0}},
+                   PgHubStore::SaveGame{{"R1", "G1", {"alice"}, std::nullopt, 1}},
+                   PgHubStore::DeleteRoom{"R1"}});
   store_->Flush();
   auto snapshot = store_->LoadSnapshot();
   ASSERT_TRUE(snapshot.ok());

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -34,6 +35,38 @@
 
 namespace golf_hub {
 
+// Receives until an event of the wanted case arrives (skipping others),
+// failing after a few frames so a wrong stream can't hang the test.
+inline std::optional<moonbase::golf::GolfEvents> ReceiveCase(
+    moonbase::golf::PlayClientStream& stream, const std::string& wanted) {
+  for (int i = 0; i < 8; ++i) {
+    auto received = stream.Receive();
+    if (!received.ok() || !received->has_value()) return std::nullopt;
+    if (wanted == (*received)->case_name()) return **received;
+  }
+  return std::nullopt;
+}
+
+// Same, but tunnels into the golf envelope: returns the first GolfUpdate
+// of the wanted case, skipping room noise and other updates in between.
+inline std::optional<moonbase::golf::GolfUpdate> ReceiveGolf(
+    moonbase::golf::PlayClientStream& stream, const std::string& wanted) {
+  for (int i = 0; i < 16; ++i) {
+    auto received = stream.Receive();
+    if (!received.ok() || !received->has_value()) return std::nullopt;
+    const auto* envelope = (*received)->as_golf_or_null();
+    if (envelope == nullptr) continue;
+    if (wanted == envelope->update.case_name()) return envelope->update;
+  }
+  return std::nullopt;
+}
+
+inline moonbase::golf::GolfCommands Move(moonbase::golf::GolfMove move) {
+  moonbase::golf::GolfCommand command;
+  command.move = std::move(move);
+  return moonbase::golf::GolfCommands::FromGolf(std::move(command));
+}
+
 class GolfHubStreamFixture : public testing::Test {
  protected:
   // The persistence seams (#1194): the default fixture stays the blessed
@@ -47,21 +80,6 @@ class GolfHubStreamFixture : public testing::Test {
 
   void SetUp() override { BuildHub(); }
 
-  // Simulates the process dying and a fresh instance booting over the
-  // same database. A crash closes nothing and says no goodbyes, so the
-  // old generation is parked as-is (its sockets close in TearDown like
-  // any abandoned test session) and a brand-new hub restores from what
-  // the store wrote through. Only the flush is synchronous — the row
-  // truth must be complete before the successor reads it.
-  void RestartHub() {
-    if (store_ != nullptr) store_->Flush();
-    retired_handlers_.push_back(std::move(handler_));
-    retired_servers_.push_back(std::move(server_));
-    retired_clients_.push_back(std::move(client_));
-    retired_stores_.push_back(std::move(store_));
-    BuildHub();
-  }
-
   void BuildHub() {
     vault_ = MakeVault();
     store_ = MakeStore();
@@ -74,6 +92,10 @@ class GolfHubStreamFixture : public testing::Test {
         vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
         /*grace_period=*/std::chrono::seconds(60),
         std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), store_);
+    if (store_ != nullptr) {
+      const absl::Status restored = handler_->RestoreFromStore();
+      ASSERT_TRUE(restored.ok()) << restored;
+    }
     server_ = std::make_unique<moonbase::golf::GolfHubServer>(handler_);
 
     auto loopback = std::make_shared<smithy::http::Loopback>();
@@ -128,18 +150,68 @@ class GolfHubStreamFixture : public testing::Test {
     return Seat{session->playerId, session->resumeToken, std::move(*stream)};
   }
 
+  // Room with two seats in a started game: with the NoShuffleDealer the
+  // first seat holds the aces and the second the kings, Q♠ seeding the
+  // discard. Returns nullopt (with an ADD_FAILURE already recorded by the
+  // failing step where possible) when any step misbehaves.
+  struct Table {
+    Seat alice;
+    Seat bob;
+    std::string room_id;
+    std::string game_id;
+  };
+  std::optional<Table> SeatedTable() {
+    auto alice = OpenSeat();
+    auto bob = OpenSeat();
+    if (!alice.has_value() || !bob.has_value()) return std::nullopt;
+    if (!ReceiveCase(alice->stream, "sessionReady").has_value()) return std::nullopt;
+    if (!ReceiveCase(bob->stream, "sessionReady").has_value()) return std::nullopt;
+
+    if (!alice->stream
+             .Send(moonbase::golf::GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{}))
+             .ok()) {
+      return std::nullopt;
+    }
+    auto created = ReceiveCase(alice->stream, "roomState");
+    if (!created.has_value()) return std::nullopt;
+    const std::string room_id = created->as_roomState_or_null()->roomId;
+    moonbase::golf::JoinRoom join_room;
+    join_room.roomId = room_id;
+    if (!bob->stream.Send(moonbase::golf::GolfCommands::FromJoinroom(join_room)).ok())
+      return std::nullopt;
+    if (!ReceiveCase(bob->stream, "roomState").has_value()) return std::nullopt;
+
+    if (!alice->stream
+             .Send(Move(moonbase::golf::GolfMove::FromCreategame(moonbase::golf::CreateGame{})))
+             .ok()) {
+      return std::nullopt;
+    }
+    auto joined = ReceiveGolf(alice->stream, "gameJoined");
+    if (!joined.has_value()) return std::nullopt;
+    const std::string game_id = joined->as_gameJoined_or_null()->view.gameId;
+
+    moonbase::golf::JoinGame join_game;
+    join_game.gameId = game_id;
+    if (!bob->stream.Send(Move(moonbase::golf::GolfMove::FromJoingame(join_game))).ok())
+      return std::nullopt;
+    if (!ReceiveGolf(bob->stream, "gameJoined").has_value()) return std::nullopt;
+
+    if (!alice->stream
+             .Send(Move(moonbase::golf::GolfMove::FromStartgame(moonbase::golf::StartGame{})))
+             .ok()) {
+      return std::nullopt;
+    }
+    if (!ReceiveGolf(alice->stream, "gameStarted").has_value()) return std::nullopt;
+    if (!ReceiveGolf(bob->stream, "gameStarted").has_value()) return std::nullopt;
+    return Table{std::move(*alice), std::move(*bob), room_id, game_id};
+  }
+
   std::shared_ptr<TicketVault> vault_;
   std::shared_ptr<PgHubStore> store_;
   std::shared_ptr<IdGenerator> ids_ = std::make_shared<SequentialIdGenerator>();
   std::shared_ptr<HubHandler> handler_;
   std::unique_ptr<moonbase::golf::GolfHubServer> server_;
   std::unique_ptr<moonbase::golf::GolfHubClient> client_;
-  // Prior generations from RestartHub, torn down with everything else
-  // once TearDown has closed their sockets.
-  std::vector<std::shared_ptr<HubHandler>> retired_handlers_;
-  std::vector<std::unique_ptr<moonbase::golf::GolfHubServer>> retired_servers_;
-  std::vector<std::unique_ptr<moonbase::golf::GolfHubClient>> retired_clients_;
-  std::vector<std::shared_ptr<PgHubStore>> retired_stores_;
   std::vector<std::shared_ptr<smithy::http::WebSocket>> sessions_;
 };
 

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -19,6 +19,7 @@
 
 #include "domains/games/apis/golf_hub/hub_handler.h"
 #include "domains/games/apis/golf_hub/id_generator.h"
+#include "domains/games/apis/golf_hub/pg_hub_store.h"
 #include "domains/games/apis/golf_hub/ticket_vault.h"
 #include "domains/games/libs/cards/dealer.h"
 #include "domains/platform/libs/futility/otel/metrics.h"
@@ -35,9 +36,35 @@ namespace golf_hub {
 
 class GolfHubStreamFixture : public testing::Test {
  protected:
-  void SetUp() override {
-    vault_ = std::make_shared<InMemoryTicketVault>(/*ticket_ttl=*/std::chrono::seconds(60),
-                                                   /*resume_ttl=*/std::chrono::seconds(60));
+  // The persistence seams (#1194): the default fixture stays the blessed
+  // all-in-memory hub; the pg e2e suite overrides both to run the same
+  // flows with durable credentials and the rooms/games write-through.
+  virtual std::shared_ptr<TicketVault> MakeVault() {
+    return std::make_shared<InMemoryTicketVault>(/*ticket_ttl=*/std::chrono::seconds(60),
+                                                 /*resume_ttl=*/std::chrono::seconds(60));
+  }
+  virtual std::shared_ptr<PgHubStore> MakeStore() { return nullptr; }
+
+  void SetUp() override { BuildHub(); }
+
+  // Simulates the process dying and a fresh instance booting over the
+  // same database. A crash closes nothing and says no goodbyes, so the
+  // old generation is parked as-is (its sockets close in TearDown like
+  // any abandoned test session) and a brand-new hub restores from what
+  // the store wrote through. Only the flush is synchronous — the row
+  // truth must be complete before the successor reads it.
+  void RestartHub() {
+    if (store_ != nullptr) store_->Flush();
+    retired_handlers_.push_back(std::move(handler_));
+    retired_servers_.push_back(std::move(server_));
+    retired_clients_.push_back(std::move(client_));
+    retired_stores_.push_back(std::move(store_));
+    BuildHub();
+  }
+
+  void BuildHub() {
+    vault_ = MakeVault();
+    store_ = MakeStore();
     // NoShuffleDealer: hands are dealt from the back of the pristine deck,
     // so every card in every test is known (first seat gets the aces).
     // Sequential ids keep players and game codes readable in failures.
@@ -46,7 +73,7 @@ class GolfHubStreamFixture : public testing::Test {
     handler_ = std::make_shared<HubHandler>(
         vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
         /*grace_period=*/std::chrono::seconds(60),
-        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"));
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), store_);
     server_ = std::make_unique<moonbase::golf::GolfHubServer>(handler_);
 
     auto loopback = std::make_shared<smithy::http::Loopback>();
@@ -102,10 +129,17 @@ class GolfHubStreamFixture : public testing::Test {
   }
 
   std::shared_ptr<TicketVault> vault_;
+  std::shared_ptr<PgHubStore> store_;
   std::shared_ptr<IdGenerator> ids_ = std::make_shared<SequentialIdGenerator>();
   std::shared_ptr<HubHandler> handler_;
   std::unique_ptr<moonbase::golf::GolfHubServer> server_;
   std::unique_ptr<moonbase::golf::GolfHubClient> client_;
+  // Prior generations from RestartHub, torn down with everything else
+  // once TearDown has closed their sockets.
+  std::vector<std::shared_ptr<HubHandler>> retired_handlers_;
+  std::vector<std::unique_ptr<moonbase::golf::GolfHubServer>> retired_servers_;
+  std::vector<std::unique_ptr<moonbase::golf::GolfHubClient>> retired_clients_;
+  std::vector<std::shared_ptr<PgHubStore>> retired_stores_;
   std::vector<std::shared_ptr<smithy::http::WebSocket>> sessions_;
 };
 


### PR DESCRIPTION
Step 2 of the persistence plan in #1194: game and room state write-through, still single instance. **Deploys stop killing games** — with `GOLF_HUB_DB_URL` set, every rooms/members/games mutation writes through to the step-1 database and a booting hub restores the lot. A player whose process died walks back in on their resume token (step 1's rows) and lands in their seat, mid-game, on the fresh process. Unset keeps the all-in-memory hub: dev mode and the blessed test harness, unchanged.

## Schema

`rooms`, `room_members` (stats + connected flag), and `games` — `roster jsonb`, `state jsonb` (the step-0 serde bytes, so #1222's format guarantees are what's on disk), and a `version` counter. Composite keys because game codes are only unique within a room; deleting a room cascades to its members and games, so an emptied room is one `DELETE`.

## `PgHubStore`

The concrete write-through component — deliberately **not** an interface, per the issue's design note (v1's `GameStoreInterface` precedent); `nullptr` keeps the in-memory hub. Mechanics:

- Ops are staged under the hub's lock exactly like the event `Outbox`, so **staging order is the truth's order**, then handed to a single writer thread that applies them FIFO. No DB latency inside the hub's lock; a failed write is logged, degraded durability — never a gameplay error. Memory stays authoritative in step 2.
- Game saves are **conditional on `version - 1`** (the hub owns the counter and increments per staged save). A zero-row save means the DB diverged from the only writer: logged loudly, repaired last-writer-wins. This is the optimistic-concurrency machinery step 3 will flip to database-authoritative.
- `~PgHubStore` drains the queue before joining, so shutdown doesn't drop staged writes.

## Hub changes

- `Play` now resyncs by **membership, not registry admission**: a restored player admits as new (the old process's registry died with it), but their room and game are in the maps — `sessionReady` says `resumed` with their `roomId`, and the `gameJoined` view arrives before they send a single command. This is the piece that makes restore usable rather than decorative.
- Boot restore rebuilds rooms, members (everyone disconnected until they resume), and games; an unreadable game state drops that game with a loud log, not the lobby.

## Tests — the step-2 slice of the integration suite

All real-postgres via `GOLF_HUB_TEST_DB_URL` (skip otherwise), now tagged `exclusive` — the DB tests share one scratch database and concurrent runs truncate each other mid-flight (found the hard way via `--runs_per_test`).

- `pg_hub_store_test`: op round-trips through `LoadSnapshot`, conditional save advancing + divergence repair, room-delete cascade.
- `pg_hub_e2e_test`: the restart-survival e2e. Two players drive a room → game → opening peeks → real moves through the actual smithy client stack; `RestartHub()` models a **crash** (the old generation is parked un-goodbyed — a crash closes nothing; only the store flushes, because the row truth must be complete before the successor reads it); both players resume by token into the same game on the brand-new hub, and the next move fans out to the restored table. Also: an emptied room vanishes from the database.
- `stream_test_fixture` grows `MakeVault`/`MakeStore` seams and `RestartHub`; the in-memory fixture and all existing `hub_e2e_test` behavior are unchanged (15/15 pass).

Two test-infrastructure findings worth noting for posterity: the in-memory pair's inline close resumes serving coroutines on the closing thread, so a mid-test teardown deadlocks on the registry's stream shares — hence the crash model instead of a drain; and undelivered event frames keep delivery chains holding stream shares, so the e2e drains each seat to its last known event at sync points.

## Deploy notes

No new configuration — the same `GOLF_HUB_DB_URL` from step 1 turns all of it on. First deploy after this creates the three tables via the in-service migrations. Known accepted edge (called out in #1194 discussion): members restored from a snapshot who never return have no grace timer, so a fully-abandoned room persists until its members' next actions — a sweep can reap those when it matters.

Remaining for #1194: step 3, LISTEN/NOTIFY fan-out — instances become interchangeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdYxwwdR5oFwZzTpf6Bra9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdYxwwdR5oFwZzTpf6Bra9)_