### PR TITLE
golf_hub: per-session stream budgets with a tighter chat sub-limit

### DIFF
--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -257,6 +257,23 @@ cc_test(
     ],
 )
 
+# Per-session stream budgets (#1240): a coroutine-frame token bucket —
+# deliberately lock-free because frames are sequential per session.
+cc_library(
+    name = "rate_limiter",
+    hdrs = ["rate_limiter.h"],
+)
+
+cc_test(
+    name = "rate_limiter_test",
+    size = "small",
+    srcs = ["rate_limiter_test.cc"],
+    deps = [
+        ":rate_limiter",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "hub_handler",
     srcs = ["hub_handler.cc"],
@@ -267,6 +284,7 @@ cc_library(
         ":hub_store",
         ":id_generator",
         ":protocol_input",
+        ":rate_limiter",
         ":ticket_vault",
         "//domains/games/libs/cards",
         "//domains/games/libs/cards:card_mapper",

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -306,7 +306,13 @@ cc_library(
 # skips otherwise.
 cc_test(
     name = "pg_hub_e2e_test",
-    size = "small",
+    # Medium: a multi-instance database e2e suite that has grown with
+    # every epic (restart, cross-instance games, chat, forfeits). The
+    # small 60s ceiling covers the whole binary, and a contended CI
+    # runner against the postgres service can exhaust it mid-suite with
+    # nothing wrong (observed on #1241: timeout after six green tests,
+    # no assertion failure; every case passes locally in ~1s).
+    size = "medium",
     srcs = [
         "pg_hub_e2e_test.cc",
         "stream_test_fixture.h",

--- a/domains/games/apis/golf_hub/hub_chat_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_chat_race_test.cc
@@ -168,7 +168,8 @@ class HubChatRaceFixture : public GolfHubStreamFixture {
     instance->handler = std::make_shared<HubHandler>(
         vault_, std::make_shared<cards::NoShuffleDealer>(), std::make_shared<RemoteIdGenerator>(),
         std::chrono::seconds(60),
-        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), store_, chat_store_);
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), store_, chat_store_,
+        UnlimitedRateLimits());
     EXPECT_TRUE(instance->handler->RestoreFromStore().ok());
     instance->server = std::make_unique<moonbase::golf::GolfHubServer>(instance->handler);
 

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -211,7 +211,7 @@ std::unique_ptr<SecondInstance> BuildSecondInstance(
   instance->handler = std::make_shared<HubHandler>(
       std::move(vault), std::make_shared<cards::NoShuffleDealer>(),
       std::make_shared<SequentialIdGenerator>(), std::chrono::seconds(60), std::move(metrics),
-      std::move(store), std::move(chat_store));
+      std::move(store), std::move(chat_store), UnlimitedRateLimits());
   EXPECT_TRUE(instance->handler->RestoreFromStore().ok());
   instance->server = std::make_unique<moonbase::golf::GolfHubServer>(instance->handler);
 

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -1571,5 +1571,81 @@ TEST_F(FailingVaultFixture, GetSessionFailsClosedWhenTheVaultIsDown) {
   ASSERT_FALSE(session.ok());
 }
 
+// Per-session stream budgets (#1240), pinned with tiny buckets whose
+// refills are effectively never — nothing a test does can accidentally
+// earn a token back, so the refusal path is deterministic.
+class RateLimitedStreamFixture : public GolfHubStreamFixture {
+ protected:
+  RateLimits MakeRateLimits() override {
+    RateLimits limits;
+    limits.command_burst = 6;
+    limits.command_refill_per_sec = 0.0001;
+    limits.chat_burst = 2;
+    limits.chat_refill_per_sec = 0.0001;
+    return limits;
+  }
+};
+
+// The chat sub-limit: the burst stores and echoes, the message after it
+// is refused before any locked work — told "slow down", counted by
+// kind, and never stored. The session stays usable.
+TEST_F(RateLimitedStreamFixture, AChatFloodStoresTheBurstAndRejectsTheRest) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+
+  moonbase::golf::Chat chat;
+  for (const char* text : {"one", "two"}) {
+    chat.text = text;
+    ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+    auto echo = NextEvent(alice->stream);
+    ASSERT_TRUE(echo.has_value());
+    ASSERT_NE(echo->as_roomChat_or_null(), nullptr);
+    EXPECT_EQ(echo->as_roomChat_or_null()->text, text);
+  }
+
+  chat.text = "three is a flood";
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromChat(chat)).ok());
+  auto refused = NextEvent(alice->stream);
+  ASSERT_TRUE(refused.has_value());
+  ASSERT_NE(refused->as_commandRejected_or_null(), nullptr);
+  EXPECT_EQ(refused->as_commandRejected_or_null()->reason, "slow down");
+
+  EXPECT_EQ(metrics_->CounterTotal("chat_appends", {{"result", "stored"}}), 2);
+  EXPECT_EQ(metrics_->CounterTotal("stream_rate_limited", {{"kind", "chat"}}), 1);
+  EXPECT_EQ(metrics_->CounterTotal("stream_rate_limited", {{"kind", "command"}}), 0);
+}
+
+// The command budget guards everything, including frames that only ever
+// earn rejections — the flood costs the hub almost nothing and honest
+// commands resume once the client backs off (here: never, the refill is
+// frozen, which is what makes the boundary exact).
+TEST_F(RateLimitedStreamFixture, ACommandFloodIsRefusedAfterTheBurst) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+
+  // Six lobby-less getRoomState frames spend the burst; each earns the
+  // ordinary rejection, proving real handling happened.
+  for (int i = 0; i < 6; ++i) {
+    ASSERT_TRUE(
+        alice->stream.Send(GolfCommands::FromGetroomstate(moonbase::golf::GetRoomState{})).ok());
+    auto rejected = NextEvent(alice->stream);
+    ASSERT_TRUE(rejected.has_value());
+    ASSERT_NE(rejected->as_commandRejected_or_null(), nullptr);
+    EXPECT_EQ(rejected->as_commandRejected_or_null()->reason, "not in a room");
+  }
+
+  ASSERT_TRUE(
+      alice->stream.Send(GolfCommands::FromGetroomstate(moonbase::golf::GetRoomState{})).ok());
+  auto limited = NextEvent(alice->stream);
+  ASSERT_TRUE(limited.has_value());
+  ASSERT_NE(limited->as_commandRejected_or_null(), nullptr);
+  EXPECT_EQ(limited->as_commandRejected_or_null()->reason, "slow down");
+  EXPECT_EQ(metrics_->CounterTotal("stream_rate_limited", {{"kind", "command"}}), 1);
+}
+
 }  // namespace
 }  // namespace golf_hub

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -146,7 +146,8 @@ std::vector<golf_hub::HubStore::StatsDelta> StatsDeltas(const golf::GameState& s
 HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards::Dealer> dealer,
                        std::shared_ptr<IdGenerator> ids, std::chrono::seconds grace_period,
                        std::shared_ptr<futility::otel::MetricsRecorder> metrics,
-                       std::shared_ptr<HubStore> store, std::shared_ptr<ChatStore> chat_store)
+                       std::shared_ptr<HubStore> store, std::shared_ptr<ChatStore> chat_store,
+                       RateLimits limits)
     : vault_(std::move(vault)),
       dealer_(std::move(dealer)),
       ids_(std::move(ids)),
