### PR TITLE
golf_hub: abandonment ends are not knocks; the forfeit rule gets its own tests

### DIFF
--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -13,6 +13,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -34,6 +35,64 @@ std::string WithNul(std::string prefix, std::string suffix) {
   prefix.push_back('\0');
   prefix.append(suffix);
   return prefix;
+}
+
+// The forfeit rule, pinned directly: an abandonment end is scored among
+// roster seats only, so the departed hand loses however well it stands.
+TEST(WinnersAmong, AbandonerWithTheBetterScoreStillLoses) {
+  using cards::Card;
+  using cards::Rank;
+  using cards::Suit;
+  // The abandoner's four threes pair-cancel to zero; the survivor holds
+  // an unpaired 2+3+4+5. The engine's own tally crowns the departed
+  // seat — it cannot know who left.
+  const golf::Player survivor{"andy", Card(Suit::Clubs, Rank::Two),
+                              Card(Suit::Diamonds, Rank::Three), Card(Suit::Hearts, Rank::Four),
+                              Card(Suit::Spades, Rank::Five)};
+  const golf::Player abandoner{"mercy", Card(Suit::Clubs, Rank::Three),
+                               Card(Suit::Diamonds, Rank::Three), Card(Suit::Hearts, Rank::Three),
+                               Card(Suit::Spades, Rank::Three)};
+  const golf::GameState state{{Card{Suit::Diamonds, Rank::Ten}},
+                              {Card{Suit::Hearts, Rank::Four}},
+                              {survivor, abandoner},
+                              false,
+                              /*_whoseTurn=*/0,
+                              golf::GameState::kAbandoned,
+                              "game",
+                              "v"};
+  ASSERT_TRUE(state.isOver());
+  ASSERT_LT(state.getPlayer(1).score(), state.getPlayer(0).score());
+  EXPECT_EQ(state.winners(), (std::unordered_set<int>{1}));
+
+  // The roster no longer names the abandoner: the survivor wins the
+  // forfeit despite the worse hand.
+  EXPECT_EQ(WinnersAmong(state, {"andy"}), (std::unordered_set<int>{0}));
+}
+
+// With every seat still on the roster this is exactly the engine's
+// rule — the knocker takes ties alone.
+TEST(WinnersAmong, OrdinaryFinishMatchesTheEngineKnockerTiesIncluded) {
+  using cards::Card;
+  using cards::Rank;
+  using cards::Suit;
+  const golf::Player andy{"andy", Card(Suit::Clubs, Rank::Two), Card(Suit::Diamonds, Rank::Two),
+                          Card(Suit::Hearts, Rank::Two), Card(Suit::Spades, Rank::Two)};
+  const golf::Player mercy{"mercy", Card(Suit::Clubs, Rank::Three),
+                           Card(Suit::Diamonds, Rank::Three), Card(Suit::Hearts, Rank::Three),
+                           Card(Suit::Spades, Rank::Three)};
+  // Both hands cancel to zero; mercy knocked and the turn came back
+  // around, ending the game with the tie hers alone.
+  const golf::GameState state{{Card{Suit::Diamonds, Rank::Ten}},
+                              {Card{Suit::Hearts, Rank::Four}},
+                              {andy, mercy},
+                              false,
+                              /*_whoseTurn=*/1,
+                              /*_whoKnocked=*/1,
+                              "game",
+                              "v"};
+  ASSERT_TRUE(state.isOver());
+  EXPECT_EQ(WinnersAmong(state, {"andy", "mercy"}), state.winners());
+  EXPECT_EQ(WinnersAmong(state, {"andy", "mercy"}), (std::unordered_set<int>{1}));
 }
 
 // A whole second hub sharing the first one's durable pieces — the
