### PR TITLE
golf_hub: establish composed chat storage

### DIFF
--- a/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
+++ b/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
@@ -12,8 +12,10 @@
 
 - Retain at most the latest 100 committed messages per room.
 - Delete chat only with its room; deleting a member preserves prior messages.
-- Keep messages immutable plain text and reject empty/whitespace-only or more than 500 UTF-8 bytes.
-- Use server-assigned monotonic IDs and server time; delivery is at-least-once and consumers deduplicate by ID.
+- Keep messages immutable plain text and reject empty/whitespace-only or more than 500 UTF-8 bytes. Handlers reject so clients see a protocol error; stores re-check through `ValidateChatText` so retention stays bounded regardless of the caller.
+- Use server-assigned monotonic IDs and server time; delivery is at-least-once and consumers deduplicate by ID. `message_id` is the only ordering key — `sent_at_unix_millis` is wall-clock and display-only.
+- Retention can prune rows a lagging cursor never read. `LoadAfter` returns the oldest row still retained above the cursor and does not report the gap, so catch-up is bounded by the 100-row window, not by the cursor. A consumer more than 100 messages behind loses the difference by design.
+- `DropRoom` means different things per implementation: `MemoryChatStore` reclaims memory only through it, while PostgreSQL cascades from the room row and no-ops. Any handler path that deletes a room must call it, and that call needs its own coverage since PostgreSQL tests cannot catch a missing one.
 - Never log or emit metrics containing message text.
 - Every blocking concurrency test must have a bounded deadline.
 - Do not commit or push implementation checkpoints unless the user explicitly requests it.
@@ -35,6 +37,7 @@
   - `ChatStore::LoadRecent(room_id, limit) -> StatusOr<vector<ChatRow>>`
   - `ChatStore::LoadAfter(room_id, after_message_id, limit) -> StatusOr<vector<ChatRow>>`
   - `ChatStore::DropRoom(room_id)`
+  - `ValidateChatText(text) -> Status`, shared by handlers and every store
 
 - [x] **Step 1: Write failing memory-store tests**
 
@@ -235,6 +238,8 @@ Use two handlers, a shared gated store, condition variables, and bounded receive
 - [ ] **Step 4: Implement cursor catch-up**
 
 Subscribe `ChatChannel` with `RoomChannel`; on chat wake or active callback, load pages after the cursor in ascending order and deliver only rows whose IDs exceed it. Remove cursor state when the room drops.
+
+`ChatChannel` yields `chat_<room_id>` to match `RoomChannel`'s `room_<room_id>`. `LISTEN` cannot take a bind parameter, so quote the channel name as an identifier there and confirm room IDs stay inside PostgreSQL's 63-byte identifier limit; `NOTIFY` goes through `pg_notify($1, $2)`.
 
 - [ ] **Step 5: Add PostgreSQL two-instance tests**
 