@@ -161,6 +162,7 @@ HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards
                                                                  const MemberAction& action) {
                           return WithMember(room_id, player_id, action);
                         })),
+      limits_(limits),
       instance_id_(InstanceId()),
       registry_([this, grace_period] {
         Registry::Options options;
@@ -571,6 +573,14 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
   }
   Deliver(resync);
 
+  // Per-session budgets (#1240), owned by this coroutine frame: frames
+  // are handled sequentially per session, so no locking, and the state
+  // dies with the connection. Every frame draws from the command
+  // bucket; chat draws from its own tighter bucket too, because each
+  // message is a durable database transaction plus fleet-wide fan-out.
+  TokenBucket command_budget(limits_.command_burst, limits_.command_refill_per_sec);
+  TokenBucket chat_budget(limits_.chat_burst, limits_.chat_refill_per_sec);
+
   while (true) {
     auto received = co_await stream.Receive();
     if (!received.ok() || !received->has_value()) {
@@ -587,6 +597,21 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
         if (auto current = CurrentRoom(player_id)) BroadcastRoom(*current);
       }
       co_return smithy::Unit{};
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (!command_budget.Admit(now)) {
+      // Refused before any locked work: the whole point is that a flood
+      // costs the hub almost nothing. The session stays open — the
+      // buckets already bound the damage, and closing floods just
+      // converts them into reconnect load.
+      Count("stream_rate_limited", {{"kind", "command"}});
+      Reject(player_id, "slow down");
+      continue;
+    }
+    if ((*received)->as_chat_or_null() != nullptr && !chat_budget.Admit(now)) {
+      Count("stream_rate_limited", {{"kind", "chat"}});
+      Reject(player_id, "slow down");
+      continue;
     }
     HandleCommand(player_id, **received);
   }

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -16,6 +16,7 @@
 #include "domains/games/apis/golf_hub/chat_store.h"
 #include "domains/games/apis/golf_hub/hub_store.h"
 #include "domains/games/apis/golf_hub/id_generator.h"
+#include "domains/games/apis/golf_hub/rate_limiter.h"
 #include "domains/games/apis/golf_hub/ticket_vault.h"
 #include "domains/games/libs/cards/dealer.h"
 #include "domains/games/libs/cards/golf/game_state.h"
@@ -83,13 +84,15 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// it neither survives a restart nor reaches another instance. A
   /// PgChatStore passed here authorizes against room_members in its own
   /// transaction and needs nothing from this handler.
+  /// `limits` are the per-session stream budgets (#1240); the defaults
+  /// serve production and tests inject extremes to pin the behavior.
   explicit HubHandler(std::shared_ptr<TicketVault> vault,
                       std::shared_ptr<cards::Dealer> dealer = std::make_shared<cards::Dealer>(),
                       std::shared_ptr<IdGenerator> ids = std::make_shared<WhimsicalIdGenerator>(),
                       std::chrono::seconds grace_period = std::chrono::minutes(5),
                       std::shared_ptr<futility::otel::MetricsRecorder> metrics = nullptr,
                       std::shared_ptr<HubStore> store = nullptr,
-                      std::shared_ptr<ChatStore> chat_store = nullptr);
+                      std::shared_ptr<ChatStore> chat_store = nullptr, RateLimits limits = {});
 
   /// Runs `action` while mu_ holds (room_id, player_id) to be a current
   /// member, or returns false without running it. Membership cannot
