### PR TITLE
one_d4: write indexed_at from the JVM clock so retention compares like with like

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
@@ -8,7 +8,7 @@ import com.muchq.games.one_d4.engine.model.GameFeatures;
 import com.muchq.games.one_d4.engine.model.Motif;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -33,7 +33,7 @@ public class GameFeatureDao implements GameFeatureStore {
           white_elo, black_elo, white_title, black_title, time_class, eco,
           opening_name, opening_family, result, played_at, num_moves,
           indexed_at, pgn
-      ) KEY (game_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, now(), ?)
+      ) KEY (game_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       """;
 
   // On conflict, refresh the derived/enriched columns too so that reindexing a period backfills
@@ -45,7 +45,7 @@ public class GameFeatureDao implements GameFeatureStore {
           white_elo, black_elo, white_title, black_title, time_class, eco,
           opening_name, opening_family, result, played_at, num_moves,
           indexed_at, pgn
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, now(), ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT (game_url) DO UPDATE SET
           indexed_at = EXCLUDED.indexed_at,
           request_id = EXCLUDED.request_id,
@@ -94,11 +94,9 @@ public class GameFeatureDao implements GameFeatureStore {
               rs.getString("opening_name"),
               rs.getString("opening_family"),
               rs.getString("result"),
-              playedAtToInstant(rs.getObject("played_at", LocalDateTime.class)),
+              fromUtcWallClock(rs.getObject("played_at", LocalDateTime.class)),
               getIntOrNull(rs, "num_moves"),
-              rs.getTimestamp("indexed_at") != null
-                  ? rs.getTimestamp("indexed_at").toInstant()
-                  : null,
+              fromUtcWallClock(rs.getObject("indexed_at", LocalDateTime.class)),
               rs.getString("pgn"));
 
   private static final RowMapper<GameForReanalysis> REANALYSIS_MAPPER =
@@ -110,10 +108,21 @@ public class GameFeatureDao implements GameFeatureStore {
 
   private final Jdbi jdbi;
   private final boolean useH2;
+  private final Clock clock;
 
   public GameFeatureDao(Jdbi jdbi, boolean useH2) {
+    this(jdbi, useH2, Clock.systemUTC());
+  }
+
+  /**
+   * @param clock stamps {@code indexed_at} when a caller supplies a row without one. Retention
+   *     compares that column against a threshold this same clock produces, so both sides have to
+   *     come from one source; see {@link #deleteOlderThan}.
+   */
+  public GameFeatureDao(Jdbi jdbi, boolean useH2, Clock clock) {
     this.jdbi = jdbi;
     this.useH2 = useH2;
+    this.clock = clock;
   }
 
   /**
@@ -133,12 +142,12 @@ public class GameFeatureDao implements GameFeatureStore {
    * Under a UTC JVM this is a no-op against the older Calendar-based binding — the conversion that
    * forced was already the identity — so existing rows keep their exact stored values.
    */
-  private static @Nullable LocalDateTime playedAtFromInstant(@Nullable Instant instant) {
+  private static @Nullable LocalDateTime toUtcWallClock(@Nullable Instant instant) {
     return instant == null ? null : instant.atOffset(ZoneOffset.UTC).toLocalDateTime();
   }
 
-  /** Inverse of {@link #playedAtFromInstant}: a stored UTC wall clock read back as an instant. */
-  private static @Nullable Instant playedAtToInstant(@Nullable LocalDateTime wallClock) {
+  /** Inverse of {@link #toUtcWallClock}: a stored UTC wall clock read back as an instant. */
+  private static @Nullable Instant fromUtcWallClock(@Nullable LocalDateTime wallClock) {
     return wallClock == null ? null : wallClock.toInstant(ZoneOffset.UTC);
   }
 
@@ -168,9 +177,15 @@ public class GameFeatureDao implements GameFeatureStore {
                 .bind(11, row.openingName())
                 .bind(12, row.openingFamily())
                 .bind(13, row.result())
-                .bindByType(14, playedAtFromInstant(row.playedAt()), LocalDateTime.class)
+                .bindByType(14, toUtcWallClock(row.playedAt()), LocalDateTime.class)
                 .bind(15, (Integer) row.numMoves())
-                .bind(16, row.pgn())
+                // Never null: the column is NOT NULL, and a row that slipped through without a
+                // stamp would be undeletable, since `NULL < threshold` is unknown.
+                .bindByType(
+                    16,
+                    toUtcWallClock(row.indexedAt() == null ? clock.instant() : row.indexedAt()),
+                    LocalDateTime.class)
+                .bind(17, row.pgn())
                 .add();
           }
           batch.execute();
@@ -178,14 +193,13 @@ public class GameFeatureDao implements GameFeatureStore {
   }
 
   /**
-   * Deliberately binds the threshold as a plain {@link Timestamp}, converting through the JVM
-   * default zone, rather than as the UTC wall clock played_at uses. This compares against
-   * indexed_at, which is written by the database's own {@code now()} / {@code current_timestamp()}
-   * rather than by the JVM, so its stored wall clock is the database server's zone. Pinning the
-   * threshold to UTC would only be right when the server also runs UTC; making retention
-   * zone-independent means changing how indexed_at is *written* (a dialect-specific SQL change that
-   * reinterprets every existing row), which is a separate concern from played_at and is not
-   * attempted here.
+   * Both sides of this comparison are UTC wall clocks written by the JVM: {@code indexed_at} is
+   * bound by {@link #insertBatch} from the caller's clock, and the threshold is bound here on the
+   * same convention. Previously {@code indexed_at} came from the database's own {@code now()} while
+   * the threshold came from the JVM, so retention straddled two clocks and drifted with host skew
+   * and the database server's timezone (#1268). Nothing in the column changed for a UTC server —
+   * {@code now()} was already producing a UTC wall clock there — so existing rows keep their exact
+   * stored values.
    */
   @Override
   public int deleteOlderThan(Instant threshold) {
@@ -193,7 +207,7 @@ public class GameFeatureDao implements GameFeatureStore {
         h -> {
           int deleted =
               h.createUpdate("DELETE FROM game_features WHERE indexed_at < ?")
-                  .bind(0, Timestamp.from(threshold))
+                  .bindByType(0, toUtcWallClock(threshold), LocalDateTime.class)
                   .execute();
           if (deleted > 0) {
             LOG.debug("Deleted {} games older than {}", deleted, threshold);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PlayedAtTimeZoneTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PlayedAtTimeZoneTest.java
@@ -112,19 +112,59 @@ public class PlayedAtTimeZoneTest {
             gameAt("julyStart", Instant.parse("2026-07-01T00:00:00Z")),
             gameAt("juneEnd", Instant.parse("2026-06-30T23:59:59.999Z"))));
 
-    assertThat(storedPlayedAt("julyStart")).isEqualTo("2026-07-01 00:00:00");
-    assertThat(storedPlayedAt("juneEnd")).isEqualTo("2026-06-30 23:59:59.999");
+    assertThat(storedColumn("played_at", "julyStart")).isEqualTo("2026-07-01 00:00:00");
+    assertThat(storedColumn("played_at", "juneEnd")).isEqualTo("2026-06-30 23:59:59.999");
+  }
+
+  /**
+   * indexed_at is what retention compares against, and it used to be written by the database's own
+   * {@code now()} while the threshold came from the JVM (#1268). On H2 that was self-consistent —
+   * the engine runs in-process and shares the JVM's zone, so both sides shifted together and no
+   * round-trip test could see it — but it made the stored value depend on whichever process wrote
+   * it. Against a real Postgres in a different zone than the app, retention deleted early.
+   *
+   * <p>So the assertion has to be on the bytes on disk, not a round trip: under UTC+14 the old path
+   * wrote {@code 2026-07-01 14:00:00} for this instant.
+   */
+  @Test
+  public void storedIndexedAtIsUtcNotJvmLocal() {
+    Instant indexedAt = Instant.parse("2026-07-01T00:00:00Z");
+    dao.insertBatch(List.of(gameAt("indexed", Instant.parse("2026-07-15T12:00:00Z"), indexedAt)));
+
+    assertThat(storedColumn("indexed_at", "indexed")).isEqualTo("2026-07-01 00:00:00");
+  }
+
+  /**
+   * Retention's threshold rides the same convention as the column, so a row on the far side of the
+   * boundary goes and one on the near side stays.
+   *
+   * <p>The surviving row sits 6 hours past the threshold — deliberately inside the zone's 14-hour
+   * offset. Days either side of the boundary would prove nothing: the offset could not move them
+   * across it, and a threshold bound through the JVM zone would pass. At 6 hours it does not: the
+   * buggy bind shifts the boundary to 14:00 and sweeps a row that is not yet due.
+   */
+  @Test
+  public void retentionComparesLikeWithLikeUnderNonUtcJvmZone() {
+    Instant threshold = Instant.parse("2026-07-10T00:00:00Z");
+    dao.insertBatch(
+        List.of(
+            gameAt("due", Instant.parse("2026-07-15T12:00:00Z"), threshold.minusSeconds(3600)),
+            gameAt(
+                "notDue", Instant.parse("2026-07-15T12:00:00Z"), threshold.plusSeconds(6 * 3600))));
+
+    assertThat(dao.deleteOlderThan(threshold)).isEqualTo(1);
+    assertThat(urlsMatching("num.moves >= 0")).containsExactly("notDue");
   }
 
   /**
    * The stored wall clock as text. {@code CAST(... AS VARCHAR)} renders the column server-side, so
    * neither the JVM's zone nor the driver's Calendar handling can touch the answer.
    */
-  private String storedPlayedAt(String gameUrl) {
+  private String storedColumn(String column, String gameUrl) {
     try (var conn = testDb.dataSource().getConnection();
         var stmt =
             conn.prepareStatement(
-                "SELECT CAST(played_at AS VARCHAR) FROM game_features WHERE game_url = ?")) {
+                "SELECT CAST(" + column + " AS VARCHAR) FROM game_features WHERE game_url = ?")) {
       stmt.setString(1, gameUrl);
       try (var rs = stmt.executeQuery()) {
         assertThat(rs.next()).isTrue();
@@ -178,6 +218,10 @@ public class PlayedAtTimeZoneTest {
   }
 
   private GameFeature gameAt(String url, Instant playedAt) {
+    return gameAt(url, playedAt, Instant.now());
+  }
+
+  private GameFeature gameAt(String url, Instant playedAt, Instant indexedAt) {
     return new GameFeature(
         null,
         requestId,
@@ -196,7 +240,7 @@ public class PlayedAtTimeZoneTest {
         "1-0",
         playedAt,
         30,
-        Instant.now(),
+        indexedAt,
         "1. e4 e5 *");
   }
 }


### PR DESCRIPTION
Closes #1268.

## The problem

`game_features.indexed_at` was stamped by the database's own `now()` — hardcoded in both dialect INSERTs (`GameFeatureDao.java:35,47`, refreshed on the PG upsert at `:50`) — while `RetentionWorker`'s threshold came from the JVM. Two clocks, one comparison.

The column is `TIMESTAMP WITHOUT TIME ZONE`, so it holds a wall clock with no offset, and whose wall clock depends on who wrote it. Against a database server in a different zone than the app, retention deletes games early: a request reports **"Indexed · 2d left"** over games that are already gone. That is the exact lie the availability signal from #1265 exists to prevent, reintroduced one layer down.

## The fix

`indexed_at` is now bound the same way `played_at` has been since #1258 — a zone-free `LocalDateTime` on the column's own type, on the documented UTC convention — and `deleteOlderThan` binds its threshold identically. Both sides of the comparison come from the `Clock` injected in #1265.

It turned out smaller than the issue suggested. `IndexWorker.buildGameFeature` has been passing `clock.instant()` into `GameFeature.indexedAt` since #1265, and `insertBatch` was **discarding it** in favour of `now()`. So this binds a value that already existed rather than adding plumbing.

The two wall-clock helpers are renamed `toUtcWallClock` / `fromUtcWallClock`; they were `playedAt`-specific by name only and now serve both columns.

## Migration: none

Confirmed with the repo owner that there are no non-UTC servers, which is what deferred this in #1265. On a UTC server `now()` was already producing a UTC wall clock, so existing rows keep their exact stored values and the change is a no-op for data already on disk. Recording that it was confirmed rather than assumed, since the whole risk of this change lived in that one question.

## Tests

Both live in `PlayedAtTimeZoneTest`, which already runs under `TZ=Pacific/Kiritimati` (UTC+14) with a self-guard that fails if the target's TZ env stops reaching the JVM.

**`storedIndexedAtIsUtcNotJvmLocal`** asserts the bytes on disk via `CAST(indexed_at AS VARCHAR)`. A round-trip test cannot see this bug at all: H2 runs in-process and shares the JVM's zone, so the old path was self-consistent within one process and only wrong across two. Under UTC+14 the old write produced `2026-07-01 14:00:00` for an instant that should store as `2026-07-01 00:00:00`.

**`retentionComparesLikeWithLikeUnderNonUtcJvmZone`** puts the surviving row 6 hours past the threshold — deliberately *inside* the zone's 14-hour offset.

That margin is the point, and I got it wrong first. The initial version used rows 9 and 10 days either side of the boundary, and the mutation reverting the threshold to a plain JVM `Timestamp` **passed** — a 14-hour shift cannot move a row that is 9 days clear, so the test proved nothing while looking correct. At 6 hours it discriminates.

Mutation-checked, both halves:

| Mutation | Result |
|---|---|
| `indexed_at` written by `now()` again | fails |
| threshold bound as a plain JVM `Timestamp` again | fails |

## Verification

All 54 Bazel targets across `one_d4` and `mcpserver` pass. Repo-wide `google-java-format --dry-run --set-exit-if-changed` exits 0.

The PG-gated suites run in CI against the `postgres:18` service; locally they skip silently without `PG_TEST_DB_URL`, so `build-and-test` is the run that actually exercises this against a separate database process rather than in-process H2 — which, given the bug is precisely about two processes disagreeing, is the signal that matters here.

---
_Generated by [Claude Code](https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA)_