### PR TITLE
golf_hub: chat observability wired through to the dashboard

### DIFF
--- a/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
+++ b/docs/superpowers/plans/2026-07-26-room-chat-persistence.md
@@ -282,15 +282,27 @@ Then repeat the deterministic race target 100 times. Expected: no duplicates, lo
 - Modify: comments in `domains/games/apis/golf_hub/hub_handler.h`
 - Modify: comments in `domains/games/apis/golf_hub/chat_store.h`
 
-- [ ] **Step 1: Add metric assertions**
+- [x] **Step 1: Add metric assertions**
 
 Assert append success/failure, catch-up rows, and history-load failures are counted without room IDs or message text.
 
-- [ ] **Step 2: Implement counters and update contracts**
+Asserted through a `CapturingMetricsRecorder` in the e2e fixture (the
+`MetricsRecorder` record methods became virtual to make that possible),
+including a sweep that no metric name or label carries the room id,
+player ids, or message text.
+
+- [x] **Step 2: Implement counters and update contracts**
 
 Document retention, ordering, at-least-once delivery, listener recovery, and the process-local limitation of `MemoryChatStore`.
 
-- [ ] **Step 3: Run the backend regression suite**
+Counters: `chat_appends{result}`, `chat_rows_delivered`,
+`chat_catch_up_rows` (per-drain distribution; observation size = rows a
+wake found this instance behind, the lag signal), `chat_history_replays`,
+`chat_failures{stage}` (history_load / catch_up / cursor_seed, replacing
+the three separate failure counters). Surfaced on the dashboard via a
+`Chat` group and four timeseries in prom_proxy's golf_hub registry entry.
+
+- [x] **Step 3: Run the backend regression suite**
 
 ```bash
 bazel test //domains/games/apis/golf_hub/... //domains/platform/libs/pg/...

--- a/domains/games/apis/golf_hub/chat_store.h
+++ b/domains/games/apis/golf_hub/chat_store.h
@@ -68,6 +68,10 @@ struct ChatRow {
 /// handler, so a membership row that vanishes while a send is in flight
 /// rejects the message instead of storing it. Where that check is atomic
 /// with the insert differs by implementation; that it happens does not.
+///
+/// Implementations and callers keep message text and identifiers out of
+/// logs and metrics alike: failures are described by status and counted
+/// by stage, never by content (#1226).
 class ChatStore {
  public:
   virtual ~ChatStore() = default;

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -114,6 +114,34 @@ class FailingAppendChatStore final : public ChatStore {
   std::shared_ptr<ChatStore> delegate_;
 };
 
+// Forwards everything except Append, which reports the sender as no
+// longer a member — the store-level stale-membership rejection that the
+// in-process guard can never produce on its own instance.
+class NotAMemberChatStore final : public ChatStore {
+ public:
+  explicit NotAMemberChatStore(std::shared_ptr<ChatStore> delegate)
+      : delegate_(std::move(delegate)) {}
+
+  absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,
+                                 const std::string& text,
+                                 const std::string& notify_payload) override {
+    return NotAMemberError();
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
+                                                  std::size_t limit) override {
+    return delegate_->LoadRecent(room_id, limit);
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
+                                                 int64_t after_message_id,
+                                                 std::size_t limit) override {
+    return delegate_->LoadAfter(room_id, after_message_id, limit);
+  }
+  void DropRoom(const std::string& room_id) override { delegate_->DropRoom(room_id); }
+
+ private:
+  std::shared_ptr<ChatStore> delegate_;
+};
+
 std::unique_ptr<SecondInstance> BuildSecondInstance(
     std::shared_ptr<TicketVault> vault, std::shared_ptr<HubStore> store,
     std::shared_ptr<ChatStore> chat_store,
@@ -913,6 +941,89 @@ TEST_F(GolfHubStreamFixture, AnUnreachableStoreCountsTheAppendAsUnavailable) {
   EXPECT_EQ(capture->CounterTotal("chat_appends", {{"result", "unavailable"}}), 1);
   EXPECT_EQ(capture->CounterTotal("chat_appends", {{"result", "stored"}}), 0);
   EXPECT_EQ(capture->CounterTotal("chat_rows_delivered"), 0);
+}
+
+// The rejected side of the same counter: the store says the sender's
+// membership vanished mid-send (the race store-level authorization
+// exists for), the client hears the same "not in a room" a pre-store
+// reject uses, and the outcome counts as rejected — an authorization
+// answer, not an outage.
+TEST_F(GolfHubStreamFixture, AStaleMembershipCountsTheAppendAsRejected) {
+  auto capture = std::make_shared<CapturingMetricsRecorder>();
+  auto instance = BuildSecondInstance(vault_, store_,
+                                      std::make_shared<NotAMemberChatStore>(chat_store_), capture);
+  ASSERT_NE(instance, nullptr);
+  auto alice = OpenSeatVia(*instance->client);
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+
+  moonbase::golf::Chat chat;
+  chat.text = "membership just vanished";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  auto rejected = ReceiveCase(alice->stream, "commandRejected");
+  ASSERT_TRUE(rejected.has_value());
+  EXPECT_EQ(rejected->as_commandRejected_or_null()->reason, "not in a room");
+
+  EXPECT_EQ(capture->CounterTotal("chat_appends", {{"result", "rejected"}}), 1);
+  EXPECT_EQ(capture->CounterTotal("chat_appends", {{"result", "unavailable"}}), 0);
+  EXPECT_EQ(capture->CounterTotal("chat_appends", {{"result", "stored"}}), 0);
+}
+
+// Drain metrics at batch grain: one wake that finds two committed rows
+// delivers them as one drain — the counter grows by the batch and the
+// distribution takes a single observation of the batch size, which is
+// what makes an observation's size read as "rows behind at the wake".
+// A redundant wake then records the zero that keeps the dashboard's
+// windowed average honest, and delivers nothing.
+TEST_F(GolfHubStreamFixture, DrainMetricsCountBatchesAndZeroWakes) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChatHistory").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+
+  // Two rows land behind the hub's back — committed straight through the
+  // store, the shape of another instance's appends.
+  ASSERT_TRUE(chat_store_->Append(room_id, alice->player_id, "first behind", "remote").ok());
+  ASSERT_TRUE(chat_store_->Append(room_id, alice->player_id, "second behind", "remote").ok());
+
+  const auto observations = [&] {
+    std::vector<double> values;
+    for (const auto& entry : metrics_->Entries()) {
+      if (entry.name == "chat_catch_up_rows") values.push_back(entry.value);
+    }
+    return values;
+  };
+  const double delivered_before = metrics_->CounterTotal("chat_rows_delivered");
+  const std::size_t drains_before = observations().size();
+
+  handler_->OnNotify(ChatChannel(room_id), "remote-instance");
+  for (auto* seat : {&*alice, &*bob}) {
+    ASSERT_TRUE(ReceiveCase(seat->stream, "roomChat").has_value());
+    ASSERT_TRUE(ReceiveCase(seat->stream, "roomChat").has_value());
+  }
+  EXPECT_EQ(metrics_->CounterTotal("chat_rows_delivered") - delivered_before, 2);
+  auto after_drain = observations();
+  ASSERT_EQ(after_drain.size(), drains_before + 1);
+  EXPECT_EQ(after_drain.back(), 2.0);
+
+  // Redundant wake: nothing new, one zero observation, nothing counted
+  // as delivered. OnNotify pumps synchronously, so no waiting.
+  handler_->OnNotify(ChatChannel(room_id), "remote-instance");
+  EXPECT_EQ(metrics_->CounterTotal("chat_rows_delivered") - delivered_before, 2);
+  auto after_redundant = observations();
+  ASSERT_EQ(after_redundant.size(), drains_before + 2);
+  EXPECT_EQ(after_redundant.back(), 0.0);
 }
 
 // The membership guard, exercised through the handler that owns it

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -85,15 +85,45 @@ class FailingHistoryChatStore final : public ChatStore {
   std::shared_ptr<ChatStore> delegate_;
 };
 
-std::unique_ptr<SecondInstance> BuildSecondInstance(std::shared_ptr<TicketVault> vault,
-                                                    std::shared_ptr<HubStore> store,
-                                                    std::shared_ptr<ChatStore> chat_store) {
+// Forwards everything except Append, which always fails as if the
+// database were unreachable — the only way to reach the handler's
+// unavailable-append branch, since MemoryChatStore cannot fail to
+// reach itself.
+class FailingAppendChatStore final : public ChatStore {
+ public:
+  explicit FailingAppendChatStore(std::shared_ptr<ChatStore> delegate)
+      : delegate_(std::move(delegate)) {}
+
+  absl::StatusOr<ChatRow> Append(const std::string& room_id, const std::string& player_id,
+                                 const std::string& text,
+                                 const std::string& notify_payload) override {
+    return absl::UnavailableError("chat store unreachable");
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadRecent(const std::string& room_id,
+                                                  std::size_t limit) override {
+    return delegate_->LoadRecent(room_id, limit);
+  }
+  absl::StatusOr<std::vector<ChatRow>> LoadAfter(const std::string& room_id,
+                                                 int64_t after_message_id,
+                                                 std::size_t limit) override {
+    return delegate_->LoadAfter(room_id, after_message_id, limit);
+  }
+  void DropRoom(const std::string& room_id) override { delegate_->DropRoom(room_id); }
+
+ private:
+  std::shared_ptr<ChatStore> delegate_;
+};
+
+std::unique_ptr<SecondInstance> BuildSecondInstance(
+    std::shared_ptr<TicketVault> vault, std::shared_ptr<HubStore> store,
+    std::shared_ptr<ChatStore> chat_store,
+    std::shared_ptr<futility::otel::MetricsRecorder> metrics =
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test")) {
   auto instance = std::make_unique<SecondInstance>();
   instance->handler = std::make_shared<HubHandler>(
       std::move(vault), std::make_shared<cards::NoShuffleDealer>(),
-      std::make_shared<SequentialIdGenerator>(), std::chrono::seconds(60),
-      std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), std::move(store),
-      std::move(chat_store));
+      std::make_shared<SequentialIdGenerator>(), std::chrono::seconds(60), std::move(metrics),
+      std::move(store), std::move(chat_store));
   EXPECT_TRUE(instance->handler->RestoreFromStore().ok());
   instance->server = std::make_unique<moonbase::golf::GolfHubServer>(instance->handler);
 
@@ -783,8 +813,9 @@ TEST_F(GolfHubStreamFixture, AFailedHistoryLoadDoesNotFailTheResume) {
   // History is best-effort: when the load fails, the resume still lands
   // (sessionReady, roomState) and the stream simply hears no history
   // event — the model's documented absence case.
-  auto instance =
-      BuildSecondInstance(vault_, store_, std::make_shared<FailingHistoryChatStore>(chat_store_));
+  auto capture = std::make_shared<CapturingMetricsRecorder>();
+  auto instance = BuildSecondInstance(
+      vault_, store_, std::make_shared<FailingHistoryChatStore>(chat_store_), capture);
   ASSERT_NE(instance, nullptr);
   auto resumed = OpenSeatVia(*instance->client, bob->resume_token);
   ASSERT_TRUE(resumed.has_value());
@@ -801,6 +832,87 @@ TEST_F(GolfHubStreamFixture, AFailedHistoryLoadDoesNotFailTheResume) {
   // client. The bounded receive times out on a live, usable stream.
   auto nothing = resumed->stream.Receive(std::chrono::milliseconds(300));
   EXPECT_FALSE(nothing.ok()) << "a failed history load must send nothing, not something";
+
+  // Both failures were counted by stage: the resume's history load, and
+  // the restore's cursor seed read that went through the same failing
+  // store — which failed open to a zero cursor rather than a loss.
+  EXPECT_EQ(capture->CounterTotal("chat_failures", {{"stage", "history_load"}}), 1);
+  EXPECT_EQ(capture->CounterTotal("chat_failures", {{"stage", "cursor_seed"}}), 1);
+}
+
+// What the chat paths count (#1226 item 10), asserted through the
+// capturing recorder — including the rule the epic states outright:
+// no room id, player id, or message text may reach a metric name or
+// label. Counts and stages only.
+TEST_F(GolfHubStreamFixture, ChatMetricsCountOutcomesWithoutIdentifiers) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChatHistory").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+
+  moonbase::golf::Chat chat;
+  chat.text = "counted, never labeled";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomChat").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomChat").has_value());
+
+  // One stored append, one drain that delivered its one row, one
+  // history replay (bob's join; createRoom sends none).
+  EXPECT_EQ(metrics_->CounterTotal("chat_appends", {{"result", "stored"}}), 1);
+  EXPECT_EQ(metrics_->CounterTotal("chat_rows_delivered"), 1);
+  EXPECT_EQ(metrics_->CounterTotal("chat_history_replays"), 1);
+  bool saw_drain = false;
+  for (const auto& entry : metrics_->Entries()) {
+    if (entry.name == "chat_catch_up_rows" && entry.value == 1.0) saw_drain = true;
+  }
+  EXPECT_TRUE(saw_drain) << "the drain's row count feeds the lag distribution";
+
+  // The sweep: nothing recorded anywhere carries the identifiers.
+  for (const auto& entry : metrics_->Entries()) {
+    for (const std::string& secret :
+         {room_id, alice->player_id, bob->player_id, std::string(chat.text)}) {
+      EXPECT_EQ(entry.name.find(secret), std::string::npos) << entry.name;
+      for (const auto& [key, value] : entry.attributes) {
+        EXPECT_EQ(key.find(secret), std::string::npos) << key;
+        EXPECT_EQ(value.find(secret), std::string::npos) << value;
+      }
+    }
+  }
+}
+
+// The unavailable side of the append counter: the store cannot be
+// reached, the sender is told so, and nothing counts as stored or
+// delivered.
+TEST_F(GolfHubStreamFixture, AnUnreachableStoreCountsTheAppendAsUnavailable) {
+  auto capture = std::make_shared<CapturingMetricsRecorder>();
+  auto instance = BuildSecondInstance(
+      vault_, store_, std::make_shared<FailingAppendChatStore>(chat_store_), capture);
+  ASSERT_NE(instance, nullptr);
+  auto alice = OpenSeatVia(*instance->client);
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+
+  moonbase::golf::Chat chat;
+  chat.text = "never stored";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  auto rejected = ReceiveCase(alice->stream, "commandRejected");
+  ASSERT_TRUE(rejected.has_value());
+  EXPECT_EQ(rejected->as_commandRejected_or_null()->reason, "chat is unavailable");
+
+  EXPECT_EQ(capture->CounterTotal("chat_appends", {{"result", "unavailable"}}), 1);
+  EXPECT_EQ(capture->CounterTotal("chat_appends", {{"result", "stored"}}), 0);
+  EXPECT_EQ(capture->CounterTotal("chat_rows_delivered"), 0);
 }
 
 // The membership guard, exercised through the handler that owns it

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -188,7 +188,7 @@ void HubHandler::SeedChatCursorLocked(const std::string& room_id) {
     // Fail toward duplication, never loss: a cursor left at 0 re-delivers
     // retained rows, which clients dedupe by id; guessing high would
     // swallow messages.
-    Count("chat_cursor_seed_failures");
+    Count("chat_failures", {{"stage", "cursor_seed"}});
     LOG(WARNING) << "chat cursor seed failed: " << rows.status();
   }
   chat_cursors_.try_emplace(room_id, cursor);
@@ -716,11 +716,12 @@ void HubHandler::HandleCommand(const std::string& player_id, const GolfCommands&
     if (!appended.ok()) {
       // Nothing was stored, so nothing is echoed: the sender is told no
       // rather than shown a message no one else will ever receive.
-      Reject(player_id, appended.status().code() == absl::StatusCode::kFailedPrecondition
-                            ? "not in a room"
-                            : "chat is unavailable");
+      const bool stale = appended.status().code() == absl::StatusCode::kFailedPrecondition;
+      Count("chat_appends", {{"result", stale ? "rejected" : "unavailable"}});
+      Reject(player_id, stale ? "not in a room" : "chat is unavailable");
       return;
     }
+    Count("chat_appends", {{"result", "stored"}});
 
     // The committed row reaches locals through the pump, like every
     // other row. That is not indirection for its own sake: a remote
@@ -1361,6 +1362,12 @@ void HubHandler::PumpChat(const std::string& room_id) {
   }
 
   bool more = true;
+  // Rows this drain staged, across pages and again-loops. Recorded as
+  // one distribution observation per drain when the drain ends: the
+  // count is delivery volume, and the size of any one observation is
+  // how far behind its wake found this instance — the lag signal the
+  // dashboard wants, with no room id attached.
+  int64_t drained = 0;
   while (more) {
     int64_t after = 0;
     {
@@ -1380,7 +1387,7 @@ void HubHandler::PumpChat(const std::string& room_id) {
       const auto room = rooms_.find(room_id);
       if (cursor == chat_cursors_.end() || room == rooms_.end()) return;
       if (!rows.ok()) {
-        Count("chat_catch_up_failures");
+        Count("chat_failures", {{"stage", "catch_up"}});
         LOG(WARNING) << "chat catch-up load failed: " << rows.status();
         if (cursor->second.again) {
           // A wake landed while this load was failing. That signal may
@@ -1392,14 +1399,18 @@ void HubHandler::PumpChat(const std::string& room_id) {
           continue;
         }
         cursor->second.pumping = false;
-        return;
+        more = false;
+        break;
       }
+      int64_t staged = 0;
       for (const ChatRow& row : *rows) {
         if (row.message_id <= cursor->second.delivered) continue;
         const GolfEvents event = GolfEvents::FromRoomchat(ChatEvent(row));
         for (const auto& member : room->second.members) outbox.To(member.first, event);
         cursor->second.delivered = row.message_id;
+        ++staged;
       }
+      drained += staged;
       more = rows->size() == kChatCatchUpPage;
       if (!more && cursor->second.again) {
         cursor->second.again = false;
@@ -1409,6 +1420,10 @@ void HubHandler::PumpChat(const std::string& room_id) {
     }
     Deliver(outbox);
   }
+  if (metrics_ != nullptr) {
+    if (drained > 0) metrics_->RecordCounter("chat_rows_delivered", drained);
+    metrics_->RecordDistribution("chat_catch_up_rows", static_cast<double>(drained));
+  }
 }
 
 void HubHandler::SendChatHistory(const std::string& room_id, const std::string& player_id) {
@@ -1416,7 +1431,7 @@ void HubHandler::SendChatHistory(const std::string& room_id, const std::string& 
   if (!rows.ok()) {
     // The admission already succeeded; chat history is not worth failing
     // it over. No room id or text in the log — the status is enough.
-    Count("chat_history_load_failures");
+    Count("chat_failures", {{"stage", "history_load"}});
     LOG(WARNING) << "chat history load failed for a joining stream: " << rows.status();
     return;
   }
@@ -1430,6 +1445,7 @@ void HubHandler::SendChatHistory(const std::string& room_id, const std::string& 
   history.messages.reserve(rows->size());
   for (const ChatRow& row : *rows) history.messages.push_back(ChatEvent(row));
   Send(player_id, GolfEvents::FromRoomchathistory(std::move(history)));
+  Count("chat_history_replays");
 }
 
 void HubHandler::Count(const char* name, const std::map<std::string, std::string>& attributes) {

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -1399,18 +1399,15 @@ void HubHandler::PumpChat(const std::string& room_id) {
           continue;
         }
         cursor->second.pumping = false;
-        more = false;
-        break;
+        break;  // ends the drain; the per-drain observation below still records
       }
-      int64_t staged = 0;
       for (const ChatRow& row : *rows) {
         if (row.message_id <= cursor->second.delivered) continue;
         const GolfEvents event = GolfEvents::FromRoomchat(ChatEvent(row));
         for (const auto& member : room->second.members) outbox.To(member.first, event);
         cursor->second.delivered = row.message_id;
-        ++staged;
+        ++drained;
       }
-      drained += staged;
       more = rows->size() == kChatCatchUpPage;
       if (!more && cursor->second.again) {
         cursor->second.again = false;

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -36,6 +36,13 @@ namespace golf_hub {
 /// — per-viewer state (own peeks, the held draw) has exactly one place to
 /// land and no identical-bytes path can leak it.
 ///
+/// Chat observability (#1226): chat_appends{result}, chat_rows_delivered,
+/// chat_catch_up_rows (a per-drain distribution — one observation's size
+/// is how far behind its wake found this instance, the lag signal),
+/// chat_history_replays, and chat_failures{stage}. Counts and stages
+/// only: room ids, player ids, and message text never reach a metric
+/// name or label, and the e2e suite sweeps for exactly that.
+///
 /// With a store attached, instances are interchangeable (#1194 step 3):
 /// the database is every game's authority. A move loads nothing extra —
 /// the local entry mirrors the stored row — but its result only counts

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -12,7 +12,9 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <utility>
@@ -117,6 +119,65 @@ inline moonbase::golf::GolfCommands Move(moonbase::golf::GolfMove move) {
   return moonbase::golf::GolfCommands::FromGolf(std::move(command));
 }
 
+// Captures every metric the hub records so tests can assert what is
+// counted — and, just as important, what never appears in a name or
+// label (room ids, player ids, message text; the model forbids them).
+// Extends the production recorder, so the real instrument paths still
+// run underneath against the no-op global meter.
+class CapturingMetricsRecorder final : public futility::otel::MetricsRecorder {
+ public:
+  CapturingMetricsRecorder() : futility::otel::MetricsRecorder("golf_hub_test") {}
+
+  struct Entry {
+    std::string name;
+    double value;
+    std::map<std::string, std::string> attributes;
+  };
+
+  void RecordCounter(const std::string& name, int64_t value,
+                     const std::map<std::string, std::string>& attributes) override {
+    Add(name, static_cast<double>(value), attributes);
+    futility::otel::MetricsRecorder::RecordCounter(name, value, attributes);
+  }
+  void RecordDistribution(const std::string& name, double value,
+                          const std::map<std::string, std::string>& attributes) override {
+    Add(name, value, attributes);
+    futility::otel::MetricsRecorder::RecordDistribution(name, value, attributes);
+  }
+  void RecordGauge(const std::string& name, double value,
+                   const std::map<std::string, std::string>& attributes) override {
+    Add(name, value, attributes);
+    futility::otel::MetricsRecorder::RecordGauge(name, value, attributes);
+  }
+
+  // Sum of increments recorded for the counter under exactly these
+  // attributes; 0 when it never fired.
+  double CounterTotal(const std::string& name,
+                      const std::map<std::string, std::string>& attributes = {}) const {
+    const std::lock_guard<std::mutex> lock(mu_);
+    double total = 0;
+    for (const Entry& entry : entries_) {
+      if (entry.name == name && entry.attributes == attributes) total += entry.value;
+    }
+    return total;
+  }
+
+  std::vector<Entry> Entries() const {
+    const std::lock_guard<std::mutex> lock(mu_);
+    return entries_;
+  }
+
+ private:
+  void Add(const std::string& name, double value,
+           const std::map<std::string, std::string>& attributes) {
+    const std::lock_guard<std::mutex> lock(mu_);
+    entries_.push_back({name, value, attributes});
+  }
+
+  mutable std::mutex mu_;
+  std::vector<Entry> entries_;
+};
+
 class GolfHubStreamFixture : public testing::Test {
  protected:
   // The default fixture uses the production memory implementations; the
@@ -156,8 +217,7 @@ class GolfHubStreamFixture : public testing::Test {
     }
     handler_ = std::make_shared<HubHandler>(
         vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
-        /*grace_period=*/std::chrono::seconds(60),
-        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), store_, chat_store_);
+        /*grace_period=*/std::chrono::seconds(60), metrics_, store_, chat_store_);
     if (default_memory_chat) {
       *guard = [handler = handler_.get()](const std::string& room_id, const std::string& player_id,
                                           const MemberAction& action) {
@@ -304,6 +364,9 @@ class GolfHubStreamFixture : public testing::Test {
   std::shared_ptr<TicketVault> vault_;
   std::shared_ptr<HubStore> store_;
   std::shared_ptr<ChatStore> chat_store_;
+  // Every suite gets capture; only the metrics tests assert on it. The
+  // no-op meter underneath means values still go nowhere.
+  std::shared_ptr<CapturingMetricsRecorder> metrics_ = std::make_shared<CapturingMetricsRecorder>();
   std::shared_ptr<IdGenerator> ids_ = std::make_shared<SequentialIdGenerator>();
   std::shared_ptr<HubHandler> handler_;
   std::unique_ptr<moonbase::golf::GolfHubServer> server_;

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -139,6 +139,11 @@ class CapturingMetricsRecorder final : public futility::otel::MetricsRecorder {
     Add(name, static_cast<double>(value), attributes);
     futility::otel::MetricsRecorder::RecordCounter(name, value, attributes);
   }
+  void RecordLatency(const std::string& name, std::chrono::microseconds duration,
+                     const std::map<std::string, std::string>& attributes) override {
+    Add(name, static_cast<double>(duration.count()), attributes);
+    futility::otel::MetricsRecorder::RecordLatency(name, duration, attributes);
+  }
   void RecordDistribution(const std::string& name, double value,
                           const std::map<std::string, std::string>& attributes) override {
     Add(name, value, attributes);

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -34,14 +34,28 @@ var serviceRegistry = map[string]serviceEntry{
 			{"Activity", "commands_per_sec", "/s", `sum(rate(stream_commands_total[5m]))`},
 			{"Activity", "events_per_sec", "/s", `sum(rate(stream_events_total[5m]))`},
 			{"Activity", "rejections_per_sec", "/s", `sum(rate(stream_rejections_total[5m]))`},
+			// Room chat (#1226): outcome counts and stages only — the emitter
+			// never labels by room, player, or text. catch_up_rows is a
+			// per-drain distribution, so its windowed average is how far
+			// behind a wake found an instance (the lag signal).
+			{"Chat", "messages_per_sec", "/s", `sum(rate(chat_appends_total{result="stored"}[5m]))`},
+			{"Chat", "stored_total", "", `sum(chat_appends_total{result="stored"})`},
+			{"Chat", "delivered_rows_per_sec", "/s", `sum(rate(chat_rows_delivered_total[5m]))`},
+			{"Chat", "catch_up_rows_avg_5m", "rows", `sum(rate(chat_catch_up_rows_sum[5m]))/sum(rate(chat_catch_up_rows_count[5m]))`},
+			{"Chat", "history_replays_total", "", `sum(chat_history_replays_total)`},
+			{"Chat", "failures_total", "", `sum(chat_failures_total)`},
 		},
 		CustomTimeseries: map[string]string{
-			"sessions_active": `sum(stream_sessions_active_gauge)`,
-			"session_starts":  `sum(increase(stream_sessions_total[5m]))`,
-			"command_rate":    `sum(rate(stream_commands_total[5m]))`,
-			"event_rate":      `sum(rate(stream_events_total[5m]))`,
-			"rejection_rate":  `sum(rate(stream_rejections_total[5m]))`,
-			"disconnect_rate": `sum(rate(stream_disconnects_total[5m]))`,
+			"sessions_active":    `sum(stream_sessions_active_gauge)`,
+			"session_starts":     `sum(increase(stream_sessions_total[5m]))`,
+			"command_rate":       `sum(rate(stream_commands_total[5m]))`,
+			"event_rate":         `sum(rate(stream_events_total[5m]))`,
+			"rejection_rate":     `sum(rate(stream_rejections_total[5m]))`,
+			"disconnect_rate":    `sum(rate(stream_disconnects_total[5m]))`,
+			"chat_message_rate":  `sum(rate(chat_appends_total{result="stored"}[5m]))`,
+			"chat_delivery_rate": `sum(rate(chat_rows_delivered_total[5m]))`,
+			"chat_failure_rate":  `sum(rate(chat_failures_total[5m]))`,
+			"chat_catch_up_rows": `sum(rate(chat_catch_up_rows_sum[5m]))/sum(rate(chat_catch_up_rows_count[5m]))`,
 		},
 	},
 	"microgpt-serve": {

--- a/domains/platform/apis/prom_proxy/service_handlers.go
+++ b/domains/platform/apis/prom_proxy/service_handlers.go
@@ -3,6 +3,7 @@ package prom_proxy
 import (
 	"context"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -181,6 +182,13 @@ func (h *MetricsHandler) GetServiceMetricsTimeSeries(w http.ResponseWriter, r *h
 			response.Series = append(response.Series, ts)
 		}
 	}
+	// The map iteration above would otherwise put the series in a fresh
+	// random order every request, and the UI's generic Trends grid renders
+	// custom series in payload order with position-indexed colors — charts
+	// would swap places and recolor on every refresh poll.
+	sort.Slice(response.Series, func(i, j int) bool {
+		return response.Series[i].MetricName < response.Series[j].MetricName
+	})
 
 	mucks.JsonOk(w, response)
 }

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -273,8 +273,14 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testin
 	assert.Equal(t, "30m", response.TimeRange)
 
 	names := map[string]bool{}
+	previous := ""
 	for _, series := range response.Series {
 		names[series.MetricName] = true
+		// Deterministic payload order: the UI renders custom series in
+		// payload order, so a map-iteration shuffle would reshuffle its
+		// charts on every refresh.
+		assert.GreaterOrEqual(t, series.MetricName, previous)
+		previous = series.MetricName
 	}
 	// The five standard series plus golf's ten custom series.
 	expected := []string{

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -159,6 +159,11 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 		response.Custom[0].Metrics[0])
 	assert.Equal(t, CustomMetricValue{Label: "commands_per_sec", Value: 206.0, Unit: "/s"},
 		response.Custom[1].Metrics[0])
+	assert.Equal(t, CustomMetricValue{Label: "rejections_per_sec", Value: 208.0, Unit: "/s"},
+		response.Custom[1].Metrics[2])
+	// Chat starts at CustomScalars index 9, so its first value is 200+9.
+	assert.Equal(t, CustomMetricValue{Label: "messages_per_sec", Value: 209.0, Unit: "/s"},
+		response.Custom[2].Metrics[0])
 	// The omitted query's descriptor survives with a zero value.
 	last := response.Custom[2].Metrics[5]
 	assert.Equal(t, omitted.Label, last.Label)

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -133,18 +133,20 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 	assert.Equal(t, 107.0, response.Standard.ActiveRequests)
 
 	// Custom groups keep registry order and every descriptor is present.
-	require.Len(t, response.Custom, 2)
+	require.Len(t, response.Custom, 3)
 	assert.Equal(t, "Sessions", response.Custom[0].Title)
 	assert.Equal(t, "Activity", response.Custom[1].Title)
+	assert.Equal(t, "Chat", response.Custom[2].Title)
 	assert.Len(t, response.Custom[0].Metrics, 6)
-	require.Len(t, response.Custom[1].Metrics, 3)
+	assert.Len(t, response.Custom[1].Metrics, 3)
+	require.Len(t, response.Custom[2].Metrics, 6)
 
 	assert.Equal(t, CustomMetricValue{Label: "active", Value: 200.0, Unit: "sessions"},
 		response.Custom[0].Metrics[0])
 	assert.Equal(t, CustomMetricValue{Label: "commands_per_sec", Value: 206.0, Unit: "/s"},
 		response.Custom[1].Metrics[0])
 	// The omitted query's descriptor survives with a zero value.
-	last := response.Custom[1].Metrics[2]
+	last := response.Custom[2].Metrics[5]
 	assert.Equal(t, omitted.Label, last.Label)
 	assert.Equal(t, 0.0, last.Value)
 }
@@ -260,12 +262,13 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testin
 	for _, series := range response.Series {
 		names[series.MetricName] = true
 	}
-	// The five standard series plus golf's six custom series.
+	// The five standard series plus golf's ten custom series.
 	expected := []string{
 		"request_rate", "error_rate_percent", "avg_duration_us", "p95_duration_us",
 		"active_requests",
 		"sessions_active", "session_starts", "command_rate", "event_rate",
 		"rejection_rate", "disconnect_rate",
+		"chat_message_rate", "chat_delivery_rate", "chat_failure_rate", "chat_catch_up_rows",
 	}
 	assert.Len(t, names, len(expected))
 	for _, name := range expected {

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -42,6 +42,20 @@ func TestRegistry_OrderAndEntriesAgree(t *testing.T) {
 	}
 }
 
+// The UI classifies series by name: anything in its STANDARD_SERIES
+// mirror renders on the standard charts, so a custom key that collides
+// is silently reclassified and never charts. The registry comment asks
+// authors to avoid this; this pins it.
+func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
+	for _, name := range serviceOrder {
+		standard := standardTimeseriesQueries(name)
+		for key := range serviceRegistry[name].CustomTimeseries {
+			_, shadows := standard[key]
+			assert.False(t, shadows, "service %q custom series %q shadows a standard series", name, key)
+		}
+	}
+}
+
 func TestMetricsHandler_GetServiceCatalog(t *testing.T) {
 	handler := &MetricsHandler{}
 

--- a/domains/platform/libs/futility/otel/metrics.h
+++ b/domains/platform/libs/futility/otel/metrics.h
@@ -54,7 +54,12 @@ class MetricsRecorder {
   /// @brief Creates a metrics recorder for the given service.
   /// @param service_name The service name used to create the meter.
   explicit MetricsRecorder(const std::string& service_name);
-  ~MetricsRecorder() = default;
+  virtual ~MetricsRecorder() = default;
+
+  // The record methods are virtual for exactly one reason: tests wrap a
+  // recorder that captures what a service counts — names, values, and
+  // labels — and assert on it (including what must never appear in a
+  // label). Production code always uses this class directly.
 
   /// @brief Records a counter metric (monotonically increasing).
   ///
@@ -63,8 +68,8 @@ class MetricsRecorder {
   /// @param metric_name The metric name (e.g., "http_requests_total").
   /// @param value The amount to increment (default: 1).
   /// @param attributes Optional key-value labels for the metric.
-  void RecordCounter(const std::string& metric_name, int64_t value = 1,
-                     const std::map<std::string, std::string>& attributes = {});
+  virtual void RecordCounter(const std::string& metric_name, int64_t value = 1,
+                             const std::map<std::string, std::string>& attributes = {});
 
   /// @brief Records a histogram metric for latency/duration measurements.
   ///
@@ -74,8 +79,8 @@ class MetricsRecorder {
   /// @param metric_name The metric name (e.g., "request_duration_us").
   /// @param duration The duration to record.
   /// @param attributes Optional key-value labels for the metric.
-  void RecordLatency(const std::string& metric_name, std::chrono::microseconds duration,
-                     const std::map<std::string, std::string>& attributes = {});
+  virtual void RecordLatency(const std::string& metric_name, std::chrono::microseconds duration,
+                             const std::map<std::string, std::string>& attributes = {});
 
   /// @brief Records one observation of a per-event quantity.
   ///
@@ -87,8 +92,8 @@ class MetricsRecorder {
   /// @param metric_name The metric name (e.g., "scene_sphere_count").
   /// @param value The observed value.
   /// @param attributes Optional key-value labels for the metric.
-  void RecordDistribution(const std::string& metric_name, double value,
-                          const std::map<std::string, std::string>& attributes = {});
+  virtual void RecordDistribution(const std::string& metric_name, double value,
+                                  const std::map<std::string, std::string>& attributes = {});
 
   /// @brief Records a gauge metric (point-in-time value).
   ///
@@ -98,8 +103,8 @@ class MetricsRecorder {
   /// @param metric_name The metric name (e.g., "connections_active").
   /// @param value The current value to record.
   /// @param attributes Optional key-value labels for the metric.
-  void RecordGauge(const std::string& metric_name, double value,
-                   const std::map<std::string, std::string>& attributes = {});
+  virtual void RecordGauge(const std::string& metric_name, double value,
+                           const std::map<std::string, std::string>& attributes = {});
 
  private:
   /// The cached instrument, created under mu_ on first use. Element


### PR DESCRIPTION
Task 6 of #1226: the chat counters the epic asked for, asserted in tests, and surfaced on the dashboard through prom_proxy's registry.

## Counters

All counts and stages only — room ids, player ids, and message text never reach a metric name or label (the epic states this outright), and the e2e suite now sweeps every captured metric for exactly that.

- `chat_appends{result=stored|rejected|unavailable}` — the append outcome at the store boundary.
- `chat_rows_delivered` — rows staged to local members by the pump.
- `chat_catch_up_rows` — a distribution with one observation per drain, so an observation's size is how far behind its wake found the instance. This is the lag signal without a per-room gauge (which would need a room-id label).
- `chat_history_replays` — join/resume replays sent.
- `chat_failures{stage=history_load|catch_up|cursor_seed}` — consolidating the three separate failure counters added during tasks 4–5, matching the `stream_rejections{reason}` label pattern and giving the dashboard one summable failure series.

## Testing seam

`futility::otel::MetricsRecorder`'s record methods become virtual (behavior unchanged; production always uses the class directly). The stream fixture gains a `CapturingMetricsRecorder` that records every name/value/label while still driving the real instrument paths, so hub_e2e can assert:

- one stored append, one delivered row, one drain observation, one history replay for the canonical two-seat chat flow;
- the unavailable-append branch counts `result="unavailable"` and nothing as stored or delivered (new `FailingAppendChatStore` decorator);
- a failing history store counts both the resume's `history_load` failure and the restore's `cursor_seed` failure — pinning that seeding fails open to a zero cursor;
- the identifier sweep across everything recorded.

## Dashboard

The golf_hub entry in prom_proxy's registry grows a `Chat` scalar group (message rate, stored total, delivered rows/s, windowed catch-up-rows average, replays, failures) and four timeseries (`chat_message_rate`, `chat_delivery_rate`, `chat_failure_rate`, `chat_catch_up_rows`). The registry design means no new routes, handlers, or UI code — the generic service page renders the new group, and the registry tests pin the new shape.

Local: all 21 targets green (golf_hub, pg, futility, prom_proxy) against postgres 16; CI runs the same suites against postgres 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY8cFki7eChwYq76DY7hU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY8cFki7eChwYq76DY7hU9)_