@@ -344,6 +347,7 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   const std::shared_ptr<futility::otel::MetricsRecorder> metrics_;
   const std::shared_ptr<HubStore> store_;
   const std::shared_ptr<ChatStore> chat_store_;
+  const RateLimits limits_;
   /// Rides every commit and rider as the notify payload, so an instance
   /// can tell its own wake-ups from the ones that carry news.
   const std::string instance_id_;

--- a/domains/games/apis/golf_hub/hub_store_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_store_race_test.cc
@@ -130,7 +130,8 @@ class HubStoreRaceFixture : public GolfHubStreamFixture {
         std::make_shared<InMemoryTicketVault>(std::chrono::seconds(60), std::chrono::seconds(60)),
         std::make_shared<cards::NoShuffleDealer>(), std::make_shared<RemoteIdGenerator>(),
         std::chrono::seconds(60),
-        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), gated_store_);
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), gated_store_,
+        /*chat_store=*/nullptr, UnlimitedRateLimits());
     EXPECT_TRUE(instance->handler->RestoreFromStore().ok());
     instance->server = std::make_unique<moonbase::golf::GolfHubServer>(instance->handler);
 

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -161,7 +161,7 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
         std::make_shared<RemoteIdGenerator>(),
         /*grace_period=*/std::chrono::seconds(60),
         std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"), instance->store,
-        MakeChatStore());
+        MakeChatStore(), UnlimitedRateLimits());
     const absl::Status restored = instance->handler->RestoreFromStore();
     EXPECT_TRUE(restored.ok()) << restored;
     instance->listener = MakeListener(instance->handler);

--- a/domains/games/apis/golf_hub/rate_limiter.h
+++ b/domains/games/apis/golf_hub/rate_limiter.h
@@ -1,0 +1,68 @@
+#ifndef DOMAINS_GAMES_APIS_GOLF_HUB_RATE_LIMITER_H
+#define DOMAINS_GAMES_APIS_GOLF_HUB_RATE_LIMITER_H
+
+#include <algorithm>
+#include <chrono>
+#include <optional>
+
+namespace golf_hub {
+
+/// A token bucket for the stream's per-session budgets (#1240). Not
+/// thread-safe on purpose: each Play coroutine owns its buckets in the
+/// coroutine frame, frames are processed sequentially per session, and
+/// the state dies with the connection — no shared map, no lock.
+///
+/// Callers pass the clock reading in, so tests pin refill behavior with
+/// fabricated time instead of sleeping.
+class TokenBucket {
+ public:
+  /// A bucket that starts full. `capacity` is the burst; `refill_per_sec`
+  /// is the sustained rate. Tokens are fractional so slow refills grant
+  /// eventually rather than never.
+  TokenBucket(double capacity, double refill_per_sec)
+      : capacity_(capacity), refill_per_sec_(refill_per_sec), tokens_(capacity) {}
+
+  /// Spends one token if the bucket (after refilling for elapsed time)
+  /// holds one; a refusal costs nothing. `now` must come from a
+  /// monotonic clock; a reading at or before the last one refills
+  /// nothing and does not move the watermark back — elapsed time is
+  /// only ever counted once.
+  bool Admit(std::chrono::steady_clock::time_point now) {
+    if (!last_.has_value()) {
+      last_ = now;
+    } else if (now > *last_) {
+      const std::chrono::duration<double> elapsed = now - *last_;
+      tokens_ = std::min(capacity_, tokens_ + elapsed.count() * refill_per_sec_);
+      last_ = now;
+    }
+    if (tokens_ < 1.0) return false;
+    tokens_ -= 1.0;
+    return true;
+  }
+
+ private:
+  const double capacity_;
+  const double refill_per_sec_;
+  double tokens_;
+  std::optional<std::chrono::steady_clock::time_point> last_;
+};
+
+/// The stream's budgets, injectable so tests pin behavior with tiny or
+/// huge values instead of racing wall-clock refills. Defaults are far
+/// above human play — moves are turn-gated and chat is typed — and far
+/// below what it takes to hurt the hub mutex or the database (#1234).
+///
+/// Every inbound frame draws from the command bucket; chat frames draw
+/// from the chat bucket too. Chat is tighter because each message is a
+/// durable PostgreSQL transaction plus fleet-wide NOTIFY fan-out, and a
+/// rate that is fine for gameplay is still a flood in a conversation.
+struct RateLimits {
+  double command_burst = 10;
+  double command_refill_per_sec = 5;
+  double chat_burst = 3;
+  double chat_refill_per_sec = 1;
+};
+
+}  // namespace golf_hub
+
+#endif

