### PR TITLE
chore(deploy): bump forgejo to 16

### DIFF
--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -318,7 +318,7 @@ services:
           memory: 512M
 
   forgejo:
-    image: codeberg.org/forgejo/forgejo:15
+    image: codeberg.org/forgejo/forgejo:16
     restart: always
     ports:
       - "222:22"


### PR DESCRIPTION
Bumps the Forgejo container from 15 to 16. Reverse proxy auth is disabled in our app.ini, so the new REVERSE_PROXY_TRUSTED_PROXIES requirement doesn't apply; the other v16 breaking change worth knowing about is that git mirrors no longer follow HTTP redirects, so a mirror whose upstream was renamed will error until its remote URL is updated.

Back up the forgejo_data volume before deploying — the schema migration on first v16 start is not reversible.