--- a/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
+++ b/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
@@ -1,0 +1,321 @@
+# Per-Room Chat Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the latest 100 room-chat messages and deliver ordered, deduplicated chat across golf-hub instances, then expose it through the Golf web UI.
+
+**Architecture:** A composed `ChatStore` owns authoritative append and cursor reads without growing the existing room/game `HubStore`. PostgreSQL appends, prunes, and notifies atomically; handlers immediately deliver committed local rows and use a dedicated chat wake plus message-ID cursor for remote catch-up. Join/resume sends a bounded history event, and the browser merges history and live rows by ID.
+
+**Tech Stack:** C++20, Bazel, GoogleTest, Smithy, libpq/PostgreSQL, React, TypeScript, Vitest.
+
+## Global Constraints
+
+- Retain at most the latest 100 committed messages per room.
+- Delete chat only with its room; deleting a member preserves prior messages.
+- Keep messages immutable plain text and reject empty/whitespace-only or more than 500 UTF-8 bytes.
+- Use server-assigned monotonic IDs and server time; delivery is at-least-once and consumers deduplicate by ID.
+- Never log or emit metrics containing message text.
+- Every blocking concurrency test must have a bounded deadline.
+- Do not commit or push implementation checkpoints unless the user explicitly requests it.
+
+---
+
+### Task 1: Define the composed `ChatStore`
+
+**Files:**
+- Create: `domains/games/apis/golf_hub/chat_store.h`
+- Create: `domains/games/apis/golf_hub/chat_store.cc`
+- Create: `domains/games/apis/golf_hub/chat_store_test.cc`
+- Modify: `domains/games/apis/golf_hub/BUILD.bazel`
+
+**Interfaces:**
+- Produces:
+  - `ChatRow { int64_t message_id; std::string room_id; std::string player_id; std::string text; int64_t sent_at_unix_millis; }`
+  - `ChatStore::Append(room_id, player_id, text, notify_payload) -> StatusOr<ChatRow>`
+  - `ChatStore::LoadRecent(room_id, limit) -> StatusOr<vector<ChatRow>>`
+  - `ChatStore::LoadAfter(room_id, after_message_id, limit) -> StatusOr<vector<ChatRow>>`
+  - `ChatStore::DropRoom(room_id)`
+
+- [x] **Step 1: Write failing memory-store tests**
+
+Add tests that append rows, assert ascending reads, retain exactly 100 of 101 rows, bound recent/cursor reads, and erase history through `DropRoom`.
+
+```cpp
+auto first = store.Append("R1", "alice", "one", "ignored");
+ASSERT_TRUE(first.ok());
+EXPECT_EQ(first->message_id, 1);
+
+auto recent = store.LoadRecent("R1", 100);
+ASSERT_TRUE(recent.ok());
+ASSERT_EQ(recent->size(), 1u);
+EXPECT_EQ(recent->front().text, "one");
+```
+
+- [x] **Step 2: Verify RED**
+
+Run:
+
+```bash
+bazel test //domains/games/apis/golf_hub:chat_store_test
+```
+
+Observed: Bazel analysis failed because the new `chat_store` target did not exist.
+
+- [x] **Step 3: Implement the minimal memory store**
+
+Use one mutex-protected global `next_chat_id_` and `std::map<std::string, std::deque<ChatRow>> chats_`. The handler remains responsible for in-process authorization; timestamp with `system_clock` milliseconds, append, and pop from the front while size exceeds 100.
+
+- [x] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+bazel test //domains/games/apis/golf_hub:chat_store_test
+```
+
+Observed: `chat_store_test` and the unchanged `hub_store_test` pass.
+
+### Task 2: Add the durable schema and composed PostgreSQL chat store
+
+**Files:**
+- Modify: `domains/platform/libs/pg/pg.h`
+- Modify: `domains/platform/libs/pg/pg.cc`
+- Modify: `domains/platform/libs/pg/pg_test.cc`
+- Modify: `domains/games/apis/golf_hub/migrations.cc`
+- Create: `domains/games/apis/golf_hub/pg_chat_store.h`
+- Create: `domains/games/apis/golf_hub/pg_chat_store.cc`
+- Create: `domains/games/apis/golf_hub/pg_chat_store_test.cc`
+- Modify: `domains/games/apis/golf_hub/BUILD.bazel`
+
+**Interfaces:**
+- Consumes: Task 1 `ChatStore` interface.
+- Produces: a `pg::Client` transaction surface that holds the connection mutex from `BEGIN` through `COMMIT`/`ROLLBACK`, and an independent `PgChatStore`.
+
+- [ ] **Step 1: Write failing PostgreSQL tests**
+
+Cover migration idempotence, append/notify, ascending recent/after reads, missing member, member deletion preserving history, room cascade, 101-to-100 pruning, two-store concurrent appends, and rollback emitting neither row nor notify.
+
+- [ ] **Step 2: Verify RED against the local PostgreSQL test database**
+
+Run:
+
+```bash
+GOLF_HUB_TEST_DB_URL='postgresql://moonbase_test:moonbase_test@127.0.0.1:55432/moonbase_test' \
+  bazel test //domains/games/apis/golf_hub:pg_chat_store_test --test_output=errors
+```
+
+Expected: compile/schema failures for missing chat support.
+
+- [ ] **Step 3: Add transaction ownership to `pg::Client`**
+
+Expose a callback transaction API whose transaction object calls `ExecLocked`, rolls back on callback failure, and does not reconnect/retry after `BEGIN`. Add unit/integration coverage proving another `Client` caller cannot interleave statements on the same connection.
+
+- [ ] **Step 4: Add the schema**
+
+Create `room_chat_messages(message_id bigint GENERATED ALWAYS AS IDENTITY, room_id text REFERENCES rooms ON DELETE CASCADE, player_id text, body text, sent_at timestamptz)` with byte-length checks and `(room_id, message_id)` index.
+
+- [ ] **Step 5: Implement atomic append**
+
+Within one transaction: lock and verify the room/member, insert and return ID/time, prune rows older than the newest 100, notify `ChatChannel(room_id)`, then commit. Return `FailedPrecondition` when membership vanished and a failed status for database errors.
+
+- [ ] **Step 6: Implement bounded reads and verify GREEN**
+
+Recent reads select newest `LIMIT n` in a subquery and return ascending; cursor reads select `message_id > $2 ORDER BY message_id LIMIT $3`.
+
+Run the focused PostgreSQL test command from Step 2. Expected: pass.
+
+### Task 3: Extend the Smithy chat protocol
+
+**Files:**
+- Modify: `domains/games/apis/golf_hub/model/games.smithy`
+- Modify: `domains/games/apis/golf_hub/model/golf_hub.smithy`
+- Modify: `domains/games/apis/golf_hub/hub_e2e_test.cc`
+
+**Interfaces:**
+- Produces:
+  - `ChatMessage { messageId: Long, playerId: String, text: String, sentAtUnixMillis: Long }`
+  - `ChatMessages` list
+  - `ChatHistory { messages: ChatMessages }`
+  - `GolfEvents.roomChatHistory`
+
+- [ ] **Step 1: Update the e2e test to require enriched live chat and join history**
+
+Assert IDs are positive, timestamps are positive, history is ascending, and an existing member does not receive another member's history replay.
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+bazel test //domains/games/apis/golf_hub:hub_e2e_test
+```
+
+Expected: generated types lack the new members/event.
+
+- [ ] **Step 3: Update Smithy shapes**
+
+Add required ID/time fields to `ChatMessage` and the separate `roomChatHistory` event. Document that history/live overlap is legal and clients deduplicate by ID.
+
+- [ ] **Step 4: Build generated client/server code**
+
+Run:
+
+```bash
+bazel build //domains/games/apis/golf_hub:golf_hub_smithy_client \
+  //domains/games/apis/golf_hub:golf_hub_smithy_server
+```
+
+Expected: both targets build.
+
+### Task 4: Persist commands and replay history in `HubHandler`
+
+**Files:**
+- Modify: `domains/games/apis/golf_hub/hub_handler.h`
+- Modify: `domains/games/apis/golf_hub/hub_handler.cc`
+- Modify: `domains/games/apis/golf_hub/hub_e2e_test.cc`
+
+**Interfaces:**
+- Consumes: Tasks 1-3 chat-store/protocol types.
+- Produces: persisted local chat delivery and join/resume history replay.
+
+- [ ] **Step 1: Add failing e2e tests**
+
+Test whitespace rejection, durable append before echo, latest-100 history on join, history on resume, no replay to existing members, and store failure producing `commandRejected` without `roomChat`.
+
+- [ ] **Step 2: Verify RED**
+
+Run the focused `hub_e2e_test`; expected failures show the current local-only fan-out and absent history.
+
+- [ ] **Step 3: Replace local-only chat**
+
+Resolve room ID under `mu_`, release the lock for `ChatStore::Append`, reacquire to ensure the sender still belongs to that room, stage the returned row to current local members, advance the room cursor, then deliver outside the lock. Inject `std::shared_ptr<ChatStore>` separately from `HubStore`, defaulting to `MemoryChatStore`.
+
+- [ ] **Step 4: Replay history**
+
+Load recent rows outside `mu_` during join/resume and send one `roomChatHistory` only to the admitted stream after `roomState`. Convert every row through one `ChatEvent` helper shared with live delivery.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```bash
+bazel test //domains/games/apis/golf_hub:hub_e2e_test \
+  //domains/games/apis/golf_hub:hub_store_test
+```
+
+Expected: pass.
+
+### Task 5: Add subscription catch-up and cross-instance fan-out
+
+**Files:**
+- Modify: `domains/platform/libs/pg/listener.h`
+- Modify: `domains/platform/libs/pg/listener.cc`
+- Modify: `domains/platform/libs/pg/listener_test.cc`
+- Modify: `domains/games/apis/golf_hub/hub_handler.h`
+- Modify: `domains/games/apis/golf_hub/hub_handler.cc`
+- Create: `domains/games/apis/golf_hub/hub_chat_race_test.cc`
+- Modify: `domains/games/apis/golf_hub/pg_hub_e2e_test.cc`
+- Modify: `domains/games/apis/golf_hub/BUILD.bazel`
+
+**Interfaces:**
+- Produces: `ChatChannel(room_id)`, listener active/re-subscribed callback, per-room highest delivered ID, and paged catch-up.
+
+- [ ] **Step 1: Write failing listener synchronization test**
+
+Subscribe once, wait on a condition variable for an active-channel callback, then send exactly one notification. Terminate the backend, assert a second active callback after re-LISTEN, and send exactly one post-reconnect notification.
+
+- [ ] **Step 2: Implement listener active signaling**
+
+Make `LISTEN` report success, update `active_` only for successful statements, and invoke the optional callback after a channel first becomes active on a connection. Never hold the listener mutex while invoking owner code.
+
+- [ ] **Step 3: Write deterministic no-PostgreSQL handler race tests**
+
+Use two handlers, a shared gated store, condition variables, and bounded receives. Cover delayed/coalesced/duplicate/own wakes, paging, room drop, and history/live overlap.
+
+- [ ] **Step 4: Implement cursor catch-up**
+
+Subscribe `ChatChannel` with `RoomChannel`; on chat wake or active callback, load pages after the cursor in ascending order and deliver only rows whose IDs exceed it. Remove cursor state when the room drops.
+
+- [ ] **Step 5: Add PostgreSQL two-instance tests**
+
+Split clients across instances, exchange messages both ways, kill/reconnect a listener during a send, join a third client for history, and verify room deletion cascades.
+
+- [ ] **Step 6: Verify GREEN and stress**
+
+Run:
+
+```bash
+bazel test //domains/platform/libs/pg:listener_test \
+  //domains/games/apis/golf_hub:hub_chat_race_test \
+  //domains/games/apis/golf_hub:pg_hub_e2e_test --test_output=errors
+```
+
+Then repeat the deterministic race target 100 times. Expected: no duplicates, loss, or timeout.
+
+### Task 6: Observability, formatting, and backend regression
+
+**Files:**
+- Modify: `domains/games/apis/golf_hub/hub_handler.cc`
+- Modify: comments in `domains/games/apis/golf_hub/hub_handler.h`
+- Modify: comments in `domains/games/apis/golf_hub/chat_store.h`
+
+- [ ] **Step 1: Add metric assertions**
+
+Assert append success/failure, catch-up rows, and history-load failures are counted without room IDs or message text.
+
+- [ ] **Step 2: Implement counters and update contracts**
+
+Document retention, ordering, at-least-once delivery, listener recovery, and the process-local limitation of `MemoryChatStore`.
+
+- [ ] **Step 3: Run the backend regression suite**
+
+```bash
+bazel test //domains/games/apis/golf_hub/... //domains/platform/libs/pg/...
+```
+
+Expected: all tests pass (database-gated tests run when their URLs are inherited).
+
+- [ ] **Step 4: Format and inspect**
+
+Run `clang-format --dry-run --Werror` over every changed C++ file, then inspect `git diff --check` and `git status`.
+
+### Task 7: Implement the web UI in `muchq/muchq.github.io`
+
+**Repository:** `https://github.com/muchq/muchq.github.io`
+
+**Files:**
+- Modify: `src/types/golfAdapter.ts`
+- Modify: `src/utils/golfV2Adapter.ts`
+- Modify: `src/hooks/useGolfGame.ts`
+- Create: `src/apps/golf/components/RoomChat.tsx`
+- Create: `src/apps/golf/components/RoomChat.module.css`
+- Create: `src/apps/golf/components/__tests__/RoomChat.test.tsx`
+- Modify: `src/apps/golf/components/GolfGame.tsx`
+- Modify: `src/apps/golf/components/GolfGame.module.css`
+- Add focused adapter and hook tests under existing `src/**/__tests__` locations.
+
+- [ ] **Step 1: Create a separate issue branch in the UI repository after the backend event shape is stable**
+
+- [ ] **Step 2: Write failing adapter tests**
+
+Require exact chat command JSON, enriched live/history parsing, ID deduplication, ordering, and reconnect merge.
+
+- [ ] **Step 3: Add typed chat state and actions**
+
+Expose `ChatMessage[]`, `sendChat(text)`, history/live callbacks, room-scoped clearing, a 100-row cap, and unread state.
+
+- [ ] **Step 4: Write failing component tests**
+
+Cover empty state, literal HTML-looking text, byte limit, Enter/Shift+Enter, offline disabled state, draft preservation, unread behavior, focus management, and restrained `aria-live`.
+
+- [ ] **Step 5: Build the responsive component**
+
+Render a desktop side panel and mobile drawer without covering game controls. Preserve scroll unless near the bottom and provide a new-message affordance otherwise.
+
+- [ ] **Step 6: Integrate lobby and game views**
+
+Keep one room-scoped chat instance alive across lobby/game transitions and clear it on room leave/switch.
+
+- [ ] **Step 7: Verify**
+
+Run repository lint, typecheck, Vitest, and production build commands from `package.json`; then review desktop, tablet, and narrow-phone screenshots.

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -93,7 +93,10 @@ cc_library(
     name = "chat_store",
     srcs = ["chat_store.cc"],
     hdrs = ["chat_store.h"],
-    deps = ["@com_google_absl//absl/status:statusor"],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
 )
 
 cc_test(
@@ -102,6 +105,7 @@ cc_test(
     srcs = ["chat_store_test.cc"],
     deps = [
         ":chat_store",
+        "@com_google_absl//absl/status",
         "@googletest//:gtest_main",
     ],
 )

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -89,6 +89,23 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "chat_store",
+    srcs = ["chat_store.cc"],
+    hdrs = ["chat_store.h"],
+    deps = ["@com_google_absl//absl/status:statusor"],
+)
+
+cc_test(
+    name = "chat_store_test",
+    size = "small",
+    srcs = ["chat_store_test.cc"],
+    deps = [
+        ":chat_store",
+        "@googletest//:gtest_main",
+    ],
+)
+
 # The postgres-backed vault and the hub's schema (#1194 step 1).
 cc_library(
     name = "pg_ticket_vault",

--- a/domains/games/apis/golf_hub/chat_store.cc
+++ b/domains/games/apis/golf_hub/chat_store.cc
@@ -2,14 +2,25 @@
 
 #include <algorithm>
 #include <chrono>
-#include <utility>
 
 namespace golf_hub {
+
+absl::Status ValidateChatText(const std::string& text) {
+  if (text.find_first_not_of(" \t\n\r\f\v") == std::string::npos) {
+    return absl::InvalidArgumentError("chat text is empty");
+  }
+  if (text.size() > kChatTextByteLimit) {
+    return absl::InvalidArgumentError("chat text is too long");
+  }
+  return absl::OkStatus();
+}
 
 absl::StatusOr<ChatRow> MemoryChatStore::Append(const std::string& room_id,
                                                 const std::string& player_id,
                                                 const std::string& text,
                                                 const std::string& /*notify_payload*/) {
+  if (const absl::Status valid = ValidateChatText(text); !valid.ok()) return valid;
+
   const std::lock_guard<std::mutex> lock(mu_);
   ChatRow row;
   row.message_id = next_message_id_++;

--- a/domains/games/apis/golf_hub/chat_store.cc
+++ b/domains/games/apis/golf_hub/chat_store.cc
@@ -1,0 +1,61 @@
+#include "domains/games/apis/golf_hub/chat_store.h"
+
+#include <algorithm>
+#include <chrono>
+#include <utility>
+
+namespace golf_hub {
+
+absl::StatusOr<ChatRow> MemoryChatStore::Append(const std::string& room_id,
+                                                const std::string& player_id,
+                                                const std::string& text,
+                                                const std::string& /*notify_payload*/) {
+  const std::lock_guard<std::mutex> lock(mu_);
+  ChatRow row;
+  row.message_id = next_message_id_++;
+  row.room_id = room_id;
+  row.player_id = player_id;
+  row.text = text;
+  row.sent_at_unix_millis = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::system_clock::now().time_since_epoch())
+                                .count();
+
+  auto& chat = chats_[room_id];
+  chat.push_back(row);
+  while (chat.size() > kChatHistoryLimit) chat.pop_front();
+  return row;
+}
+
+absl::StatusOr<std::vector<ChatRow>> MemoryChatStore::LoadRecent(const std::string& room_id,
+                                                                 std::size_t limit) {
+  const std::lock_guard<std::mutex> lock(mu_);
+  std::vector<ChatRow> rows;
+  const auto chat = chats_.find(room_id);
+  if (chat == chats_.end() || limit == 0) return rows;
+  const std::size_t start = chat->second.size() - std::min(limit, chat->second.size());
+  rows.insert(rows.end(), chat->second.begin() + static_cast<std::ptrdiff_t>(start),
+              chat->second.end());
+  return rows;
+}
+
+absl::StatusOr<std::vector<ChatRow>> MemoryChatStore::LoadAfter(const std::string& room_id,
+                                                                int64_t after_message_id,
+                                                                std::size_t limit) {
+  const std::lock_guard<std::mutex> lock(mu_);
+  std::vector<ChatRow> rows;
+  const auto chat = chats_.find(room_id);
+  if (chat == chats_.end() || limit == 0) return rows;
+  for (const ChatRow& row : chat->second) {
+    if (row.message_id <= after_message_id) continue;
+    rows.push_back(row);
+    if (rows.size() == limit) break;
+  }
+  return rows;
+}
+
+void MemoryChatStore::DropRoom(const std::string& room_id) {
+  const std::lock_guard<std::mutex> lock(mu_);
+  chats_.erase(room_id);
+}
+
+}  // namespace golf_hub

--- a/domains/games/apis/golf_hub/chat_store.h
+++ b/domains/games/apis/golf_hub/chat_store.h
@@ -9,13 +9,23 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
 namespace golf_hub {
 
 inline constexpr std::size_t kChatHistoryLimit = 100;
-inline std::string ChatChannel(const std::string& room_id) { return "golf_chat_" + room_id; }
+inline constexpr std::size_t kChatTextByteLimit = 500;
+inline std::string ChatChannel(const std::string& room_id) { return "chat_" + room_id; }
 
+/// Rejects empty/whitespace-only text and text over kChatTextByteLimit bytes.
+/// Handlers validate before appending so clients get a protocol-level
+/// rejection; stores call it again so retention stays bounded regardless.
+absl::Status ValidateChatText(const std::string& text);
+
+/// One committed message. message_id is the only ordering key: timestamps
+/// come from the wall clock and can move backwards across an adjustment, so
+/// sent_at_unix_millis is for display, never for sorting or deduplication.
 struct ChatRow {
   int64_t message_id = 0;
   std::string room_id;
@@ -27,23 +37,38 @@ struct ChatRow {
 /// Authoritative, ordered room-chat persistence. Room membership remains
 /// HubHandler/HubStore's responsibility; PostgreSQL implementations also
 /// guard appends against the durable membership row in their transaction.
+/// Rooms retain their newest kChatHistoryLimit messages and nothing older.
 class ChatStore {
  public:
   virtual ~ChatStore() = default;
 
+  /// Commits one message and returns the row that readers will observe.
   virtual absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,
                                          const std::string& text,
                                          const std::string& notify_payload) = 0;
+
+  /// The newest `limit` retained rows, ascending by message_id.
   virtual absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
                                                           std::size_t limit) = 0;
+
+  /// Retained rows above `after_message_id`, ascending, at most `limit`.
+  /// Retention prunes rows a lagging cursor never read: this returns the
+  /// oldest row still retained above the cursor and does not report the gap,
+  /// so catch-up is bounded by kChatHistoryLimit rather than by the cursor.
   virtual absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
                                                          int64_t after_message_id,
                                                          std::size_t limit) = 0;
+
+  /// Erases a room's history. MemoryChatStore reclaims memory only here, so
+  /// handlers must call this whenever a room is deleted; PostgreSQL
+  /// implementations cascade from the room row and no-op.
   virtual void DropRoom(const std::string& room_id) = 0;
 };
 
 /// Process-local chat persistence for non-PostgreSQL production and tests.
 /// The handler authorizes appends; this class owns ordering and retention.
+/// History does not survive a restart and does not reach other instances,
+/// and rooms accumulate until DropRoom erases them.
 class MemoryChatStore final : public ChatStore {
  public:
   absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,

--- a/domains/games/apis/golf_hub/chat_store.h
+++ b/domains/games/apis/golf_hub/chat_store.h
@@ -1,0 +1,67 @@
+#ifndef DOMAINS_GAMES_APIS_GOLF_HUB_CHAT_STORE_H
+#define DOMAINS_GAMES_APIS_GOLF_HUB_CHAT_STORE_H
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "absl/status/statusor.h"
+
+namespace golf_hub {
+
+inline constexpr std::size_t kChatHistoryLimit = 100;
+inline std::string ChatChannel(const std::string& room_id) { return "golf_chat_" + room_id; }
+
+struct ChatRow {
+  int64_t message_id = 0;
+  std::string room_id;
+  std::string player_id;
+  std::string text;
+  int64_t sent_at_unix_millis = 0;
+};
+
+/// Authoritative, ordered room-chat persistence. Room membership remains
+/// HubHandler/HubStore's responsibility; PostgreSQL implementations also
+/// guard appends against the durable membership row in their transaction.
+class ChatStore {
+ public:
+  virtual ~ChatStore() = default;
+
+  virtual absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,
+                                         const std::string& text,
+                                         const std::string& notify_payload) = 0;
+  virtual absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
+                                                          std::size_t limit) = 0;
+  virtual absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
+                                                         int64_t after_message_id,
+                                                         std::size_t limit) = 0;
+  virtual void DropRoom(const std::string& room_id) = 0;
+};
+
+/// Process-local chat persistence for non-PostgreSQL production and tests.
+/// The handler authorizes appends; this class owns ordering and retention.
+class MemoryChatStore final : public ChatStore {
+ public:
+  absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,
+                                 const std::string& text,
+                                 const std::string& notify_payload) override;
+  absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
+                                                  std::size_t limit) override;
+  absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
+                                                 int64_t after_message_id,
+                                                 std::size_t limit) override;
+  void DropRoom(const std::string& room_id) override;
+
+ private:
+  std::mutex mu_;
+  std::map<std::string, std::deque<ChatRow>> chats_;
+  int64_t next_message_id_ = 1;
+};
+
+}  // namespace golf_hub
+
+#endif

