### PR TITLE
bazel: bump smithy-cpp to latest (064b427); Beyoncé Rule contract tests for its surface

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "c9592b46647e2a94e7dc1ad5dcaf4b7e2119b6cc",
+    commit = "064b42711c37229fbdb86f5a342b8186a2f80b82",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -51,6 +51,24 @@ cc_test(
     ],
 )
 
+# Beyoncé Rule contract tests (hub tier; platform tier lives in
+# //domains/platform/libs/aura:smithy_contract_test): the smithy-cpp
+# behaviors the hub depends on — RequireOrigin, the in-memory socket pair,
+# and SessionRegistry admission/grace/fan-out — pinned so a pin bump that
+# changes one fails with a named contract. Non-Beast deps only.
+cc_test(
+    name = "smithy_contract_test",
+    size = "small",
+    srcs = ["smithy_contract_test.cc"],
+    deps = [
+        "@googletest//:gtest_main",
+        "@smithy_cpp//runtime:core",
+        "@smithy_cpp//runtime:eventstream",
+        "@smithy_cpp//runtime:http",
+        "@smithy_cpp//runtime:server",
+    ],
+)
+
 cc_library(
     name = "ticket_vault",
     srcs = ["ticket_vault.cc"],

--- a/domains/games/apis/golf_hub/smithy_contract_test.cc
+++ b/domains/games/apis/golf_hub/smithy_contract_test.cc
@@ -1,0 +1,215 @@
+// Beyoncé Rule for smithy-cpp, golf_hub tier (see also
+// domains/platform/libs/aura/smithy_contract_test.cc for the platform
+// tier): the upstream behaviors the hub itself depends on, pinned as
+// MoonBase-side contract tests so a smithy-cpp pin bump that changes any
+// of them fails here with a named contract.
+//
+// What the hub relies on and where:
+//   RequireOrigin           golf_hub_main.cc websocket_gate (ADR-0018)
+//   InMemoryWebSocketPair   every hub session test harness
+//   SessionRegistry         hub_handler.cc: ResumeOrAdd admission
+//                           (ADR-0022), Detach + grace + on_expired
+//                           (ADR-0020/0021), SendTo fan-out
+//
+// Deliberately non-Beast so it runs in restricted-egress sandboxes; the
+// full transport path is covered by the hub e2e suites in CI.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "smithy/eventstream/event_stream.h"
+#include "smithy/eventstream/frame.h"
+#include "smithy/http/message.h"
+#include "smithy/http/websocket.h"
+#include "smithy/http/websocket_pair.h"
+#include "smithy/server/origin_gate.h"
+#include "smithy/server/session_registry.h"
+
+namespace {
+
+using smithy::http::HttpRequest;
+
+// --- RequireOrigin: the hub's cross-site-WebSocket-hijacking gate. ------
+
+HttpRequest UpgradeWithOrigin(const std::string& origin) {
+  HttpRequest request;
+  if (!origin.empty()) {
+    request.headers.Set("Origin", origin);
+  }
+  return request;
+}
+
+TEST(RequireOriginContract, AdmitsAllowlistedAndAbsentRefusesForeignAndNull) {
+  auto gate = smithy::server::RequireOrigin({"https://muchq.com"});
+
+  // Allowlisted origin and the no-Origin non-browser client are admitted.
+  EXPECT_FALSE(gate(UpgradeWithOrigin("https://muchq.com")).has_value());
+  EXPECT_FALSE(gate(UpgradeWithOrigin("")).has_value());
+
+  // A foreign origin is refused with 403 — the attack this gate exists
+  // for cannot omit the header.
+  auto refusal = gate(UpgradeWithOrigin("https://evil.example"));
+  ASSERT_TRUE(refusal.has_value());
+  EXPECT_EQ(refusal->status, 403);
+
+  // "null" (sandboxed iframe / file://) is refused unless allowlisted.
+  EXPECT_TRUE(gate(UpgradeWithOrigin("null")).has_value());
+}
+
+TEST(RequireOriginContract, NormalizesCaseAndDefaultPorts) {
+  auto gate = smithy::server::RequireOrigin({"https://muchq.com"});
+  EXPECT_FALSE(gate(UpgradeWithOrigin("HTTPS://MUCHQ.COM")).has_value());
+  EXPECT_FALSE(gate(UpgradeWithOrigin("https://muchq.com:443")).has_value());
+  // Same host, wrong scheme is a different origin.
+  EXPECT_TRUE(gate(UpgradeWithOrigin("http://muchq.com")).has_value());
+}
+
+// --- InMemoryWebSocketPair: the hub test harness's wire. -----------------
+
+TEST(WebSocketPairContract, DeliversBothDirectionsAndCloseEndsCleanly) {
+  auto [a, b] = smithy::http::InMemoryWebSocketPair::Create();
+
+  smithy::eventstream::Message ping;
+  ping.headers = {{":event-type", "ping"}};
+  ping.payload = smithy::Blob::FromString("hello");
+  ASSERT_TRUE(a->Send(ping).ok());
+
+  auto received = b->Receive();
+  ASSERT_TRUE(received.ok());
+  ASSERT_TRUE(received.value().has_value());
+  EXPECT_EQ(received.value()->payload.ToString(), "hello");
+
+  smithy::eventstream::Message pong;
+  pong.payload = smithy::Blob::FromString("yo");
+  ASSERT_TRUE(b->Send(pong).ok());
+  auto back = a->Receive();
+  ASSERT_TRUE(back.ok());
+  ASSERT_TRUE(back.value().has_value());
+
+  // Close from one side: the peer's Receive observes the clean end
+  // (ok + nullopt), which is what every hub serve loop breaks on.
+  a->Close();
+  auto ended = b->Receive();
+  ASSERT_TRUE(ended.ok());
+  EXPECT_FALSE(ended.value().has_value());
+}
+
+// --- SessionRegistry: admission, grace, and fan-out (ADR-0020/21/22). ----
+// Mirrors the hub's exact configuration: async_delivery=true (falls back
+// to writer threads on sockets without async support, exactly as in the
+// in-memory harness), a grace period, and on_expired.
+
+struct Note {
+  std::string text;
+};
+
+smithy::Outcome<smithy::eventstream::Message> EncodeNote(const Note& note) {
+  smithy::eventstream::Message message;
+  message.headers = {{":event-type", "note"}};
+  message.payload = smithy::Blob::FromString(note.text);
+  return message;
+}
+
+using ServerStream = smithy::eventstream::EventStream<Note, smithy::eventstream::NoEvents>;
+using Registry = smithy::server::SessionRegistry<Note>;
+
+struct Session {
+  std::shared_ptr<smithy::http::WebSocket> client;
+  std::unique_ptr<ServerStream> stream;
+};
+
+Session MakeSession() {
+  auto [client_end, server_end] = smithy::http::InMemoryWebSocketPair::Create();
+  Session session;
+  session.client = client_end;
+  session.stream = std::make_unique<ServerStream>(server_end, EncodeNote, nullptr);
+  return session;
+}
+
+std::optional<std::string> ReceivePayload(smithy::http::WebSocket& socket) {
+  auto received = socket.Receive(std::chrono::milliseconds(2000));
+  if (!received.ok() || !received.value().has_value()) {
+    return std::nullopt;
+  }
+  return received.value()->payload.ToString();
+}
+
+TEST(SessionRegistryContract, ResumeOrAddReportsAddedRefusedAndResumed) {
+  Registry::Options options;
+  options.grace_period = std::chrono::seconds(30);
+  Registry registry(std::move(options));
+
+  Session first = MakeSession();
+  EXPECT_EQ(registry.ResumeOrAdd(
+                "p1", [&first] { return first.stream->Share(); }, std::chrono::seconds(1)),
+            Registry::Admission::kAdded);
+
+  // Same seat while the first connection is live: refused (the hub's
+  // SeatConflict path).
+  Session intruder = MakeSession();
+  EXPECT_EQ(registry.ResumeOrAdd(
+                "p1", [&intruder] { return intruder.stream->Share(); }, std::chrono::seconds(1)),
+            Registry::Admission::kRefused);
+
+  // Detach parks the seat; a reconnect resumes it.
+  EXPECT_TRUE(registry.Detach("p1"));
+  Session reconnect = MakeSession();
+  EXPECT_EQ(registry.ResumeOrAdd(
+                "p1", [&reconnect] { return reconnect.stream->Share(); }, std::chrono::seconds(1)),
+            Registry::Admission::kResumed);
+
+  // Fan-out lands on the resumed connection.
+  registry.SendTo("p1", Note{.text = "after-resume"});
+  EXPECT_EQ(ReceivePayload(*reconnect.client).value_or(""), "after-resume");
+}
+
+TEST(SessionRegistryContract, GraceExpiryFiresOnExpiredExactlyOnce) {
+  std::atomic<int> expired{0};
+  Registry::Options options;
+  options.grace_period = std::chrono::seconds(1);
+  options.on_expired = [&expired](const std::string&) { expired++; };
+  Registry registry(std::move(options));
+
+  Session session = MakeSession();
+  ASSERT_EQ(registry.ResumeOrAdd(
+                "p1", [&session] { return session.stream->Share(); }, std::chrono::seconds(1)),
+            Registry::Admission::kAdded);
+  ASSERT_TRUE(registry.Detach("p1"));
+
+  // The hub's OnExpired cleanup depends on exactly-once delivery after the
+  // grace period.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (expired.load() == 0 && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  EXPECT_EQ(expired.load(), 1);
+}
+
+TEST(SessionRegistryContract, SendToUnknownIdIsSafeAndRemoveCancelsSeat) {
+  Registry registry{};
+
+  // Fan-out to an id that never registered must be a harmless no-op.
+  registry.SendTo("ghost", Note{.text = "into the void"});
+
+  Session session = MakeSession();
+  ASSERT_EQ(registry.ResumeOrAdd(
+                "p1", [&session] { return session.stream->Share(); }, std::chrono::seconds(1)),
+            Registry::Admission::kAdded);
+  EXPECT_TRUE(registry.Remove("p1"));
+  EXPECT_FALSE(registry.Remove("p1"));
+
+  // After Remove the seat is free for a fresh add, not a resume.
+  Session fresh = MakeSession();
+  EXPECT_EQ(registry.ResumeOrAdd(
+                "p1", [&fresh] { return fresh.stream->Share(); }, std::chrono::seconds(1)),
+            Registry::Admission::kAdded);
+}
+
+}  // namespace

--- a/domains/platform/libs/aura/BUILD.bazel
+++ b/domains/platform/libs/aura/BUILD.bazel
@@ -19,6 +19,23 @@ cc_library(
     ],
 )
 
