### PR TITLE
golf_hub: replay chat history to joining and resuming streams

### DIFF
--- a/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
+++ b/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
@@ -186,19 +186,23 @@ Expected: both targets build.
 - Consumes: Tasks 1-3 chat-store/protocol types.
 - Produces: persisted local chat delivery and join/resume history replay.
 
-- [ ] **Step 1: Add failing e2e tests**
+- [x] **Step 1: Add failing e2e tests**
 
 Test whitespace rejection, durable append before echo, latest-100 history on join, history on resume, no replay to existing members, and store failure producing `commandRejected` without `roomChat`.
 
-- [ ] **Step 2: Verify RED**
+Observed: whitespace rejection, durable-append-before-echo, and store-failure-rejects landed with Task 3 (#1229). History-on-join (frame-order asserted), empty-history-on-join, no-replay-to-existing-members, and history-on-resume landed with this task. Resume is exercised through a second handler instance sharing the first's vault and stores — the store-restart shape of resume — rather than by simulating a wire failure, which the in-memory transport does not model. The latest-100 boundary stays pinned at the store layer (both stores); the e2e pins the wiring, ordering, and audience.
+
+- [x] **Step 2: Verify RED**
 
 Run the focused `hub_e2e_test`; expected failures show the current local-only fan-out and absent history.
 
-- [ ] **Step 3: Replace local-only chat**
+Observed: not runnable in the restricted-egress sandbox (`boost.beast`, see `docs/BUILD_AND_IDE.md`); the new tests fail by construction against a handler with no history path, and the GREEN half of the loop runs locally.
+
+- [x] **Step 3: Replace local-only chat** (landed with Task 3, #1229)
 
 Resolve room ID under `mu_`, release the lock for `ChatStore::Append`, reacquire to stage the returned row to current local members, advance the room cursor, then deliver outside the lock. Inject `std::shared_ptr<ChatStore>` separately from `HubStore`, defaulting to `MemoryChatStore`; its `MemberGuard` reacquires `mu_`, verifies membership, and invokes the memory append before releasing that lock.
 
-- [ ] **Step 4: Replay history**
+- [x] **Step 4: Replay history**
 
 Load recent rows outside `mu_` during join/resume and send one `roomChatHistory` only to the admitted stream after `roomState`. Convert every row through one `ChatEvent` helper shared with live delivery.
 

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -6,8 +6,13 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "domains/games/apis/golf_hub/stream_test_fixture.h"
 
@@ -24,6 +29,73 @@ std::string WithNul(std::string prefix, std::string suffix) {
   prefix.push_back('\0');
   prefix.append(suffix);
   return prefix;
+}
+
+// One frame, bounded, no skipping — for asserting exact event order.
+// ReceiveCase would silently step over an event that must not be there.
+std::optional<moonbase::golf::GolfEvents> NextEvent(moonbase::golf::PlayClientStream& stream) {
+  auto received = stream.Receive(std::chrono::seconds(5));
+  if (!received.ok()) {
+    ADD_FAILURE() << "receive failed mid-sequence: " << received.error().message();
+    return std::nullopt;
+  }
+  if (!received->has_value()) {
+    ADD_FAILURE() << "stream closed mid-sequence";
+    return std::nullopt;
+  }
+  return **received;
+}
+
+// A whole second hub sharing the first one's durable pieces — the
+// hub_store_race_test pattern. Restoring from the shared store is what a
+// process restart looks like from the store's side, so resuming here
+// exercises the membership-decides-the-resync branch of Play() without
+// simulating a wire failure.
+struct SecondInstance {
+  std::shared_ptr<HubHandler> handler;
+  std::unique_ptr<moonbase::golf::GolfHubServer> server;
+  std::unique_ptr<moonbase::golf::GolfHubClient> client;
+  std::vector<std::shared_ptr<smithy::http::WebSocket>> sessions;
+
+  ~SecondInstance() {
+    for (auto& session : sessions) session->Close();
+  }
+};
+
+std::unique_ptr<SecondInstance> BuildSecondInstance(std::shared_ptr<TicketVault> vault,
+                                                    std::shared_ptr<HubStore> store,
+                                                    std::shared_ptr<ChatStore> chat_store) {
+  auto instance = std::make_unique<SecondInstance>();
+  instance->handler = std::make_shared<HubHandler>(
+      std::move(vault), std::make_shared<cards::NoShuffleDealer>(),
+      std::make_shared<SequentialIdGenerator>(), std::chrono::seconds(60),
+      std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), std::move(store),
+      std::move(chat_store));
+  EXPECT_TRUE(instance->handler->RestoreFromStore().ok());
+  instance->server = std::make_unique<moonbase::golf::GolfHubServer>(instance->handler);
+
+  auto loopback = std::make_shared<smithy::http::Loopback>();
+  EXPECT_TRUE(loopback->Start(instance->server->Handler()).ok());
+  smithy::ClientConfig config;
+  config.retry.max_attempts = 1;
+  config.http_client = loopback;
+  SecondInstance* raw = instance.get();
+  config.websocket_dialer = [raw](const smithy::http::WebSocketDialRequest& request)
+      -> smithy::Outcome<std::shared_ptr<smithy::http::WebSocket>> {
+    auto [near, far] = smithy::http::InMemoryWebSocketPair::Create();
+    smithy::http::HttpRequest upgrade;
+    upgrade.method = "GET";
+    upgrade.target = request.target;
+    upgrade.headers = request.headers;
+    raw->sessions.push_back(far);
+    raw->server->StreamRouter()->ServeSession()(upgrade, far);
+    return near;
+  };
+  auto client = moonbase::golf::GolfHubClient::Create(std::move(config));
+  EXPECT_TRUE(client.ok());
+  if (!client.ok()) return nullptr;
+  instance->client = std::make_unique<moonbase::golf::GolfHubClient>(std::move(*client));
+  return instance;
 }
 
 }  // namespace