@@ -1230,9 +1289,21 @@ TEST_F(ShortGraceFixture, GraceExpiryResolvesTheGameWithEverySeatScored) {
 
   table->bob.stream.Close();
 
-  // The window runs out with bob still gone: alice takes the game, and
-  // the summary keeps bob's seat — name and standing score — next to
-  // hers.
+  // The window runs out with bob still gone. The ceremony's terminal
+  // view precedes the result — and a forfeit is not a knock, so it
+  // names no knocker.
+  std::optional<moonbase::golf::GameView> ended_view;
+  for (int i = 0; i < 4 && !ended_view.has_value(); ++i) {
+    auto view_update = ReceiveGolf(alice.stream, "gameState");
+    ASSERT_TRUE(view_update.has_value());
+    const auto& view = view_update->as_gameState_or_null()->view;
+    if (view.phase == "ended") ended_view = view;
+  }
+  ASSERT_TRUE(ended_view.has_value());
+  EXPECT_FALSE(ended_view->knockedPlayerId.has_value());
+
+  // Alice takes the game, and the summary keeps bob's seat — name and
+  // standing score — next to hers.
   auto ended = ReceiveGolf(alice.stream, "gameEnded");
   ASSERT_TRUE(ended.has_value());
   const auto* result = ended->as_gameEnded_or_null();

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -27,6 +27,30 @@ using moonbase::golf::GolfEvents;
 using moonbase::golf::GolfMove;
 using moonbase::golf::GolfUpdate;
 
+std::unordered_set<int> WinnersAmong(const golf::GameState& state,
+                                     const std::vector<std::string>& roster) {
+  std::unordered_set<int> winning;
+  int min_score = std::numeric_limits<int>::max();
+  for (std::size_t i = 0; i < state.getPlayers().size(); ++i) {
+    const golf::Player& seat = state.getPlayer(static_cast<int>(i));
+    const std::string occupant = seat.getName().value_or("");
+    if (std::find(roster.begin(), roster.end(), occupant) == roster.end()) continue;
+    const int score = seat.score();
+    if (score < min_score) {
+      min_score = score;
+      winning.clear();
+    }
+    if (score == min_score) winning.insert(static_cast<int>(i));
+  }
+  // The knocker takes ties alone — when still in contention. An
+  // abandonment end carries no knocker (kAbandoned is never a seat).
+  if (winning.contains(state.getWhoKnocked())) {
+    winning.clear();
+    winning.insert(state.getWhoKnocked());
+  }
+  return winning;
+}
+
 namespace {
 
 constexpr std::size_t kMaxSeats = 4;
@@ -70,7 +94,7 @@ moonbase::golf::Card WireCard(const cards::Card& card) {
 std::string PhaseString(const golf::GameState& state) {
   if (state.isOver()) return "ended";
   if (state.revealCountdownActive()) return "peeking";
-  if (state.getWhoKnocked() != -1) return "knocked";
+  if (state.getWhoKnocked() >= 0) return "knocked";
   return "playing";
 }
 
@@ -93,35 +117,6 @@ constexpr int kMaxCommitAttempts = 3;
 std::string InstanceId() {
   absl::BitGen gen;
   return absl::StrCat("hub-", absl::Hex(absl::Uniform<uint64_t>(gen), absl::kZeroPad16));
-}
-
-// winners() restricted to the seats the roster still names. A final
-// state can carry a seat its roster has dropped — an abandonment that
-// ended the game keeps the departed hand so its cards and score reach
-// the scorecard (#1236) — and such a seat cannot win: the game resolved
-// against it. For an ordinary finish the roster names every seat and
-// this is exactly the engine's rule, knocker-takes-ties included.
-std::unordered_set<int> WinnersAmong(const golf::GameState& state,
-                                     const std::vector<std::string>& roster) {
-  std::unordered_set<int> winning;
-  int min_score = std::numeric_limits<int>::max();
-  for (std::size_t i = 0; i < state.getPlayers().size(); ++i) {
-    const golf::Player& seat = state.getPlayer(static_cast<int>(i));
-    const std::string occupant = seat.getName().value_or("");
-    if (std::find(roster.begin(), roster.end(), occupant) == roster.end()) continue;
-    const int score = seat.score();
-    if (score < min_score) {
-      min_score = score;
-      winning.clear();
-    }
-    if (score == min_score) winning.insert(static_cast<int>(i));
-  }
-  // The knocker takes ties alone — when still in contention.
-  if (winning.contains(state.getWhoKnocked())) {
-    winning.clear();
-    winning.insert(state.getWhoKnocked());
-  }
-  return winning;
 }
 
 // The per-seat stat deltas a finished game applies — the payload of
@@ -1560,7 +1555,9 @@ moonbase::golf::GameView HubHandler::ViewLocked(const std::string& game_id, cons
   view.drawPileCount = static_cast<int>(state.getDrawPile().size());
   view.discardCount = static_cast<int>(state.getDiscardPile().size());
   if (!state.getDiscardPile().empty()) view.discardTop = WireCard(state.getDiscardPile().back());
-  if (state.getWhoKnocked() != -1) view.knockedPlayerId = PlayerIdAt(state, state.getWhoKnocked());
+  // Only a real seat's knock is advertised: an abandonment end carries
+  // the kAbandoned sentinel, not a knock somebody would be blamed for.
+  if (state.getWhoKnocked() >= 0) view.knockedPlayerId = PlayerIdAt(state, state.getWhoKnocked());
   view.allPlayersPeeked = state.allPlayersPeeked();
   // The drawn card rides only to the player who is looking at it.
   if (state.getPeekedAtDrawPile() && !ended &&

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -24,6 +25,16 @@
 #include "smithy/server/session_registry.h"
 
 namespace golf_hub {
+
+/// winners() restricted to the seats the roster still names — the
+/// forfeit rule. A final state can carry a seat its roster has dropped:
+/// an abandonment that ended the game keeps the departed hand so its
+/// cards and score reach the scorecard (#1236), and such a seat cannot
+/// win — however good its standing score, the game resolved against it.
+/// For an ordinary finish the roster names every seat and this is
+/// exactly the engine's rule, knocker-takes-ties included.
+[[nodiscard]] std::unordered_set<int> WinnersAmong(const golf::GameState& state,
+                                                   const std::vector<std::string>& roster);
 
 /// The hub, phase 2 (#1187): session admission, rooms, chat, and the
 /// game layer on the reshaped libs/cards/golf engine. One SessionRegistry

--- a/domains/games/libs/cards/golf/game_state.cc
+++ b/domains/games/libs/cards/golf/game_state.cc
@@ -55,7 +55,9 @@ absl::StatusOr<GameState> dealGolfGame(const string& game_id, const std::vector<
                    ""};
 }
 
-bool GameState::isOver() const { return drawPile.empty() || whoseTurn == whoKnocked; }
+bool GameState::isOver() const {
+  return drawPile.empty() || whoKnocked == kAbandoned || whoseTurn == whoKnocked;
+}
 
 // The preamble every turn move shares; per-move checks stay at the sites.
 absl::Status GameState::ensurePlayableTurn(int player) const {
@@ -341,11 +343,12 @@ absl::StatusOr<GameState> GameState::removePlayer(int player) const {
 
   // Below two remaining seats there is no game left to play: every seat
   // stays — the abandoned hand's cards and score stand for the final
-  // tally, and the caller's own roster records who left — with isOver
-  // forced so the finish resolves through the ordinary scoring path.
+  // tally, and the caller's own roster records who left — with the
+  // abandonment sentinel forcing isOver, so the finish scores like any
+  // other without inventing a knock nobody made.
   if (players.size() <= 2) {
-    return GameState{drawPile,  discardPile, players, false,     whoseTurn,
-                     whoseTurn, peeksHidden, gameId,  version_id};
+    return GameState{drawPile,   discardPile, players, false,     whoseTurn,
+                     kAbandoned, peeksHidden, gameId,  version_id};
   }
 
   vector<Player> updatedPlayers;

--- a/domains/games/libs/cards/golf/game_state.h
+++ b/domains/games/libs/cards/golf/game_state.h
@@ -28,6 +28,13 @@ class GameState;
 
 class GameState {
  public:
+  /// whoKnocked values outside the seat range: no knock yet, and a game
+  /// over by abandonment. The sentinel keeps a forced finish out of the
+  /// knock fields — views and the knocker-takes-ties rule only honor a
+  /// real seat — while isOver() still reads it as terminal.
+  static constexpr int kNoKnock = -1;
+  static constexpr int kAbandoned = -2;
+
   GameState(std::deque<Card> _drawPile, std::deque<Card> _discardPile, std::vector<Player> _players,
             bool _peekedAtDrawPile, int _whoseTurn, int _whoKnocked)
       : drawPile(std::move(_drawPile)),
@@ -84,10 +91,11 @@ class GameState {
 
   /// A seat abandoned mid-game. With three or more seats the abandoned
   /// seat disappears and indices compact (a departing knocker voids the
-  /// knock). Below two remaining seats the game is over with every seat
-  /// kept — cards and scores stand for the final tally; only the
-  /// caller's own roster records who left, so winners() alone cannot
-  /// exclude the abandoner.
+  /// knock). Below two remaining seats the game is over by abandonment
+  /// (whoKnocked becomes kAbandoned — any earlier knock is superseded)
+  /// with every seat kept — cards and scores stand for the final tally;
+  /// only the caller's own roster records who left, so winners() alone
+  /// cannot exclude the abandoner.
   [[nodiscard]] absl::StatusOr<GameState> removePlayer(int player) const;
 
   [[nodiscard]] GameState withPlayers(std::vector<Player> newPlayers) const;

--- a/domains/games/libs/cards/golf/game_state_serde.cc
+++ b/domains/games/libs/cards/golf/game_state_serde.cc
@@ -183,7 +183,9 @@ absl::StatusOr<GameState> deserializeGameState(const std::string& serialized) {
   const int64_t seats = static_cast<int64_t>(players.size());
   auto whose_turn = readIntInRange(parsed, "whoseTurn", 0, seats - 1);
   if (!whose_turn.ok()) return whose_turn.status();
-  auto who_knocked = readIntInRange(parsed, "whoKnocked", -1, seats - 1);
+  // kAbandoned marks a game over by abandonment; rows older than the
+  // sentinel carry a synthetic knock on a real seat and still parse.
+  auto who_knocked = readIntInRange(parsed, "whoKnocked", GameState::kAbandoned, seats - 1);
   if (!who_knocked.ok()) return who_knocked.status();
 
   return GameState{*std::move(draw_pile),

--- a/domains/games/libs/cards/golf/game_state_serde_test.cc
+++ b/domains/games/libs/cards/golf/game_state_serde_test.cc
@@ -123,6 +123,24 @@ TEST(GameStateSerde, RoundTripsAnAbandonedSeatAndEmptyPiles) {
   expectRoundTrips(state);
 }
 
+TEST(GameStateSerde, RoundTripsAGameOverByAbandonment) {
+  // The terminal shape a below-two-seats abandonment commits (#1236):
+  // whoKnocked carries the kAbandoned sentinel, every seat kept.
+  const Player stayed{"andy", Card(Suit::Clubs, Rank::Two), Card(Suit::Diamonds, Rank::Three),
+                      Card(Suit::Hearts, Rank::Four), Card(Suit::Spades, Rank::Five)};
+  const Player left{"mercy", Card(Suit::Clubs, Rank::Six), Card(Suit::Diamonds, Rank::Seven),
+                    Card(Suit::Hearts, Rank::Eight), Card(Suit::Spades, Rank::Nine)};
+  const GameState state{{Card(0), Card(1)},    {Card(2)}, {stayed, left}, false, 0,
+                        GameState::kAbandoned, true,      "g-forfeit",    "v-1"};
+  ASSERT_TRUE(state.isOver());
+  expectRoundTrips(state);
+
+  const auto restored = deserializeGameState(serializeGameState(state));
+  ASSERT_TRUE(restored.ok()) << restored.status();
+  EXPECT_TRUE(restored->isOver());
+  EXPECT_EQ(restored->getWhoKnocked(), GameState::kAbandoned);
+}
+
 // The frozen shape of a stored row. Everything else in this suite
 // generates its bytes with the code under test, so only this test can
 // catch a simultaneous serialize+deserialize change that would orphan —
@@ -240,8 +258,10 @@ TEST(GameStateSerde, RejectsSeatIndexAtTheBoundary) {
   payload["whoKnocked"] = 2;
   expectRejected(payload);
 
+  // kAbandoned (-2) is the one legal value below "no knock"; the range
+  // ends right after it.
   payload = dealtPayload();
-  payload["whoKnocked"] = -2;
+  payload["whoKnocked"] = -3;
   expectRejected(payload);
 
   // An empty roster has no seat 0, and the engine's turn arithmetic

--- a/domains/games/libs/cards/golf/game_state_test.cc
+++ b/domains/games/libs/cards/golf/game_state_test.cc
@@ -483,8 +483,13 @@ TEST(GameState, RemoveToBelowTwoPlayersEndsTheGame) {
   auto lone = game.removePlayer(1);
   ASSERT_TRUE(lone.ok());
   EXPECT_TRUE(lone->isOver());
-  const std::unordered_set<int> expected{0};
-  EXPECT_EQ(lone->winners(), expected);
+  // The finish is marked as abandonment, not as a knock nobody made.
+  EXPECT_EQ(lone->getWhoKnocked(), GameState::kAbandoned);
+  // Both hands pair-cancel to zero and the tie stands: with no knocker
+  // in the state, winners() has no one to hand the tie to. Excluding
+  // the abandoner is the caller's job — its roster knows who left.
+  const std::unordered_set<int> tied{0, 1};
+  EXPECT_EQ(lone->winners(), tied);
 
   // Every seat stays on the final scorecard: the abandoned hand keeps
   // its cards and score. Who actually left lives in the caller's roster,
@@ -492,6 +497,28 @@ TEST(GameState, RemoveToBelowTwoPlayersEndsTheGame) {
   ASSERT_EQ(lone->getPlayers().size(), 2u);
   EXPECT_EQ(*lone->getPlayer(1).getName(), "Mercy");
   EXPECT_EQ(lone->getPlayer(1).score(), 0);  // four threes pair-cancel
+}
+
+TEST(GameState, AbandonedGameCannotExcludeTheAbandonerByScore) {
+  // The abandoner leaves holding the better hand: four threes cancel to
+  // zero against the survivor's unpaired 2+3+4+5. The engine's tally
+  // crowns the departed seat — by design it cannot know who left, so
+  // the forfeit (survivor wins regardless) must come from the caller's
+  // roster, which is what the hub's WinnersAmong pins.
+  const Player survivor{"Andy", Card(Suit::Clubs, Rank::Two), Card(Suit::Diamonds, Rank::Three),
+                        Card(Suit::Hearts, Rank::Four), Card(Suit::Spades, Rank::Five)};
+  const Player abandoner{"Mercy", Card(Suit::Clubs, Rank::Three), Card(Suit::Diamonds, Rank::Three),
+                         Card(Suit::Hearts, Rank::Three), Card(Suit::Spades, Rank::Three)};
+  const std::deque<Card> drawPile{Card{Suit::Diamonds, Rank::Ten}};
+  const std::deque<Card> discardPile{Card{Suit::Hearts, Rank::Four}};
+
+  const GameState game{drawPile, discardPile, {survivor, abandoner}, false, 0, -1, "foo", "bar"};
+  auto lone = game.removePlayer(1);
+  ASSERT_TRUE(lone.ok());
+  EXPECT_TRUE(lone->isOver());
+  EXPECT_LT(lone->getPlayer(1).score(), lone->getPlayer(0).score());
+  const std::unordered_set<int> engine_pick{1};
+  EXPECT_EQ(lone->winners(), engine_pick);
 }
 
 // Validation negatives for the corrected rules (#1187): no blind moves,


### PR DESCRIPTION
Follow-ups from #1237 (issue #1236).

## The phantom knock

Forcing a below-two-seats abandonment over by writing `whoseTurn` into `whoKnocked` left the state indistinguishable from a real knock, so final views could advertise a knock nobody made. A `GameState::kAbandoned` sentinel (`-2`) now marks that finish:

- `isOver()` reads the sentinel as terminal; no synthetic self-knock.
- `ViewLocked` only sets `knockedPlayerId` for a real seat (`>= 0`), so abandonment ends stop naming a knocker.
- The knocker-takes-ties rule has no synthetic seat to hand a tie to: the engine's `winners()` now lets an abandonment tie stand, and the hub's roster does the excluding — the layering the docs already claimed.
- The serde admits the sentinel on read, so rows written with the old synthetic knock still parse; the reject boundary moves to `-3` and the boundary test moves with it.

## The forfeit rule, pinned directly

`WinnersAmong` moves out of the handler's anonymous namespace (declared in `hub_handler.h`) so the forfeit is unit-tested rather than implied: the abandoner holds the strictly better hand — four threes cancelling to zero against an unpaired 14 — and still loses to the roster-only survivor. A parity test pins that a full roster reproduces the engine's rule exactly, knocker-takes-ties included, and an engine-side test documents the complementary half: `winners()` alone crowns the departed seat, which is why the roster must do the excluding.

The grace-expiry e2e now also asserts the terminal view names no knocker.

## Not in this PR

Keeping 3+ player leavers on the eventual scorecard (the seat compacts away so the game can continue) is a product call — flagged in #1236's thread of work; the natural shape is hub-side tracking of departed hands appended at ceremony time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xrUJHRRqjSmMu7Cv2kkZg

---
_Generated by [Claude Code](https://claude.ai/code/session_016xrUJHRRqjSmMu7Cv2kkZg)_