+# Beyoncé Rule contract tests (platform tier): every smithy-cpp behavior the
+# aura chain — and through it every C++ service — depends on, pinned here so
+# a pin bump that changes one fails with a named contract. Non-Beast deps
+# only, so this runs in restricted-egress sandboxes where :http_beast can't
+# fetch boost.
+cc_test(
+    name = "smithy_contract_test",
+    size = "small",
+    srcs = ["smithy_contract_test.cc"],
+    deps = [
+        "@googletest//:gtest_main",
+        "@smithy_cpp//runtime:core",
+        "@smithy_cpp//runtime:http",
+        "@smithy_cpp//runtime:server",
+    ],
+)
+
 cc_test(
     name = "middleware_test",
     size = "small",

--- a/domains/platform/libs/aura/middleware.cc
+++ b/domains/platform/libs/aura/middleware.cc
@@ -157,12 +157,12 @@ std::optional<smithy::http::TrustedProxies> TrustedProxiesFromEnv() {
     LOG(ERROR) << "TRUSTED_PROXY_CIDRS is set but empty; unset it to serve direct-connect";
     return std::nullopt;
   }
-  try {
-    return smithy::http::TrustedProxies(cidrs);
-  } catch (const std::invalid_argument& error) {
-    LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << error.what();
+  auto parsed = smithy::http::TrustedProxies::Parse(cidrs);
+  if (!parsed.ok()) {
+    LOG(ERROR) << "Invalid TRUSTED_PROXY_CIDRS: " << parsed.error().message();
     return std::nullopt;
   }
+  return std::move(parsed).value();
 }
 
 }  // namespace aura