--- a/domains/games/apis/golf_hub/chat_store_test.cc
+++ b/domains/games/apis/golf_hub/chat_store_test.cc
@@ -1,0 +1,79 @@
+#include "domains/games/apis/golf_hub/chat_store.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace golf_hub {
+namespace {
+
+TEST(MemoryChatStoreTest, AppendsAndReadsRowsInMessageOrder) {
+  MemoryChatStore store;
+
+  auto first = store.Append("R1", "alice", "one", "ignored");
+  ASSERT_TRUE(first.ok());
+  EXPECT_EQ(first->message_id, 1);
+  EXPECT_EQ(first->room_id, "R1");
+  EXPECT_EQ(first->player_id, "alice");
+  EXPECT_EQ(first->text, "one");
+  EXPECT_GT(first->sent_at_unix_millis, 0);
+
+  auto second = store.Append("R1", "bob", "two", "ignored");
+  ASSERT_TRUE(second.ok());
+  EXPECT_GT(second->message_id, first->message_id);
+
+  auto recent = store.LoadRecent("R1", 100);
+  ASSERT_TRUE(recent.ok());
+  ASSERT_EQ(recent->size(), 2u);
+  EXPECT_EQ((*recent)[0].text, "one");
+  EXPECT_EQ((*recent)[1].text, "two");
+
+  auto after_first = store.LoadAfter("R1", first->message_id, 100);
+  ASSERT_TRUE(after_first.ok());
+  ASSERT_EQ(after_first->size(), 1u);
+  EXPECT_EQ(after_first->front().message_id, second->message_id);
+}
+
+TEST(MemoryChatStoreTest, RetainsLatestHundredAndDropsRoomHistory) {
+  MemoryChatStore store;
+  for (int i = 1; i <= 101; ++i) {
+    auto appended = store.Append("R1", "alice", "message-" + std::to_string(i), "ignored");
+    ASSERT_TRUE(appended.ok());
+  }
+
+  auto recent = store.LoadRecent("R1", 100);
+  ASSERT_TRUE(recent.ok());
+  ASSERT_EQ(recent->size(), 100u);
+  EXPECT_EQ(recent->front().text, "message-2");
+  EXPECT_EQ(recent->back().text, "message-101");
+
+  store.DropRoom("R1");
+  recent = store.LoadRecent("R1", 100);
+  ASSERT_TRUE(recent.ok());
+  EXPECT_TRUE(recent->empty());
+}
+
+TEST(MemoryChatStoreTest, LimitsRecentAndCursorReads) {
+  MemoryChatStore store;
+  for (int i = 1; i <= 5; ++i) {
+    ASSERT_TRUE(store.Append("R1", "alice", std::to_string(i), "ignored").ok());
+  }
+
+  auto recent = store.LoadRecent("R1", 2);
+  ASSERT_TRUE(recent.ok());
+  ASSERT_EQ(recent->size(), 2u);
+  EXPECT_EQ(recent->front().text, "4");
+  EXPECT_EQ(recent->back().text, "5");
+
+  auto after = store.LoadAfter("R1", 1, 2);
+  ASSERT_TRUE(after.ok());
+  ASSERT_EQ(after->size(), 2u);
+  EXPECT_EQ(after->front().text, "2");
+  EXPECT_EQ(after->back().text, "3");
+
+  ASSERT_TRUE(store.LoadRecent("R1", 0)->empty());
+  ASSERT_TRUE(store.LoadAfter("R1", 0, 0)->empty());
+}
+
+}  // namespace
+}  // namespace golf_hub

