### PR TITLE
golf_hub: cross-instance chat fan-out with cursor catch-up

### DIFF
--- a/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
+++ b/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
@@ -232,29 +232,38 @@ Expected: pass.
 **Interfaces:**
 - Produces: `ChatChannel(room_id)`, listener active/re-subscribed callback, per-room highest delivered ID, and paged catch-up.
 
-- [ ] **Step 1: Write failing listener synchronization test**
+- [x] **Step 1: Write failing listener synchronization test**
 
 Subscribe once, wait on a condition variable for an active-channel callback, then send exactly one notification. Terminate the backend, assert a second active callback after re-LISTEN, and send exactly one post-reconnect notification.
 
-- [ ] **Step 2: Implement listener active signaling**
+- [x] **Step 2: Implement listener active signaling**
 
 Make `LISTEN` report success, update `active_` only for successful statements, and invoke the optional callback after a channel first becomes active on a connection. Never hold the listener mutex while invoking owner code.
 
-- [ ] **Step 3: Write deterministic no-PostgreSQL handler race tests**
+- [x] **Step 3: Write deterministic no-PostgreSQL handler race tests**
 
 Use two handlers, a shared gated store, condition variables, and bounded receives. Cover delayed/coalesced/duplicate/own wakes, paging, room drop, and history/live overlap.
 
-- [ ] **Step 4: Implement cursor catch-up**
+- [x] **Step 4: Implement cursor catch-up**
 
 Subscribe `ChatChannel` with `RoomChannel`; on chat wake or active callback, load pages after the cursor in ascending order and deliver only rows whose IDs exceed it. Remove cursor state when the room drops.
 
 `ChatChannel` yields `chat_<room_id>` to match `RoomChannel`'s `room_<room_id>`. `LISTEN` cannot take a bind parameter, so quote the channel name as an identifier there and confirm room IDs stay inside PostgreSQL's 63-byte identifier limit; `NOTIFY` goes through `pg_notify($1, $2)`.
 
-- [ ] **Step 5: Add PostgreSQL two-instance tests**
+- [x] **Step 5: Add PostgreSQL two-instance tests**
 
 Split clients across instances, exchange messages both ways, kill/reconnect a listener during a send, join a third client for history, and verify room deletion cascades.
 