--- a/domains/games/apis/golf_hub/rate_limiter_test.cc
+++ b/domains/games/apis/golf_hub/rate_limiter_test.cc
@@ -1,0 +1,70 @@
+#include "domains/games/apis/golf_hub/rate_limiter.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+namespace golf_hub {
+namespace {
+
+using std::chrono::milliseconds;
+using std::chrono::steady_clock;
+
+// All time is fabricated: the bucket's contract is about elapsed time it
+// is told about, never about the wall clock.
+const steady_clock::time_point kEpoch{};
+
+TEST(TokenBucketTest, GrantsTheBurstThenRefuses) {
+  TokenBucket bucket(/*capacity=*/3, /*refill_per_sec=*/1);
+  EXPECT_TRUE(bucket.Admit(kEpoch));
+  EXPECT_TRUE(bucket.Admit(kEpoch));
+  EXPECT_TRUE(bucket.Admit(kEpoch));
+  EXPECT_FALSE(bucket.Admit(kEpoch));
+  // A refusal costs nothing: still refused, not doubly indebted.
+  EXPECT_FALSE(bucket.Admit(kEpoch));
+}
+
+TEST(TokenBucketTest, RefillsAtTheSustainedRate) {
+  TokenBucket bucket(/*capacity=*/2, /*refill_per_sec=*/2);
+  EXPECT_TRUE(bucket.Admit(kEpoch));
+  EXPECT_TRUE(bucket.Admit(kEpoch));
+  EXPECT_FALSE(bucket.Admit(kEpoch));
+
+  // 500ms at 2/s is one whole token.
+  EXPECT_TRUE(bucket.Admit(kEpoch + milliseconds(500)));
+  EXPECT_FALSE(bucket.Admit(kEpoch + milliseconds(500)));
+}
+
+TEST(TokenBucketTest, FractionalRefillsAccumulate) {
+  TokenBucket bucket(/*capacity=*/1, /*refill_per_sec=*/1);
+  EXPECT_TRUE(bucket.Admit(kEpoch));
+  // Four quarter-second refusals each bank 0.25 tokens...
+  EXPECT_FALSE(bucket.Admit(kEpoch + milliseconds(250)));
+  EXPECT_FALSE(bucket.Admit(kEpoch + milliseconds(500)));
+  EXPECT_FALSE(bucket.Admit(kEpoch + milliseconds(750)));
+  // ...and the fourth quarter completes the token.
+  EXPECT_TRUE(bucket.Admit(kEpoch + milliseconds(1000)));
+}
+
+TEST(TokenBucketTest, RefillCapsAtCapacity) {
+  TokenBucket bucket(/*capacity=*/2, /*refill_per_sec=*/1000);
+  EXPECT_TRUE(bucket.Admit(kEpoch));
+  // An hour idle banks no more than the burst.
+  const auto later = kEpoch + std::chrono::hours(1);
+  EXPECT_TRUE(bucket.Admit(later));
+  EXPECT_TRUE(bucket.Admit(later));
+  EXPECT_FALSE(bucket.Admit(later));
+}
+
+TEST(TokenBucketTest, TimeMovingBackwardsRefillsNothing) {
+  TokenBucket bucket(/*capacity=*/1, /*refill_per_sec=*/1000);
+  EXPECT_TRUE(bucket.Admit(kEpoch + milliseconds(1000)));
+  // An earlier reading must not mint tokens (steady_clock shouldn't do
+  // this, but the bucket must not amplify a platform bug into free
+  // budget).
+  EXPECT_FALSE(bucket.Admit(kEpoch));
+  EXPECT_FALSE(bucket.Admit(kEpoch + milliseconds(1000)));
+}
+
+}  // namespace
+}  // namespace golf_hub

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -113,6 +113,19 @@ inline std::optional<moonbase::golf::GolfUpdate> ReceiveGolf(
   return std::nullopt;
 }
 