--- a/domains/platform/libs/aura/middleware_test.cc
+++ b/domains/platform/libs/aura/middleware_test.cc
@@ -106,7 +106,7 @@ class AuraMiddlewareTest : public ::testing::Test {
             .metrics = sink_,
             .allow_request =
                 [limiter = limiter_](const std::string& client) { return limiter->allow(client); },
-            .trusted_proxies = smithy::http::TrustedProxies({kProxy}),
+            .trusted_proxies = smithy::http::TrustedProxies::Parse({kProxy}).value(),
             .retry_after = std::chrono::seconds(60)},
         EchoHandler());
     loopback_ = std::make_shared<smithy::http::Loopback>();

--- a/domains/platform/libs/aura/smithy_contract_test.cc
+++ b/domains/platform/libs/aura/smithy_contract_test.cc
@@ -1,0 +1,292 @@
+// Beyoncé Rule for smithy-cpp (if we depend on it, we put a test on it):
+// every upstream behavior the aura serving chain — and through it every
+// C++ service (portrait, golf_hub) — relies on, pinned as a MoonBase-side
+// contract test. A pin bump that changes any of these fails HERE with a
+// named contract, instead of surfacing as a production surprise or a
+// grep through upstream diffs (the TrustedProxies constructor removal
+// that motivated this file arrived exactly that way).
+//
+// Deliberately depends only on smithy-cpp's non-Beast targets so it runs
+// in restricted-egress sandboxes (scripts/bazel_restricted_egress.sh
+// LIMITS); the Beast transport's own contracts (limits, deadlines,
+// rejection hooks) are exercised by the service e2e suites in CI.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "smithy/core/error.h"
+#include "smithy/core/outcome.h"
+#include "smithy/http/forwarded.h"
+#include "smithy/http/loopback.h"
+#include "smithy/http/message.h"
+#include "smithy/http/trace_context.h"
+#include "smithy/http/transport.h"
+#include "smithy/server/middleware.h"
+
+namespace {
+
+using smithy::http::DeriveClient;
+using smithy::http::HttpRequest;
+using smithy::http::HttpResponse;
+using smithy::http::RequestHandler;
+using smithy::http::TrustedProxies;
+
+HttpRequest RequestFrom(const std::string& peer, const std::string& xff = "") {
+  HttpRequest request;
+  request.peer_address = peer;
+  if (!xff.empty()) {
+    request.headers.Set("X-Forwarded-For", xff);
+  }
+  return request;
+}
+
+// --- TrustedProxies / DeriveClient: the ADR-0012 trust boundary. --------
+// aura::TrustedProxiesFromEnv builds on Parse; PerClientRateLimit keys its
+// buckets on DeriveClient's answer. Every deployed C++ service sits
+// behind the same Caddy with TRUSTED_PROXY_CIDRS pinned to these
+// semantics (deploy/consolidated/compose.yaml).
+
+TEST(TrustedProxiesContract, ParseAcceptsCidrsAndNamesTheMalformedEntry) {
+  auto parsed = TrustedProxies::Parse({"172.28.0.2/32", "10.0.0.0/8"});
+  ASSERT_TRUE(parsed.ok());
+  EXPECT_TRUE(parsed.value().Contains("172.28.0.2"));
+  EXPECT_TRUE(parsed.value().Contains("10.1.2.3"));
+  EXPECT_FALSE(parsed.value().Contains("192.168.0.1"));
+
+  auto malformed = TrustedProxies::Parse({"not-a-cidr"});
+  ASSERT_FALSE(malformed.ok());
+  // aura logs this message verbatim on startup refusal.
+  EXPECT_NE(malformed.error().message().find("not-a-cidr"), std::string::npos);
+}
+
+TEST(TrustedProxiesContract, NoneTrustsNothingAndGarbageIsInNoNetwork) {
+  const TrustedProxies none = TrustedProxies::None();
+  EXPECT_FALSE(none.Contains("127.0.0.1"));
+
+  auto proxies = TrustedProxies::Parse({"10.0.0.0/8"});
+  ASSERT_TRUE(proxies.ok());
+  EXPECT_FALSE(proxies.value().Contains("definitely-not-an-address"));
+  // IPv4-mapped IPv6 matches as the embedded IPv4.
+  EXPECT_TRUE(proxies.value().Contains("::ffff:10.1.2.3"));
+}
+
+TEST(DeriveClientContract, DirectPeerAndUntrustedHeaderIgnored) {
+  const TrustedProxies none = TrustedProxies::None();
+
+  auto direct = DeriveClient(RequestFrom("203.0.113.9"), none);
+  EXPECT_EQ(direct.address, "203.0.113.9");
+  EXPECT_EQ(direct.source, smithy::http::DerivedClient::Source::kDirectPeer);
+
+  // A spoofed X-Forwarded-For from an untrusted peer must not move the
+  // rate-limit key.
+  auto spoofed = DeriveClient(RequestFrom("203.0.113.9", "198.51.100.7"), none);
+  EXPECT_EQ(spoofed.address, "203.0.113.9");
+  EXPECT_EQ(spoofed.source, smithy::http::DerivedClient::Source::kUntrustedHeaderIgnored);
+}
+
+TEST(DeriveClientContract, ForwardedWalkEndsOnClientEntryAndTrustedTier) {
+  auto proxies = TrustedProxies::Parse({"172.28.0.2/32"});
+  ASSERT_TRUE(proxies.ok());
+
+  // Trusted proxy in front: the client is the rightmost untrusted hop.
+  auto forwarded =
+      DeriveClient(RequestFrom("172.28.0.2", "198.51.100.7, 172.28.0.2"), proxies.value());
+  EXPECT_EQ(forwarded.address, "198.51.100.7");
+  EXPECT_EQ(forwarded.source, smithy::http::DerivedClient::Source::kForwarded);
+
+  // No header from inside the trust set: the walk never leaves it.
+  auto tier = DeriveClient(RequestFrom("172.28.0.2"), proxies.value());
+  EXPECT_EQ(tier.source, smithy::http::DerivedClient::Source::kTrustedTier);
+
+  // Loopback/hand-driven requests have no peer at all.
+  auto unknown = DeriveClient(RequestFrom(""), proxies.value());
+  EXPECT_EQ(unknown.source, smithy::http::DerivedClient::Source::kUnknown);
+}
+
+// --- The middleware chain aura::ProductionChain composes. ---------------
+
+TEST(MiddlewareContract, ChainAppliesOutermostFirst) {
+  std::vector<std::string> order;
+  auto tag = [&order](std::string name) -> smithy::server::Middleware {
+    return [&order, name = std::move(name)](RequestHandler next) -> RequestHandler {
+      return [&order, name, next = std::move(next)](const HttpRequest& request) {
+        order.push_back(name);
+        return next(request);
+      };
+    };
+  };
+  auto handler = smithy::server::Chain({tag("outer"), tag("inner")},
+                                       [](const HttpRequest&) { return HttpResponse{}; });
+
+  handler(HttpRequest{});
+  ASSERT_EQ(order.size(), 2u);
+  EXPECT_EQ(order[0], "outer");
+  EXPECT_EQ(order[1], "inner");
+}
+
+TEST(MiddlewareContract, HealthEndpointInterceptsItsPathOnlyAndPassesOthers) {
+  bool reached = false;
+  auto handler = smithy::server::Chain({smithy::server::HealthEndpoint("/health")},
+                                       [&reached](const HttpRequest&) {
+                                         reached = true;
+                                         return HttpResponse{.status = 418};
+                                       });
+
+  HttpRequest health;
+  health.target = "/health";
+  EXPECT_EQ(handler(health).status, 200);
+  EXPECT_FALSE(reached);
+
+  HttpRequest other;
+  other.target = "/anything";
+  EXPECT_EQ(handler(other).status, 418);
+  EXPECT_TRUE(reached);
+}
+
+TEST(MiddlewareContract, PerClientRateLimitKeysOnDerivedClientAnd429sWithRetryAfter) {
+  auto proxies = TrustedProxies::Parse({"172.28.0.2/32"});
+  ASSERT_TRUE(proxies.ok());
+
+  // Deny exactly the derived client, not the proxy: proves the limiter
+  // buckets on DeriveClient's answer (what aura's 429s key on).
+  auto limited = smithy::server::PerClientRateLimit(
+      [](const std::string& client) { return client != "198.51.100.7"; }, proxies.value(),
+      std::chrono::seconds(60));
+  auto handler = smithy::server::Chain(
+      {limited}, [](const HttpRequest&) { return HttpResponse{.status = 200}; });
+
+  HttpResponse denied = handler(RequestFrom("172.28.0.2", "198.51.100.7, 172.28.0.2"));
+  EXPECT_EQ(denied.status, 429);
+  EXPECT_EQ(denied.headers.Get("Retry-After").value_or(""), "60");
+
+  HttpResponse allowed = handler(RequestFrom("172.28.0.2", "198.51.100.8, 172.28.0.2"));
+  EXPECT_EQ(allowed.status, 200);
+}
+
+TEST(MiddlewareContract, ObservePairsStartAndCompleteWithStatusAndDuration) {
+  std::atomic<int> starts{0};
+  std::atomic<int> completes{0};
+  smithy::server::RequestObservation seen;
+
+  auto observe = smithy::server::Observe(
+      [&completes, &seen](const smithy::server::RequestObservation& observation) {
+        completes++;
+        seen = observation;
+      },
+      [&starts](const smithy::server::RequestStart&) { starts++; });
+  auto handler = smithy::server::Chain(
+      {observe}, [](const HttpRequest&) -> HttpResponse { return HttpResponse{.status = 204}; });
+
+  HttpRequest request;
+  request.method = "POST";
+  request.target = "/v1/thing";
+  handler(request);
+
+  EXPECT_EQ(starts.load(), 1);
+  EXPECT_EQ(completes.load(), 1);
+  EXPECT_EQ(seen.method, "POST");
+  EXPECT_EQ(seen.target, "/v1/thing");
+  EXPECT_EQ(seen.status, 204);
+  EXPECT_GE(seen.duration.count(), 0);
+}
+
+// --- Traceparent parsing the aura access log builds on. -----------------
+
+TEST(TraceContextContract, ParsesW3CTraceparentAndRejectsGarbage) {
+  auto parsed =
+      smithy::http::ParseTraceparent("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(parsed->trace_id, "0af7651916cd43dd8448eb211c80319c");
+  EXPECT_EQ(parsed->parent_id, "b7ad6b7169203331");
+  EXPECT_TRUE(parsed->sampled);
+
+  EXPECT_FALSE(smithy::http::ParseTraceparent("").has_value());
+  EXPECT_FALSE(smithy::http::ParseTraceparent("not-a-traceparent").has_value());
+
+  // Round trip: what we format, we parse (the transport guard mints these).
+  const smithy::http::TraceContext minted = smithy::http::GenerateTraceContext();
+  auto reparsed = smithy::http::ParseTraceparent(smithy::http::FormatTraceparent(minted));
+  ASSERT_TRUE(reparsed.has_value());
+  EXPECT_EQ(reparsed->trace_id, minted.trace_id);
+}
+
+// --- Message shapes handlers construct all over MoonBase. ---------------
+
+TEST(MessageContract, HeadersAreCaseInsensitiveFirstValueWithSetReplaceAddAppend) {
+  smithy::http::Headers headers;
+  headers.Add("X-Forwarded-For", "a");
+  headers.Add("x-forwarded-for", "b");
+
+  EXPECT_EQ(headers.Get("X-FORWARDED-FOR").value_or(""), "a");
+  EXPECT_EQ(headers.GetAll("x-Forwarded-For").size(), 2u);
+
+  headers.Set("X-Forwarded-For", "c");
+  EXPECT_EQ(headers.GetAll("x-forwarded-for").size(), 1u);
+  EXPECT_EQ(headers.Get("x-forwarded-for").value_or(""), "c");
+}
+
+TEST(MessageContract, PartialAggregateInitializationStaysValid) {
+  // Upstream documents this shape as supported and warning-free; handler
+  // code across portrait and golf_hub writes it constantly.
+  const HttpResponse response{404, {}, "not found"};
+  EXPECT_EQ(response.status, 404);
+  EXPECT_EQ(response.body, "not found");
+  EXPECT_TRUE(response.operation.empty());
+
+  const HttpRequest defaults{};
+  EXPECT_EQ(defaults.method, "GET");
+  EXPECT_EQ(defaults.target, "/");
+}
+
+// --- Loopback: the in-memory transport every middleware test stands on. -
+
+TEST(LoopbackContract, RoundTripsNoHandlerErrorAndContainsHandlerFailure) {
+  smithy::http::Loopback loopback;
+
+  auto unstarted = loopback.Send(HttpRequest{});
+  EXPECT_FALSE(unstarted.ok());
+
+  ASSERT_TRUE(loopback
+                  .Start([](const HttpRequest& request) {
+                    return HttpResponse{.status = 200, .body = "echo:" + request.body};
+                  })
+                  .ok());
+  auto round = loopback.Send(HttpRequest{.body = "hi"});
+  ASSERT_TRUE(round.ok());
+  EXPECT_EQ(round.value().body, "echo:hi");
+
+  // A throwing handler must be contained at the transport boundary
+  // (ADR-0003) — the caller sees a response or an Outcome error, never an
+  // escaping exception.
+  loopback.Stop();
+  ASSERT_TRUE(
+      loopback.Start([](const HttpRequest&) -> HttpResponse { throw std::runtime_error("boom"); })
+          .ok());
+  auto contained = loopback.Send(HttpRequest{});
+  if (contained.ok()) {
+    EXPECT_GE(contained.value().status, 500);
+  } else {
+    EXPECT_FALSE(contained.error().message().empty());
+  }
+}
+
+// --- Outcome/Error idioms used at every boundary. ------------------------
+
+TEST(OutcomeContract, OkErrorAndMoveValueSemantics) {
+  smithy::Outcome<std::string> good = std::string("value");
+  ASSERT_TRUE(good.ok());
+  EXPECT_EQ(std::move(good).value(), "value");
+
+  smithy::Outcome<std::string> bad = smithy::Error::Validation("nope");
+  ASSERT_FALSE(bad.ok());
+  EXPECT_EQ(bad.error().message(), "nope");
+}
+
+}  // namespace


### PR DESCRIPTION
Bumps the `smithy_cpp` git pin from `c9592b4` to `064b427` (latest on the default branch — no tagged releases to track, per the note in `bazel/smithy.MODULE.bazel`), and adopts the Beyoncé Rule for the smithy-cpp API surface: every upstream behavior MoonBase services depend on is now pinned by a MoonBase-side contract test.

## What the bump pulls in

Security and correctness fixes on the HTTP transport and runtime:
- Control bytes rejected in outbound headers (response splitting) and in the client request line; the WebSocket upgrade target guarded against request-line injection.
- gzip fed to zlib in bounded slices instead of a truncating 32-bit cast, with fuzzing.
- Negative fractional epoch-seconds rendered correctly in timestamps.
- Exceptions contained at Outcome/io-thread boundaries (`-fno-exceptions` gated); `TrustedProxies` config parsing returns an `Outcome` instead of aborting.
- Dep bumps: rules_java 9.7.0, junit-bom 6, spotless 8.

## MoonBase adaptation

`TrustedProxies` lost its throwing public constructor in favor of `static Outcome&lt;TrustedProxies&gt; Parse(...)`. Two call sites updated in `domains/platform/libs/aura`: `TrustedProxiesFromEnv` keeps its documented contract (malformed → log + `nullopt`, fail startup) by branching on the `Outcome`, and the middleware test unwraps `Parse(...).value()` directly. Remaining deltas in headers MoonBase includes are source-compatible.

## Beyoncé Rule: contract tests for the behaviors we depend on

That constructor removal was caught by grepping upstream diffs, not by our tests. Now it would fail a named contract test:

- **Platform tier** (`aura:smithy_contract_test` — behaviors every C++ service inherits through the aura chain): `TrustedProxies` Parse/None/Contains including the logged malformed-entry message and IPv4-mapped IPv6; `DeriveClient` across all ADR-0012 provenance paths (spoofed X-Forwarded-For from an untrusted peer must not move the rate-limit key); `PerClientRateLimit` keying on the derived client with 429 + Retry-After; `HealthEndpoint`, `Chain` ordering, `Observe` start/complete pairing; traceparent parse/format round trip; case-insensitive `Headers`; partial aggregate init of the message types; `Loopback` round trip and throwing-handler containment; `Outcome` idioms.
- **Hub tier** (`golf_hub:smithy_contract_test`): `RequireOrigin` (allowlisted/absent admitted, foreign 403, null refused, case + default-port normalization); `InMemoryWebSocketPair` delivery and clean-close semantics the serve loops break on; `SessionRegistry` in the hub's exact configuration — `ResumeOrAdd` Added/Refused/Resumed (ADR-0022 seat conflict), Detach + grace fires `on_expired` exactly once (ADR-0020/21), `SendTo` fan-out and unknown-id no-op, `Remove` frees the seat.

Both targets depend only on smithy-cpp's non-Beast runtime, so they run in restricted-egress sandboxes; the Beast transport contracts (limits, deadlines, rejection hooks) remain with the service e2e suites in CI.

## Verification

- Both new contract suites pass against the new pin, first run.
- golf_hub store-level tests and the golf_hub/portrait Smithy codegen clients pass/build against the new pin.
- The Beast-transport targets (aura middleware test, service binaries) need boost archives this sandbox's egress blocks — CI compiles and tests those with full network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA