### PR TITLE
bazel: bump smithy-cpp to latest (c3fc0af)

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -6,6 +6,6 @@ bazel_dep(name = "smithy_cpp", version = "0.0.0")
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
 git_override(
     module_name = "smithy_cpp",
-    commit = "064b42711c37229fbdb86f5a342b8186a2f80b82",
+    commit = "c3fc0af31828d64b9e17336657051ba85ae30db0",
     remote = "https://github.com/aaylward/smithy-cpp.git",
 )


### PR DESCRIPTION
Bumps the `smithy_cpp` git pin from `064b427` to `c3fc0af` (latest on the default branch — no tagged releases to track, per the note in `bazel/smithy.MODULE.bazel`).

## What's in the delta

Eight commits, all dependency and test work upstream:

- boringssl → `0.20260713.0`, rules_shell → `0.8.0`, rules_testing → `0.9.0`
- A new upstream test pinning client-side TLS hostname verification and the TLS 1.2 floor

## No adaptation needed

Upstream touched six files. None is a header MoonBase includes — checked mechanically against every `smithy/` include across `domains/`. The only header in the diff is `runtime/testing/include/smithy/testing/tls_test_identity.h`, upstream test scaffolding we don't consume. Unlike the last bump (which removed `TrustedProxies`' throwing constructor), there's no source change on our side.

## Verification

The Beyoncé Rule contract tests from #1253/#1254 are the gate here, and they pass unchanged:

- `aura:smithy_contract_test` and `golf_hub:smithy_contract_test` — the platform and hub tiers of the upstream API surface, including the ADR-0018 JSON frame codec
- `golf_hub:golf_hub_wire_test` and `portrait:portrait_smithy_wire_test` — the consumer-facing wire contracts
- golf_hub store tests, `portrait:types_test`, and all three Smithy codegen targets build and pass

The Beast-transport targets need boost archives this sandbox's egress blocks (documented in `scripts/bazel_restricted_egress.sh`), so CI compiles and tests those with full network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA

---
_Generated by [Claude Code](https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA)_