+// Effectively-unlimited stream budgets (#1240) for suites whose flows
+// send at test speed, not human speed. Every direct HubHandler
+// construction in a test should pass this unless the test is about the
+// limiter itself.
+inline RateLimits UnlimitedRateLimits() {
+  RateLimits limits;
+  limits.command_burst = 1e9;
+  limits.command_refill_per_sec = 1e9;
+  limits.chat_burst = 1e9;
+  limits.chat_refill_per_sec = 1e9;
+  return limits;
+}
+
 inline moonbase::golf::GolfCommands Move(moonbase::golf::GolfMove move) {
   moonbase::golf::GolfCommand command;
   command.move = std::move(move);
@@ -197,10 +210,11 @@ class GolfHubStreamFixture : public testing::Test {
   /// overrides with PgChatStore, which authorizes in its own transaction
   /// and needs nothing from the handler.
   virtual std::shared_ptr<ChatStore> MakeChatStore() { return nullptr; }
-  /// The stream budgets (#1240). Defaults are far above anything a test
-  /// sends; rate-limit tests override with tiny buckets to pin the
-  /// refusal behavior without racing wall-clock refills.
-  virtual RateLimits MakeRateLimits() { return {}; }
+  /// The stream budgets (#1240). Tests get effectively-unlimited
+  /// buckets: e2e flows blast frames far faster than any human, and only
+  /// the rate-limit suite wants refusals — it overrides with tiny
+  /// buckets whose refills are frozen.
+  virtual RateLimits MakeRateLimits() { return UnlimitedRateLimits(); }
   /// ADR-0020 reconnect grace — long enough that no test sees an expiry
   /// by accident; the expiry suites override it down to something a
   /// receive budget can wait out.

--- a/domains/games/apis/golf_hub/stream_test_fixture.h
+++ b/domains/games/apis/golf_hub/stream_test_fixture.h
@@ -197,6 +197,10 @@ class GolfHubStreamFixture : public testing::Test {
   /// overrides with PgChatStore, which authorizes in its own transaction
   /// and needs nothing from the handler.
   virtual std::shared_ptr<ChatStore> MakeChatStore() { return nullptr; }
+  /// The stream budgets (#1240). Defaults are far above anything a test
+  /// sends; rate-limit tests override with tiny buckets to pin the
+  /// refusal behavior without racing wall-clock refills.
+  virtual RateLimits MakeRateLimits() { return {}; }
   /// ADR-0020 reconnect grace — long enough that no test sees an expiry
   /// by accident; the expiry suites override it down to something a
   /// receive budget can wait out.
@@ -224,9 +228,9 @@ class GolfHubStreamFixture : public testing::Test {
           [guard](const std::string& room_id, const std::string& player_id,
                   const MemberAction& action) { return (*guard)(room_id, player_id, action); });
     }
-    handler_ =
-        std::make_shared<HubHandler>(vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
-                                     /*grace_period=*/GracePeriod(), metrics_, store_, chat_store_);
+    handler_ = std::make_shared<HubHandler>(
+        vault_, std::make_shared<cards::NoShuffleDealer>(), ids_,
+        /*grace_period=*/GracePeriod(), metrics_, store_, chat_store_, MakeRateLimits());
     if (default_memory_chat) {
       *guard = [handler = handler_.get()](const std::string& room_id, const std::string& player_id,
                                           const MemberAction& action) {

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -34,6 +34,7 @@ var serviceRegistry = map[string]serviceEntry{
 			{"Activity", "commands_per_sec", "/s", `sum(rate(stream_commands_total[5m]))`},
 			{"Activity", "events_per_sec", "/s", `sum(rate(stream_events_total[5m]))`},
 			{"Activity", "rejections_per_sec", "/s", `sum(rate(stream_rejections_total[5m]))`},
+			{"Activity", "rate_limited_per_sec", "/s", `sum(rate(stream_rate_limited_total[5m]))`},
 			// Room chat (#1226): outcome counts and stages only — the emitter
 			// never labels by room, player, or text. catch_up_rows is a
 			// per-drain distribution, so its windowed average is how far
@@ -52,6 +53,7 @@ var serviceRegistry = map[string]serviceEntry{
 			"event_rate":         `sum(rate(stream_events_total[5m]))`,
 			"rejection_rate":     `sum(rate(stream_rejections_total[5m]))`,
 			"disconnect_rate":    `sum(rate(stream_disconnects_total[5m]))`,
+			"rate_limited_rate":  `sum(rate(stream_rate_limited_total[5m]))`,
 			"chat_message_rate":  `sum(rate(chat_appends_total{result="stored"}[5m]))`,
 			"chat_delivery_rate": `sum(rate(chat_rows_delivered_total[5m]))`,
 			"chat_failure_rate":  `sum(rate(chat_failures_total[5m]))`,

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -152,7 +152,7 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 	assert.Equal(t, "Activity", response.Custom[1].Title)
 	assert.Equal(t, "Chat", response.Custom[2].Title)
 	assert.Len(t, response.Custom[0].Metrics, 6)
-	assert.Len(t, response.Custom[1].Metrics, 3)
+	assert.Len(t, response.Custom[1].Metrics, 4)
 	require.Len(t, response.Custom[2].Metrics, 6)
 
 	assert.Equal(t, CustomMetricValue{Label: "active", Value: 200.0, Unit: "sessions"},
@@ -161,8 +161,8 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 		response.Custom[1].Metrics[0])
 	assert.Equal(t, CustomMetricValue{Label: "rejections_per_sec", Value: 208.0, Unit: "/s"},
 		response.Custom[1].Metrics[2])
-	// Chat starts at CustomScalars index 9, so its first value is 200+9.
-	assert.Equal(t, CustomMetricValue{Label: "messages_per_sec", Value: 209.0, Unit: "/s"},
+	// Chat starts at CustomScalars index 10, so its first value is 200+10.
+	assert.Equal(t, CustomMetricValue{Label: "messages_per_sec", Value: 210.0, Unit: "/s"},
 		response.Custom[2].Metrics[0])
 	// The omitted query's descriptor survives with a zero value.
 	last := response.Custom[2].Metrics[5]
@@ -294,6 +294,7 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testin
 		"sessions_active", "session_starts", "command_rate", "event_rate",
 		"rejection_rate", "disconnect_rate",
 		"chat_message_rate", "chat_delivery_rate", "chat_failure_rate", "chat_catch_up_rows",
+		"rate_limited_rate",
 	}
 	assert.Len(t, names, len(expected))
 	for _, name := range expected {


### PR DESCRIPTION
Closes #1240. The `Play` loop processed every inbound frame at whatever rate the socket delivered — no command budget, no chat cooldown. Chat was the cheapest denial-of-service on the fleet: each frame is a durable PostgreSQL transaction plus NOTIFY-driven catch-up work on every instance holding the room (#1234 quantifies the mutex side), and junk frames or create/leave cycling reach locked work at wire speed too.

## What changed

**Token buckets in the `Play` coroutine frame.** Frames are handled sequentially per session, so the buckets need no shared map and no locking, and their state dies with the connection. Every frame draws from a command bucket (burst 10, refill 5/s); chat frames draw from a tighter bucket too (burst 3, refill 1/s) — a rate that's fine for turn-gated gameplay is still a flood in a conversation, and each chat message is a durable transaction.

**Refusal is cheap and non-fatal.** Exhaustion rejects with `"slow down"` before any locked work runs, counts `stream_rate_limited{kind: command | chat}`, and keeps the session open — closing floods would just convert them into reconnect load.

**`TokenBucket` takes the clock reading as an argument**, so its unit tests pin refill behavior with fabricated time: burst then refusal, sustained-rate refills, fractional accumulation, capacity cap after long idle, and that a backwards clock reading neither mints tokens nor moves the watermark.

**Limits are injectable** (`RateLimits` on the handler ctor). Tests run with effectively-unlimited buckets — e2e flows blast frames at test speed, not human speed — and only the rate-limit suite overrides with tiny frozen-refill buckets, which makes the boundary exact: the chat flood test stores and echoes precisely the burst and gets the next message refused unstored (pinned via the metrics capture: `chat_appends{stored}` frozen at the burst, `stream_rate_limited{chat}` counted); the command flood test earns real `"not in a room"` rejections for the burst and the limiter's `"slow down"` after.

**Dashboard**: `rate_limited_per_sec` joins the golf_hub Activity group and `rate_limited_rate` the timeseries in prom_proxy's registry — group counts and mock values re-pinned in the handler test, and the new key passes the no-shadowing-`STANDARD_SERIES` check.

## Tests

Local: all 16 golf_hub + pg + prom_proxy targets green, including the new `rate_limiter_test` and the two flood e2e tests. The unlimited-budget test seam is its own commit, since production defaults initially throttled suites that send 35 messages in a tight loop — exactly the behavior the limiter exists to refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XY8cFki7eChwYq76DY7hU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01XY8cFki7eChwYq76DY7hU9)_