### PR TITLE
yodel: the Java services join the http_server_* observability rails

### DIFF
--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -199,6 +199,9 @@ services:
     environment:
       - PORT=8080
       - APP_NAME=mcpserver
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
+      - OTEL_SERVICE_NAME=mcpserver
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=mcpserver,service.version=${MCPSERVER_SHA:-${DEPLOY_SHA:-latest}}
     volumes:
       - /etc/mcpserver:/etc/mcpserver
     networks:
@@ -269,6 +272,9 @@ services:
     environment:
       - PORT=8080
       - SENTRY_DSN=${ONE_D4_SENTRY_DSN}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
+      - OTEL_SERVICE_NAME=one_d4
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=one_d4,service.version=${ONE_D4_SHA:-${DEPLOY_SHA:-latest}}
     volumes:
       - /etc/one_d4:/etc/one_d4
     networks:

--- a/domains/games/apis/mcpserver/BUILD.bazel
+++ b/domains/games/apis/mcpserver/BUILD.bazel
@@ -61,8 +61,8 @@ java_binary(
     ],
     visibility = ["//visibility:public"],
     runtime_deps = [
-        "//domains/platform/libs/yodel:micronaut",
         "//domains/platform/libs/logging",
+        "//domains/platform/libs/yodel:micronaut",
     ],
     deps = [
         ":dtos",

--- a/domains/games/apis/mcpserver/BUILD.bazel
+++ b/domains/games/apis/mcpserver/BUILD.bazel
@@ -61,6 +61,7 @@ java_binary(
     ],
     visibility = ["//visibility:public"],
     runtime_deps = [
+        "//domains/platform/libs/yodel:micronaut",
         "//domains/platform/libs/logging",
     ],
     deps = [

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -214,8 +214,8 @@ java_binary(
     ],
     visibility = ["//visibility:public"],
     runtime_deps = [
-        "//domains/platform/libs/yodel:micronaut",
         "//domains/platform/libs/logging",
+        "//domains/platform/libs/yodel:micronaut",
         artifact("org.postgresql:postgresql"),
     ],
     deps = [

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -214,6 +214,7 @@ java_binary(
     ],
     visibility = ["//visibility:public"],
     runtime_deps = [
+        "//domains/platform/libs/yodel:micronaut",
         "//domains/platform/libs/logging",
         artifact("org.postgresql:postgresql"),
     ],

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -20,7 +20,7 @@ type serviceEntry struct {
 }
 
 // Catalog order doubles as the UI's tab order.
-var serviceOrder = []string{"golf_hub", "microgpt-serve", "mithril", "portrait", "posterize"}
+var serviceOrder = []string{"golf_hub", "mcpserver", "microgpt-serve", "mithril", "one_d4", "portrait", "posterize"}
 
 var serviceRegistry = map[string]serviceEntry{
 	"golf_hub": {
@@ -74,6 +74,10 @@ var serviceRegistry = map[string]serviceEntry{
 			"avg_duration_ms":   `sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`,
 		},
 	},
+	// The Java services (#1212): yodel's standard instruments only, no
+	// custom set yet.
+	"mcpserver": {},
+	"one_d4":    {},
 	// Wordchains: server_pal's standard instruments only, no custom set.
 	"mithril": {},
 	// Image blur/edges: server_pal's standard instruments only.

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -74,8 +74,10 @@ func TestMetricsHandler_GetServiceCatalog(t *testing.T) {
 		hasCustom bool
 	}{
 		{"golf_hub", true},
+		{"mcpserver", false},
 		{"microgpt-serve", true},
 		{"mithril", false},
+		{"one_d4", false},
 		{"portrait", true},
 		{"posterize", false},
 	}

--- a/domains/platform/libs/yodel/BUILD.bazel
+++ b/domains/platform/libs/yodel/BUILD.bazel
@@ -1,0 +1,95 @@
+load("//bazel/rules:java.bzl", "artifact", "java_library", "java_test_suite")
+
+java_library(
+    name = "yodel",
+    srcs = [
+        "src/main/java/com/muchq/platform/yodel/HttpMetricsPipeline.java",
+        "src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java",
+        "src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java",
+        "src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        artifact("com.fasterxml.jackson.core:jackson-core"),
+        artifact("com.fasterxml.jackson.core:jackson-databind"),
+        artifact("org.jspecify:jspecify"),
+        artifact("org.slf4j:slf4j-api"),
+    ],
+)
+
+# Dropping this on a Micronaut service's runtime classpath is the whole
+# integration: the filter registers itself and the http_server_* family
+# exports whenever OTEL_EXPORTER_OTLP_ENDPOINT is set.
+java_library(
+    name = "micronaut",
+    srcs = [
+        "src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":yodel",
+        artifact("io.micronaut:micronaut-core"),
+        artifact("io.micronaut:micronaut-http"),
+        artifact("io.micronaut:micronaut-inject"),
+        artifact("io.projectreactor:reactor-core"),
+        artifact("jakarta.annotation:jakarta.annotation-api"),
+        artifact("jakarta.inject:jakarta-inject-api"),
+        artifact("org.reactivestreams:reactive-streams"),
+    ],
+)
+
+java_test_suite(
+    name = "yodel_tests",
+    size = "small",
+    srcs = [
+        "src/test/java/com/muchq/platform/yodel/HttpMetricsPipelineTest.java",
+        "src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java",
+        "src/test/java/com/muchq/platform/yodel/OtlpHttpMetricsExporterTest.java",
+        "src/test/java/com/muchq/platform/yodel/OtlpJsonEncoderTest.java",
+    ],
+    deps = [
+        ":yodel",
+        artifact("com.fasterxml.jackson.core:jackson-databind"),
+        artifact("org.junit.jupiter:junit-jupiter-api"),
+        artifact("org.assertj:assertj-core"),
+    ],
+)
+
+# The controller lives in its own java_library (not the suite srcs) because
+# only java_library targets run the Micronaut annotation processors that
+# generate its bean definition.
+java_library(
+    name = "filter_test_app",
+    testonly = True,
+    srcs = [
+        "src/test/java/com/muchq/platform/yodel/micronaut/TestEndpointController.java",
+    ],
+    deps = [
+        artifact("io.micronaut:micronaut-core"),
+        artifact("io.micronaut:micronaut-http"),
+        artifact("io.micronaut:micronaut-inject"),
+        artifact("jakarta.inject:jakarta-inject-api"),
+    ],
+)
+
+java_test_suite(
+    name = "micronaut_tests",
+    size = "small",
+    srcs = [
+        "src/test/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilterTest.java",
+    ],
+    runtime_deps = [
+        ":filter_test_app",
+        artifact("io.micronaut:micronaut-jackson-databind"),
+    ],
+    deps = [
+        ":yodel",
+        ":micronaut",
+        artifact("io.micronaut:micronaut-context"),
+        artifact("io.micronaut:micronaut-http-server-netty"),
+        artifact("io.micronaut:micronaut-inject"),
+        artifact("io.micronaut:micronaut-runtime"),
+        artifact("org.junit.jupiter:junit-jupiter-api"),
+        artifact("org.assertj:assertj-core"),
+    ],
+)

--- a/domains/platform/libs/yodel/BUILD.bazel
+++ b/domains/platform/libs/yodel/BUILD.bazel
@@ -83,8 +83,8 @@ java_test_suite(
         artifact("io.micronaut:micronaut-jackson-databind"),
     ],
     deps = [
-        ":yodel",
         ":micronaut",
+        ":yodel",
         artifact("io.micronaut:micronaut-context"),
         artifact("io.micronaut:micronaut-http-server-netty"),
         artifact("io.micronaut:micronaut-inject"),

--- a/domains/platform/libs/yodel/README.md
+++ b/domains/platform/libs/yodel/README.md
@@ -1,0 +1,60 @@
+# yodel
+
+The Java rails for MoonBase observability (#1212): how a Java service emits
+the shared `http_server_*` serving metrics so the collector, prom_proxy, and
+the dashboard read it exactly like the C++ (`aura`/`futility`) and Rust
+(`server_pal`) services.
+
+## The contract
+
+Instrument names, labels, and units are pinned to the family the other
+languages emit — parity is the whole point:
+
+| OTLP instrument | Kind | Prometheus name |
+|---|---|---|
+| `http_server_requests` | monotonic sum | `http_server_requests_total` |
+| `http_server_requests_success` | monotonic sum | `http_server_requests_success_total` |
+| `http_server_requests_failure` | monotonic sum | `http_server_requests_failure_total` |
+| `http_server_requests_active_gauge` | non-monotonic sum | `http_server_requests_active_gauge` |
+| `http_server_request_duration_microseconds` | histogram (values in **microseconds**) | `..._{sum,count,bucket}` |
+
+Every data point carries `service_name` (from `OTEL_SERVICE_NAME`) and
+`http_method` — the same label set as `server_pal`. Success means status
+< 400. Durations use the OTel SDK default bucket bounds, matching the
+other emitters.
+
+Rather than pulling the OpenTelemetry SDK + Micrometer dependency trees into
+`maven_install.json` for five fixed instruments (and then remapping
+Micrometer's `http.server.requests` names/units back to this family), the
+library speaks the small OTLP/HTTP JSON surface directly with deps the repo
+already has (Jackson, JDK HttpClient).
+
+## Joining a Micronaut service
+
+1. Add `"//domains/platform/libs/yodel:micronaut"` to the binary's
+   `runtime_deps`. The `HttpServerMetricsFilter` registers itself for all
+   routes in the METRICS filter phase — outside auth and routing, so rejected
+   and unmatched requests are measured too.
+2. Set the standard env block in `deploy/consolidated/compose.yaml`
+   (same as every other service):
+
+   ```yaml
+   OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
+   OTEL_SERVICE_NAME: my_service
+   OTEL_RESOURCE_ATTRIBUTES: service.name=my_service,service.version=${MY_SERVICE_SHA:-latest}
+   ```
+
+3. Add the service to `serviceOrder` / `serviceRegistry` in
+   `domains/platform/apis/prom_proxy/registry.go` so it gets a catalog entry
+   and service page.
+
+Without `OTEL_EXPORTER_OTLP_ENDPOINT` the instruments record in memory and
+nothing exports — the same no-op contract as `server_pal::init_otel`, so
+tests and local runs need no configuration.
+
+## Non-Micronaut use
+
+`HttpMetricsPipeline.fromEnv()` + `recordRequestStart` /
+`recordRequestComplete` are framework-agnostic; the Micronaut filter is just
+the first transport binding. Future cross-cutting families (`rate_limit_*`,
+`cache_*` — #1209) should ride the same exporter.

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpMetricsPipeline.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpMetricsPipeline.java
@@ -1,0 +1,73 @@
+package com.muchq.platform.yodel;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * How a Java service joins the shared observability rails: reads the standard OTEL_* env vars
+ * (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME, OTEL_RESOURCE_ATTRIBUTES) and assembles the
+ * http_server_* instruments plus a periodic OTLP exporter. Without the endpoint the instruments
+ * still record in memory and nothing exports — the same no-op contract as server_pal's init_otel.
+ */
+public final class HttpMetricsPipeline implements AutoCloseable {
+  private static final Duration EXPORT_INTERVAL = Duration.ofSeconds(15);
+
+  private final HttpServerMetrics metrics;
+  private final @Nullable OtlpHttpMetricsExporter exporter;
+
+  private HttpMetricsPipeline(
+      HttpServerMetrics metrics, @Nullable OtlpHttpMetricsExporter exporter) {
+    this.metrics = metrics;
+    this.exporter = exporter;
+  }
+
+  public static HttpMetricsPipeline fromEnv() {
+    return fromEnv(System.getenv());
+  }
+
+  static HttpMetricsPipeline fromEnv(Map<String, String> env) {
+    String serviceName = env.getOrDefault("OTEL_SERVICE_NAME", "");
+    HttpServerMetrics metrics =
+        new HttpServerMetrics(serviceName, System.currentTimeMillis() * 1_000_000L);
+    String endpoint = env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
+    if (endpoint == null || endpoint.isBlank()) {
+      return new HttpMetricsPipeline(metrics, null);
+    }
+    OtlpHttpMetricsExporter exporter =
+        new OtlpHttpMetricsExporter(
+            endpoint, resourceAttributes(env, serviceName), metrics, EXPORT_INTERVAL);
+    exporter.start();
+    return new HttpMetricsPipeline(metrics, exporter);
+  }
+
+  /**
+   * OTEL_RESOURCE_ATTRIBUTES ("k=v,k=v") with OTEL_SERVICE_NAME winning for service.name — the same
+   * precedence the SDK resource detectors implement.
+   */
+  static Map<String, String> resourceAttributes(Map<String, String> env, String serviceName) {
+    Map<String, String> attributes = new LinkedHashMap<>();
+    for (String pair : env.getOrDefault("OTEL_RESOURCE_ATTRIBUTES", "").split(",")) {
+      int eq = pair.indexOf('=');
+      if (eq > 0 && eq < pair.length() - 1) {
+        attributes.put(pair.substring(0, eq).trim(), pair.substring(eq + 1).trim());
+      }
+    }
+    if (!serviceName.isEmpty()) {
+      attributes.put("service.name", serviceName);
+    }
+    return attributes;
+  }
+
+  public HttpServerMetrics metrics() {
+    return metrics;
+  }
+
+  @Override
+  public void close() {
+    if (exporter != null) {
+      exporter.close();
+    }
+  }
+}

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java
@@ -1,0 +1,135 @@
+package com.muchq.platform.yodel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * The shared HTTP serving instruments (http_server_requests, http_server_requests_success /
+ * _failure, http_server_requests_active_gauge, http_server_request_duration_microseconds) labeled
+ * by service_name and http_method, mirroring futility/otel (C++) and server_pal (Rust) so
+ * prom_proxy's standard block reads Java services with zero changes
+ * (https://github.com/muchq/MoonBase/issues/1212).
+ */
+public final class HttpServerMetrics {
+  // The OTel SDK default explicit bucket boundaries. The C++ and Rust emitters
+  // record microseconds against these same defaults, and the dashboard's
+  // histogram_quantile and avg queries are built on them.
+  static final double[] BUCKET_BOUNDS = {
+    0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000
+  };
+
+  private final String serviceName;
+  private final long startTimeUnixNanos;
+  private final ConcurrentHashMap<String, MethodStats> byMethod = new ConcurrentHashMap<>();
+
+  public HttpServerMetrics(String serviceName, long startTimeUnixNanos) {
+    this.serviceName = serviceName;
+    this.startTimeUnixNanos = startTimeUnixNanos;
+  }
+
+  public String serviceName() {
+    return serviceName;
+  }
+
+  public long startTimeUnixNanos() {
+    return startTimeUnixNanos;
+  }
+
+  public void recordRequestStart(String httpMethod) {
+    MethodStats stats = statsFor(httpMethod);
+    stats.requests.increment();
+    stats.active.incrementAndGet();
+  }
+
+  public void recordRequestComplete(String httpMethod, int statusCode, double durationMicros) {
+    MethodStats stats = statsFor(httpMethod);
+    stats.active.decrementAndGet();
+    if (statusCode < 400) {
+      stats.success.increment();
+    } else {
+      stats.failure.increment();
+    }
+    stats.durationSumMicros.add(durationMicros);
+    stats.durationCount.increment();
+    stats.bucketFor(durationMicros).increment();
+  }
+
+  /**
+   * A request that ended without a response (the client went away first): only the in-flight gauge
+   * moves, matching server_pal's drop-guard semantics.
+   */
+  public void recordRequestAbandoned(String httpMethod) {
+    statsFor(httpMethod).active.decrementAndGet();
+  }
+
+  /** Point-in-time cumulative totals per method, ordered by method for stable payloads. */
+  public List<MethodSnapshot> snapshot() {
+    List<MethodSnapshot> out = new ArrayList<>(byMethod.size());
+    byMethod.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(e -> out.add(e.getValue().snapshot(e.getKey())));
+    return out;
+  }
+
+  private MethodStats statsFor(String httpMethod) {
+    return byMethod.computeIfAbsent(httpMethod, m -> new MethodStats());
+  }
+
+  public record MethodSnapshot(
+      String httpMethod,
+      long requests,
+      long success,
+      long failure,
+      long active,
+      double durationSumMicros,
+      long durationCount,
+      long[] bucketCounts) {}
+
+  private static final class MethodStats {
+    final LongAdder requests = new LongAdder();
+    final LongAdder success = new LongAdder();
+    final LongAdder failure = new LongAdder();
+    final AtomicLong active = new AtomicLong();
+    final DoubleAdder durationSumMicros = new DoubleAdder();
+    final LongAdder durationCount = new LongAdder();
+    final LongAdder[] buckets;
+
+    MethodStats() {
+      buckets = new LongAdder[BUCKET_BOUNDS.length + 1];
+      for (int i = 0; i < buckets.length; i++) {
+        buckets[i] = new LongAdder();
+      }
+    }
+
+    // OTLP buckets are upper-inclusive: bounds[i-1] < x <= bounds[i].
+    LongAdder bucketFor(double micros) {
+      for (int i = 0; i < BUCKET_BOUNDS.length; i++) {
+        if (micros <= BUCKET_BOUNDS[i]) {
+          return buckets[i];
+        }
+      }
+      return buckets[BUCKET_BOUNDS.length];
+    }
+
+    MethodSnapshot snapshot(String httpMethod) {
+      long[] counts = new long[buckets.length];
+      for (int i = 0; i < buckets.length; i++) {
+        counts[i] = buckets[i].sum();
+      }
+      return new MethodSnapshot(
+          httpMethod,
+          requests.sum(),
+          success.sum(),
+          failure.sum(),
+          active.get(),
+          durationSumMicros.sum(),
+          durationCount.sum(),
+          counts);
+    }
+  }
+}

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java
@@ -1,0 +1,97 @@
+package com.muchq.platform.yodel;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodically POSTs the http_server_* snapshot as OTLP JSON to {@code <endpoint>/v1/metrics} from
+ * a daemon thread. Export failures are logged and retried on the next tick; they never affect
+ * serving.
+ */
+public final class OtlpHttpMetricsExporter implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(OtlpHttpMetricsExporter.class);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  private final URI metricsUri;
+  private final Map<String, String> resourceAttributes;
+  private final HttpServerMetrics metrics;
+  private final Duration interval;
+  private final HttpClient client;
+  private final Thread thread;
+  private volatile boolean started;
+  private volatile boolean closed;
+
+  public OtlpHttpMetricsExporter(
+      String endpoint,
+      Map<String, String> resourceAttributes,
+      HttpServerMetrics metrics,
+      Duration interval) {
+    String base = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+    this.metricsUri = URI.create(base + "/v1/metrics");
+    this.resourceAttributes = Map.copyOf(resourceAttributes);
+    this.metrics = metrics;
+    this.interval = interval;
+    this.client = HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build();
+    this.thread = new Thread(this::runLoop, "yodel-otlp-exporter");
+    this.thread.setDaemon(true);
+  }
+
+  public void start() {
+    started = true;
+    thread.start();
+    LOG.info("OTel metrics initialised (endpoint: {})", metricsUri);
+  }
+
+  private void runLoop() {
+    while (!closed) {
+      try {
+        Thread.sleep(interval.toMillis());
+      } catch (InterruptedException e) {
+        return;
+      }
+      if (!closed) {
+        exportOnce();
+      }
+    }
+  }
+
+  // Package-private so tests can drive an export without waiting out the interval.
+  void exportOnce() {
+    byte[] body =
+        OtlpJsonEncoder.encode(
+            resourceAttributes, metrics, System.currentTimeMillis() * 1_000_000L);
+    HttpRequest request =
+        HttpRequest.newBuilder(metricsUri)
+            .timeout(REQUEST_TIMEOUT)
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+            .build();
+    try {
+      HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+      if (response.statusCode() / 100 != 2) {
+        LOG.warn("OTLP export to {} returned {}", metricsUri, response.statusCode());
+      }
+    } catch (IOException e) {
+      LOG.warn("OTLP export to {} failed: {}", metricsUri, e.toString());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+    thread.interrupt();
+    if (started) {
+      // Final flush so the last interval's counts aren't lost on clean shutdown.
+      exportOnce();
+    }
+  }
+}

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java
@@ -1,0 +1,156 @@
+package com.muchq.platform.yodel;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
+
+/**
+ * Renders the http_server_* family as an OTLP/HTTP JSON ExportMetricsServiceRequest. 64-bit values
+ * are encoded as strings per the proto3 JSON mapping, temporality is cumulative, and instrument
+ * names match futility/otel and server_pal exactly — the collector's Prometheus exporter turns them
+ * into http_server_requests_total, http_server_requests_active_gauge, and
+ * http_server_request_duration_microseconds_{sum,count,bucket}.
+ */
+final class OtlpJsonEncoder {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final int AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
+
+  private OtlpJsonEncoder() {}
+
+  static byte[] encode(
+      Map<String, String> resourceAttributes, HttpServerMetrics metrics, long timeUnixNanos) {
+    ObjectNode root = MAPPER.createObjectNode();
+    ObjectNode resourceMetric = root.putArray("resourceMetrics").addObject();
+    ArrayNode resourceAttrs = resourceMetric.putObject("resource").putArray("attributes");
+    resourceAttributes.forEach((key, value) -> addAttribute(resourceAttrs, key, value));
+
+    ObjectNode scopeMetric = resourceMetric.putArray("scopeMetrics").addObject();
+    scopeMetric.putObject("scope").put("name", "http_server");
+    ArrayNode metricNodes = scopeMetric.putArray("metrics");
+
+    List<HttpServerMetrics.MethodSnapshot> snapshots = metrics.snapshot();
+    String serviceName = metrics.serviceName();
+    long startNanos = metrics.startTimeUnixNanos();
+
+    metricNodes.add(
+        sum(
+            "http_server_requests",
+            "HTTP requests received",
+            true,
+            HttpServerMetrics.MethodSnapshot::requests,
+            snapshots,
+            serviceName,
+            startNanos,
+            timeUnixNanos));
+    metricNodes.add(
+        sum(
+            "http_server_requests_success",
+            "HTTP requests completed successfully (2xx-3xx)",
+            true,
+            HttpServerMetrics.MethodSnapshot::success,
+            snapshots,
+            serviceName,
+            startNanos,
+            timeUnixNanos));
+    metricNodes.add(
+        sum(
+            "http_server_requests_failure",
+            "HTTP requests that returned 4xx or 5xx",
+            true,
+            HttpServerMetrics.MethodSnapshot::failure,
+            snapshots,
+            serviceName,
+            startNanos,
+            timeUnixNanos));
+    metricNodes.add(
+        sum(
+            "http_server_requests_active_gauge",
+            "HTTP requests currently in flight",
+            false,
+            HttpServerMetrics.MethodSnapshot::active,
+            snapshots,
+            serviceName,
+            startNanos,
+            timeUnixNanos));
+    metricNodes.add(histogram(snapshots, serviceName, startNanos, timeUnixNanos));
+
+    try {
+      return MAPPER.writeValueAsBytes(root);
+    } catch (JsonProcessingException e) {
+      // The tree is built from strings and numbers only; serialization cannot fail.
+      throw new IllegalStateException("failed to serialize OTLP payload", e);
+    }
+  }
+
+  private static ObjectNode sum(
+      String name,
+      String description,
+      boolean monotonic,
+      ToLongFunction<HttpServerMetrics.MethodSnapshot> value,
+      List<HttpServerMetrics.MethodSnapshot> snapshots,
+      String serviceName,
+      long startNanos,
+      long timeNanos) {
+    ObjectNode metric = MAPPER.createObjectNode();
+    metric.put("name", name);
+    metric.put("description", description);
+    ObjectNode sum = metric.putObject("sum");
+    sum.put("aggregationTemporality", AGGREGATION_TEMPORALITY_CUMULATIVE);
+    sum.put("isMonotonic", monotonic);
+    ArrayNode points = sum.putArray("dataPoints");
+    for (HttpServerMetrics.MethodSnapshot snapshot : snapshots) {
+      ObjectNode point = points.addObject();
+      point.put("startTimeUnixNano", Long.toString(startNanos));
+      point.put("timeUnixNano", Long.toString(timeNanos));
+      point.put("asInt", Long.toString(value.applyAsLong(snapshot)));
+      addPointAttributes(point, serviceName, snapshot.httpMethod());
+    }
+    return metric;
+  }
+
+  private static ObjectNode histogram(
+      List<HttpServerMetrics.MethodSnapshot> snapshots,
+      String serviceName,
+      long startNanos,
+      long timeNanos) {
+    ObjectNode metric = MAPPER.createObjectNode();
+    metric.put("name", "http_server_request_duration_microseconds");
+    metric.put("description", "HTTP request duration in microseconds");
+    ObjectNode histogram = metric.putObject("histogram");
+    histogram.put("aggregationTemporality", AGGREGATION_TEMPORALITY_CUMULATIVE);
+    ArrayNode points = histogram.putArray("dataPoints");
+    for (HttpServerMetrics.MethodSnapshot snapshot : snapshots) {
+      ObjectNode point = points.addObject();
+      point.put("startTimeUnixNano", Long.toString(startNanos));
+      point.put("timeUnixNano", Long.toString(timeNanos));
+      point.put("count", Long.toString(snapshot.durationCount()));
+      point.put("sum", snapshot.durationSumMicros());
+      ArrayNode bucketCounts = point.putArray("bucketCounts");
+      for (long count : snapshot.bucketCounts()) {
+        bucketCounts.add(Long.toString(count));
+      }
+      ArrayNode bounds = point.putArray("explicitBounds");
+      for (double bound : HttpServerMetrics.BUCKET_BOUNDS) {
+        bounds.add(bound);
+      }
+      addPointAttributes(point, serviceName, snapshot.httpMethod());
+    }
+    return metric;
+  }
+
+  private static void addPointAttributes(ObjectNode point, String serviceName, String httpMethod) {
+    ArrayNode attributes = point.putArray("attributes");
+    addAttribute(attributes, "http_method", httpMethod);
+    addAttribute(attributes, "service_name", serviceName);
+  }
+
+  private static void addAttribute(ArrayNode attributes, String key, String value) {
+    ObjectNode attribute = attributes.addObject();
+    attribute.put("key", key);
+    attribute.putObject("value").put("stringValue", value);
+  }
+}

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
@@ -1,0 +1,82 @@
+package com.muchq.platform.yodel.micronaut;
+
+import com.muchq.platform.yodel.HttpMetricsPipeline;
+import com.muchq.platform.yodel.HttpServerMetrics;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.HttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import io.micronaut.http.filter.ServerFilterPhase;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+/**
+ * Counts every request into the shared http_server_* family. Runs in the METRICS filter phase —
+ * outside auth and routing — so rejected and unmatched requests are measured too. Adding this
+ * library to a Micronaut service's runtime classpath is the whole integration; export turns on when
+ * OTEL_EXPORTER_OTLP_ENDPOINT is set (https://github.com/muchq/MoonBase/issues/1212).
+ */
+@Filter(Filter.MATCH_ALL_PATTERN)
+public class HttpServerMetricsFilter implements HttpServerFilter {
+  private final HttpMetricsPipeline pipeline;
+
+  @Inject
+  public HttpServerMetricsFilter() {
+    this(HttpMetricsPipeline.fromEnv());
+  }
+
+  HttpServerMetricsFilter(HttpMetricsPipeline pipeline) {
+    this.pipeline = pipeline;
+  }
+
+  public HttpServerMetrics metrics() {
+    return pipeline.metrics();
+  }
+
+  @Override
+  public int getOrder() {
+    return ServerFilterPhase.METRICS.order();
+  }
+
+  @Override
+  public Publisher<MutableHttpResponse<?>> doFilter(
+      HttpRequest<?> request, ServerFilterChain chain) {
+    HttpServerMetrics metrics = pipeline.metrics();
+    String method = request.getMethodName();
+    long startNanos = System.nanoTime();
+    metrics.recordRequestStart(method);
+    AtomicBoolean recorded = new AtomicBoolean();
+    return Mono.from(chain.proceed(request))
+        .doOnNext(
+            response -> {
+              if (recorded.compareAndSet(false, true)) {
+                metrics.recordRequestComplete(
+                    method, response.code(), (System.nanoTime() - startNanos) / 1000.0);
+              }
+            })
+        .doOnError(
+            t -> {
+              if (recorded.compareAndSet(false, true)) {
+                metrics.recordRequestComplete(
+                    method, 500, (System.nanoTime() - startNanos) / 1000.0);
+              }
+            })
+        .doFinally(
+            signal -> {
+              // Cancellation (client gone before a response) emits neither next nor
+              // error; only the in-flight gauge moves, like server_pal's drop guard.
+              if (recorded.compareAndSet(false, true)) {
+                metrics.recordRequestAbandoned(method);
+              }
+            });
+  }
+
+  @PreDestroy
+  void stop() {
+    pipeline.close();
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpMetricsPipelineTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpMetricsPipelineTest.java
@@ -1,0 +1,48 @@
+package com.muchq.platform.yodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class HttpMetricsPipelineTest {
+
+  @Test
+  public void withoutEndpointRecordsInMemoryAndNeverExports() {
+    try (HttpMetricsPipeline pipeline = HttpMetricsPipeline.fromEnv(Map.of())) {
+      pipeline.metrics().recordRequestStart("GET");
+      assertThat(pipeline.metrics().snapshot()).hasSize(1);
+      assertThat(pipeline.metrics().serviceName()).isEmpty();
+    }
+  }
+
+  @Test
+  public void serviceNameComesFromTheStandardEnvVar() {
+    try (HttpMetricsPipeline pipeline =
+        HttpMetricsPipeline.fromEnv(Map.of("OTEL_SERVICE_NAME", "one_d4"))) {
+      assertThat(pipeline.metrics().serviceName()).isEqualTo("one_d4");
+    }
+  }
+
+  @Test
+  public void resourceAttributesParseWithServiceNamePrecedence() {
+    Map<String, String> attributes =
+        HttpMetricsPipeline.resourceAttributes(
+            Map.of(
+                "OTEL_RESOURCE_ATTRIBUTES",
+                "service.name=wrong, service.version=abc123 ,malformed,=alsobad",
+                "OTEL_SERVICE_NAME",
+                "one_d4"),
+            "one_d4");
+
+    assertThat(attributes)
+        .containsEntry("service.name", "one_d4")
+        .containsEntry("service.version", "abc123")
+        .hasSize(2);
+  }
+
+  @Test
+  public void emptyEnvironmentYieldsNoResourceAttributes() {
+    assertThat(HttpMetricsPipeline.resourceAttributes(Map.of(), "")).isEmpty();
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java
@@ -1,0 +1,88 @@
+package com.muchq.platform.yodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class HttpServerMetricsTest {
+
+  @Test
+  public void startAndCompleteKeepCountersAndGaugeSymmetric() {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 0L);
+
+    metrics.recordRequestStart("GET");
+    List<HttpServerMetrics.MethodSnapshot> inFlight = metrics.snapshot();
+    assertThat(inFlight).hasSize(1);
+    assertThat(inFlight.get(0).requests()).isEqualTo(1);
+    assertThat(inFlight.get(0).active()).isEqualTo(1);
+    assertThat(inFlight.get(0).durationCount()).isZero();
+
+    metrics.recordRequestComplete("GET", 200, 42.0);
+    HttpServerMetrics.MethodSnapshot done = metrics.snapshot().get(0);
+    assertThat(done.requests()).isEqualTo(1);
+    assertThat(done.active()).isZero();
+    assertThat(done.success()).isEqualTo(1);
+    assertThat(done.failure()).isZero();
+    assertThat(done.durationCount()).isEqualTo(1);
+    assertThat(done.durationSumMicros()).isEqualTo(42.0);
+  }
+
+  @Test
+  public void statusSplitsAtFourHundred() {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 0L);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 399, 1.0);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 400, 1.0);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 500, 1.0);
+
+    HttpServerMetrics.MethodSnapshot snapshot = metrics.snapshot().get(0);
+    assertThat(snapshot.success()).isEqualTo(1);
+    assertThat(snapshot.failure()).isEqualTo(2);
+  }
+
+  @Test
+  public void abandonedRequestsOnlyMoveTheGauge() {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 0L);
+    metrics.recordRequestStart("POST");
+    metrics.recordRequestAbandoned("POST");
+
+    HttpServerMetrics.MethodSnapshot snapshot = metrics.snapshot().get(0);
+    assertThat(snapshot.requests()).isEqualTo(1);
+    assertThat(snapshot.active()).isZero();
+    assertThat(snapshot.success()).isZero();
+    assertThat(snapshot.failure()).isZero();
+    assertThat(snapshot.durationCount()).isZero();
+  }
+
+  @Test
+  public void durationsLandInUpperInclusiveBuckets() {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 0L);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 200, 5.0); // on the boundary: bucket for <=5
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 200, 6.0); // bucket for <=10
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 200, 20_000.0); // overflow bucket
+
+    long[] buckets = metrics.snapshot().get(0).bucketCounts();
+    assertThat(buckets).hasSize(HttpServerMetrics.BUCKET_BOUNDS.length + 1);
+    assertThat(buckets[1]).isEqualTo(1); // (0, 5]
+    assertThat(buckets[2]).isEqualTo(1); // (5, 10]
+    assertThat(buckets[buckets.length - 1]).isEqualTo(1); // (10000, +Inf)
+  }
+
+  @Test
+  public void snapshotOrdersMethodsDeterministically() {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 0L);
+    metrics.recordRequestStart("POST");
+    metrics.recordRequestStart("DELETE");
+    metrics.recordRequestStart("GET");
+
+    assertThat(metrics.snapshot())
+        .extracting(HttpServerMetrics.MethodSnapshot::httpMethod)
+        .containsExactly("DELETE", "GET", "POST");
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/OtlpHttpMetricsExporterTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/OtlpHttpMetricsExporterTest.java
@@ -1,0 +1,67 @@
+package com.muchq.platform.yodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OtlpHttpMetricsExporterTest {
+  private record Received(String path, String contentType, byte[] body) {}
+
+  private HttpServer server;
+  private final BlockingQueue<Received> received = new ArrayBlockingQueue<>(4);
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext(
+        "/",
+        exchange -> {
+          received.add(
+              new Received(
+                  exchange.getRequestURI().getPath(),
+                  exchange.getRequestHeaders().getFirst("Content-Type"),
+                  exchange.getRequestBody().readAllBytes()));
+          exchange.sendResponseHeaders(200, -1);
+          exchange.close();
+        });
+    server.start();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    server.stop(0);
+  }
+
+  @Test
+  public void postsOtlpJsonToTheMetricsPath() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 200, 42.0);
+
+    String endpoint = "http://127.0.0.1:" + server.getAddress().getPort();
+    OtlpHttpMetricsExporter exporter =
+        new OtlpHttpMetricsExporter(
+            endpoint, Map.of("service.name", "svc"), metrics, Duration.ofHours(1));
+    exporter.exportOnce();
+
+    Received request = received.poll(5, TimeUnit.SECONDS);
+    assertThat(request).isNotNull();
+    assertThat(request.path()).isEqualTo("/v1/metrics");
+    assertThat(request.contentType()).isEqualTo("application/json");
+
+    JsonNode payload = new ObjectMapper().readTree(request.body());
+    assertThat(payload.at("/resourceMetrics/0/scopeMetrics/0/metrics/0/name").asText())
+        .isEqualTo("http_server_requests");
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/OtlpJsonEncoderTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/OtlpJsonEncoderTest.java
@@ -1,0 +1,121 @@
+package com.muchq.platform.yodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the wire contract: instrument names, service_name/http_method labels, cumulative
+ * temporality, and string-encoded 64-bit values, so the collector reads Java exactly like the C++
+ * and Rust emitters (#1212).
+ */
+public class OtlpJsonEncoderTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static JsonNode encode(HttpServerMetrics metrics) throws Exception {
+    byte[] payload =
+        OtlpJsonEncoder.encode(
+            Map.of("service.name", "svc", "service.version", "abc123"), metrics, 2_000_000_000L);
+    return MAPPER.readTree(payload);
+  }
+
+  @Test
+  public void emitsTheFiveStandardInstruments() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 200, 42.0);
+
+    JsonNode metricNodes = encode(metrics).at("/resourceMetrics/0/scopeMetrics/0/metrics");
+
+    List<String> names = new ArrayList<>();
+    metricNodes.forEach(m -> names.add(m.get("name").asText()));
+    assertThat(names)
+        .containsExactly(
+            "http_server_requests",
+            "http_server_requests_success",
+            "http_server_requests_failure",
+            "http_server_requests_active_gauge",
+            "http_server_request_duration_microseconds");
+  }
+
+  @Test
+  public void sumsAreCumulativeWithProtoJsonStringInts() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 200, 42.0);
+    metrics.recordRequestStart("GET");
+
+    JsonNode requests = encode(metrics).at("/resourceMetrics/0/scopeMetrics/0/metrics/0/sum");
+    assertThat(requests.get("aggregationTemporality").asInt()).isEqualTo(2);
+    assertThat(requests.get("isMonotonic").asBoolean()).isTrue();
+
+    JsonNode point = requests.at("/dataPoints/0");
+    assertThat(point.get("asInt").isTextual()).isTrue();
+    assertThat(point.get("asInt").asText()).isEqualTo("2");
+    assertThat(point.get("startTimeUnixNano").asText()).isEqualTo("1000000000");
+    assertThat(point.get("timeUnixNano").asText()).isEqualTo("2000000000");
+  }
+
+  @Test
+  public void activeGaugeIsANonMonotonicSum() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+    metrics.recordRequestStart("GET");
+
+    JsonNode active = encode(metrics).at("/resourceMetrics/0/scopeMetrics/0/metrics/3");
+    assertThat(active.get("name").asText()).isEqualTo("http_server_requests_active_gauge");
+    assertThat(active.at("/sum/isMonotonic").asBoolean()).isFalse();
+    assertThat(active.at("/sum/dataPoints/0/asInt").asText()).isEqualTo("1");
+  }
+
+  @Test
+  public void histogramCarriesMicrosecondsWithDefaultBounds() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+    metrics.recordRequestStart("GET");
+    metrics.recordRequestComplete("GET", 200, 42.0);
+
+    JsonNode histogram =
+        encode(metrics).at("/resourceMetrics/0/scopeMetrics/0/metrics/4/histogram");
+    assertThat(histogram.get("aggregationTemporality").asInt()).isEqualTo(2);
+
+    JsonNode point = histogram.at("/dataPoints/0");
+    assertThat(point.get("count").asText()).isEqualTo("1");
+    assertThat(point.get("sum").asDouble()).isEqualTo(42.0);
+    assertThat(point.get("explicitBounds")).hasSize(HttpServerMetrics.BUCKET_BOUNDS.length);
+    assertThat(point.get("bucketCounts")).hasSize(HttpServerMetrics.BUCKET_BOUNDS.length + 1);
+    assertThat(point.at("/bucketCounts/0").isTextual()).isTrue();
+  }
+
+  @Test
+  public void pointsCarryServiceNameAndHttpMethodLabels() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+    metrics.recordRequestStart("POST");
+
+    JsonNode attributes =
+        encode(metrics)
+            .at("/resourceMetrics/0/scopeMetrics/0/metrics/0/sum/dataPoints/0/attributes");
+    Map<String, String> labels = attributeMap(attributes);
+    assertThat(labels)
+        .containsExactly(Map.entry("http_method", "POST"), Map.entry("service_name", "svc"));
+  }
+
+  @Test
+  public void resourceCarriesTheOtelAttributes() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+
+    JsonNode attributes = encode(metrics).at("/resourceMetrics/0/resource/attributes");
+    assertThat(attributeMap(attributes))
+        .containsEntry("service.name", "svc")
+        .containsEntry("service.version", "abc123");
+  }
+
+  private static Map<String, String> attributeMap(JsonNode attributes) {
+    Map<String, String> out = new java.util.LinkedHashMap<>();
+    attributes.forEach(a -> out.put(a.get("key").asText(), a.at("/value/stringValue").asText()));
+    return out;
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilterTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilterTest.java
@@ -1,0 +1,61 @@
+package com.muchq.platform.yodel.micronaut;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.muchq.platform.yodel.HttpServerMetrics;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.runtime.server.EmbeddedServer;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class HttpServerMetricsFilterTest {
+
+  private EmbeddedServer server;
+  private HttpClient client;
+  private String baseUrl;
+
+  @BeforeEach
+  public void setUp() {
+    server = ApplicationContext.run(EmbeddedServer.class, Map.of("micronaut.server.port", "-1"));
+    client = HttpClient.newHttpClient();
+    baseUrl = "http://localhost:" + server.getPort();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    server.stop();
+  }
+
+  private int get(String path) throws Exception {
+    HttpRequest request = HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).GET().build();
+    return client.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+  }
+
+  @Test
+  public void countsMatchedFailingAndUnmatchedRequests() throws Exception {
+    assertThat(get("/yodel-test/ok")).isEqualTo(200);
+    assertThat(get("/yodel-test/boom")).isEqualTo(500);
+    assertThat(get("/no-such-route")).isEqualTo(404);
+
+    HttpServerMetricsFilter filter =
+        server.getApplicationContext().getBean(HttpServerMetricsFilter.class);
+    HttpServerMetrics.MethodSnapshot get =
+        filter.metrics().snapshot().stream()
+            .filter(s -> s.httpMethod().equals("GET"))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(get.requests()).isEqualTo(3);
+    assertThat(get.success()).isEqualTo(1);
+    assertThat(get.failure()).isEqualTo(2);
+    assertThat(get.active()).isZero();
+    assertThat(get.durationCount()).isEqualTo(3);
+    assertThat(get.durationSumMicros()).isGreaterThan(0.0);
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/TestEndpointController.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/TestEndpointController.java
@@ -1,0 +1,18 @@
+package com.muchq.platform.yodel.micronaut;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+
+@Controller("/yodel-test")
+public class TestEndpointController {
+
+  @Get("/ok")
+  public String ok() {
+    return "ok";
+  }
+
+  @Get("/boom")
+  public String boom() {
+    throw new RuntimeException("boom");
+  }
+}


### PR DESCRIPTION
Closes #1212.

C++ (`aura`/`futility`) and Rust (`server_pal`) emit the shared `http_server_*` family; the Java services (one_d4, mcpserver) were deployed and invisible. This adds the cross-service Java rails once, then applies them to both.

## The library: `domains/platform/libs/yodel`

The five standard instruments with exact name/label/unit parity — `http_server_requests`, `http_server_requests_success` / `_failure`, `http_server_requests_active_gauge`, and the **microseconds** `http_server_request_duration_microseconds` histogram — labeled by `service_name` and `http_method` (server_pal's label set), exported as OTLP/HTTP JSON to the existing collector on the standard `OTEL_*` env vars. Without `OTEL_EXPORTER_OTLP_ENDPOINT` it's a no-op, same contract as `server_pal::init_otel`, so tests and local runs need no configuration.

On the "decide in impl" question from the issue: rather than pulling the OTel SDK + Micrometer dependency trees into `maven_install.json` for five fixed instruments and then remapping Micrometer's `http.server.requests` names/units back to this family, yodel speaks the small OTLP JSON surface directly with deps the repo already has (Jackson, JDK HttpClient). The wire contract (names, labels, cumulative temporality, proto3-JSON string-encoded 64-bit values, default bucket bounds) is pinned by tests.

`yodel/micronaut` is the transport binding: a METRICS-phase server filter — outside auth and routing, so rejected and unmatched requests are measured too. Adding it to a Micronaut binary's `runtime_deps` is the whole per-service integration, which is also mcpserver's "lighter touch": no per-service code at all.

## Wiring

- **one_d4, mcpserver**: `//domains/platform/libs/yodel:micronaut` in `runtime_deps`.
- **compose**: the standard OTEL env block for both (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES` with `service.name` + `service.version` from the deploy SHA — #1208 §4), so they also get running-version and crash-loop visibility for free.
- **prom_proxy**: both services in `serviceOrder`/`serviceRegistry` (standard instruments only, like mithril/posterize). The catalog drives the UI tabs, so no frontend changes.

Once #1209 lands, the `rate_limit_*`/`cache_*` families should ride the same exporter (`HttpMetricsPipeline` is framework-agnostic; noted in the README).

## Verification

- `bazel test //domains/platform/libs/yodel:all` — 5 suites, including a Micronaut embedded-server test asserting matched/failing/unmatched requests all count with a symmetric active gauge.
- `bazel test //domains/games/apis/one_d4:all //domains/games/apis/mcpserver:all` — 38 suites pass; `//domains/platform/apis/prom_proxy/...` passes with the new registry entries.
- End-to-end smoke test: booted the mcpserver deploy jar with the OTEL env pointed at a captured endpoint; it exported the exact family to `/v1/metrics` with correct resource attributes and success/failure split:

```
resource: service.name=mcpserver, service.version=smoketest
http_server_requests        {http_method: GET,  service_name: mcpserver} = 1
http_server_requests        {http_method: POST, service_name: mcpserver} = 1
http_server_requests_success{http_method: POST, service_name: mcpserver} = 1
http_server_requests_failure{http_method: GET,  service_name: mcpserver} = 1
http_server_requests_active_gauge {...} = 0
http_server_request_duration_microseconds {...} count = 1 each
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgnYFoR3TFcgqsqvSNZ6Xs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgnYFoR3TFcgqsqvSNZ6Xs)_