### PR TITLE
golf_hub: bound the e2e receive helpers on a deadline

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "2ba6bd84023d231d8ed30cb12e3e3551f31a3d08",
+    commit = "c9592b46647e2a94e7dc1ad5dcaf4b7e2119b6cc",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -35,13 +35,41 @@
 
 namespace golf_hub {
 
+// How long a receive helper waits in total for the event it wants. The
+// frame counts below bound the wrong-events case; this bounds the case
+// they cannot see — an expectation for an event the hub never sends,
+// which without a deadline blocks inside Receive() forever and burns the
+// test's whole timeout with nothing to show for it.
+inline constexpr std::chrono::milliseconds kReceiveBudget{5000};
+
+// Spends what is left of `budget` on one receive, or reports the timeout
+// itself when the budget is gone. Feeding the remainder to each call
+// keeps the helper's total wait bounded no matter how many frames arrive.
+inline auto ReceiveWithin(moonbase::golf::PlayClientStream& stream,
+                          std::chrono::steady_clock::time_point deadline) {
+  const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+      deadline - std::chrono::steady_clock::now());
+  // A non-positive deadline polls rather than blocks, which is what we
+  // want on the last look: take an event already in hand, else time out.
+  return stream.Receive(remaining);
+}
+
 // Receives until an event of the wanted case arrives (skipping others),
-// failing after a few frames so a wrong stream can't hang the test.
+// giving up after a few frames so a wrong stream can't hang the test, or
+// after kReceiveBudget so a silent one can't either.
 inline std::optional<moonbase::golf::GolfEvents> ReceiveCase(
-    moonbase::golf::PlayClientStream& stream, const std::string& wanted) {
+    moonbase::golf::PlayClientStream& stream, const std::string& wanted,
+    std::chrono::milliseconds budget = kReceiveBudget) {
+  const auto deadline = std::chrono::steady_clock::now() + budget;
   for (int i = 0; i < 8; ++i) {
-    auto received = stream.Receive();
-    if (!received.ok() || !received->has_value()) return std::nullopt;
+    auto received = ReceiveWithin(stream, deadline);
+    if (!received.ok()) {
+      // Name the event nobody sent: the whole point of the deadline is a
+      // test that says what it was waiting for instead of hanging.
+      ADD_FAILURE() << "gave up waiting for " << wanted << ": " << received.error().message();
+      return std::nullopt;
+    }
+    if (!received->has_value()) return std::nullopt;
     if (wanted == (*received)->case_name()) return **received;
   }
   return std::nullopt;
@@ -50,10 +78,16 @@ inline std::optional<moonbase::golf::GolfEvents> ReceiveCase(
 // Same, but tunnels into the golf envelope: returns the first GolfUpdate
 // of the wanted case, skipping room noise and other updates in between.
 inline std::optional<moonbase::golf::GolfUpdate> ReceiveGolf(
-    moonbase::golf::PlayClientStream& stream, const std::string& wanted) {
+    moonbase::golf::PlayClientStream& stream, const std::string& wanted,
+    std::chrono::milliseconds budget = kReceiveBudget) {
+  const auto deadline = std::chrono::steady_clock::now() + budget;
   for (int i = 0; i < 16; ++i) {
-    auto received = stream.Receive();
-    if (!received.ok() || !received->has_value()) return std::nullopt;
+    auto received = ReceiveWithin(stream, deadline);
+    if (!received.ok()) {
+      ADD_FAILURE() << "gave up waiting for golf " << wanted << ": " << received.error().message();
+      return std::nullopt;
+    }
+    if (!received->has_value()) return std::nullopt;
     const auto* envelope = (*received)->as_golf_or_null();
     if (envelope == nullptr) continue;
     if (wanted == envelope->update.case_name()) return envelope->update;


### PR DESCRIPTION
Bumps smithy-cpp to pick up `WebSocket::Receive(timeout)` (upstream #129) and uses it to bound the e2e receive helpers.

## Why

`ReceiveCase` already gave up after 8 frames, which covers the wrong events arriving. It did nothing for the case that actually bit us on #1229: an expectation for an event the hub never sends. The frame loop never advances, because the block is inside `Receive()`, so the test hangs until the harness kills it — no assertion, no indication of what it was waiting for. That cost a debugging cycle and surfaced only locally, since the streaming suites don't run in restricted-egress CI.

Upstream added a deadline for exactly this. `EventStream::Receive(timeout)` returns `Error::Timeout` ("TimeoutError") distinctly from a clean close and from a session error, and a timeout leaves the session usable — so a helper can stop waiting without ending the stream.

## The helpers

Both `ReceiveCase` and `ReceiveGolf` take a total budget, defaulting to 5s, and feed each call whatever is left of it. Bounding the total rather than each receive keeps the worst case at one budget instead of budget × frame-count, which matters at `size = "small"`.

On expiry they `ADD_FAILURE()` naming the event nobody sent, then return `nullopt` as before. No call site changes — every existing caller already treats `nullopt` as a failure path — so the difference is that a silent hang becomes a red test that says what it wanted.

## The pin

`2ba6bd84` → `c9592b4`. Deliberate, per the note in `bazel/smithy.MODULE.bazel`, and it carries upstream #125–#129, not only the deadline.

Upstream made `Receive(timeout)` pure virtual, which is breaking for consumers that implement `smithy::http::WebSocket` themselves. We don't: the fixtures get their sockets from `smithy::http::InMemoryWebSocketPair::Create()` and only hold them as `shared_ptr`. Nothing under `domains/` implements the interface, so there's no adapter here to update.

## Test plan

The Smithy client and server targets build against the new pin — codegen reran and the generated sources compile — and `chat_store_test`, `hub_store_test`, `ticket_vault_test`, and `id_generator_test` pass.

The e2e suites themselves aren't built here: `hub_e2e_test` needs `boost.beast`, whose archive this sandbox's egress policy blocks (see `docs/BUILD_AND_IDE.md`). Since the helper change lives in `stream_test_fixture.h`, which only those suites use, **this needs a local `bazel test //domains/games/apis/golf_hub/...` before merge** — that's the only thing that exercises the change at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY8cFki7eChwYq76DY7hU9)_