--- a/domains/games/apis/golf_hub/chat_store_test.cc
+++ b/domains/games/apis/golf_hub/chat_store_test.cc
@@ -2,7 +2,15 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <vector>
+
+#include "absl/status/status.h"
 
 namespace golf_hub {
 namespace {
@@ -71,8 +79,104 @@ TEST(MemoryChatStoreTest, LimitsRecentAndCursorReads) {
   EXPECT_EQ(after->front().text, "2");
   EXPECT_EQ(after->back().text, "3");
 
-  ASSERT_TRUE(store.LoadRecent("R1", 0)->empty());
-  ASSERT_TRUE(store.LoadAfter("R1", 0, 0)->empty());
+  const auto oversized = store.LoadRecent("R1", 50);
+  ASSERT_TRUE(oversized.ok());
+  EXPECT_EQ(oversized->size(), 5u);
+
+  const auto past_newest = store.LoadAfter("R1", 5, 100);
+  ASSERT_TRUE(past_newest.ok());
+  EXPECT_TRUE(past_newest->empty());
+
+  const auto no_recent = store.LoadRecent("R1", 0);
+  ASSERT_TRUE(no_recent.ok());
+  EXPECT_TRUE(no_recent->empty());
+
+  const auto no_after = store.LoadAfter("R1", 0, 0);
+  ASSERT_TRUE(no_after.ok());
+  EXPECT_TRUE(no_after->empty());
+}
+
+TEST(MemoryChatStoreTest, KeepsRoomsIsolated) {
+  MemoryChatStore store;
+  const auto first = store.Append("R1", "alice", "room one", "ignored");
+  const auto second = store.Append("R2", "bob", "room two", "ignored");
+  ASSERT_TRUE(first.ok());
+  ASSERT_TRUE(second.ok());
+  EXPECT_GT(second->message_id, first->message_id);
+
+  const auto one = store.LoadRecent("R1", 100);
+  ASSERT_TRUE(one.ok());
+  ASSERT_EQ(one->size(), 1u);
+  EXPECT_EQ(one->front().text, "room one");
+
+  // A room's cursor reads never see IDs the shared counter handed another room.
+  const auto after_gap = store.LoadAfter("R2", first->message_id, 100);
+  ASSERT_TRUE(after_gap.ok());
+  ASSERT_EQ(after_gap->size(), 1u);
+  EXPECT_EQ(after_gap->front().text, "room two");
+
+  store.DropRoom("R1");
+  const auto survivor = store.LoadRecent("R2", 100);
+  ASSERT_TRUE(survivor.ok());
+  EXPECT_EQ(survivor->size(), 1u);
+
+  store.DropRoom("never-existed");
+  const auto unknown = store.LoadRecent("never-existed", 100);
+  ASSERT_TRUE(unknown.ok());
+  EXPECT_TRUE(unknown->empty());
+}
+
+TEST(MemoryChatStoreTest, RejectsEmptyAndOversizedText) {
+  MemoryChatStore store;
+  EXPECT_EQ(store.Append("R1", "alice", "", "ignored").status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(store.Append("R1", "alice", " \t\n", "ignored").status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(store.Append("R1", "alice", std::string(kChatTextByteLimit + 1, 'x'), "ignored")
+                .status()
+                .code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_TRUE(store.Append("R1", "alice", std::string(kChatTextByteLimit, 'x'), "ignored").ok());
+
+  const auto recent = store.LoadRecent("R1", 100);
+  ASSERT_TRUE(recent.ok());
+  EXPECT_EQ(recent->size(), 1u);
+}
+
+TEST(MemoryChatStoreTest, ConcurrentAppendsGetUniqueAscendingIds) {
+  constexpr int kThreads = 4;
+  constexpr int kPerThread = 50;
+  MemoryChatStore store;
+
+  std::mutex mu;
+  std::vector<int64_t> ids;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&store, &mu, &ids, t] {
+      const std::string room_id = t % 2 == 0 ? "R1" : "R2";
+      for (int i = 0; i < kPerThread; ++i) {
+        auto appended = store.Append(room_id, "alice", std::to_string(i), "ignored");
+        ASSERT_TRUE(appended.ok());
+        const std::lock_guard<std::mutex> lock(mu);
+        ids.push_back(appended->message_id);
+      }
+    });
+  }
+  for (std::thread& thread : threads) thread.join();
+
+  ASSERT_EQ(ids.size(), static_cast<std::size_t>(kThreads * kPerThread));
+  std::sort(ids.begin(), ids.end());
+  EXPECT_EQ(std::adjacent_find(ids.begin(), ids.end()), ids.end());
+
+  for (const char* room_id : {"R1", "R2"}) {
+    const auto rows = store.LoadRecent(room_id, kChatHistoryLimit);
+    ASSERT_TRUE(rows.ok());
+    EXPECT_EQ(rows->size(), kChatHistoryLimit);
+    EXPECT_TRUE(std::is_sorted(
+        rows->begin(), rows->end(),
+        [](const ChatRow& lhs, const ChatRow& rhs) { return lhs.message_id < rhs.message_id; }));
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- introduce a focused `ChatStore` abstraction instead of expanding the existing room/game `HubStore`
- add an in-memory implementation with monotonic IDs, ordered cursor reads, 100-message retention, and room cleanup
- document the remaining PostgreSQL, protocol, fan-out, and web UI implementation plan

Part of #1226.

## Test plan
- [x] `bazel test //domains/games/apis/golf_hub:chat_store_test //domains/games/apis/golf_hub:hub_store_test //domains/games/apis/golf_hub:hub_e2e_test //domains/games/apis/golf_hub:hub_store_race_test //domains/platform/libs/pg:listener_test`
- [x] `clang-format --dry-run --Werror domains/games/apis/golf_hub/chat_store.h domains/games/apis/golf_hub/chat_store.cc domains/games/apis/golf_hub/chat_store_test.cc`
- [x] `git diff --check`