@@ -476,6 +548,157 @@ TEST_F(GolfHubStreamFixture, LastMemberLeavingDropsTheRoomsChatHistory) {
   const auto remaining = chat_store_->LoadRecent(room_id, 100);
   ASSERT_TRUE(remaining.ok());
   EXPECT_TRUE(remaining->empty()) << "the room is gone; its history must be too";
+}
+
+TEST_F(GolfHubStreamFixture, JoiningReplaysChatHistoryAfterRoomState) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
+
+  std::vector<int64_t> sent_ids;
+  for (const char* text : {"one", "two", "three"}) {
+    moonbase::golf::Chat chat;
+    chat.text = text;
+    ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+    auto echo = ReceiveCase(alice->stream, "roomChat");
+    ASSERT_TRUE(echo.has_value());
+    sent_ids.push_back(echo->as_roomChat_or_null()->messageId);
+  }
+
+  auto bob = OpenSeat();
+  ASSERT_TRUE(bob.has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+
+  // Frame by frame: the room snapshot first, then exactly one history
+  // event carrying the retained messages — the ids and order the live
+  // echoes already reported, so history and live describe one sequence.
+  auto first = NextEvent(bob->stream);
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(std::string(first->case_name()), "roomState");
+  auto second = NextEvent(bob->stream);
+  ASSERT_TRUE(second.has_value());
+  ASSERT_EQ(std::string(second->case_name()), "roomChatHistory");
+  const auto* history = second->as_roomChatHistory_or_null();
+  ASSERT_EQ(history->messages.size(), 3u);
+  EXPECT_EQ(history->messages[0].text, "one");
+  EXPECT_EQ(history->messages[1].text, "two");
+  EXPECT_EQ(history->messages[2].text, "three");
+  for (std::size_t i = 0; i < sent_ids.size(); ++i) {
+    EXPECT_EQ(history->messages[i].messageId, sent_ids[i]);
+    EXPECT_EQ(history->messages[i].playerId, alice->player_id);
+    EXPECT_GT(history->messages[i].sentAtUnixMillis, 0);
+  }
+
+  // Alice was already in the room, so no replay for her: her next frames
+  // are bob's join broadcast and then live chat, nothing in between.
+  // NextEvent (not ReceiveCase) because a skipped stray event would pass.
+  moonbase::golf::Chat live;
+  live.text = "welcome";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(live)).ok());
+  auto alice_first = NextEvent(alice->stream);
+  ASSERT_TRUE(alice_first.has_value());
+  EXPECT_EQ(std::string(alice_first->case_name()), "roomState");
+  auto alice_second = NextEvent(alice->stream);
+  ASSERT_TRUE(alice_second.has_value());
+  EXPECT_EQ(std::string(alice_second->case_name()), "roomChat");
+
+  // The live message continues the id sequence the history reported.
+  auto bob_live = ReceiveCase(bob->stream, "roomChat");
+  ASSERT_TRUE(bob_live.has_value());
+  EXPECT_EQ(bob_live->as_roomChat_or_null()->text, "welcome");
+  EXPECT_GT(bob_live->as_roomChat_or_null()->messageId, sent_ids.back());
+}
+
+TEST_F(GolfHubStreamFixture, JoiningAChatlessRoomHearsAnEmptyHistory) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(created.has_value());
+
+  moonbase::golf::JoinRoom join;
+  join.roomId = created->as_roomState_or_null()->roomId;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+
+  // The event arrives even with nothing to replay, so a client learns
+  // "history loaded, and it is empty" instead of inferring from silence.
+  auto state = NextEvent(bob->stream);
+  ASSERT_TRUE(state.has_value());
+  EXPECT_EQ(std::string(state->case_name()), "roomState");
+  auto history = NextEvent(bob->stream);
+  ASSERT_TRUE(history.has_value());
+  ASSERT_EQ(std::string(history->case_name()), "roomChatHistory");
+  EXPECT_TRUE(history->as_roomChatHistory_or_null()->messages.empty());
+}
+
+TEST_F(GolfHubStreamFixture, ResumingOnAFreshInstanceReplaysChatHistory) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+
+  moonbase::golf::Chat chat;
+  chat.text = "hello";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChat").has_value());
+  chat.text = "hi back";
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChat").has_value());
+
+  // A second hub restores rooms and members from the shared store; its
+  // registry has never seen bob, so his resume admits as new with his
+  // membership intact — the store-restart shape of resume, no wire
+  // failure needed. His live seat on the first instance is irrelevant
+  // here: registries are per-instance.
+  auto instance = BuildSecondInstance(vault_, store_, chat_store_);
+  ASSERT_NE(instance, nullptr);
+  auto resumed = OpenSeatVia(*instance->client, bob->resume_token);
+  ASSERT_TRUE(resumed.has_value());
+  EXPECT_EQ(resumed->player_id, bob->player_id);
+
+  auto ready = NextEvent(resumed->stream);
+  ASSERT_TRUE(ready.has_value());
+  ASSERT_EQ(std::string(ready->case_name()), "sessionReady");
+  EXPECT_TRUE(ready->as_sessionReady_or_null()->resumed);
+  ASSERT_TRUE(ready->as_sessionReady_or_null()->roomId.has_value());
+  EXPECT_EQ(*ready->as_sessionReady_or_null()->roomId, room_id);
+
+  // The snapshot he missed, then the chat he missed, in that order.
+  auto state = NextEvent(resumed->stream);
+  ASSERT_TRUE(state.has_value());
+  EXPECT_EQ(std::string(state->case_name()), "roomState");
+  auto replay = NextEvent(resumed->stream);
+  ASSERT_TRUE(replay.has_value());
+  ASSERT_EQ(std::string(replay->case_name()), "roomChatHistory");
+  const auto* history = replay->as_roomChatHistory_or_null();
+  ASSERT_EQ(history->messages.size(), 2u);
+  EXPECT_EQ(history->messages[0].text, "hello");
+  EXPECT_EQ(history->messages[0].playerId, alice->player_id);
+  EXPECT_EQ(history->messages[1].text, "hi back");
+  EXPECT_EQ(history->messages[1].playerId, bob->player_id);
+  EXPECT_GT(history->messages[1].messageId, history->messages[0].messageId);
 }
 
 // The membership guard, exercised through the handler that owns it

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -14,6 +15,9 @@
 #include <utility>
 #include <vector>
 
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "domains/games/apis/golf_hub/chat_store.h"
 #include "domains/games/apis/golf_hub/stream_test_fixture.h"
 
 namespace golf_hub {
@@ -31,26 +35,17 @@ std::string WithNul(std::string prefix, std::string suffix) {
   return prefix;
 }
 
-// One frame, bounded, no skipping — for asserting exact event order.
-// ReceiveCase would silently step over an event that must not be there.
-std::optional<moonbase::golf::GolfEvents> NextEvent(moonbase::golf::PlayClientStream& stream) {
-  auto received = stream.Receive(std::chrono::seconds(5));
-  if (!received.ok()) {
-    ADD_FAILURE() << "receive failed mid-sequence: " << received.error().message();
-    return std::nullopt;
-  }
-  if (!received->has_value()) {
-    ADD_FAILURE() << "stream closed mid-sequence";
-    return std::nullopt;
-  }
-  return **received;
-}
-
 // A whole second hub sharing the first one's durable pieces — the
 // hub_store_race_test pattern. Restoring from the shared store is what a
 // process restart looks like from the store's side, so resuming here
 // exercises the membership-decides-the-resync branch of Play() without
 // simulating a wire failure.
+//
+// One trap: the shared MemoryChatStore's member guard was wired to the
+// FIRST handler in the fixture's SetUp, so appends through this instance
+// authorize against instance one's membership. Reads (history) are
+// unguarded and safe; treat this instance as read-only for chat unless
+// the guard is rewired.
 struct SecondInstance {
   std::shared_ptr<HubHandler> handler;
   std::unique_ptr<moonbase::golf::GolfHubServer> server;
@@ -60,6 +55,34 @@ struct SecondInstance {
   ~SecondInstance() {
     for (auto& session : sessions) session->Close();
   }
+};
+
+// Forwards everything except LoadRecent, which always fails — the only
+// way to reach the handler's failed-history-load branch, since
+// MemoryChatStore's own LoadRecent cannot return a non-ok status.
+class FailingHistoryChatStore final : public ChatStore {
+ public:
+  explicit FailingHistoryChatStore(std::shared_ptr<ChatStore> delegate)
+      : delegate_(std::move(delegate)) {}
+
+  absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,
+                                 const std::string& text,
+                                 const std::string& notify_payload) override {
+    return delegate_->Append(room_id, player_id, text, notify_payload);
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
+                                                  std::size_t limit) override {
+    return absl::InternalError("chat database unavailable");
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
+                                                 int64_t after_message_id,
+                                                 std::size_t limit) override {
+    return delegate_->LoadAfter(room_id, after_message_id, limit);
+  }
+  void DropRoom(const std::string& room_id) override { delegate_->DropRoom(room_id); }
+
+ private:
+  std::shared_ptr<ChatStore> delegate_;
 };
 
 std::unique_ptr<SecondInstance> BuildSecondInstance(std::shared_ptr<TicketVault> vault,
@@ -554,10 +577,8 @@ TEST_F(GolfHubStreamFixture, JoiningReplaysChatHistoryAfterRoomState) {
   auto alice = OpenSeat();
   ASSERT_TRUE(alice.has_value());
   ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
-  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
-  auto created = ReceiveCase(alice->stream, "roomState");
-  ASSERT_TRUE(created.has_value());
-  const std::string room_id = created->as_roomState_or_null()->roomId;
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
 
   std::vector<int64_t> sent_ids;
   for (const char* text : {"one", "two", "three"}) {
@@ -622,12 +643,11 @@ TEST_F(GolfHubStreamFixture, JoiningAChatlessRoomHearsAnEmptyHistory) {
   ASSERT_TRUE(alice.has_value() && bob.has_value());
   ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
   ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
-  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
-  auto created = ReceiveCase(alice->stream, "roomState");
-  ASSERT_TRUE(created.has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
 
   moonbase::golf::JoinRoom join;
-  join.roomId = created->as_roomState_or_null()->roomId;
+  join.roomId = room_id;
   ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
 
   // The event arrives even with nothing to replay, so a client learns
@@ -639,6 +659,13 @@ TEST_F(GolfHubStreamFixture, JoiningAChatlessRoomHearsAnEmptyHistory) {
   ASSERT_TRUE(history.has_value());
   ASSERT_EQ(std::string(history->case_name()), "roomChatHistory");
   EXPECT_TRUE(history->as_roomChatHistory_or_null()->messages.empty());
+
+  // The creator hears no history at all — creating is not joining. Her
+  // next frame after her create-roomState is bob's join broadcast; a
+  // stray replay to her would land here and fail the case check.
+  auto alice_next = NextEvent(alice->stream);
+  ASSERT_TRUE(alice_next.has_value());
+  EXPECT_EQ(std::string(alice_next->case_name()), "roomState");
 }
 
 TEST_F(GolfHubStreamFixture, ResumingOnAFreshInstanceReplaysChatHistory) {
@@ -647,10 +674,8 @@ TEST_F(GolfHubStreamFixture, ResumingOnAFreshInstanceReplaysChatHistory) {
   ASSERT_TRUE(alice.has_value() && bob.has_value());
   ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
   ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
-  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
-  auto created = ReceiveCase(alice->stream, "roomState");
-  ASSERT_TRUE(created.has_value());
-  const std::string room_id = created->as_roomState_or_null()->roomId;
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
   moonbase::golf::JoinRoom join;
   join.roomId = room_id;
   ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
@@ -699,6 +724,83 @@ TEST_F(GolfHubStreamFixture, ResumingOnAFreshInstanceReplaysChatHistory) {
   EXPECT_EQ(history->messages[1].text, "hi back");
   EXPECT_EQ(history->messages[1].playerId, bob->player_id);
   EXPECT_GT(history->messages[1].messageId, history->messages[0].messageId);
+}
+
+TEST_F(GolfHubStreamFixture, JoinHistoryIsCappedAtTheRetentionLimit) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+
+  // One over the retention window, so the replay must both cap at the
+  // limit and hold the newest end — a hardcoded smaller LoadRecent limit
+  // or an off-by-one prune fails here, where the 3-message test cannot.
+  for (std::size_t i = 1; i <= kChatHistoryLimit + 1; ++i) {
+    moonbase::golf::Chat chat;
+    chat.text = "m-" + std::to_string(i);
+    ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+    ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
+  }
+
+  auto bob = OpenSeat();
+  ASSERT_TRUE(bob.has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+
+  auto replay = NextEvent(bob->stream);
+  ASSERT_TRUE(replay.has_value());
+  ASSERT_EQ(std::string(replay->case_name()), "roomChatHistory");
+  const auto* history = replay->as_roomChatHistory_or_null();
+  ASSERT_EQ(history->messages.size(), kChatHistoryLimit);
+  EXPECT_EQ(history->messages.front().text, "m-2") << "the oldest message fell to retention";
+  EXPECT_EQ(history->messages.back().text, "m-" + std::to_string(kChatHistoryLimit + 1));
+}
+
+TEST_F(GolfHubStreamFixture, AFailedHistoryLoadDoesNotFailTheResume) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+
+  moonbase::golf::Chat chat;
+  chat.text = "stored fine";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChat").has_value());
+
+  // History is best-effort: when the load fails, the resume still lands
+  // (sessionReady, roomState) and the stream simply hears no history
+  // event — the model's documented absence case.
+  auto instance =
+      BuildSecondInstance(vault_, store_, std::make_shared<FailingHistoryChatStore>(chat_store_));
+  ASSERT_NE(instance, nullptr);
+  auto resumed = OpenSeatVia(*instance->client, bob->resume_token);
+  ASSERT_TRUE(resumed.has_value());
+
+  auto ready = NextEvent(resumed->stream);
+  ASSERT_TRUE(ready.has_value());
+  ASSERT_EQ(std::string(ready->case_name()), "sessionReady");
+  EXPECT_TRUE(ready->as_sessionReady_or_null()->resumed);
+  auto state = NextEvent(resumed->stream);
+  ASSERT_TRUE(state.has_value());
+  EXPECT_EQ(std::string(state->case_name()), "roomState");
+
+  // Nothing further: no history event, and no failure surfaced to the
+  // client. The bounded receive times out on a live, usable stream.
+  auto nothing = resumed->stream.Receive(std::chrono::milliseconds(300));
+  EXPECT_FALSE(nothing.ok()) << "a failed history load must send nothing, not something";
 }
 
 // The membership guard, exercised through the handler that owns it

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -30,8 +30,8 @@ namespace {
 constexpr std::size_t kMaxSeats = 4;
 
 // The one place a stored row becomes a wire message. Live delivery and
-// (once #1226 lands it) history replay share it, so the two can never
-// describe the same message differently.
+// history replay share it, so the two can never describe the same
+// message differently.
 moonbase::golf::ChatMessage ChatEvent(const ChatRow& row) {
   moonbase::golf::ChatMessage message;
   message.messageId = row.message_id;
@@ -483,7 +483,9 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
   Send(player_id, GolfEvents::FromSessionready(std::move(ready)));
   // A resumed seat's room sees the connected flip (and the resumer gets
   // the current snapshot it missed) — then the chat it missed, after its
-  // roomState per the documented order, and only to this stream.
+  // roomState per the documented order, and only to this stream. The
+  // resync game view goes last, deliberately: it is delivered after the
+  // history load, whether or not that load succeeds.
   if (room.has_value()) {
     BroadcastRoom(*room);
     SendChatHistory(*room, player_id);

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -482,8 +482,12 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
   if (room.has_value()) ready.roomId = *room;
   Send(player_id, GolfEvents::FromSessionready(std::move(ready)));
   // A resumed seat's room sees the connected flip (and the resumer gets
-  // the current snapshot it missed).
-  if (room.has_value()) BroadcastRoom(*room);
+  // the current snapshot it missed) — then the chat it missed, after its
+  // roomState per the documented order, and only to this stream.
+  if (room.has_value()) {
+    BroadcastRoom(*room);
+    SendChatHistory(*room, player_id);
+  }
   Deliver(resync);
 
   while (true) {
@@ -575,6 +579,10 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
     }
     if (joined) {
       Deliver(outbox);
+      // After the joiner's roomState, the chat they missed. Loaded
+      // outside mu_; a message committing right now may appear in both
+      // history and live delivery, which the model declares legal.
+      SendChatHistory(join->roomId, player_id);
     } else {
       Reject(player_id, "room unavailable or already in a room");
     }
@@ -1287,6 +1295,24 @@ void HubHandler::Deliver(Outbox& outbox) {
     Send(player_id, std::move(event));
   }
   outbox.events.clear();
+}
+
+void HubHandler::SendChatHistory(const std::string& room_id, const std::string& player_id) {
+  auto rows = chat_store_->LoadRecent(room_id, kChatHistoryLimit);
+  if (!rows.ok()) {
+    // The admission already succeeded; chat history is not worth failing
+    // it over. No room id or text in the log — the status is enough.
+    Count("chat_history_load_failures");
+    LOG(WARNING) << "chat history load failed for a joining stream: " << rows.status();
+    return;
+  }
+  // Sent even when empty: a stream that entered a room always hears one
+  // history event, so the client has a deterministic signal rather than
+  // inferring emptiness from absence.
+  moonbase::golf::ChatHistory history;
+  history.messages.reserve(rows->size());
+  for (const ChatRow& row : *rows) history.messages.push_back(ChatEvent(row));
+  Send(player_id, GolfEvents::FromRoomchathistory(std::move(history)));
 }
 
 void HubHandler::Count(const char* name, const std::map<std::string, std::string>& attributes) {

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -195,6 +195,12 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// only unary requests, so admissions, live-session count, disconnects,
   /// and the command/event flow are counted here. All no-ops when no
   /// recorder is injected.
+  void Count(const char* name, const std::map<std::string, std::string>& attributes = {});
+  void TrackActive(int delta);
+  void CountCommand(const moonbase::golf::GolfCommands& command);
+  /// Every event leaves through here so stream_events sees each send.
+  void Send(const std::string& player_id, moonbase::golf::GolfEvents event);
+
   /// Loads the room's retained history and sends one roomChatHistory to
   /// the just-admitted player — nobody else; the room already has it.
   /// Call outside mu_ (the load may reach a database) and after the
@@ -202,12 +208,6 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// counted and skipped rather than failing the join: live delivery
   /// catches the client up from here, and overlap is legal anyway.
   void SendChatHistory(const std::string& room_id, const std::string& player_id);
-
-  void Count(const char* name, const std::map<std::string, std::string>& attributes = {});
-  void TrackActive(int delta);
-  void CountCommand(const moonbase::golf::GolfCommands& command);
-  /// Every event leaves through here so stream_events sees each send.
-  void Send(const std::string& player_id, moonbase::golf::GolfEvents event);
 
   void SetConnected(const std::string& player_id, bool connected);
   std::optional<std::string> CurrentRoom(const std::string& player_id);

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -195,6 +195,14 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// only unary requests, so admissions, live-session count, disconnects,
   /// and the command/event flow are counted here. All no-ops when no
   /// recorder is injected.
+  /// Loads the room's retained history and sends one roomChatHistory to
+  /// the just-admitted player — nobody else; the room already has it.
+  /// Call outside mu_ (the load may reach a database) and after the
+  /// stream's roomState, the order the model documents. A failed load is
+  /// counted and skipped rather than failing the join: live delivery
+  /// catches the client up from here, and overlap is legal anyway.
+  void SendChatHistory(const std::string& room_id, const std::string& player_id);
+
   void Count(const char* name, const std::map<std::string, std::string>& attributes = {});
   void TrackActive(int delta);
   void CountCommand(const moonbase::golf::GolfCommands& command);

--- a/domains/games/apis/golf_hub/model/games.smithy
+++ b/domains/games/apis/golf_hub/model/games.smithy
@@ -143,6 +143,14 @@ list ChatMessages {
 /// by messageId and capped at the room's retained history. It goes only
 /// to the stream that just arrived, after that stream's roomState, and
 /// never to members already in the room.
+///
+/// It is sent exactly once per join or resume, even when the room has no
+/// messages — an empty list means "history loaded, and it is empty", so
+/// clients need not infer emptiness from silence. Two exceptions: a
+/// freshly created room sends nothing (no history exists, and creating
+/// is not joining), and a failed history load sends nothing (delivery is
+/// best-effort; live messages catch the client up). A client must
+/// therefore tolerate absence, but may treat arrival as authoritative.
 structure ChatHistory {
     @required
     messages: ChatMessages

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -465,23 +465,28 @@ TEST_F(PgGolfHubFixture, StatsSurviveARestart) {
   auto alice_back = OpenSeat(alice_token);
   ASSERT_TRUE(alice_back.has_value());
   ASSERT_TRUE(ReceiveCase(alice_back->stream, "sessionReady").has_value());
-  auto restored = alice_back->stream.Receive();
-  ASSERT_TRUE(restored.ok());
-  ASSERT_TRUE(restored->has_value());
-  ASSERT_EQ((*restored)->case_name(), "roomState");
-  const auto* restored_lobby = (*restored)->as_roomState_or_null();
+  auto restored = NextEvent(alice_back->stream);
+  ASSERT_TRUE(restored.has_value());
+  ASSERT_EQ(std::string(restored->case_name()), "roomState");
+  const auto* restored_lobby = restored->as_roomState_or_null();
   ASSERT_NE(restored_lobby, nullptr);
   EXPECT_TRUE(restored_lobby->games.empty());
 
+  // A resume also replays the room's chat (#1226) — one history event
+  // after the snapshot, empty here since nobody said anything.
+  auto replay = NextEvent(alice_back->stream);
+  ASSERT_TRUE(replay.has_value());
+  ASSERT_EQ(std::string(replay->case_name()), "roomChatHistory");
+  EXPECT_TRUE(replay->as_roomChatHistory_or_null()->messages.empty());
+
   ASSERT_TRUE(
       alice_back->stream.Send(GolfCommands::FromGetroomstate(moonbase::golf::GetRoomState{})).ok());
-  // After the automatic resume snapshot, the next frame is the requested
-  // lobby itself: no restored game resync or ceremony was queued.
-  auto lobby = alice_back->stream.Receive();
-  ASSERT_TRUE(lobby.ok());
-  ASSERT_TRUE(lobby->has_value());
-  ASSERT_EQ((*lobby)->case_name(), "roomState");
-  const auto* lobby_state = (*lobby)->as_roomState_or_null();
+  // After the resume snapshot and its chat replay, the next frame is the
+  // requested lobby itself: no restored game resync or ceremony queued.
+  auto lobby = NextEvent(alice_back->stream);
+  ASSERT_TRUE(lobby.has_value());
+  ASSERT_EQ(std::string(lobby->case_name()), "roomState");
+  const auto* lobby_state = lobby->as_roomState_or_null();
   ASSERT_NE(lobby_state, nullptr);
   EXPECT_TRUE(lobby_state->games.empty());
   // Identical zero-scoring deals; the knocker takes the tie alone.

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -75,6 +75,22 @@ inline std::optional<moonbase::golf::GolfEvents> ReceiveCase(
   return std::nullopt;
 }
 
+// One frame, bounded, no skipping — for asserting exact event order.
+// ReceiveCase would silently step over an event that must not be there.
+inline std::optional<moonbase::golf::GolfEvents> NextEvent(
+    moonbase::golf::PlayClientStream& stream, std::chrono::milliseconds budget = kReceiveBudget) {
+  auto received = stream.Receive(budget);
+  if (!received.ok()) {
+    ADD_FAILURE() << "receive failed mid-sequence: " << received.error().message();
+    return std::nullopt;
+  }
+  if (!received->has_value()) {
+    ADD_FAILURE() << "stream closed mid-sequence";
+    return std::nullopt;
+  }
+  return **received;
+}
+
 // Same, but tunnels into the golf envelope: returns the first GolfUpdate
 // of the wanted case, skipping room noise and other updates in between.
 inline std::optional<moonbase::golf::GolfUpdate> ReceiveGolf(
@@ -197,6 +213,25 @@ class GolfHubStreamFixture : public testing::Test {
   }
   std::optional<Seat> OpenSeat(const std::optional<std::string>& resume_token = std::nullopt) {
     return OpenSeatVia(*client_, resume_token);
+  }
+
+  // The create-room preamble a dozen tests otherwise spell out: sends
+  // CreateRoom from an already-ready seat, receives the creator's
+  // roomState, and returns the room id — empty (with a failure already
+  // recorded) when any step misbehaves.
+  std::string CreateRoomFor(Seat& seat) {
+    if (!seat.stream
+             .Send(moonbase::golf::GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{}))
+             .ok()) {
+      ADD_FAILURE() << "CreateRoom send failed";
+      return "";
+    }
+    auto created = ReceiveCase(seat.stream, "roomState");
+    if (!created.has_value()) {
+      ADD_FAILURE() << "no roomState after CreateRoom";
+      return "";
+    }
+    return created->as_roomState_or_null()->roomId;
   }
 
   // Room with two seats in a started game: with the NoShuffleDealer the


### PR DESCRIPTION
Task 4 of #1226, remaining half: a stream that enters a room now hears the chat it missed. The live-append half landed in #1229. A follow-up commit applies fifteen findings from a four-lens review panel (readability, simplification, test depth, altitude), each adversarially verified before landing.

## What changed

`HubHandler::SendChatHistory` loads the room's retained history and sends one `roomChatHistory` to a just-admitted stream — nobody else, since the room already has it. Two call sites:

- **join** — after `Deliver(outbox)`, so the joiner's `roomState` precedes the history, the order the model documents.
- **resume** — after `BroadcastRoom`, same ordering for the resumer. This covers both grace-window resumes and players restored from the store. The resync game view goes last, deliberately: it is delivered after the history load, whether or not that load succeeds.

The event is sent even when empty: a stream that entered a room always hears exactly one history event, so a client learns "history loaded, and it is empty" instead of inferring from silence. Rooms freshly created send nothing — there is no history by construction, and creating is not joining. A failed load is counted (`chat_history_load_failures`) and skipped rather than failing the admission. All of this is now documented in the `ChatHistory` model doc, since the web UI codes against the model, not handler comments.

History is loaded outside `mu_`, so a message committing during the join can appear in both history and live delivery; the model declares that overlap legal and clients dedupe by `messageId`. Rows convert through the same `ChatEvent` helper as live delivery, so history and live can never describe the same message differently.

## Tests

- `JoiningReplaysChatHistoryAfterRoomState` — frame-order asserted with the bounded `Receive(timeout)` from #1230 rather than `ReceiveCase`, which would silently skip a stray event: the joiner gets `roomState` then exactly one history event whose ids match the live echoes; the existing member gets the join broadcast then live chat with **no** replay in between.
- `JoiningAChatlessRoomHearsAnEmptyHistory` — the deterministic empty signal, plus a frame-order pin that the *creator* hears no history at all.
- `ResumingOnAFreshInstanceReplaysChatHistory` — a second handler instance sharing the first's vault and stores (the `hub_store_race_test` pattern) restores from the store and admits the resume as new with membership intact: `sessionReady(resumed=true, roomId)`, then `roomState`, then the history.
- `JoinHistoryIsCappedAtTheRetentionLimit` — a limit-plus-one join replays exactly `kChatHistoryLimit` messages, newest end retained.
- `AFailedHistoryLoadDoesNotFailTheResume` — a delegating `ChatStore` whose `LoadRecent` always fails drives the otherwise-unreachable failed-load branch: the resume still lands, and a bounded receive proves no history event follows.

## Verification

The `build-and-test` CI job on this PR is the authoritative run: it executes the full impacted suite — including `hub_e2e_test` and, via its `postgres:18` service, the pg-gated suites. (An earlier revision of this description claimed the streaming suites don't run in CI; that was wrong — CI runs on unrestricted GitHub-hosted runners and has been executing them all along.)

Locally: `chat_store_test` and `hub_store_test` pass under Bazel, the Smithy targets build with the updated model doc, and both changed TUs typecheck via `g++ -fsyntax-only` against the real generated headers and runtime.

Part of #1226. Remaining after this: Task 5 (cross-instance fan-out and cursors), Task 6 (metrics polish), Task 7 (web UI).