-- [ ] **Step 6: Verify GREEN and stress**
+The two-instance exchange test earned its keep immediately: it flaked
+1-in-10 against wake-time cursor adoption (an append committing while
+the adoption's off-lock read was in flight got consumed as "the past"
+and was never delivered locally). Cursors are now born in the same
+critical section that makes a room held — createRoom at zero,
+materialization and restore seeded from the newest retained id — and
+the schedule is pinned by a deterministic latch test
+(`AppendCommittingDuringAnInFlightWakeLoadIsStillDelivered`).
+
+- [x] **Step 6: Verify GREEN and stress**
 
 Run:
 

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -366,6 +366,7 @@ cc_test(
         ":ticket_vault",
         "//domains/games/libs/cards:dealer",
         "//domains/platform/libs/futility/otel:metrics",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@googletest//:gtest_main",
         "@smithy_cpp//runtime:client",

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -303,6 +303,7 @@ cc_test(
         ":hub_handler",
         ":hub_store",
         ":id_generator",
+        ":pg_chat_store",
         ":pg_hub_store",
         ":pg_ticket_vault",
         ":ticket_vault",
@@ -345,6 +346,35 @@ cc_test(
     ],
 )
 
+# The chat pump's cross-instance behavior, pinned deterministically over
+# shared memory stores with hand-delivered wakes — the orderings the pg
+# e2e suite's real NOTIFY wire won't schedule on demand.
+cc_test(
+    name = "hub_chat_race_test",
+    size = "small",
+    srcs = [
+        "hub_chat_race_test.cc",
+        "stream_test_fixture.h",
+    ],
+    deps = [
+        ":chat_store",
+        ":golf_hub_smithy_client",
+        ":golf_hub_smithy_server",
+        ":hub_handler",
+        ":hub_store",
+        ":id_generator",
+        ":ticket_vault",
+        "//domains/games/libs/cards:dealer",
+        "//domains/platform/libs/futility/otel:metrics",
+        "@com_google_absl//absl/strings",
+        "@googletest//:gtest_main",
+        "@smithy_cpp//runtime:client",
+        "@smithy_cpp//runtime:core",
+        "@smithy_cpp//runtime:http",
+        "@smithy_cpp//runtime:http_beast",
+    ],
+)
+
 cc_test(
     name = "hub_store_race_test",
     size = "small",
@@ -378,6 +408,7 @@ cc_binary(
         ":hub_handler",
         ":hub_store",
         ":id_generator",
+        ":pg_chat_store",
         ":pg_hub_store",
         ":pg_ticket_vault",
         ":protocol_input",

--- a/domains/games/apis/golf_hub/chat_store.h
+++ b/domains/games/apis/golf_hub/chat_store.h
@@ -17,6 +17,10 @@ namespace golf_hub {
 
 inline constexpr std::size_t kChatHistoryLimit = 100;
 inline constexpr std::size_t kChatTextByteLimit = 500;
+/// One LoadAfter page during live catch-up. Small enough that a drain
+/// yields the lock between pages, large enough that draining the whole
+/// retention window is a handful of reads.
+inline constexpr std::size_t kChatCatchUpPage = 16;
 inline std::string ChatChannel(const std::string& room_id) { return "chat_" + room_id; }
 
 /// Rejects text a room cannot store: empty or whitespace-only, over

--- a/domains/games/apis/golf_hub/golf_hub_main.cc
+++ b/domains/games/apis/golf_hub/golf_hub_main.cc
@@ -25,6 +25,7 @@
 #include "domains/games/apis/golf_hub/hub_store.h"
 #include "domains/games/apis/golf_hub/id_generator.h"
 #include "domains/games/apis/golf_hub/migrations.h"
+#include "domains/games/apis/golf_hub/pg_chat_store.h"
 #include "domains/games/apis/golf_hub/pg_hub_store.h"
 #include "domains/games/apis/golf_hub/pg_ticket_vault.h"
 #include "domains/games/apis/golf_hub/protocol_input.h"
@@ -83,6 +84,7 @@ int main() {
   constexpr auto kResumeTtl = std::chrono::hours(24);
   std::shared_ptr<golf_hub::TicketVault> vault;
   std::shared_ptr<golf_hub::HubStore> store;
+  std::shared_ptr<golf_hub::ChatStore> chat_store;
   const char* db_url = std::getenv("GOLF_HUB_DB_URL");
   if (db_url != nullptr && *db_url != '\0') {
     auto db = std::make_shared<pg::Client>(db_url);
@@ -92,10 +94,15 @@ int main() {
     }
     vault = std::make_shared<golf_hub::PgTicketVault>(std::move(db), kTicketTtl, kResumeTtl);
     store = std::make_shared<golf_hub::PgHubStore>(std::make_shared<pg::Client>(db_url));
-    LOG(INFO) << "Persistence: postgres (credentials + rooms/games write-through)";
+    // Chat gets its own connection too (#1226): appends are synchronous
+    // in the command path and must not queue behind the write-through.
+    chat_store = std::make_shared<golf_hub::PgChatStore>(std::make_shared<pg::Client>(db_url));
+    LOG(INFO) << "Persistence: postgres (credentials + rooms/games write-through + chat)";
   } else {
     vault = std::make_shared<golf_hub::InMemoryTicketVault>(kTicketTtl, kResumeTtl);
     store = std::make_shared<golf_hub::MemoryHubStore>();
+    // chat_store stays null: the handler builds its own MemoryChatStore
+    // wired to its membership guard.
     LOG(INFO) << "Persistence: in-memory (GOLF_HUB_DB_URL unset; restarts forget everything)";
   }
   // Stream-side instruments (sessions, commands, events) ride the same
@@ -103,7 +110,7 @@ int main() {
   auto handler = std::make_shared<golf_hub::HubHandler>(
       vault, std::make_shared<cards::Dealer>(), std::make_shared<golf_hub::WhimsicalIdGenerator>(),
       /*grace_period=*/std::chrono::minutes(5),
-      std::make_shared<futility::otel::MetricsRecorder>("golf_hub"), store);
+      std::make_shared<futility::otel::MetricsRecorder>("golf_hub"), store, chat_store);
   // Same policy as the migration above: a database we can't read at boot
   // is a reason to let the supervisor retry, not to serve amnesiac.
   if (absl::Status restored = handler->RestoreFromStore(); !restored.ok()) {
@@ -117,9 +124,11 @@ int main() {
   std::unique_ptr<pg::Listener> listener;
   if (db_url != nullptr && *db_url != '\0') {
     listener = std::make_unique<pg::Listener>(
-        db_url, [&handler](const std::string& channel, const std::string& payload) {
+        db_url,
+        [&handler](const std::string& channel, const std::string& payload) {
           handler->OnNotify(channel, payload);
-        });
+        },
+        [&handler](const std::string& channel) { handler->OnChannelActive(channel); });
     handler->AttachListener(listener.get());
   }
 

--- a/domains/games/apis/golf_hub/hub_chat_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_chat_race_test.cc
@@ -62,10 +62,10 @@ class TestGate {
   bool open_ = false;
 };
 
-// Forwards everything; when armed, the next LoadAfter announces itself
-// and blocks until released. That parks a pump mid-drain at a chosen
-// point — the only way to deterministically land a second wake while the
-// first is still draining.
+// Forwards everything; when armed, the next load (either kind) announces
+// itself and blocks until released. That parks a pump mid-drain at a
+// chosen point — the only way to deterministically land an append or a
+// second wake while a load is in flight.
 class GatedChatStore final : public ChatStore {
  public:
   explicit GatedChatStore(std::shared_ptr<ChatStore> delegate) : delegate_(std::move(delegate)) {}
@@ -77,15 +77,13 @@ class GatedChatStore final : public ChatStore {
   }
   absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
                                                   std::size_t limit) override {
+    Gate();
     return delegate_->LoadRecent(room_id, limit);
   }
   absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
                                                  int64_t after_message_id,
                                                  std::size_t limit) override {
-    if (armed_.exchange(false)) {
-      entered_.Open();
-      released_.Wait();
-    }
+    Gate();
     return delegate_->LoadAfter(room_id, after_message_id, limit);
   }
   void DropRoom(const std::string& room_id) override { delegate_->DropRoom(room_id); }
@@ -95,6 +93,13 @@ class GatedChatStore final : public ChatStore {
   void Release() { released_.Open(); }
 
  private:
+  void Gate() {
+    if (armed_.exchange(false)) {
+      entered_.Open();
+      released_.Wait();
+    }
+  }
+
   std::shared_ptr<ChatStore> delegate_;
   std::atomic<bool> armed_ = false;
   TestGate entered_;
@@ -352,14 +357,14 @@ TEST_F(HubChatRaceFixture, WakesForUnheldRoomsAreIgnored) {
 }
 
 // An instance that restores a room from the store (a restart, from the
-// store's point of view) meets its chat with no cursor. First contact
-// adopts the newest retained id and replays nothing live — history
-// replay owns the past. The adopted cursor also stands where adoption
-// left it, so a row committed between adoption and a member's resume is
+// store's point of view) seeds the room's cursor at the newest retained
+// id during the restore itself, so the past is never replayed live —
+// history replay owns it. The seed then stands where the restore left
+// it, so a row committed between the restore and a member's resume is
 // heard twice: once in the resume's replay and once live. That overlap
 // is the model's documented contract — at-least-once, dedupe by id —
 // and this pins it on purpose.
-TEST_F(HubChatRaceFixture, RestoredInstanceAdoptsTheCursorInsteadOfReplayingThePast) {
+TEST_F(HubChatRaceFixture, RestoredInstanceSeedsTheCursorInsteadOfReplayingThePast) {
   auto alice = OpenSeat();
   auto bob = OpenSeat();
   ASSERT_TRUE(alice.has_value() && bob.has_value());
@@ -378,8 +383,8 @@ TEST_F(HubChatRaceFixture, RestoredInstanceAdoptsTheCursorInsteadOfReplayingTheP
   ASSERT_GT(ExpectNextChat(*alice, "old"), 0);
   ASSERT_GT(ExpectNextChat(*bob, "old"), 0);
 
-  // A third instance restores the room, then hears its first chat wake:
-  // adoption. Nothing to observe yet — its members are all disconnected —
+  // A third instance restores the room, cursor seeded at "old". A chat
+  // wake right after delivers nothing — its members are all disconnected —
   // which is the point: the past is not replayed at anyone.
   auto restored = BuildInstance();
   ASSERT_NE(restored, nullptr);
@@ -406,14 +411,72 @@ TEST_F(HubChatRaceFixture, RestoredInstanceAdoptsTheCursorInsteadOfReplayingTheP
   ASSERT_GT(ExpectNextChat(*alice, "new"), 0);
   ASSERT_GT(ExpectNextChat(*bob, "new"), 0);
 
-  // One wake after the resume: live delivery starts at the adopted
-  // cursor, so "mid" overlaps the replay and "old" — behind the cursor —
+  // One wake after the resume: live delivery starts at the restore's
+  // seed, so "mid" overlaps the replay and "old" — behind the cursor —
   // does not repeat.
   restored->handler->OnNotify(ChatChannel(room_id), "wake");
   const int64_t mid_id = ExpectNextChat(*resumed, "mid");
   const int64_t new_id = ExpectNextChat(*resumed, "new");
   ASSERT_GT(mid_id, 0);
   EXPECT_GT(new_id, mid_id);
+}
+
+// The regression drill for the seed-at-birth rule, in the schedule the
+// pg suite once caught by chance (~1 in 10): a chat wake's store load is
+// in flight on an instance at the moment a local member's append
+// commits. Wake-time cursor creation used to adopt "the newest retained
+// id" from that off-lock read, which classified the raced append as the
+// past — consumed without delivery, so its sender never saw their own
+// message. With cursors born with the room, the parked drain reads
+// pages above the seed and must deliver the append when it resumes.
+TEST_F(HubChatRaceFixture, AppendCommittingDuringAnInFlightWakeLoadIsStillDelivered) {
+  // The room and both memberships predate the third instance; bob's
+  // seat arrives there by resume, the shape the pg flake had.
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChatHistory").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+
+  auto restored = BuildInstance();
+  ASSERT_NE(restored, nullptr);
+
+  // Park the wake's load before bob's seat exists on this instance, so
+  // the pump's view of the room predates everything that follows.
+  gated_->ArmGate();
+  std::thread wake([&] { restored->handler->OnChannelActive(ChatChannel(room_id)); });
+  const bool entered = gated_->WaitForEntry(std::chrono::seconds(5));
+  EXPECT_TRUE(entered);
+
+  auto resumed = OpenSeatVia(*restored->client, bob->resume_token);
+  ASSERT_TRUE(resumed.has_value());
+  ASSERT_TRUE(ReceiveCase(resumed->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(resumed->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(resumed->stream, "roomChatHistory").has_value());
+
+  // Commits while the wake's load is parked; the append's own pump
+  // coalesces into the parked drain rather than starting a second one.
+  ASSERT_TRUE(SendChat(*resumed, "raced"));
+
+  gated_->Release();
+  wake.join();
+
+  // The resumed drain hands bob his own message — exactly once, which
+  // the sentinel's arrival as the very next frame then proves.
+  ASSERT_GT(ExpectNextChat(*resumed, "raced"), 0);
+  ASSERT_TRUE(SendChat(*alice, "sentinel"));
+  ASSERT_GT(ExpectNextChat(*alice, "raced"), 0);  // primary catches up off its own pump
+  ASSERT_GT(ExpectNextChat(*alice, "sentinel"), 0);
+  restored->handler->OnNotify(ChatChannel(room_id), "primary");
+  ASSERT_GT(ExpectNextChat(*resumed, "sentinel"), 0);
 }
 
 // A wake that lands while a drain is already running must neither start

--- a/domains/games/apis/golf_hub/hub_chat_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_chat_race_test.cc
@@ -1,0 +1,458 @@
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "domains/games/apis/golf_hub/chat_store.h"
+#include "domains/games/apis/golf_hub/hub_store.h"
+#include "domains/games/apis/golf_hub/stream_test_fixture.h"
+#include "domains/games/libs/cards/dealer.h"
+#include "smithy/client/config.h"
+#include "smithy/core/outcome.h"
+#include "smithy/http/loopback.h"
+#include "smithy/http/message.h"
+#include "smithy/http/websocket.h"
+#include "smithy/http/websocket_pair.h"
+
+// The chat pump's cross-instance behavior, pinned deterministically: the
+// handlers share the memory stores, and the tests hand-deliver the wakes
+// PostgreSQL's LISTEN/NOTIFY would carry. The pg e2e suite proves the
+// same protocol over a real wire; this suite owns the orderings a real
+// wire won't schedule on demand — a notify that hasn't arrived yet, a
+// duplicate wake, a wake landing mid-drain.
+
+namespace golf_hub {
+namespace {
+
+using moonbase::golf::GolfCommands;
+
+class TestGate {
+ public:
+  void Open() {
+    {
+      const std::lock_guard<std::mutex> lock(mu_);
+      open_ = true;
+    }
+    cv_.notify_all();
+  }
+
+  bool WaitFor(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mu_);
+    return cv_.wait_for(lock, timeout, [this] { return open_; });
+  }
+
+  void Wait() {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_.wait(lock, [this] { return open_; });
+  }
+
+ private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+  bool open_ = false;
+};
+
+// Forwards everything; when armed, the next LoadAfter announces itself
+// and blocks until released. That parks a pump mid-drain at a chosen
+// point — the only way to deterministically land a second wake while the
+// first is still draining.
+class GatedChatStore final : public ChatStore {
+ public:
+  explicit GatedChatStore(std::shared_ptr<ChatStore> delegate) : delegate_(std::move(delegate)) {}
+
+  absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,
+                                 const std::string& text,
+                                 const std::string& notify_payload) override {
+    return delegate_->Append(room_id, player_id, text, notify_payload);
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
+                                                  std::size_t limit) override {
+    return delegate_->LoadRecent(room_id, limit);
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
+                                                 int64_t after_message_id,
+                                                 std::size_t limit) override {
+    if (armed_.exchange(false)) {
+      entered_.Open();
+      released_.Wait();
+    }
+    return delegate_->LoadAfter(room_id, after_message_id, limit);
+  }
+  void DropRoom(const std::string& room_id) override { delegate_->DropRoom(room_id); }
+
+  void ArmGate() { armed_ = true; }
+  bool WaitForEntry(std::chrono::milliseconds timeout) { return entered_.WaitFor(timeout); }
+  void Release() { released_.Open(); }
+
+ private:
+  std::shared_ptr<ChatStore> delegate_;
+  std::atomic<bool> armed_ = false;
+  TestGate entered_;
+  TestGate released_;
+};
+
+// Secondary instances mint from their own space so two hubs can never
+// hand out the same player id.
+class RemoteIdGenerator final : public IdGenerator {
+ public:
+  std::string PlayerId() override { return "remote-player-" + std::to_string(++players_); }
+  std::string RoomId() override { return "remote-room-" + std::to_string(++rooms_); }
+  std::string GameCode() override { return "RGAME" + std::to_string(++games_); }
+
+ private:
+  int players_ = 0;
+  int rooms_ = 0;
+  int games_ = 0;
+};
+
+class HubChatRaceFixture : public GolfHubStreamFixture {
+ protected:
+  struct Instance {
+    std::shared_ptr<HubHandler> handler;
+    std::unique_ptr<moonbase::golf::GolfHubServer> server;
+    std::unique_ptr<moonbase::golf::GolfHubClient> client;
+    std::vector<std::shared_ptr<smithy::http::WebSocket>> sessions;
+
+    ~Instance() {
+      for (auto& session : sessions) session->Close();
+    }
+  };
+
+  // Membership lives on whichever instance seats the sender, so the
+  // shared store's guard tries the primary handler first and the remote
+  // second — a fixed order, so two concurrent appends can never take the
+  // two handlers' locks in opposite orders.
+  std::shared_ptr<ChatStore> MakeChatStore() override {
+    auto shared = std::make_shared<MemoryChatStore>([this](const std::string& room_id,
+                                                           const std::string& player_id,
+                                                           const MemberAction& action) {
+      if (handler_ != nullptr && handler_->WithMember(room_id, player_id, action)) return true;
+      return remote_ != nullptr && remote_->handler->WithMember(room_id, player_id, action);
+    });
+    gated_ = std::make_shared<GatedChatStore>(std::move(shared));
+    return gated_;
+  }
+
+  void SetUp() override {
+    GolfHubStreamFixture::SetUp();
+    remote_ = BuildInstance();
+    ASSERT_NE(remote_, nullptr);
+  }
+
+  // A hub sharing the primary's vault (so seats resume across instances)
+  // and both stores. Restores on build, like main would.
+  std::unique_ptr<Instance> BuildInstance() {
+    auto instance = std::make_unique<Instance>();
+    instance->handler = std::make_shared<HubHandler>(
+        vault_, std::make_shared<cards::NoShuffleDealer>(), std::make_shared<RemoteIdGenerator>(),
+        std::chrono::seconds(60),
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), store_, chat_store_);
+    EXPECT_TRUE(instance->handler->RestoreFromStore().ok());
+    instance->server = std::make_unique<moonbase::golf::GolfHubServer>(instance->handler);
+
+    auto loopback = std::make_shared<smithy::http::Loopback>();
+    EXPECT_TRUE(loopback->Start(instance->server->Handler()).ok());
+    smithy::ClientConfig config;
+    config.retry.max_attempts = 1;
+    config.http_client = loopback;
+    Instance* raw = instance.get();
+    config.websocket_dialer = [raw](const smithy::http::WebSocketDialRequest& request)
+        -> smithy::Outcome<std::shared_ptr<smithy::http::WebSocket>> {
+      auto [near, far] = smithy::http::InMemoryWebSocketPair::Create();
+      smithy::http::HttpRequest upgrade;
+      upgrade.method = "GET";
+      upgrade.target = request.target;
+      upgrade.headers = request.headers;
+      raw->sessions.push_back(far);
+      raw->server->StreamRouter()->ServeSession()(upgrade, far);
+      return near;
+    };
+    auto client = moonbase::golf::GolfHubClient::Create(std::move(config));
+    EXPECT_TRUE(client.ok());
+    if (!client.ok()) return nullptr;
+    instance->client = std::make_unique<moonbase::golf::GolfHubClient>(std::move(*client));
+    return instance;
+  }
+
+  // Alice seated on the primary owns a room; bob joins it through the
+  // remote. Neither instance has been woken about the other's activity —
+  // every wake after this point is one the test delivers by hand.
+  struct Pair {
+    Seat alice;
+    Seat bob;
+    std::string room_id;
+  };
+  std::optional<Pair> SplitRoom() {
+    auto alice = OpenSeat();
+    auto bob = OpenSeatVia(*remote_->client);
+    if (!alice.has_value() || !bob.has_value()) return std::nullopt;
+    if (!ReceiveCase(alice->stream, "sessionReady").has_value()) return std::nullopt;
+    if (!ReceiveCase(bob->stream, "sessionReady").has_value()) return std::nullopt;
+    const std::string room_id = CreateRoomFor(*alice);
+    if (room_id.empty()) return std::nullopt;
+    moonbase::golf::JoinRoom join;
+    join.roomId = room_id;
+    if (!bob->stream.Send(GolfCommands::FromJoinroom(join)).ok()) return std::nullopt;
+    if (!ReceiveCase(bob->stream, "roomState").has_value()) return std::nullopt;
+    if (!ReceiveCase(bob->stream, "roomChatHistory").has_value()) return std::nullopt;
+    return Pair{std::move(*alice), std::move(*bob), room_id};
+  }
+
+  bool SendChat(Seat& seat, const std::string& text) {
+    moonbase::golf::Chat chat;
+    chat.text = text;
+    return seat.stream.Send(GolfCommands::FromChat(chat)).ok();
+  }
+
+  // Asserts the stream's next frame — not merely a later one — is a
+  // roomChat carrying `text`. Returns its message id, 0 on failure.
+  int64_t ExpectNextChat(Seat& seat, const std::string& text) {
+    auto event = NextEvent(seat.stream);
+    if (!event.has_value()) return 0;
+    const auto* chat = event->as_roomChat_or_null();
+    if (chat == nullptr) {
+      ADD_FAILURE() << "expected roomChat \"" << text << "\", got " << event->case_name();
+      return 0;
+    }
+    EXPECT_EQ(chat->text, text);
+    return chat->messageId;
+  }
+
+  std::shared_ptr<GatedChatStore> gated_;
+  std::unique_ptr<Instance> remote_;
+};
+
+// The ordering the pump exists for. Bob's message commits on the remote
+// while its notify to the primary is still "in flight" (here: never
+// delivered — the tests own the wire). Alice's append must not step over
+// it: her own pump walks the cursor and delivers bob's earlier row first,
+// with no wake involved. An append path that staged only its own row and
+// advanced the cursor past it would skip bob's message on the primary
+// for good.
+TEST_F(HubChatRaceFixture, RacedRemoteCommitReachesLocalsInIdOrder) {
+  auto pair = SplitRoom();
+  ASSERT_TRUE(pair.has_value());
+
+  ASSERT_TRUE(SendChat(pair->bob, "from bob"));
+  ASSERT_GT(ExpectNextChat(pair->bob, "from bob"), 0);
+
+  ASSERT_TRUE(SendChat(pair->alice, "from alice"));
+  const int64_t bobs = ExpectNextChat(pair->alice, "from bob");
+  const int64_t alices = ExpectNextChat(pair->alice, "from alice");
+  ASSERT_GT(bobs, 0);
+  EXPECT_GT(alices, bobs);
+
+  // The remote hears about alice's row the ordinary way: its wake. The
+  // chat pump ignores the payload — even an own-instance payload pumps.
+  remote_->handler->OnNotify(ChatChannel(pair->room_id), "some-instance");
+  EXPECT_EQ(ExpectNextChat(pair->bob, "from alice"), alices);
+}
+
+// A single wake delivers everything committed since the cursor, however
+// many pages that takes — a burst wide enough to cross three LoadAfter
+// pages arrives complete and in order off one notify.
+TEST_F(HubChatRaceFixture, OneWakeDrainsEverythingCommittedAcrossPages) {
+  auto pair = SplitRoom();
+  ASSERT_TRUE(pair.has_value());
+
+  const int total = static_cast<int>(kChatCatchUpPage) * 2 + 3;
+  for (int i = 1; i <= total; ++i) {
+    ASSERT_TRUE(SendChat(pair->alice, absl::StrCat("m", i)));
+  }
+  for (int i = 1; i <= total; ++i) {
+    ASSERT_GT(ExpectNextChat(pair->alice, absl::StrCat("m", i)), 0);
+  }
+
+  remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");
+  int64_t last = 0;
+  for (int i = 1; i <= total; ++i) {
+    const int64_t id = ExpectNextChat(pair->bob, absl::StrCat("m", i));
+    EXPECT_GT(id, last);
+    last = id;
+  }
+}
+
+// Notifies are at-least-once and our own commits wake us too; all the
+// redundancy lands on the cursor and delivers nothing twice. The proof
+// is ordering: after the extra wakes, the very next frame each side
+// receives is the sentinel, not a replay.
+TEST_F(HubChatRaceFixture, RedundantWakesDeliverNothingNew) {
+  auto pair = SplitRoom();
+  ASSERT_TRUE(pair.has_value());
+
+  ASSERT_TRUE(SendChat(pair->alice, "first"));
+  ASSERT_GT(ExpectNextChat(pair->alice, "first"), 0);
+  remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");
+  ASSERT_GT(ExpectNextChat(pair->bob, "first"), 0);
+
+  remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");  // duplicate
+  handler_->OnNotify(ChatChannel(pair->room_id), "own-commit");       // our own echo
+
+  ASSERT_TRUE(SendChat(pair->alice, "sentinel"));
+  ASSERT_GT(ExpectNextChat(pair->alice, "sentinel"), 0);
+  remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");
+  ASSERT_GT(ExpectNextChat(pair->bob, "sentinel"), 0);
+}
+
+// The listener's channel-active signal is a wake like any other: rows
+// committed while an instance was not subscribed queued no notification,
+// and the signal alone heals the gap.
+TEST_F(HubChatRaceFixture, ActiveSignalHealsAMissedNotify) {
+  auto pair = SplitRoom();
+  ASSERT_TRUE(pair.has_value());
+
+  ASSERT_TRUE(SendChat(pair->alice, "missed"));
+  ASSERT_GT(ExpectNextChat(pair->alice, "missed"), 0);
+
+  remote_->handler->OnChannelActive(ChatChannel(pair->room_id));
+  ASSERT_GT(ExpectNextChat(pair->bob, "missed"), 0);
+}
+
+// Wakes for rooms an instance does not hold — dropped rooms, rooms it
+// never materialized, channels that never existed — deliver nothing and
+// resurrect nothing, and leave the instance healthy.
+TEST_F(HubChatRaceFixture, WakesForUnheldRoomsAreIgnored) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+
+  // The remote never materialized this room, and the last one is not a
+  // room at all.
+  remote_->handler->OnNotify(ChatChannel(room_id), "wake");
+  remote_->handler->OnChannelActive(ChatChannel(room_id));
+  remote_->handler->OnNotify(ChatChannel("never-existed"), "wake");
+
+  ASSERT_TRUE(SendChat(*alice, "still works"));
+  ASSERT_GT(ExpectNextChat(*alice, "still works"), 0);
+
+  // And the remote can still meet the room the ordinary way afterwards.
+  auto bob = OpenSeatVia(*remote_->client);
+  ASSERT_TRUE(bob.has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  auto replay = ReceiveCase(bob->stream, "roomChatHistory");
+  ASSERT_TRUE(replay.has_value());
+  ASSERT_EQ(replay->as_roomChatHistory_or_null()->messages.size(), 1u);
+  EXPECT_EQ(replay->as_roomChatHistory_or_null()->messages[0].text, "still works");
+}
+
+// An instance that restores a room from the store (a restart, from the
+// store's point of view) meets its chat with no cursor. First contact
+// adopts the newest retained id and replays nothing live — history
+// replay owns the past. The adopted cursor also stands where adoption
+// left it, so a row committed between adoption and a member's resume is
+// heard twice: once in the resume's replay and once live. That overlap
+// is the model's documented contract — at-least-once, dedupe by id —
+// and this pins it on purpose.
+TEST_F(HubChatRaceFixture, RestoredInstanceAdoptsTheCursorInsteadOfReplayingThePast) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChatHistory").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+
+  ASSERT_TRUE(SendChat(*alice, "old"));
+  ASSERT_GT(ExpectNextChat(*alice, "old"), 0);
+  ASSERT_GT(ExpectNextChat(*bob, "old"), 0);
+
+  // A third instance restores the room, then hears its first chat wake:
+  // adoption. Nothing to observe yet — its members are all disconnected —
+  // which is the point: the past is not replayed at anyone.
+  auto restored = BuildInstance();
+  ASSERT_NE(restored, nullptr);
+  restored->handler->OnNotify(ChatChannel(room_id), "wake");
+
+  ASSERT_TRUE(SendChat(*alice, "mid"));
+  ASSERT_GT(ExpectNextChat(*alice, "mid"), 0);
+  ASSERT_GT(ExpectNextChat(*bob, "mid"), 0);
+
+  // Bob resumes onto the restored instance; the replay hands him
+  // everything retained, including what committed after adoption.
+  auto resumed = OpenSeatVia(*restored->client, bob->resume_token);
+  ASSERT_TRUE(resumed.has_value());
+  ASSERT_TRUE(ReceiveCase(resumed->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(resumed->stream, "roomState").has_value());
+  auto replay = ReceiveCase(resumed->stream, "roomChatHistory");
+  ASSERT_TRUE(replay.has_value());
+  const auto* history = replay->as_roomChatHistory_or_null();
+  ASSERT_EQ(history->messages.size(), 2u);
+  EXPECT_EQ(history->messages[0].text, "old");
+  EXPECT_EQ(history->messages[1].text, "mid");
+
+  ASSERT_TRUE(SendChat(*alice, "new"));
+  ASSERT_GT(ExpectNextChat(*alice, "new"), 0);
+  ASSERT_GT(ExpectNextChat(*bob, "new"), 0);
+
+  // One wake after the resume: live delivery starts at the adopted
+  // cursor, so "mid" overlaps the replay and "old" — behind the cursor —
+  // does not repeat.
+  restored->handler->OnNotify(ChatChannel(room_id), "wake");
+  const int64_t mid_id = ExpectNextChat(*resumed, "mid");
+  const int64_t new_id = ExpectNextChat(*resumed, "new");
+  ASSERT_GT(mid_id, 0);
+  EXPECT_GT(new_id, mid_id);
+}
+
+// A wake that lands while a drain is already running must neither start
+// a second concurrent drain nor be dropped: the drainer notices and
+// loops once more. The gate parks the first pump inside its LoadAfter so
+// the second wake deterministically hits a drain in flight.
+TEST_F(HubChatRaceFixture, WakeLandingMidDrainCoalescesIntoOneDelivery) {
+  auto pair = SplitRoom();
+  ASSERT_TRUE(pair.has_value());
+
+  ASSERT_TRUE(SendChat(pair->alice, "before"));
+  ASSERT_GT(ExpectNextChat(pair->alice, "before"), 0);
+  remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");
+  ASSERT_GT(ExpectNextChat(pair->bob, "before"), 0);
+
+  ASSERT_TRUE(SendChat(pair->alice, "gated"));
+  ASSERT_GT(ExpectNextChat(pair->alice, "gated"), 0);
+
+  gated_->ArmGate();
+  std::thread first_wake(
+      [&] { remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary"); });
+  const bool entered = gated_->WaitForEntry(std::chrono::seconds(5));
+  EXPECT_TRUE(entered);
+  if (entered) {
+    // Lands while the first drain is parked inside LoadAfter: returns
+    // immediately, leaving the drainer one more loop to run.
+    remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");
+  }
+  gated_->Release();
+  first_wake.join();
+
+  // Exactly one delivery for the coalesced pair of wakes; the sentinel
+  // arriving as bob's very next frame proves no duplicate snuck out.
+  ASSERT_GT(ExpectNextChat(pair->bob, "gated"), 0);
+  ASSERT_TRUE(SendChat(pair->alice, "sentinel"));
+  ASSERT_GT(ExpectNextChat(pair->alice, "sentinel"), 0);
+  remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");
+  ASSERT_GT(ExpectNextChat(pair->bob, "sentinel"), 0);
+}
+
+}  // namespace
+}  // namespace golf_hub

--- a/domains/games/apis/golf_hub/hub_chat_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_chat_race_test.cc
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "domains/games/apis/golf_hub/chat_store.h"
 #include "domains/games/apis/golf_hub/hub_store.h"
@@ -63,9 +64,10 @@ class TestGate {
 };
 
 // Forwards everything; when armed, the next load (either kind) announces
-// itself and blocks until released. That parks a pump mid-drain at a
-// chosen point — the only way to deterministically land an append or a
-// second wake while a load is in flight.
+// itself and blocks until released — and, when asked, fails after the
+// release instead of forwarding. That parks a pump mid-drain at a chosen
+// point, the only way to deterministically land an append, a second
+// wake, or a transient store failure while a load is in flight.
 class GatedChatStore final : public ChatStore {
  public:
   explicit GatedChatStore(std::shared_ptr<ChatStore> delegate) : delegate_(std::move(delegate)) {}
@@ -77,31 +79,36 @@ class GatedChatStore final : public ChatStore {
   }
   absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
                                                   std::size_t limit) override {
-    Gate();
+    if (Gate()) return absl::UnavailableError("gated load failure");
     return delegate_->LoadRecent(room_id, limit);
   }
   absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
                                                  int64_t after_message_id,
                                                  std::size_t limit) override {
-    Gate();
+    if (Gate()) return absl::UnavailableError("gated load failure");
     return delegate_->LoadAfter(room_id, after_message_id, limit);
   }
   void DropRoom(const std::string& room_id) override { delegate_->DropRoom(room_id); }
 
   void ArmGate() { armed_ = true; }
+  void FailOnRelease() { fail_on_release_ = true; }
   bool WaitForEntry(std::chrono::milliseconds timeout) { return entered_.WaitFor(timeout); }
   void Release() { released_.Open(); }
 
  private:
-  void Gate() {
+  // Returns true when the gated call should fail instead of forwarding.
+  bool Gate() {
     if (armed_.exchange(false)) {
       entered_.Open();
       released_.Wait();
+      return fail_on_release_.exchange(false);
     }
+    return false;
   }
 
   std::shared_ptr<ChatStore> delegate_;
   std::atomic<bool> armed_ = false;
+  std::atomic<bool> fail_on_release_ = false;
   TestGate entered_;
   TestGate released_;
 };
@@ -477,6 +484,33 @@ TEST_F(HubChatRaceFixture, AppendCommittingDuringAnInFlightWakeLoadIsStillDelive
   ASSERT_GT(ExpectNextChat(*alice, "sentinel"), 0);
   restored->handler->OnNotify(ChatChannel(room_id), "primary");
   ASSERT_GT(ExpectNextChat(*resumed, "sentinel"), 0);
+}
+
+// A transient store failure must not eat a wake that coalesced into the
+// failing drain: that signal may be the only one an already-committed
+// append gets (its own pump call already came and coalesced), so the
+// drain spends it on one immediate retry. The gate parks the remote's
+// catch-up load, lands the second wake, then fails the parked load on
+// release — with no further wakes, the retry is bob's only path.
+TEST_F(HubChatRaceFixture, WakeCoalescedIntoAFailingLoadStillDelivers) {
+  auto pair = SplitRoom();
+  ASSERT_TRUE(pair.has_value());
+
+  ASSERT_TRUE(SendChat(pair->alice, "storm"));
+  ASSERT_GT(ExpectNextChat(pair->alice, "storm"), 0);
+
+  gated_->ArmGate();
+  gated_->FailOnRelease();
+  std::thread wake([&] { remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary"); });
+  const bool entered = gated_->WaitForEntry(std::chrono::seconds(5));
+  EXPECT_TRUE(entered);
+  if (entered) {
+    remote_->handler->OnNotify(ChatChannel(pair->room_id), "primary");  // coalesces
+  }
+  gated_->Release();
+  wake.join();
+
+  ASSERT_GT(ExpectNextChat(pair->bob, "storm"), 0);
 }
 
 // A wake that lands while a drain is already running must neither start

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -248,10 +248,21 @@ void HubHandler::AttachListener(pg::Listener* listener) {
   const std::lock_guard<std::mutex> lock(mu_);
   listener_ = listener;
   if (listener_ == nullptr) return;
-  for (const auto& [room_id, room] : rooms_) listener_->Listen(RoomChannel(room_id));
+  for (const auto& [room_id, room] : rooms_) {
+    listener_->Listen(RoomChannel(room_id));
+    listener_->Listen(ChatChannel(room_id));
+  }
 }
 
 void HubHandler::OnNotify(const std::string& channel, const std::string& payload) {
+  constexpr std::string_view kChatPrefix = "chat_";
+  if (absl::StartsWith(channel, kChatPrefix)) {
+    // Own wakes pump too, deliberately: the cursor makes it a no-op in
+    // the common case, and it is what recovers an append whose
+    // connection died between COMMIT and the reply.
+    PumpChat(std::string(channel.substr(kChatPrefix.size())));
+    return;
+  }
   if (payload == instance_id_) return;  // our own commit; locals already heard it
   constexpr std::string_view kPrefix = "room_";
   if (!absl::StartsWith(channel, kPrefix)) return;
@@ -265,6 +276,16 @@ void HubHandler::OnNotify(const std::string& channel, const std::string& payload
     RefreshRoomLocked(room_id, outbox);
   }
   Deliver(outbox);
+}
+
+void HubHandler::OnChannelActive(const std::string& channel) {
+  // Only chat needs the signal: a room wake re-reads everything anyway,
+  // but chat delivery is cursor-driven, and rows committed while we were
+  // not subscribed queued no notification for us.
+  constexpr std::string_view kChatPrefix = "chat_";
+  if (absl::StartsWith(channel, kChatPrefix)) {
+    PumpChat(std::string(channel.substr(kChatPrefix.size())));
+  }
 }
 
 void HubHandler::RefreshRoomLocked(const std::string& room_id, Outbox& outbox) {
@@ -299,6 +320,7 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
     // whole of an append, so no append can be mid-flight here and land a
     // message after the drop.
     chat_store_->DropRoom(room_id);
+    chat_cursors_.erase(room_id);
     UnlistenRoomLocked(room_id);
     return;
   }
@@ -395,11 +417,15 @@ void HubHandler::DropGameLocked(const GameRef& ref) {
 }
 
 void HubHandler::ListenRoomLocked(const std::string& room_id) {
-  if (listener_ != nullptr) listener_->Listen(RoomChannel(room_id));
+  if (listener_ == nullptr) return;
+  listener_->Listen(RoomChannel(room_id));
+  listener_->Listen(ChatChannel(room_id));
 }
 
 void HubHandler::UnlistenRoomLocked(const std::string& room_id) {
-  if (listener_ != nullptr) listener_->Unlisten(RoomChannel(room_id));
+  if (listener_ == nullptr) return;
+  listener_->Unlisten(RoomChannel(room_id));
+  listener_->Unlisten(ChatChannel(room_id));
 }
 
 smithy::Outcome<moonbase::golf::GetSessionOutput> HubHandler::GetSession(
@@ -537,6 +563,9 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
         room_id = ids_->RoomId();
         while (rooms_.contains(room_id)) room_id = ids_->RoomId();
         const auto [member, inserted] = rooms_[room_id].members.emplace(player_id, Member{});
+        // Born at zero with its room: the creator's first message must
+        // pump from the very beginning, not adopt-past its own append.
+        chat_cursors_.emplace(room_id, ChatCursor{});
         player_room_[player_id] = room_id;
         ListenRoomLocked(room_id);
         StageLocked(writes, HubStore::UpsertRoom{room_id});
@@ -670,19 +699,12 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
       return;
     }
 
-    Outbox outbox;
-    {
-      const std::lock_guard<std::mutex> lock(mu_);
-      // Whoever is in the room now: the roster can have moved while the
-      // append ran, and a member who left has no claim on the message.
-      if (const auto room = rooms_.find(room_id); room != rooms_.end()) {
-        const moonbase::golf::ChatMessage message = ChatEvent(*appended);
-        for (const auto& member : room->second.members) {
-          outbox.To(member.first, GolfEvents::FromRoomchat(message));
-        }
-      }
-    }
-    Deliver(outbox);
+    // The committed row reaches locals through the pump, like every
+    // other row. That is not indirection for its own sake: a remote
+    // append our commit raced past holds a lower id, and the pump's
+    // cursor walk delivers it before ours — staging just our own row
+    // and advancing the cursor over it would skip it for good.
+    PumpChat(room_id);
     return;
   }
 
@@ -1162,6 +1184,7 @@ void HubHandler::LeaveEverywhere(const std::string& player_id, Outbox& outbox, W
     // it is what production runs today — without this an emptied room
     // keeps its last hundred messages for the life of the process.
     chat_store_->DropRoom(room_id);
+    chat_cursors_.erase(room_id);
     // One DeleteRoom; the row's cascade takes members and games with it.
     // The wake rider tells any instance that still holds the room (a
     // race, not the norm — an emptied room has no members anywhere).
@@ -1299,6 +1322,76 @@ void HubHandler::Deliver(Outbox& outbox) {
   outbox.events.clear();
 }
 
+void HubHandler::PumpChat(const std::string& room_id) {
+  {
+    const std::lock_guard<std::mutex> lock(mu_);
+    if (!rooms_.contains(room_id)) return;  // stale wake; nothing to resurrect
+    const auto [cursor, inserted] = chat_cursors_.try_emplace(room_id);
+    if (inserted) cursor->second.adopt = true;  // first contact: seed, don't replay
+    if (cursor->second.pumping) {
+      // One drain at a time; the drainer loops once more for us.
+      cursor->second.again = true;
+      return;
+    }
+    cursor->second.pumping = true;
+  }
+
+  bool more = true;
+  while (more) {
+    int64_t after = 0;
+    bool adopt = false;
+    {
+      const std::lock_guard<std::mutex> lock(mu_);
+      const auto cursor = chat_cursors_.find(room_id);
+      if (cursor == chat_cursors_.end()) return;  // room dropped mid-pump
+      after = cursor->second.delivered;
+      adopt = cursor->second.adopt;
+    }
+
+    // Outside mu_: the load may reach a database. Adoption reads one row
+    // (the newest) instead of a page — history replay owns the past, so
+    // a cursor meeting a room for the first time starts at now.
+    auto rows = adopt ? chat_store_->LoadRecent(room_id, 1)
+                      : chat_store_->LoadAfter(room_id, after, kChatCatchUpPage);
+
+    Outbox outbox;
+    {
+      const std::lock_guard<std::mutex> lock(mu_);
+      const auto cursor = chat_cursors_.find(room_id);
+      const auto room = rooms_.find(room_id);
+      if (cursor == chat_cursors_.end() || room == rooms_.end()) return;
+      if (!rows.ok()) {
+        Count("chat_catch_up_failures");
+        LOG(WARNING) << "chat catch-up load failed: " << rows.status();
+        cursor->second.pumping = false;
+        cursor->second.again = false;  // the next wake retries
+        return;
+      }
+      if (adopt) {
+        if (!rows->empty()) {
+          cursor->second.delivered = std::max(cursor->second.delivered, rows->back().message_id);
+        }
+        cursor->second.adopt = false;
+        more = true;  // now drain anything above the adopted point
+        continue;
+      }
+      for (const ChatRow& row : *rows) {
+        if (row.message_id <= cursor->second.delivered) continue;
+        const GolfEvents event = GolfEvents::FromRoomchat(ChatEvent(row));
+        for (const auto& member : room->second.members) outbox.To(member.first, event);
+        cursor->second.delivered = row.message_id;
+      }
+      more = rows->size() == kChatCatchUpPage;
+      if (!more && cursor->second.again) {
+        cursor->second.again = false;
+        more = true;
+      }
+      if (!more) cursor->second.pumping = false;
+    }
+    Deliver(outbox);
+  }
+}
+
 void HubHandler::SendChatHistory(const std::string& room_id, const std::string& player_id) {
   auto rows = chat_store_->LoadRecent(room_id, kChatHistoryLimit);
   if (!rows.ok()) {
@@ -1307,6 +1400,15 @@ void HubHandler::SendChatHistory(const std::string& room_id, const std::string& 
     Count("chat_history_load_failures");
     LOG(WARNING) << "chat history load failed for a joining stream: " << rows.status();
     return;
+  }
+  {
+    // Seed the room's live cursor where this replay ends. try_emplace:
+    // if the pump already owns a cursor for this room, its progression
+    // wins — a slightly stale replay just overlaps, which is legal.
+    const std::lock_guard<std::mutex> lock(mu_);
+    ChatCursor seeded;
+    seeded.delivered = rows->empty() ? 0 : rows->back().message_id;
+    chat_cursors_.try_emplace(room_id, seeded);
   }
   // Sent even when empty: a stream that entered a room always hears one
   // history event, so the client has a deterministic signal rather than

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -1382,8 +1382,16 @@ void HubHandler::PumpChat(const std::string& room_id) {
       if (!rows.ok()) {
         Count("chat_catch_up_failures");
         LOG(WARNING) << "chat catch-up load failed: " << rows.status();
+        if (cursor->second.again) {
+          // A wake landed while this load was failing. That signal may
+          // be the only one an already-committed append gets — its own
+          // pump call already came and coalesced — so it buys one
+          // immediate retry instead of being thrown away. Bounded: each
+          // retry consumes a signal, so a persistent outage still exits.
+          cursor->second.again = false;
+          continue;
+        }
         cursor->second.pumping = false;
-        cursor->second.again = false;  // the next wake retries
         return;
       }
       for (const ChatRow& row : *rows) {

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -171,9 +171,27 @@ absl::Status HubHandler::RestoreFromStore() {
     for (const std::string& member_id : entry.roster) player_game_[member_id] = row.game_id;
     rooms_[row.room_id].games.emplace(row.game_id, std::move(entry));
   }
+  // Every restored room gets its cursor before anything can pump it —
+  // still inside the boot lock, before the listener or any stream exists.
+  for (const auto& [room_id, room] : rooms_) SeedChatCursorLocked(room_id);
   LOG(INFO) << "hub restored " << snapshot->rooms.size() << " rooms, " << snapshot->members.size()
             << " members, " << snapshot->games.size() << " games";
   return absl::OkStatus();
+}
+
+void HubHandler::SeedChatCursorLocked(const std::string& room_id) {
+  auto rows = chat_store_->LoadRecent(room_id, 1);
+  ChatCursor cursor;
+  if (rows.ok()) {
+    cursor.delivered = rows->empty() ? 0 : rows->back().message_id;
+  } else {
+    // Fail toward duplication, never loss: a cursor left at 0 re-delivers
+    // retained rows, which clients dedupe by id; guessing high would
+    // swallow messages.
+    Count("chat_cursor_seed_failures");
+    LOG(WARNING) << "chat cursor seed failed: " << rows.status();
+  }
+  chat_cursors_.try_emplace(room_id, cursor);
 }
 
 void HubHandler::EnqueueWritesLocked(Writes& writes) {
@@ -325,8 +343,13 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
     return;
   }
 
+  const bool materialized = !rooms_.contains(room_id);
   Room& room = rooms_[room_id];
   ListenRoomLocked(room_id);  // idempotent; covers a room just materialized
+  // A cursor born in the same critical section that makes the room held:
+  // no member exists locally yet, so no append can commit behind it and
+  // then be stepped over — the adoption race a wake-time seed would have.
+  if (materialized) SeedChatCursorLocked(room_id);
 
   // Members mirror the rows: every instance writes its own players'
   // rows, and the refresh flush made ours current.
@@ -563,8 +586,8 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
         room_id = ids_->RoomId();
         while (rooms_.contains(room_id)) room_id = ids_->RoomId();
         const auto [member, inserted] = rooms_[room_id].members.emplace(player_id, Member{});
-        // Born at zero with its room: the creator's first message must
-        // pump from the very beginning, not adopt-past its own append.
+        // Born at zero with its room: it provably has no rows, and the
+        // creator's first message must pump from the very beginning.
         chat_cursors_.emplace(room_id, ChatCursor{});
         player_room_[player_id] = room_id;
         ListenRoomLocked(room_id);
@@ -1325,9 +1348,10 @@ void HubHandler::Deliver(Outbox& outbox) {
 void HubHandler::PumpChat(const std::string& room_id) {
   {
     const std::lock_guard<std::mutex> lock(mu_);
-    if (!rooms_.contains(room_id)) return;  // stale wake; nothing to resurrect
-    const auto [cursor, inserted] = chat_cursors_.try_emplace(room_id);
-    if (inserted) cursor->second.adopt = true;  // first contact: seed, don't replay
+    // No cursor means no room (they live and die together): a stale wake
+    // must not resurrect anything.
+    const auto cursor = chat_cursors_.find(room_id);
+    if (cursor == chat_cursors_.end()) return;
     if (cursor->second.pumping) {
       // One drain at a time; the drainer loops once more for us.
       cursor->second.again = true;
@@ -1339,20 +1363,15 @@ void HubHandler::PumpChat(const std::string& room_id) {
   bool more = true;
   while (more) {
     int64_t after = 0;
-    bool adopt = false;
     {
       const std::lock_guard<std::mutex> lock(mu_);
       const auto cursor = chat_cursors_.find(room_id);
       if (cursor == chat_cursors_.end()) return;  // room dropped mid-pump
       after = cursor->second.delivered;
-      adopt = cursor->second.adopt;
     }
 
-    // Outside mu_: the load may reach a database. Adoption reads one row
-    // (the newest) instead of a page — history replay owns the past, so
-    // a cursor meeting a room for the first time starts at now.
-    auto rows = adopt ? chat_store_->LoadRecent(room_id, 1)
-                      : chat_store_->LoadAfter(room_id, after, kChatCatchUpPage);
+    // Outside mu_: the load may reach a database.
+    auto rows = chat_store_->LoadAfter(room_id, after, kChatCatchUpPage);
 
     Outbox outbox;
     {
@@ -1366,14 +1385,6 @@ void HubHandler::PumpChat(const std::string& room_id) {
         cursor->second.pumping = false;
         cursor->second.again = false;  // the next wake retries
         return;
-      }
-      if (adopt) {
-        if (!rows->empty()) {
-          cursor->second.delivered = std::max(cursor->second.delivered, rows->back().message_id);
-        }
-        cursor->second.adopt = false;
-        more = true;  // now drain anything above the adopted point
-        continue;
       }
       for (const ChatRow& row : *rows) {
         if (row.message_id <= cursor->second.delivered) continue;
@@ -1401,15 +1412,9 @@ void HubHandler::SendChatHistory(const std::string& room_id, const std::string& 
     LOG(WARNING) << "chat history load failed for a joining stream: " << rows.status();
     return;
   }
-  {
-    // Seed the room's live cursor where this replay ends. try_emplace:
-    // if the pump already owns a cursor for this room, its progression
-    // wins — a slightly stale replay just overlaps, which is legal.
-    const std::lock_guard<std::mutex> lock(mu_);
-    ChatCursor seeded;
-    seeded.delivered = rows->empty() ? 0 : rows->back().message_id;
-    chat_cursors_.try_emplace(room_id, seeded);
-  }
+  // No cursor work here: the room's cursor predates every join (born
+  // with the room under mu_), and a replay ending behind it or ahead of
+  // it just overlaps live delivery, which the model declares legal.
   // Sent even when empty: a stream that entered a room always hears one
   // history event, so the client has a deterministic signal rather than
   // inferring emptiness from absence.

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -343,7 +343,7 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
     bool pumping = false;
     bool again = false;
   };
-  std::map<std::string, ChatCursor> chat_cursors_;
+  std::unordered_map<std::string, ChatCursor> chat_cursors_;
 
   std::unordered_map<std::string, std::string> player_room_;
   std::unordered_map<std::string, std::string> player_game_;

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -118,8 +118,18 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// The listener callback target; runs on the listener's thread. A
   /// wake-up for a held room re-reads its rows and re-projects views to
   /// local players; payloads carrying our own instance id are skipped
-  /// (locals already heard the local fan-out).
+  /// (locals already heard the local fan-out). Chat wake-ups instead run
+  /// the chat pump — including our own, which the cursor makes idempotent
+  /// and which closes the ambiguous-commit path (an append whose
+  /// connection died after COMMIT still reaches everyone).
   void OnNotify(const std::string& channel, const std::string& payload);
+
+  /// The listener's channel-active target; runs on the listener's
+  /// thread. A chat channel becoming active (first LISTEN, or re-LISTEN
+  /// after a reconnect) pumps that room: anything committed while we
+  /// were not subscribed never queued a notification, so the cursor
+  /// read is the only thing that closes the gap.
+  void OnChannelActive(const std::string& channel);
 
  private:
   struct Member {
@@ -207,7 +217,25 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// stream's roomState, the order the model documents. A failed load is
   /// counted and skipped rather than failing the join: live delivery
   /// catches the client up from here, and overlap is legal anyway.
+  /// Also seeds the room's chat cursor at the newest loaded id, so live
+  /// delivery starts where the replay ended.
   void SendChatHistory(const std::string& room_id, const std::string& player_id);
+
+  /// The one path every live chat row takes to local members: load pages
+  /// above the room's cursor, stage rows to current members, advance,
+  /// repeat while pages come back full. Local appends call this after
+  /// their commit instead of staging directly, which is what makes a
+  /// remote commit our append raced past (a lower id committed just
+  /// before ours) reach locals in id order — a blind "deliver mine,
+  /// advance cursor" would step over it. Remote wakes, our own wakes,
+  /// duplicate wakes, and channel-active signals all funnel here too;
+  /// the cursor makes every redundant call a cheap no-op, and a per-room
+  /// in-flight flag collapses concurrent pumps into one.
+  ///
+  /// Call outside mu_ (it takes mu_ itself, and reads may reach a
+  /// database). A pump for a room this instance no longer holds delivers
+  /// nothing and resurrects nothing.
+  void PumpChat(const std::string& room_id);
 
   void SetConnected(const std::string& player_id, bool connected);
   std::optional<std::string> CurrentRoom(const std::string& player_id);
@@ -291,6 +319,22 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   std::mutex mu_;
   pg::Listener* listener_ = nullptr;  // owned by the caller; guarded by mu_
   std::unordered_map<std::string, Room> rooms_;
+
+  /// Where live chat delivery stands for one held room. `delivered` is
+  /// the highest message id every current local member has been staged
+  /// (a cursor is born at 0 only when its room is born; any other first
+  /// contact adopts the newest retained id without delivering, since
+  /// history replay owns the past). `pumping`/`again` collapse
+  /// concurrent PumpChat calls into one drain. The entry dies with the
+  /// room.
+  struct ChatCursor {
+    int64_t delivered = 0;
+    bool adopt = false;  // first contact: seed from newest, deliver nothing
+    bool pumping = false;
+    bool again = false;
+  };
+  std::map<std::string, ChatCursor> chat_cursors_;
+
   std::unordered_map<std::string, std::string> player_room_;
   std::unordered_map<std::string, std::string> player_game_;
   // Declared last: destroyed first, joining registry threads before the

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -217,9 +217,19 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// stream's roomState, the order the model documents. A failed load is
   /// counted and skipped rather than failing the join: live delivery
   /// catches the client up from here, and overlap is legal anyway.
-  /// Also seeds the room's chat cursor at the newest loaded id, so live
-  /// delivery starts where the replay ended.
   void SendChatHistory(const std::string& room_id, const std::string& player_id);
+
+  /// Births the room's chat cursor at the newest retained message id,
+  /// inside the same mu_ hold that makes the room held — the reason no
+  /// message can ever be skipped: an append cannot commit "behind" a
+  /// cursor whose seed read shares the critical section that made its
+  /// sender's membership visible, and everything at or below the seed
+  /// predates every local member's history replay. A failed seed read
+  /// leaves the cursor at 0, which fails toward re-delivering retained
+  /// rows (clients dedupe by id) — never toward losing one. createRoom
+  /// births its cursor directly at 0 instead: the room provably has no
+  /// rows, and its creator's first append must not be read as the past.
+  void SeedChatCursorLocked(const std::string& room_id);
 
   /// The one path every live chat row takes to local members: load pages
   /// above the room's cursor, stage rows to current members, advance,
@@ -230,7 +240,9 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// advance cursor" would step over it. Remote wakes, our own wakes,
   /// duplicate wakes, and channel-active signals all funnel here too;
   /// the cursor makes every redundant call a cheap no-op, and a per-room
-  /// in-flight flag collapses concurrent pumps into one.
+  /// in-flight flag collapses concurrent pumps into one. Cursors are
+  /// only ever read here, never created: SeedChatCursorLocked births
+  /// them with the room, so a missing cursor means a stale wake.
   ///
   /// Call outside mu_ (it takes mu_ itself, and reads may reach a
   /// database). A pump for a room this instance no longer holds delivers
@@ -321,15 +333,13 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   std::unordered_map<std::string, Room> rooms_;
 
   /// Where live chat delivery stands for one held room. `delivered` is
-  /// the highest message id every current local member has been staged
-  /// (a cursor is born at 0 only when its room is born; any other first
-  /// contact adopts the newest retained id without delivering, since
-  /// history replay owns the past). `pumping`/`again` collapse
-  /// concurrent PumpChat calls into one drain. The entry dies with the
-  /// room.
+  /// the highest message id every current local member has been staged.
+  /// A cursor is born in the same mu_ critical section that makes its
+  /// room held — SeedChatCursorLocked — and dies with the room, so every
+  /// held room has one and PumpChat never creates them. `pumping`/`again`
+  /// collapse concurrent PumpChat calls into one drain.
   struct ChatCursor {
     int64_t delivered = 0;
-    bool adopt = false;  // first contact: seed from newest, deliver nothing
     bool pumping = false;
     bool again = false;
   };

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "domains/games/apis/golf_hub/migrations.h"
+#include "domains/games/apis/golf_hub/pg_chat_store.h"
 #include "domains/games/apis/golf_hub/pg_hub_store.h"
 #include "domains/games/apis/golf_hub/pg_ticket_vault.h"
 #include "domains/games/apis/golf_hub/stream_test_fixture.h"
@@ -102,12 +103,19 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
   std::shared_ptr<HubStore> MakeStore() override {
     return std::make_shared<PgHubStore>(std::make_shared<pg::Client>(url_));
   }
+  std::shared_ptr<ChatStore> MakeChatStore() override {
+    return std::make_shared<PgChatStore>(std::make_shared<pg::Client>(url_));
+  }
 
   std::unique_ptr<pg::Listener> MakeListener(const std::shared_ptr<HubHandler>& handler) {
     auto listener = std::make_unique<pg::Listener>(
-        url_, [handler](const std::string& channel, const std::string& payload) {
+        url_,
+        [handler](const std::string& channel, const std::string& payload) {
           handler->OnNotify(channel, payload);
-        });
+        },
+        // The active signal is chat's catch-up trigger: rows committed
+        // before a (re)LISTEN landed never notified this instance.
+        [handler](const std::string& channel) { handler->OnChannelActive(channel); });
     handler->AttachListener(listener.get());
     return listener;
   }
@@ -152,7 +160,8 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
         MakeVault(), std::make_shared<cards::NoShuffleDealer>(),
         std::make_shared<RemoteIdGenerator>(),
         /*grace_period=*/std::chrono::seconds(60),
-        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), instance->store);
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), instance->store,
+        MakeChatStore());
     const absl::Status restored = instance->handler->RestoreFromStore();
     EXPECT_TRUE(restored.ok()) << restored;
     instance->listener = MakeListener(instance->handler);
@@ -719,12 +728,133 @@ TEST_F(PgGolfHubFixture, RemoteFinishRunsOneCeremonyEverywhere) {
   }
 }
 
+// Chat across the real wire (#1226 task 5): a message committed on one
+// instance reaches the other's members via its NOTIFY — or, when the
+// commit raced the receiving side's LISTEN, via the channel-active
+// catch-up read. Which path fired is deliberately invisible: delivery
+// is bounded either way, which is the whole at-least-once claim.
+TEST_F(PgGolfHubFixture, ChatCrossesInstancesBothWays) {
+  auto remote = BuildInstance();
+  ASSERT_NE(remote, nullptr);
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  auto bob = OpenSeatVia(*remote->client);
+  ASSERT_TRUE(bob.has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
+  // Room and membership rows are written through asynchronously; the
+  // remote's join needs the room row, and each sender's append
+  // authorizes against their member row.
+  store_->Flush();
+
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChatHistory").has_value());
+  remote->store->Flush();
+
+  moonbase::golf::Chat chat;
+  chat.text = "hello from remote";
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromChat(chat)).ok());
+  auto bob_echo = ReceiveCase(bob->stream, "roomChat");
+  ASSERT_TRUE(bob_echo.has_value());
+  auto to_alice = ReceiveCase(alice->stream, "roomChat");
+  ASSERT_TRUE(to_alice.has_value());
+  EXPECT_EQ(to_alice->as_roomChat_or_null()->text, "hello from remote");
+  EXPECT_EQ(to_alice->as_roomChat_or_null()->messageId, bob_echo->as_roomChat_or_null()->messageId);
+
+  chat.text = "hello from primary";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
+  auto to_bob = ReceiveCase(bob->stream, "roomChat");
+  ASSERT_TRUE(to_bob.has_value());
+  EXPECT_EQ(to_bob->as_roomChat_or_null()->text, "hello from primary");
+  EXPECT_GT(to_bob->as_roomChat_or_null()->messageId, bob_echo->as_roomChat_or_null()->messageId);
+
+  // A later joiner replays both messages from the database, in id order,
+  // regardless of which instance stored them.
+  auto charlie = OpenSeatVia(*remote->client);
+  ASSERT_TRUE(charlie.has_value());
+  ASSERT_TRUE(ReceiveCase(charlie->stream, "sessionReady").has_value());
+  ASSERT_TRUE(charlie->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(charlie->stream, "roomState").has_value());
+  auto replay = ReceiveCase(charlie->stream, "roomChatHistory");
+  ASSERT_TRUE(replay.has_value());
+  const auto* history = replay->as_roomChatHistory_or_null();
+  ASSERT_EQ(history->messages.size(), 2u);
+  EXPECT_EQ(history->messages[0].text, "hello from remote");
+  EXPECT_EQ(history->messages[1].text, "hello from primary");
+}
+
+// LISTEN/NOTIFY has no replay: a notify fired while a listener's
+// connection is down reaches no one, ever. What makes chat delivery
+// at-least-once anyway is the reconnect: the re-LISTEN's channel-active
+// signal triggers a catch-up read of everything the cursor missed.
+TEST_F(PgGolfHubFixture, ChatCommittedDuringListenerOutageArrivesAfterReconnect) {
+  auto remote = BuildInstance();
+  ASSERT_NE(remote, nullptr);
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  auto bob = OpenSeatVia(*remote->client);
+  ASSERT_TRUE(bob.has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
+  store_->Flush();
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChatHistory").has_value());
+  remote->store->Flush();
+
+  // One exchanged message proves live delivery is up before the outage.
+  moonbase::golf::Chat chat;
+  chat.text = "before";
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChat").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
+
+  // Kill every listener backend; the poll threads reconnect on their own.
+  pg::Client db(url_);
+  ASSERT_TRUE(db.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity"
+                      " WHERE query LIKE 'LISTEN%' AND pid <> pg_backend_pid()")
+                  .ok());
+
+  // Committed while (most likely) nobody was subscribed. The sender's
+  // own echo needs no listener — the local pump runs off the append —
+  // but alice's instance can only learn of the row from a wake, and if
+  // its notify fired into the gap, only the catch-up read remains.
+  chat.text = "during outage";
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChat").has_value());
+  auto healed = ReceiveCase(alice->stream, "roomChat");
+  ASSERT_TRUE(healed.has_value());
+  EXPECT_EQ(healed->as_roomChat_or_null()->text, "during outage");
+}
+
 TEST_F(PgGolfHubFixture, EmptiedRoomVanishesFromTheDatabase) {
   auto alice = OpenSeat();
   ASSERT_TRUE(alice.has_value());
   ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
   ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
   ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+  // A stored message, so the vanishing below has chat to take with it.
+  store_->Flush();
+  moonbase::golf::Chat chat;
+  chat.text = "soon gone";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
   ASSERT_TRUE(alice->stream.Send(GolfCommands::FromLeaveroom(moonbase::golf::LeaveRoom{})).ok());
   ASSERT_TRUE(ReceiveCase(alice->stream, "roomLeft").has_value());
 
@@ -732,6 +862,13 @@ TEST_F(PgGolfHubFixture, EmptiedRoomVanishesFromTheDatabase) {
   EXPECT_TRUE(rows.rooms.empty());
   EXPECT_TRUE(rows.members.empty());
   EXPECT_TRUE(rows.games.empty());
+  // The room row's deletion cascades to its chat: nothing retains a
+  // message for a room that no longer exists.
+  pg::Client db(url_);
+  auto chat_rows = db.Exec("SELECT count(*) FROM room_chat_messages");
+  ASSERT_TRUE(chat_rows.ok());
+  ASSERT_TRUE(chat_rows->Get(0, 0).has_value());
+  EXPECT_EQ(*chat_rows->Get(0, 0), "0");
 }
 
 }  // namespace

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -126,6 +126,11 @@ class GolfHubStreamFixture : public testing::Test {
                                                  /*resume_ttl=*/std::chrono::seconds(60));
   }
   virtual std::shared_ptr<HubStore> MakeStore() { return std::make_shared<MemoryHubStore>(); }
+  /// Null selects the default: a MemoryChatStore authorized through the
+  /// handler's membership guard, wired up two-phase below. The pg suite
+  /// overrides with PgChatStore, which authorizes in its own transaction
+  /// and needs nothing from the handler.
+  virtual std::shared_ptr<ChatStore> MakeChatStore() { return nullptr; }
 
   void SetUp() override { BuildHub(); }
 
@@ -142,17 +147,23 @@ class GolfHubStreamFixture : public testing::Test {
     // filled in after construction because it calls the handler that
     // does not exist yet; nothing appends before then.
     auto guard = std::make_shared<MemberGuard>();
-    chat_store_ = std::make_shared<MemoryChatStore>(
-        [guard](const std::string& room_id, const std::string& player_id,
-                const MemberAction& action) { return (*guard)(room_id, player_id, action); });
+    chat_store_ = MakeChatStore();
+    const bool default_memory_chat = chat_store_ == nullptr;
+    if (default_memory_chat) {
+      chat_store_ = std::make_shared<MemoryChatStore>(
+          [guard](const std::string& room_id, const std::string& player_id,
+                  const MemberAction& action) { return (*guard)(room_id, player_id, action); });
+    }
     handler_ = std::make_shared<HubHandler>(
         vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
         /*grace_period=*/std::chrono::seconds(60),
         std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), store_, chat_store_);
-    *guard = [handler = handler_.get()](const std::string& room_id, const std::string& player_id,
-                                        const MemberAction& action) {
-      return handler->WithMember(room_id, player_id, action);
-    };
+    if (default_memory_chat) {
+      *guard = [handler = handler_.get()](const std::string& room_id, const std::string& player_id,
+                                          const MemberAction& action) {
+        return handler->WithMember(room_id, player_id, action);
+      };
+    }
     const absl::Status restored = handler_->RestoreFromStore();
     ASSERT_TRUE(restored.ok()) << restored;
     server_ = std::make_unique<moonbase::golf::GolfHubServer>(handler_);
@@ -292,7 +303,7 @@ class GolfHubStreamFixture : public testing::Test {
 
   std::shared_ptr<TicketVault> vault_;
   std::shared_ptr<HubStore> store_;
-  std::shared_ptr<MemoryChatStore> chat_store_;
+  std::shared_ptr<ChatStore> chat_store_;
   std::shared_ptr<IdGenerator> ids_ = std::make_shared<SequentialIdGenerator>();
   std::shared_ptr<HubHandler> handler_;
   std::unique_ptr<moonbase::golf::GolfHubServer> server_;

--- a/domains/platform/libs/pg/listener.cc
+++ b/domains/platform/libs/pg/listener.cc
@@ -24,19 +24,21 @@ std::string QuotedListen(PGconn* conn, const std::string& verb, const std::strin
   return sql;
 }
 
-void RunOrWarn(PGconn* conn, const std::string& sql) {
-  if (sql.empty()) return;
+bool RunOrWarn(PGconn* conn, const std::string& sql) {
+  if (sql.empty()) return false;
   PGresult* result = PQexec(conn, sql.c_str());
-  if (result == nullptr || PQresultStatus(result) != PGRES_COMMAND_OK) {
-    LOG(WARNING) << "listener statement failed: " << sql;
-  }
+  const bool ok = result != nullptr && PQresultStatus(result) == PGRES_COMMAND_OK;
+  if (!ok) LOG(WARNING) << "listener statement failed: " << sql;
   if (result != nullptr) PQclear(result);
+  return ok;
 }
 
 }  // namespace
 
-Listener::Listener(std::string conninfo, Callback on_notify)
-    : conninfo_(std::move(conninfo)), on_notify_(std::move(on_notify)) {
+Listener::Listener(std::string conninfo, Callback on_notify, ActiveCallback on_active)
+    : conninfo_(std::move(conninfo)),
+      on_notify_(std::move(on_notify)),
+      on_active_(std::move(on_active)) {
   int fds[2] = {-1, -1};
   if (pipe(fds) == 0) {
     wake_read_ = fds[0];
@@ -85,13 +87,31 @@ void Listener::SyncChannels(PGconn* conn) {
     const std::lock_guard<std::mutex> lock(mu_);
     wanted = wanted_;
   }
+  // active_ tracks what the server actually LISTENs, so a failed
+  // statement stays out of it and is retried on the next pass (the poll
+  // bounds each pass at a second) instead of being assumed through.
+  std::vector<std::string> newly_active;
   for (const std::string& channel : wanted) {
-    if (!active_.contains(channel)) RunOrWarn(conn, QuotedListen(conn, "LISTEN", channel));
+    if (active_.contains(channel)) continue;
+    if (RunOrWarn(conn, QuotedListen(conn, "LISTEN", channel))) {
+      active_.insert(channel);
+      newly_active.push_back(channel);
+    }
   }
-  for (const std::string& channel : active_) {
-    if (!wanted.contains(channel)) RunOrWarn(conn, QuotedListen(conn, "UNLISTEN", channel));
+  for (auto it = active_.begin(); it != active_.end();) {
+    if (wanted.contains(*it)) {
+      ++it;
+    } else if (RunOrWarn(conn, QuotedListen(conn, "UNLISTEN", *it))) {
+      it = active_.erase(it);
+    } else {
+      ++it;  // failed UNLISTEN: still subscribed server-side, retry
+    }
   }
-  active_ = std::move(wanted);
+  // Off-mutex by construction — active_ belongs to this thread alone —
+  // so the owner may call Listen/Unlisten from inside the callback.
+  if (on_active_) {
+    for (const std::string& channel : newly_active) on_active_(channel);
+  }
 }
 
 void Listener::Loop() {

--- a/domains/platform/libs/pg/listener.h
+++ b/domains/platform/libs/pg/listener.h
@@ -18,14 +18,20 @@ namespace pg {
 /// channel. Dropped notifications during the gap are fine by protocol:
 /// a notify is only a wake-up, and every wake re-reads current state.
 ///
-/// The callback runs on the listener's thread. It may call Listen and
+/// The callbacks run on the listener's thread. They may call Listen and
 /// Unlisten (they only flag work for the poll thread), but must not
-/// block for long — nothing else is delivered while it runs.
+/// block for long — nothing else is delivered while they run.
 class Listener {
  public:
   using Callback = std::function<void(const std::string& channel, const std::string& payload)>;
+  /// Fired after a channel's LISTEN succeeds on a connection — on first
+  /// subscription and again after every reconnect's re-LISTEN. This is
+  /// the "you may have missed notifications" signal: anything committed
+  /// before this point never queued for us, so an owner that needs
+  /// at-least-once delivery does a catch-up read when it fires.
+  using ActiveCallback = std::function<void(const std::string& channel)>;
 
-  Listener(std::string conninfo, Callback on_notify);
+  Listener(std::string conninfo, Callback on_notify, ActiveCallback on_active = nullptr);
   ~Listener();
   Listener(const Listener&) = delete;
   Listener& operator=(const Listener&) = delete;
@@ -45,6 +51,7 @@ class Listener {
 
   const std::string conninfo_;
   const Callback on_notify_;
+  const ActiveCallback on_active_;
   int wake_read_ = -1;
   int wake_write_ = -1;
   std::mutex mu_;

--- a/domains/platform/libs/pg/listener_test.cc
+++ b/domains/platform/libs/pg/listener_test.cc
@@ -84,6 +84,44 @@ TEST_F(ListenerTest, DeliversNotificationsAndChannelChurn) {
   }
 }
 
+// The active callback removes the "retry until the LISTEN lands" dance:
+// once it fires, the server-side LISTEN is in place, so a single notify
+// is enough — this test sends each notify exactly once, no loops.
+TEST_F(ListenerTest, ActiveFiresOnSubscribeAndAgainAfterReconnect) {
+  Received notified;
+  Received active;
+  pg::Listener listener(
+      url_,
+      [&](const std::string& channel, const std::string& payload) {
+        notified.Add(channel, payload);
+      },
+      [&](const std::string& channel) { active.Add(channel, ""); });
+  listener.Listen("sync");
+
+  ASSERT_TRUE(active.WaitForCount(1, std::chrono::seconds(10)));
+  EXPECT_EQ(active.events[0].first, "sync");
+
+  pg::Client client(url_);
+  ASSERT_TRUE(client.Exec("SELECT pg_notify('sync', 'one')").ok());
+  ASSERT_TRUE(notified.WaitForCount(1, std::chrono::seconds(10)));
+  EXPECT_EQ(notified.events[0].first, "sync");
+  EXPECT_EQ(notified.events[0].second, "one");
+
+  // Kill the backend. The reconnect's re-LISTEN must announce the channel
+  // active again — that second signal is what tells an owner it may have
+  // missed notifications and should catch up.
+  ASSERT_TRUE(client
+                  .Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity"
+                        " WHERE query LIKE 'LISTEN%' AND pid <> pg_backend_pid()")
+                  .ok());
+  ASSERT_TRUE(active.WaitForCount(2, std::chrono::seconds(10)));
+  EXPECT_EQ(active.events[1].first, "sync");
+
+  ASSERT_TRUE(client.Exec("SELECT pg_notify('sync', 'two')").ok());
+  ASSERT_TRUE(notified.WaitForCount(2, std::chrono::seconds(10)));
+  EXPECT_EQ(notified.events[1].second, "two");
+}
+
 TEST_F(ListenerTest, ReconnectsAndReListensAfterConnectionLoss) {
   Received received;
   pg::Listener listener(url_, [&](const std::string& channel, const std::string& payload) {


### PR DESCRIPTION
Task 5 of #1226: live chat now reaches every instance holding the room, with delivery that survives missed notifications.

## What changed

**pg::Listener** grows an optional `ActiveCallback`, fired off-mutex after a channel's LISTEN lands — on first subscription and again after every reconnect's re-LISTEN. This is the "you may have missed notifications" signal: `active_` now tracks only successful statements, so a failed LISTEN retries on the next pass instead of being assumed through.

**HubHandler** subscribes `chat_<room>` beside `room_<room>` and funnels all live chat through one `PumpChat` path: load pages above the room's cursor, stage to current members, advance, repeat while pages come back full. Local appends go through the pump too — a remote commit our append raced past (a lower id committed just before ours) is delivered first instead of being stepped over. Remote wakes, own wakes, duplicate wakes, and channel-active signals all funnel into the same pump; the cursor makes redundant calls cheap no-ops, and a per-room in-flight flag collapses concurrent pumps into one drain.

**Cursors are born with their rooms**, inside the same critical section that makes a room held: `createRoom` at zero, refresh-materialization and boot restore seeded from the newest retained id read right there. `OnChannelActive` pumps the room when its chat channel (re)activates, closing the gap for rows committed while the instance wasn't subscribed.

**main** wires `PgChatStore` and the active callback in the postgres path.

## A bug the new pg test caught

The first cut created cursors lazily at wake time, adopting "the newest retained id" from an off-lock read. `ChatCrossesInstancesBothWays` flaked 1-in-10 locally: an append committing while that adoption read was in flight was classified as the past — consumed without delivery, so its sender never saw their own message. Cursor birth is now atomic with room birth, the adopt path is deleted outright, and the schedule is pinned by a deterministic latch test (`AppendCommittingDuringAnInFlightWakeLoadIsStillDelivered`) that parks a wake's load with a gated store, commits an append mid-window, and asserts the drain delivers it exactly once. A failed seed read leaves the cursor at zero, failing toward re-delivery (clients dedupe by id), never toward loss.

## Tests

- `listener_test`: the active signal removes the retry-until-live dance — one un-retried notify after the first signal, a second signal after backend termination, one un-retried notify after reconnect.
- `hub_chat_race_test` (new): the pump pinned deterministically over shared memory stores with hand-delivered wakes — raced-commit id ordering with no wake at all, a 35-message drain across three pages off one wake, redundant/own wakes proven no-ops by sentinel ordering, the active signal healing a missed notify, stale wakes for unheld rooms, restore-time seeding with the documented history/live overlap, wake-mid-drain coalescing, and the adoption-race regression drill.
- `pg_hub_e2e_test`: two instances exchange chat both ways over the real NOTIFY wire, a third client's join replays both messages, a message committed during a listener outage arrives after the reconnect's catch-up, and the emptied-room test now asserts the chat-row cascade.

Local: all 14 golf_hub + pg targets green against postgres 16; `hub_chat_race_test` 100/100 runs, pg chat tests 30/30 (max 0.6s — the flake's 5s timeouts are gone). CI runs the full suites against postgres 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY8cFki7eChwYq76DY7hU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY8cFki7eChwYq76DY7hU9)_