### PR TITLE
golf_hub: park closed streams for reconnect grace; keep abandoned seats on the scorecard

### DIFF
--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -370,7 +371,7 @@ TEST_F(GolfHubStreamFixture, CommandsOutsideARoomAreRejectedInBand) {
   EXPECT_TRUE(ReceiveCase(seat->stream, "roomState").has_value());
 }
 
-TEST_F(GolfHubStreamFixture, CleanCloseFreesTheRoomSlotAndNotifies) {
+TEST_F(GolfHubStreamFixture, CleanCloseParksTheSeatAndResumeReclaimsIt) {
   auto alice = OpenSeat();
   auto bob = OpenSeat();
   ASSERT_TRUE(alice.has_value() && bob.has_value());
@@ -380,17 +381,45 @@ TEST_F(GolfHubStreamFixture, CleanCloseFreesTheRoomSlotAndNotifies) {
   ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
   auto created = ReceiveCase(alice->stream, "roomState");
   ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
   moonbase::golf::JoinRoom join;
-  join.roomId = created->as_roomState_or_null()->roomId;
+  join.roomId = room_id;
   ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
   ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
   ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
 
+  // A closed tab is a clean websocket close, byte-identical to any other
+  // deliberate-looking exit the browser makes on the way out (#1236).
+  // Close carries no leave intent — only the explicit leaveRoom command
+  // does — so the seat parks for the grace window instead of emptying.
   bob->stream.Close();
-  auto shrunk = ReceiveCase(alice->stream, "roomState");
-  ASSERT_TRUE(shrunk.has_value());
-  ASSERT_EQ(shrunk->as_roomState_or_null()->players.size(), 1u);
-  EXPECT_EQ(shrunk->as_roomState_or_null()->players[0].playerId, alice->player_id);
+  auto parked = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(parked.has_value());
+  {
+    const auto* room = parked->as_roomState_or_null();
+    ASSERT_EQ(room->players.size(), 2u);
+    for (const auto& player : room->players) {
+      EXPECT_EQ(player.connected, player.playerId == alice->player_id);
+    }
+  }
+
+  // The resume token reclaims the parked seat, and the room sees the
+  // connected flag flip back.
+  auto resumed = OpenSeat(bob->resume_token);
+  ASSERT_TRUE(resumed.has_value());
+  EXPECT_EQ(resumed->player_id, bob->player_id);
+  auto ready = ReceiveCase(resumed->stream, "sessionReady");
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_TRUE(ready->as_sessionReady_or_null()->resumed);
+  ASSERT_TRUE(ready->as_sessionReady_or_null()->roomId.has_value());
+  EXPECT_EQ(*ready->as_sessionReady_or_null()->roomId, room_id);
+  auto rejoined = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(rejoined.has_value());
+  {
+    const auto* room = rejoined->as_roomState_or_null();
+    ASSERT_EQ(room->players.size(), 2u);
+    for (const auto& player : room->players) EXPECT_TRUE(player.connected);
+  }
 }
 
 TEST_F(GolfGameFixture, FullGameKnockerTieWinsAlone) {
@@ -1076,6 +1105,10 @@ TEST_F(GolfHubStreamFixture, WithMemberRunsOnlyForCurrentMembers) {
 TEST_F(GolfGameFixture, AbandoningALiveGameResolvesIt) {
   auto table = SeatedTable();
   ASSERT_TRUE(table.has_value());
+  // Drain the opening deals so the next gameState each seat sees is the
+  // finish ceremony's.
+  ASSERT_TRUE(ReceiveGolf(table->alice.stream, "gameState").has_value());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "gameState").has_value());
 
   ASSERT_TRUE(
       table->bob.stream.Send(Move(GolfMove::FromLeavegame(moonbase::golf::LeaveGame{}))).ok());
@@ -1084,15 +1117,142 @@ TEST_F(GolfGameFixture, AbandoningALiveGameResolvesIt) {
   EXPECT_EQ(ack->as_gameLeft_or_null()->gameId, table->game_id);
 
   // Alice is the last seat standing: the game resolves in her favor and
-  // leaves the room's game list empty.
+  // leaves the room's game list empty. The final view and the summary
+  // still carry bob's seat — his name, his cards face up, and the score
+  // they stood at — not just the survivor's (#1236).
+  auto final_view = ReceiveGolf(table->alice.stream, "gameState");
+  ASSERT_TRUE(final_view.has_value());
+  {
+    const auto& view = final_view->as_gameState_or_null()->view;
+    EXPECT_EQ(view.phase, "ended");
+    ASSERT_EQ(view.players.size(), 2u);
+    for (const auto& player : view.players) {
+      EXPECT_EQ(player.revealedIndexes.size(), 4u) << player.playerId;
+      EXPECT_TRUE(player.score.has_value()) << player.playerId;
+    }
+  }
   auto ended = ReceiveGolf(table->alice.stream, "gameEnded");
   ASSERT_TRUE(ended.has_value());
-  ASSERT_EQ(ended->as_gameEnded_or_null()->winners.size(), 1u);
-  EXPECT_EQ(ended->as_gameEnded_or_null()->winners[0], table->alice.player_id);
+  const auto* result = ended->as_gameEnded_or_null();
+  ASSERT_EQ(result->winners.size(), 1u);
+  EXPECT_EQ(result->winners[0], table->alice.player_id);
+  ASSERT_EQ(result->finalScores.size(), 2u);
+  std::set<std::string> scored;
+  for (const auto& score : result->finalScores) scored.insert(score.playerId);
+  EXPECT_TRUE(scored.contains(table->alice.player_id));
+  EXPECT_TRUE(scored.contains(table->bob.player_id));
 
   auto room = ReceiveCase(table->alice.stream, "roomState");
   ASSERT_TRUE(room.has_value());
   EXPECT_TRUE(room->as_roomState_or_null()->games.empty());
+}
+
+// The reported bug (#1236): an accidental browser close mid-game arrives
+// as a clean websocket close, which used to resolve the game against the
+// absent player within seconds. A close parks the seat instead: the
+// table sees the disconnect, nothing ends, and the resume token reclaims
+// the seat with the game intact.
+TEST_F(GolfGameFixture, MidGameBrowserCloseParksTheSeatAndTheGameSurvives) {
+  auto table = SeatedTable();
+  ASSERT_TRUE(table.has_value());
+  auto& alice = table->alice;
+  ASSERT_TRUE(ReceiveGolf(alice.stream, "gameState").has_value());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "gameState").has_value());
+
+  table->bob.stream.Close();
+
+  // Alice hears the disconnect — and nothing that ends the game.
+  bool bob_disconnected = false;
+  for (int i = 0; i < 8 && !bob_disconnected; ++i) {
+    auto event = NextEvent(alice.stream);
+    ASSERT_TRUE(event.has_value());
+    if (const auto* envelope = event->as_golf_or_null()) {
+      EXPECT_EQ(envelope->update.as_gameEnded_or_null(), nullptr)
+          << "a parked seat must not resolve the game";
+      continue;
+    }
+    const auto* room = event->as_roomState_or_null();
+    if (room == nullptr) continue;
+    ASSERT_EQ(room->players.size(), 2u);
+    for (const auto& player : room->players) {
+      if (player.playerId == table->bob.player_id) bob_disconnected = !player.connected;
+    }
+  }
+  ASSERT_TRUE(bob_disconnected);
+  // And then silence: no verdict follows the park.
+  EXPECT_FALSE(alice.stream.Receive(std::chrono::milliseconds(300)).ok());
+
+  // The resume token reclaims the seat with the game still going.
+  auto resumed = OpenSeat(table->bob.resume_token);
+  ASSERT_TRUE(resumed.has_value());
+  EXPECT_EQ(resumed->player_id, table->bob.player_id);
+  auto ready = ReceiveCase(resumed->stream, "sessionReady");
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_TRUE(ready->as_sessionReady_or_null()->resumed);
+  auto rejoined = ReceiveGolf(resumed->stream, "gameJoined");
+  ASSERT_TRUE(rejoined.has_value());
+  {
+    const auto& view = rejoined->as_gameJoined_or_null()->view;
+    EXPECT_EQ(view.gameId, table->game_id);
+    EXPECT_NE(view.phase, "ended");
+    ASSERT_EQ(view.players.size(), 2u);
+  }
+  // The reclaimed seat still plays: an opening peek comes back revealed.
+  moonbase::golf::PeekCard peek;
+  peek.cardIndex = 0;
+  ASSERT_TRUE(resumed->stream.Send(Move(GolfMove::FromPeekcard(peek))).ok());
+  auto peeked = ReceiveGolf(resumed->stream, "gameState");
+  ASSERT_TRUE(peeked.has_value());
+  {
+    const auto& view = peeked->as_gameState_or_null()->view;
+    ASSERT_EQ(view.players.size(), 2u);
+    for (const auto& player : view.players) {
+      if (player.playerId != table->bob.player_id) continue;
+      EXPECT_EQ(player.revealedIndexes, std::vector<int>{0});
+    }
+  }
+}
+
+// Grace expiry is the deliberate end of a disconnect (#1236): only after
+// the window runs out does the absence resolve the game — in the
+// survivor's favor, with every seat still on the scorecard.
+class ShortGraceFixture : public GolfGameFixture {
+ protected:
+  std::chrono::seconds GracePeriod() override { return std::chrono::seconds(1); }
+};
+
+TEST_F(ShortGraceFixture, GraceExpiryResolvesTheGameWithEverySeatScored) {
+  auto table = SeatedTable();
+  ASSERT_TRUE(table.has_value());
+  auto& alice = table->alice;
+  ASSERT_TRUE(ReceiveGolf(alice.stream, "gameState").has_value());
+  ASSERT_TRUE(ReceiveGolf(table->bob.stream, "gameState").has_value());
+
+  table->bob.stream.Close();
+
+  // The window runs out with bob still gone: alice takes the game, and
+  // the summary keeps bob's seat — name and standing score — next to
+  // hers.
+  auto ended = ReceiveGolf(alice.stream, "gameEnded");
+  ASSERT_TRUE(ended.has_value());
+  const auto* result = ended->as_gameEnded_or_null();
+  EXPECT_EQ(result->winner, alice.player_id);
+  ASSERT_EQ(result->winners.size(), 1u);
+  EXPECT_EQ(result->winners[0], alice.player_id);
+  ASSERT_EQ(result->finalScores.size(), 2u);
+  std::set<std::string> scored;
+  for (const auto& score : result->finalScores) scored.insert(score.playerId);
+  EXPECT_TRUE(scored.contains(alice.player_id));
+  EXPECT_TRUE(scored.contains(table->bob.player_id));
+
+  // The reaped seat leaves the room: alice ends up alone.
+  bool alone = false;
+  for (int i = 0; i < 4 && !alone; ++i) {
+    auto room = ReceiveCase(alice.stream, "roomState");
+    ASSERT_TRUE(room.has_value());
+    alone = room->as_roomState_or_null()->players.size() == 1;
+  }
+  EXPECT_TRUE(alone);
 }
 
 TEST_F(GolfGameFixture, IllegalMovesRejectInBandAndTheGameContinues) {

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <deque>
+#include <limits>
 #include <set>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -93,16 +95,49 @@ std::string InstanceId() {
   return absl::StrCat("hub-", absl::Hex(absl::Uniform<uint64_t>(gen), absl::kZeroPad16));
 }
 
+// winners() restricted to the seats the roster still names. A final
+// state can carry a seat its roster has dropped — an abandonment that
+// ended the game keeps the departed hand so its cards and score reach
+// the scorecard (#1236) — and such a seat cannot win: the game resolved
+// against it. For an ordinary finish the roster names every seat and
+// this is exactly the engine's rule, knocker-takes-ties included.
+std::unordered_set<int> WinnersAmong(const golf::GameState& state,
+                                     const std::vector<std::string>& roster) {
+  std::unordered_set<int> winning;
+  int min_score = std::numeric_limits<int>::max();
+  for (std::size_t i = 0; i < state.getPlayers().size(); ++i) {
+    const golf::Player& seat = state.getPlayer(static_cast<int>(i));
+    const std::string occupant = seat.getName().value_or("");
+    if (std::find(roster.begin(), roster.end(), occupant) == roster.end()) continue;
+    const int score = seat.score();
+    if (score < min_score) {
+      min_score = score;
+      winning.clear();
+    }
+    if (score == min_score) winning.insert(static_cast<int>(i));
+  }
+  // The knocker takes ties alone — when still in contention.
+  if (winning.contains(state.getWhoKnocked())) {
+    winning.clear();
+    winning.insert(state.getWhoKnocked());
+  }
+  return winning;
+}
+
 // The per-seat stat deltas a finished game applies — the payload of
 // CommitGameFinish, and the same numbers FinalizeGameLocked mirrors into
-// the local member rows.
-std::vector<golf_hub::HubStore::StatsDelta> StatsDeltas(const golf::GameState& state) {
-  const auto winner_indexes = state.winners();
+// the local member rows. Roster seats only: an abandoned seat shows on
+// the scorecard but tallies nothing.
+std::vector<golf_hub::HubStore::StatsDelta> StatsDeltas(const golf::GameState& state,
+                                                        const std::vector<std::string>& roster) {
+  const auto winner_indexes = WinnersAmong(state, roster);
   std::vector<golf_hub::HubStore::StatsDelta> deltas;
   for (std::size_t i = 0; i < state.getPlayers().size(); ++i) {
     const golf::Player& seat = state.getPlayer(static_cast<int>(i));
+    const std::string occupant = seat.getName().value_or("");
+    if (std::find(roster.begin(), roster.end(), occupant) == roster.end()) continue;
     golf_hub::HubStore::StatsDelta delta;
-    delta.player_id = seat.getName().value_or("");
+    delta.player_id = occupant;
     delta.played = 1;
     delta.won = winner_indexes.contains(static_cast<int>(i)) ? 1 : 0;
     delta.score = seat.score();
@@ -543,31 +578,19 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
 
   while (true) {
     auto received = co_await stream.Receive();
-    if (!received.ok()) {
-      // Abrupt loss (or our own slow-consumer close): park the seat for
-      // the grace window (ADR-0020); expiry reaps it. Detach fails only
-      // when the entry is already gone — nothing left to do then.
+    if (!received.ok() || !received->has_value()) {
+      // Any close parks the seat for the grace window (ADR-0020) —
+      // expiry reaps it, a resume reclaims it. A clean close carries no
+      // leave intent: a closed tab sends the same close frame (#1236),
+      // and the deliberate exit is the explicit leaveRoom command.
+      // Detach fails only when the entry is already gone — nothing left
+      // to do then.
       if (registry_.Detach(player_id)) {
         TrackActive(-1);
-        Count("stream_disconnects", {{"kind", "abrupt"}});
+        Count("stream_disconnects", {{"kind", received.ok() ? "clean" : "abrupt"}});
         SetConnected(player_id, false);
         if (auto current = CurrentRoom(player_id)) BroadcastRoom(*current);
       }
-      co_return smithy::Unit{};
-    }
-    if (!received->has_value()) {
-      // Clean close: a deliberate leave. Free the seat, game, and room.
-      registry_.Remove(player_id);
-      TrackActive(-1);
-      Count("stream_disconnects", {{"kind", "clean"}});
-      Outbox outbox;
-      Writes writes;
-      {
-        const std::lock_guard<std::mutex> lock(mu_);
-        LeaveEverywhere(player_id, outbox, writes);
-        EnqueueWritesLocked(writes);
-      }
-      Deliver(outbox);
       co_return smithy::Unit{};
     }
     HandleCommand(player_id, **received);
@@ -1076,7 +1099,7 @@ void HubHandler::EngineMove(const std::string& player_id, const MoveFn& move, Mo
             effects.announce_turn ? PlayerIdAt(state, state.getWhoseTurn()) : std::string();
         const bool over = next->isOver();
         std::vector<HubStore::StatsDelta> deltas;
-        if (over) deltas = StatsDeltas(*next);
+        if (over) deltas = StatsDeltas(*next, ref->entry->roster);
         const Commit commit =
             CommitEntryLocked(ref->room_id, ref->game_id, *ref->entry, ref->entry->roster,
                               *std::move(next), over ? &deltas : nullptr);
@@ -1254,6 +1277,10 @@ void HubHandler::LeaveGameLocked(const std::string& player_id, Outbox& outbox, W
     if (entry.started()) {
       const int seat = entry.state->playerIndex(player_id);
       if (seat >= 0) {
+        // With seats to spare the game continues compacted; at two the
+        // engine keeps every seat and ends the game, so the departed
+        // hand still reaches the scorecard (#1236). The shrunken roster
+        // is what records who left — and who can still win.
         auto next = entry.state->removePlayer(seat);
         state.emplace(next.ok() ? *std::move(next) : *entry.state);
       } else {
@@ -1262,7 +1289,7 @@ void HubHandler::LeaveGameLocked(const std::string& player_id, Outbox& outbox, W
     }
     const bool over = state.has_value() && state->isOver();
     std::vector<HubStore::StatsDelta> deltas;
-    if (over) deltas = StatsDeltas(*state);
+    if (over) deltas = StatsDeltas(*state, roster);
     const Commit commit = CommitEntryLocked(ref->room_id, ref->game_id, entry, roster, state,
                                             over ? &deltas : nullptr);
     if (commit == Commit::kRebased) continue;
@@ -1581,8 +1608,9 @@ void HubHandler::StageGameOverLocked(const std::string& room_id, Room& room,
   if (game == room.games.end() || !game->second.started()) return;
   const golf::GameState& state = *game->second.state;
 
-  // Seat order, so the display string is stable.
-  const auto winner_indexes = state.winners();
+  // Seat order, so the display string is stable. Winners come from the
+  // roster's seats; the scores keep every seat, abandoned or not.
+  const auto winner_indexes = WinnersAmong(state, game->second.roster);
   std::vector<std::string> winner_ids;
   for (std::size_t i = 0; i < state.getPlayers().size(); ++i) {
     if (winner_indexes.contains(static_cast<int>(i))) {
@@ -1616,17 +1644,15 @@ void HubHandler::FinalizeGameLocked(const std::string& room_id, Room& room,
   if (game == room.games.end() || !game->second.started()) return;
   const golf::GameState& state = *game->second.state;
 
-  // Room-scoped running stats: every seat played, every winner won.
-  // With a store these same deltas already rode the finish commit; this
-  // mirrors them into the local rows (and IS the update in-memory).
-  const auto winner_indexes = state.winners();
-  for (std::size_t i = 0; i < state.getPlayers().size(); ++i) {
-    const golf::Player& seat = state.getPlayer(static_cast<int>(i));
-    const auto member = room.members.find(seat.getName().value_or(""));
+  // Room-scoped running stats: every roster seat played, every winner
+  // won. With a store these same deltas already rode the finish commit;
+  // this mirrors them into the local rows (and IS the update in-memory).
+  for (const HubStore::StatsDelta& delta : StatsDeltas(state, game->second.roster)) {
+    const auto member = room.members.find(delta.player_id);
     if (member == room.members.end()) continue;
-    member->second.games_played++;
-    member->second.total_score += seat.score();
-    if (winner_indexes.contains(static_cast<int>(i))) member->second.games_won++;
+    member->second.games_played += delta.played;
+    member->second.games_won += delta.won;
+    member->second.total_score += delta.score;
   }
 
   StageGameOverLocked(room_id, room, game_id, outbox);

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -260,8 +260,9 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   std::optional<std::string> CurrentRoom(const std::string& player_id);
   Room* FindRoomLocked(const std::string& player_id);
   std::optional<GameRef> FindGameLocked(const std::string& player_id);
-  /// Removes the player from their game and room (deliberate leave, clean
-  /// close, or grace expiry) and stages every notification that implies.
+  /// Removes the player from their game and room (deliberate leave or
+  /// grace expiry — never a mere close, which only parks the seat) and
+  /// stages every notification that implies.
   void LeaveEverywhere(const std::string& player_id, Outbox& outbox, Writes& writes);
   void LeaveGameLocked(const std::string& player_id, Outbox& outbox, Writes& writes);
   void BroadcastRoom(const std::string& room_id);

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -197,6 +197,10 @@ class GolfHubStreamFixture : public testing::Test {
   /// overrides with PgChatStore, which authorizes in its own transaction
   /// and needs nothing from the handler.
   virtual std::shared_ptr<ChatStore> MakeChatStore() { return nullptr; }
+  /// ADR-0020 reconnect grace — long enough that no test sees an expiry
+  /// by accident; the expiry suites override it down to something a
+  /// receive budget can wait out.
+  virtual std::chrono::seconds GracePeriod() { return std::chrono::seconds(60); }
 
   void SetUp() override { BuildHub(); }
 
@@ -222,7 +226,7 @@ class GolfHubStreamFixture : public testing::Test {
     }
     handler_ = std::make_shared<HubHandler>(
         vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
-        /*grace_period=*/std::chrono::seconds(60), metrics_, store_, chat_store_);
+        /*grace_period=*/GracePeriod(), metrics_, store_, chat_store_);
     if (default_memory_chat) {
       *guard = [handler = handler_.get()](const std::string& room_id, const std::string& player_id,
                                           const MemberAction& action) {

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -224,9 +224,9 @@ class GolfHubStreamFixture : public testing::Test {
           [guard](const std::string& room_id, const std::string& player_id,
                   const MemberAction& action) { return (*guard)(room_id, player_id, action); });
     }
-    handler_ = std::make_shared<HubHandler>(
-        vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
-        /*grace_period=*/GracePeriod(), metrics_, store_, chat_store_);
+    handler_ =
+        std::make_shared<HubHandler>(vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
+                                     /*grace_period=*/GracePeriod(), metrics_, store_, chat_store_);
     if (default_memory_chat) {
       *guard = [handler = handler_.get()](const std::string& room_id, const std::string& player_id,
                                           const MemberAction& action) {

--- a/domains/games/libs/cards/golf/game_state.cc
+++ b/domains/games/libs/cards/golf/game_state.cc
@@ -344,9 +344,8 @@ absl::StatusOr<GameState> GameState::removePlayer(int player) const {
   // tally, and the caller's own roster records who left — with isOver
   // forced so the finish resolves through the ordinary scoring path.
   if (players.size() <= 2) {
-    return GameState{drawPile,    discardPile, players,
-                     false,       whoseTurn,   whoseTurn,
-                     peeksHidden, gameId,      version_id};
+    return GameState{drawPile,  discardPile, players, false,     whoseTurn,
+                     whoseTurn, peeksHidden, gameId,  version_id};
   }
 
   vector<Player> updatedPlayers;

--- a/domains/games/libs/cards/golf/game_state.cc
+++ b/domains/games/libs/cards/golf/game_state.cc
@@ -339,6 +339,16 @@ absl::StatusOr<GameState> GameState::removePlayer(int player) const {
     return FailedPreconditionError("no such player");
   }
 
+  // Below two remaining seats there is no game left to play: every seat
+  // stays — the abandoned hand's cards and score stand for the final
+  // tally, and the caller's own roster records who left — with isOver
+  // forced so the finish resolves through the ordinary scoring path.
+  if (players.size() <= 2) {
+    return GameState{drawPile,    discardPile, players,
+                     false,       whoseTurn,   whoseTurn,
+                     peeksHidden, gameId,      version_id};
+  }
+
   vector<Player> updatedPlayers;
   for (size_t i = 0; i < players.size(); i++) {
     if (static_cast<int>(i) != player) {
@@ -350,23 +360,13 @@ absl::StatusOr<GameState> GameState::removePlayer(int player) const {
   if (player < newWhoseTurn) {
     newWhoseTurn--;
   }
-  if (!updatedPlayers.empty()) {
-    newWhoseTurn = newWhoseTurn % static_cast<int>(updatedPlayers.size());
-  } else {
-    newWhoseTurn = 0;
-  }
+  newWhoseTurn = newWhoseTurn % static_cast<int>(updatedPlayers.size());
 
   int newWhoKnocked = whoKnocked;
   if (player == newWhoKnocked) {
     newWhoKnocked = -1;  // the knocker fled; the knock is void
   } else if (newWhoKnocked != -1 && player < newWhoKnocked) {
     newWhoKnocked--;
-  }
-
-  // Below two players there is no game left to play: force isOver so the
-  // remaining seat's win resolves through the ordinary scoring path.
-  if (updatedPlayers.size() < 2) {
-    newWhoKnocked = newWhoseTurn;
   }
 
   return GameState{drawPile,    discardPile,  std::move(updatedPlayers),

--- a/domains/games/libs/cards/golf/game_state.h
+++ b/domains/games/libs/cards/golf/game_state.h
@@ -82,9 +82,12 @@ class GameState {
   [[nodiscard]] bool revealCountdownActive() const;
   [[nodiscard]] bool getPeeksHidden() const { return peeksHidden; }
 
-  /// A seat abandoned mid-game: the seat disappears and indices compact.
-  /// A departing knocker voids the knock; below two players the game is
-  /// over and scores stand.
+  /// A seat abandoned mid-game. With three or more seats the abandoned
+  /// seat disappears and indices compact (a departing knocker voids the
+  /// knock). Below two remaining seats the game is over with every seat
+  /// kept — cards and scores stand for the final tally; only the
+  /// caller's own roster records who left, so winners() alone cannot
+  /// exclude the abandoner.
   [[nodiscard]] absl::StatusOr<GameState> removePlayer(int player) const;
 
   [[nodiscard]] GameState withPlayers(std::vector<Player> newPlayers) const;

--- a/domains/games/libs/cards/golf/game_state_test.cc
+++ b/domains/games/libs/cards/golf/game_state_test.cc
@@ -485,6 +485,13 @@ TEST(GameState, RemoveToBelowTwoPlayersEndsTheGame) {
   EXPECT_TRUE(lone->isOver());
   const std::unordered_set<int> expected{0};
   EXPECT_EQ(lone->winners(), expected);
+
+  // Every seat stays on the final scorecard: the abandoned hand keeps
+  // its cards and score. Who actually left lives in the caller's roster,
+  // not the state.
+  ASSERT_EQ(lone->getPlayers().size(), 2u);
+  EXPECT_EQ(*lone->getPlayer(1).getName(), "Mercy");
+  EXPECT_EQ(lone->getPlayer(1).score(), 0);  // four threes pair-cancel
 }
 
 // Validation negatives for the corrected rules (#1187): no blind moves,


### PR DESCRIPTION
Fixes #1236.

## The bug

A golf v2 player who accidentally closed their browser mid-game had no chance to rejoin: the other player got "You won" within a couple of seconds, and the game summary listed only the survivor's name and score.

Two defects compounded:

1. **A clean websocket close was read as a deliberate leave.** Browsers send the same clean close frame (1001) for a closed tab as for anything else on the way out, but the `Play` receive loop freed the seat, game, and room on the spot — only abrupt losses got the ADR-0020 grace window. The protocol's explicit `leaveRoom`/`leaveGame` commands are the actual leave signals, so a close carries no leave intent of its own.
2. **The abandonment finish erased the departed seat.** `GameState::removePlayer` dropped the leaver's seat and forced the game over, so the final views, `gameEnded.finalScores`, the committed terminal state (and therefore remote instances' ceremonies) all showed only the survivor.

## The fix

- **Any stream close parks the seat** for the grace window: expiry reaps it, a resume reclaims it, and only the explicit leave commands (or expiry) free the seat. The `stream_disconnects{kind=clean|abrupt}` metric split is unchanged.
- **Below two remaining seats the engine keeps every seat** and ends the game, so the departed hand — name, cards face up, standing score — stays on the scorecard everywhere the terminal state travels. The shrunken roster records who left: the new `WinnersAmong(state, roster)` resolves winners and stat deltas among roster seats only, which reduces exactly to the engine's rule (knocker-takes-ties included) for ordinary finishes and settles abandonment as a forfeit to the survivor. Stat accrual is unchanged from before: abandoned seats show on the scorecard but tally nothing.

## Reproducing tests (fail without the fix, pass with it)

- `CleanCloseParksTheSeatAndResumeReclaimsIt` — a room-level close parks the seat (opponent sees `connected=false`, roster intact) and the resume token reclaims it.
- `MidGameBrowserCloseParksTheSeatAndTheGameSurvives` — the reported scenario: mid-game close ends nothing, the survivor sees the disconnect and silence (no `gameEnded`), and the reclaimed seat still plays.
- `ShortGraceFixture.GraceExpiryResolvesTheGameWithEverySeatScored` — grace runs out for real (the fixture's grace period is now overridable): the survivor wins, and `finalScores` carries both seats.
- `AbandoningALiveGameResolvesIt` — extended to assert the final view and summary keep the leaver's seat, cards revealed and scored.
- `RemoveToBelowTwoPlayersEndsTheGame` — pins the engine's new keep-every-seat terminal contract.

`bazel test //domains/games/apis/golf_hub/... //domains/games/libs/cards/...` — 18/18 pass locally (the pg suites skip without a database and run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xrUJHRRqjSmMu7Cv2kkZg

---
_Generated by [Claude Code](https://claude.ai/code/session_016xrUJHRRqjSmMu7Cv2kkZg)_