### PR TITLE
Make the LRU cache unable to fail mid-promotion, and give caching a home in aura

### DIFF
--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -73,10 +73,22 @@ Before committing anything non-trivial, run a self-review panel:
 - **Three independent agents, three distinct lenses.** Typically correctness
   and control flow; data access, SQL, and resource safety; and tests, docs, and
   CI gates. The lenses should barely overlap.
+- **Panel agents read; they never write.** No edits, no `scripts/mutation-check`,
+  no "revert it and see what happens" — not even a change the agent fully
+  intends to undo. The panel runs several agents at once over the same files,
+  so one agent's scratch mutation is another's mystery failure; an agent that
+  dies mid-run leaves deliberately-broken code in the tree; and a dirty tree
+  invites a commit that ships the mutation. An agent that wants to know whether
+  a test bites reports that as a finding instead of finding out.
 - **Each agent hunts, then tries to refute its own findings** before reporting.
   This is what keeps the signal-to-noise usable.
 - **Verify the survivors yourself** before acting on them. Agents are sometimes
   confidently wrong; don't take a finding at face value.
+- **Aggregation is where the writing happens.** Every surviving finding not
+  already covered gets a test — positive *and* negative — including the
+  findings you decide *not* to act on, where the test pins the behavior you
+  chose to keep so the next reader doesn't reopen the question. Mutation
+  checking belongs here too: it needs a clean tree and a single writer.
 
 **If the panel didn't run, say so.** A restart, an interrupt, or simply
 forgetting can kill it. Report that plainly rather than letting the reader

--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -43,7 +43,10 @@ cc_library(
         "//domains/graphics/libs/image_core",
         "//domains/graphics/libs/png_plusplus",
         "//domains/graphics/libs/tracy_cpp:tracy",
-        "//domains/platform/libs/futility/cache",
+        # :cache, not :aura — the latter pulls the Beast transport, which
+        # this library has no use for and whose tests would then need
+        # sandbox setup to build.
+        "//domains/platform/libs/aura:cache",
         "//domains/platform/libs/futility/otel:metrics",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",

--- a/domains/graphics/apis/portrait/BUILD.bazel
+++ b/domains/graphics/apis/portrait/BUILD.bazel
@@ -44,8 +44,7 @@ cc_library(
         "//domains/graphics/libs/png_plusplus",
         "//domains/graphics/libs/tracy_cpp:tracy",
         # :cache, not :aura — the latter pulls the Beast transport, which
-        # this library has no use for and whose tests would then need
-        # sandbox setup to build.
+        # this library has no use for.
         "//domains/platform/libs/aura:cache",
         "//domains/platform/libs/futility/otel:metrics",
         "@com_google_absl//absl/log",

--- a/domains/graphics/apis/portrait/tracer_service.cc
+++ b/domains/graphics/apis/portrait/tracer_service.cc
@@ -57,11 +57,8 @@ absl::StatusOr<TraceResponse> TracerService::trace(TraceRequest& trace_request) 
       metrics_->RecordLatency("trace_request_duration",
                               std::chrono::duration_cast<std::chrono::microseconds>(duration),
                               {{"cache_hit", "true"}});
-      metrics_->RecordCounter("trace_cache_hits");
       return toResponse(trace_request.output, *cached_png);
     }
-
-    metrics_->RecordCounter("trace_cache_misses");
 
     auto [scene, perspective, output] = trace_request;
 

--- a/domains/graphics/apis/portrait/tracer_service.h
+++ b/domains/graphics/apis/portrait/tracer_service.h
@@ -19,28 +19,23 @@ namespace portrait {
 /// Service for rendering 3D ray-traced scenes with result caching.
 class TracerService {
  public:
-  /// The service_name label on every instrument this service emits. Shared
-  /// by the recorder and the cache so the two cannot drift apart.
-  static constexpr std::string_view kServiceName = "portrait";
-
   /// Constructs a TracerService with default cache size of 50.
   explicit TracerService() : TracerService(50) {}
   /// Constructs a TracerService with a specified cache size.
   explicit TracerService(uint16_t _cache_size)
-      : TracerService(_cache_size, std::make_shared<futility::otel::MetricsRecorder>(
-                                       std::string(kServiceName))) {}
+      : TracerService(_cache_size, std::make_shared<futility::otel::MetricsRecorder>("portrait")) {}
   /// Takes the recorder so a test can assert what was counted. The failure
   /// counters carry the only label distinguishing an out-of-memory render
   /// from any other, and a label nothing asserts on is one that can silently
   /// become wrong.
   ///
-  /// The cache shares that recorder rather than holding one of its own, so
-  /// its hit/miss series carry the same service_name as everything else.
-  /// Both members copy it: moving into one of them would make correctness
-  /// depend on the order the members happen to be declared in.
+  /// The cache shares that recorder rather than holding one of its own. That
+  /// is also where its `service_name` label comes from, so it names whatever
+  /// service this was built for instead of restating it here and hoping the
+  /// two stay equal. Both members copy the pointer: moving into one of them
+  /// would make correctness depend on the order they happen to be declared.
   TracerService(uint16_t _cache_size, std::shared_ptr<futility::otel::MetricsRecorder> metrics)
-      : cache_({.service_name = std::string(kServiceName), .cache = "trace"}, _cache_size, metrics),
-        metrics_(metrics) {}
+      : cache_("trace", _cache_size, metrics), metrics_(metrics) {}
   virtual ~TracerService() = default;
 
   /// Traces a scene and returns the encoded PNG bytes plus dimensions.

--- a/domains/graphics/apis/portrait/tracer_service.h
+++ b/domains/graphics/apis/portrait/tracer_service.h
@@ -4,13 +4,14 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "absl/status/statusor.h"
 #include "domains/graphics/libs/image_core/image_core.h"
 #include "domains/graphics/libs/tracy_cpp/tracy.h"
-#include "domains/platform/libs/futility/cache/lru_cache.h"
+#include "domains/platform/libs/aura/cache.h"
 #include "domains/platform/libs/futility/otel/metrics.h"
 #include "types.h"
 
@@ -18,17 +19,28 @@ namespace portrait {
 /// Service for rendering 3D ray-traced scenes with result caching.
 class TracerService {
  public:
+  /// The service_name label on every instrument this service emits. Shared
+  /// by the recorder and the cache so the two cannot drift apart.
+  static constexpr std::string_view kServiceName = "portrait";
+
   /// Constructs a TracerService with default cache size of 50.
   explicit TracerService() : TracerService(50) {}
   /// Constructs a TracerService with a specified cache size.
   explicit TracerService(uint16_t _cache_size)
-      : TracerService(_cache_size, std::make_shared<futility::otel::MetricsRecorder>("portrait")) {}
+      : TracerService(_cache_size, std::make_shared<futility::otel::MetricsRecorder>(
+                                       std::string(kServiceName))) {}
   /// Takes the recorder so a test can assert what was counted. The failure
   /// counters carry the only label distinguishing an out-of-memory render
   /// from any other, and a label nothing asserts on is one that can silently
   /// become wrong.
+  ///
+  /// The cache shares that recorder rather than holding one of its own, so
+  /// its hit/miss series carry the same service_name as everything else.
+  /// Both members copy it: moving into one of them would make correctness
+  /// depend on the order the members happen to be declared in.
   TracerService(uint16_t _cache_size, std::shared_ptr<futility::otel::MetricsRecorder> metrics)
-      : cache_(_cache_size), metrics_(std::move(metrics)) {}
+      : cache_({.service_name = std::string(kServiceName), .cache = "trace"}, _cache_size, metrics),
+        metrics_(metrics) {}
   virtual ~TracerService() = default;
 
   /// Traces a scene and returns the encoded PNG bytes plus dimensions.
@@ -70,7 +82,7 @@ class TracerService {
   tracy::LightType tracify(const LightType& lightType);
   TraceResponse toResponse(const Output& output, const std::vector<std::uint8_t>& png_bytes);
 
-  futility::cache::LRUCache<TraceRequest, std::vector<std::uint8_t>> cache_;
+  aura::Cache<TraceRequest, std::vector<std::uint8_t>> cache_;
   std::shared_ptr<futility::otel::MetricsRecorder> metrics_;
 };
 }  // namespace portrait

--- a/domains/graphics/apis/portrait/tracer_service_test.cc
+++ b/domains/graphics/apis/portrait/tracer_service_test.cc
@@ -529,13 +529,19 @@ TEST_F(TracerServiceTest, SubclassingAloneDoesNotBreakTheRender) {
 // the real service, with portrait's labels, rather than only through the
 // wrapper's own unit tests.
 
+/// The service these cache tests speak for. The cache reads its
+/// service_name label off the recorder, so a recorder built for some other
+/// name would emit some other label — which is the property that keeps the
+/// two from drifting, and the reason this is one constant here too.
+constexpr const char* kService = "portrait";
+
 /// The labels every portrait cache series carries.
 std::map<std::string, std::string> TraceCacheLabels() {
-  return {{"service_name", "portrait"}, {"cache", "trace"}};
+  return {{"service_name", kService}, {"cache", "trace"}};
 }
 
 TEST_F(TracerServiceTest, TheFirstRenderIsAMissAndTheRepeatIsAHit) {
-  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>("portrait_test");
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>(kService);
   TracerService service(10, metrics);
   TraceRequest request{basic_scene_, basic_perspective_, basic_output_};
 
@@ -550,7 +556,7 @@ TEST_F(TracerServiceTest, TheFirstRenderIsAMissAndTheRepeatIsAHit) {
 }
 
 TEST_F(TracerServiceTest, ADifferentSceneMissesRatherThanReusingTheLastRender) {
-  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>("portrait_test");
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>(kService);
   TracerService service(10, metrics);
   TraceRequest first{basic_scene_, basic_perspective_, basic_output_};
 
@@ -566,7 +572,7 @@ TEST_F(TracerServiceTest, ADifferentSceneMissesRatherThanReusingTheLastRender) {
 }
 
 TEST_F(TracerServiceTest, TheBespokeTraceCacheCountersAreGone) {
-  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>("portrait_test");
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>(kService);
   TracerService service(10, metrics);
   TraceRequest request{basic_scene_, basic_perspective_, basic_output_};
 
@@ -576,8 +582,16 @@ TEST_F(TracerServiceTest, TheBespokeTraceCacheCountersAreGone) {
   // prom_proxy now queries the standard family. A migration that emitted
   // both names would satisfy the assertions above while leaving the old
   // series to rot, so the absence is its own assertion.
-  EXPECT_EQ(metrics->CounterTotal("trace_cache_hits"), 0);
-  EXPECT_EQ(metrics->CounterTotal("trace_cache_misses"), 0);
+  //
+  // Scanned by name over every entry rather than through CounterTotal:
+  // CounterTotal matches attributes exactly, so asking it for the bare
+  // "trace_cache_hits" says nothing about a resurrected counter that carries
+  // any label at all. That is not hypothetical — it is the form the counter
+  // would take if it came back beside the new one.
+  for (const futility::otel::CapturingMetricsRecorder::Entry& entry : metrics->Entries()) {
+    EXPECT_EQ(entry.name.find("trace_cache_"), std::string::npos)
+        << "the bespoke counter is back, labelled: " << entry.name;
+  }
 }
 
 }  // namespace

--- a/domains/graphics/apis/portrait/tracer_service_test.cc
+++ b/domains/graphics/apis/portrait/tracer_service_test.cc
@@ -523,5 +523,62 @@ TEST_F(TracerServiceTest, SubclassingAloneDoesNotBreakTheRender) {
   EXPECT_TRUE(pngpp::isPng(result->png_bytes));
 }
 
+// --- Cache metrics (#1211) ---------------------------------------------
+// The service no longer counts its own cache outcomes; it gets them by
+// holding an aura::Cache. These assert the standard family arrives through
+// the real service, with portrait's labels, rather than only through the
+// wrapper's own unit tests.
+
+/// The labels every portrait cache series carries.
+std::map<std::string, std::string> TraceCacheLabels() {
+  return {{"service_name", "portrait"}, {"cache", "trace"}};
+}
+
+TEST_F(TracerServiceTest, TheFirstRenderIsAMissAndTheRepeatIsAHit) {
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>("portrait_test");
+  TracerService service(10, metrics);
+  TraceRequest request{basic_scene_, basic_perspective_, basic_output_};
+
+  ASSERT_TRUE(service.trace(request).ok());
+  EXPECT_EQ(metrics->CounterTotal("cache_misses", TraceCacheLabels()), 1);
+  EXPECT_EQ(metrics->CounterTotal("cache_hits", TraceCacheLabels()), 0);
+
+  ASSERT_TRUE(service.trace(request).ok());
+  EXPECT_EQ(metrics->CounterTotal("cache_hits", TraceCacheLabels()), 1);
+  EXPECT_EQ(metrics->CounterTotal("cache_misses", TraceCacheLabels()), 1)
+      << "the second, identical request missed";
+}
+
+TEST_F(TracerServiceTest, ADifferentSceneMissesRatherThanReusingTheLastRender) {
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>("portrait_test");
+  TracerService service(10, metrics);
+  TraceRequest first{basic_scene_, basic_perspective_, basic_output_};
+
+  Scene other_scene = basic_scene_;
+  other_scene.spheres[0].center = {1.0, 0.0, 5.0};
+  TraceRequest second{other_scene, basic_perspective_, basic_output_};
+
+  ASSERT_TRUE(service.trace(first).ok());
+  ASSERT_TRUE(service.trace(second).ok());
+
+  EXPECT_EQ(metrics->CounterTotal("cache_misses", TraceCacheLabels()), 2);
+  EXPECT_EQ(metrics->CounterTotal("cache_hits", TraceCacheLabels()), 0);
+}
+
+TEST_F(TracerServiceTest, TheBespokeTraceCacheCountersAreGone) {
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>("portrait_test");
+  TracerService service(10, metrics);
+  TraceRequest request{basic_scene_, basic_perspective_, basic_output_};
+
+  ASSERT_TRUE(service.trace(request).ok());
+  ASSERT_TRUE(service.trace(request).ok());
+
+  // prom_proxy now queries the standard family. A migration that emitted
+  // both names would satisfy the assertions above while leaving the old
+  // series to rot, so the absence is its own assertion.
+  EXPECT_EQ(metrics->CounterTotal("trace_cache_hits"), 0);
+  EXPECT_EQ(metrics->CounterTotal("trace_cache_misses"), 0);
+}
+
 }  // namespace
 }  // namespace portrait

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -19,6 +19,24 @@ type serviceEntry struct {
 	CustomTimeseries map[string]string
 }
 
+// Portrait's render cache emits the standard cache family (#1209) from
+// aura::Cache rather than bespoke trace_cache_* counters, so its queries
+// select on both labels: which service, and which cache within it. Named
+// here because every cache query below is built from the same two rates.
+//
+// These stay in portrait's custom block for now: generalizing them into a
+// standard cache block parameterized by service_name — the way the
+// http_server_* block already works — is the prom_proxy half of #1209, and
+// wants a second emitter to generalize against.
+const (
+	portraitCacheHitRate  = `rate(cache_hits_total{service_name="portrait",cache="trace"}[5m])`
+	portraitCacheMissRate = `rate(cache_misses_total{service_name="portrait",cache="trace"}[5m])`
+
+	portraitCacheHitPercent = portraitCacheHitRate + `/(` + portraitCacheHitRate + `+` +
+		portraitCacheMissRate + `)*100`
+	portraitCacheOpsRate = portraitCacheHitRate + `+` + portraitCacheMissRate
+)
+
 // Catalog order doubles as the UI's tab order.
 var serviceOrder = []string{"golf_hub", "mcpserver", "microgpt-serve", "mithril", "one_d4", "portrait", "posterize"}
 
@@ -84,16 +102,16 @@ var serviceRegistry = map[string]serviceEntry{
 	"posterize": {},
 	"portrait": {
 		CustomScalars: []customScalarDef{
-			{"Render cache", "hit_rate_percent", "%", `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`},
-			{"Render cache", "operations_per_sec", "/s", `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`},
+			{"Render cache", "hit_rate_percent", "%", portraitCacheHitPercent},
+			{"Render cache", "operations_per_sec", "/s", portraitCacheOpsRate},
 			// Windowed averages over RecordDistribution histograms:
 			// rate(sum)/rate(count) = mean per request in the window.
 			{"Scene complexity", "avg_spheres_1h", "spheres", `sum(rate(scene_sphere_count_sum[1h]))/sum(rate(scene_sphere_count_count[1h]))`},
 			{"Scene complexity", "avg_lights_1h", "lights", `sum(rate(scene_light_count_sum[1h]))/sum(rate(scene_light_count_count[1h]))`},
 		},
 		CustomTimeseries: map[string]string{
-			"cache_hit_rate":        `rate(trace_cache_hits_total[5m])/(rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m]))*100`,
-			"cache_operations_rate": `rate(trace_cache_hits_total[5m])+rate(trace_cache_misses_total[5m])`,
+			"cache_hit_rate":        portraitCacheHitPercent,
+			"cache_operations_rate": portraitCacheOpsRate,
 			"scene_sphere_count":    `sum(rate(scene_sphere_count_sum[5m]))/sum(rate(scene_sphere_count_count[5m]))`,
 			"scene_light_count":     `sum(rate(scene_light_count_sum[5m]))/sum(rate(scene_light_count_count[5m]))`,
 		},

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -54,6 +55,52 @@ func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
 			assert.False(t, shadows, "service %q custom series %q shadows a standard series", name, key)
 		}
 	}
+}
+
+// One reference to a standard cache counter, with whatever label selector
+// follows it.
+var cacheSelectorPattern = regexp.MustCompile(`cache_(?:hits|misses)_total(\{[^}]*\})?`)
+
+// Portrait's cache queries follow the emitter: aura::Cache emits the
+// standard cache family labeled by service and cache, so the bespoke
+// trace_cache_* series no longer exist to be queried. A rename on one side
+// only leaves the dashboard reading a metric nothing writes — which looks
+// exactly like a cache that is never used.
+func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
+	portrait := serviceRegistry["portrait"]
+
+	// The panels the UI renders by key.
+	require.Contains(t, portrait.CustomTimeseries, "cache_hit_rate")
+	require.Contains(t, portrait.CustomTimeseries, "cache_operations_rate")
+
+	var queries []string
+	for _, def := range portrait.CustomScalars {
+		queries = append(queries, def.Query)
+	}
+	for _, query := range portrait.CustomTimeseries {
+		queries = append(queries, query)
+	}
+	require.NotEmpty(t, queries)
+
+	selectors := 0
+	for _, query := range queries {
+		assert.NotContains(t, query, "trace_cache_",
+			"query still reads the deleted bespoke series: %s", query)
+
+		// Per selector, not per query. A hit-rate query names both counters,
+		// so asserting the query as a whole contains the labels passes while
+		// either half of it is unscoped — and an unscoped half silently sums
+		// every service's caches into portrait's panel.
+		for _, match := range cacheSelectorPattern.FindAllStringSubmatch(query, -1) {
+			selectors++
+			labels := match[1]
+			assert.Contains(t, labels, `service_name="portrait"`,
+				"selector %q is not scoped to portrait, in %s", match[0], query)
+			assert.Contains(t, labels, `cache="trace"`,
+				"selector %q does not name which cache, in %s", match[0], query)
+		}
+	}
+	assert.NotZero(t, selectors, "portrait no longer queries the standard cache family at all")
 }
 
 func TestMetricsHandler_GetServiceCatalog(t *testing.T) {

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -57,9 +57,14 @@ func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
 	}
 }
 
-// One reference to a standard cache counter, with whatever label selector
-// follows it.
-var cacheSelectorPattern = regexp.MustCompile(`cache_(?:hits|misses)_total(\{[^}]*\})?`)
+// Any reference to a cache metric, with whatever label selector follows it.
+//
+// Deliberately broader than cache_hits_total|cache_misses_total: a selector
+// the pattern does not match is a selector that escapes the label checks
+// below entirely, so a half-finished rename (cache_misses, or a
+// cache_evictions_total nobody emits) would slip through unexamined rather
+// than being flagged.
+var cacheSelectorPattern = regexp.MustCompile(`\bcache_[a-z_]+\b(\{[^}]*\})?`)
 
 // Portrait's cache queries follow the emitter: aura::Cache emits the
 // standard cache family labeled by service and cache, so the bespoke
@@ -82,7 +87,7 @@ func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
 	}
 	require.NotEmpty(t, queries)
 
-	selectors := 0
+	seen := map[string]int{}
 	for _, query := range queries {
 		assert.NotContains(t, query, "trace_cache_",
 			"query still reads the deleted bespoke series: %s", query)
@@ -92,7 +97,8 @@ func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
 		// either half of it is unscoped — and an unscoped half silently sums
 		// every service's caches into portrait's panel.
 		for _, match := range cacheSelectorPattern.FindAllStringSubmatch(query, -1) {
-			selectors++
+			name := strings.SplitN(match[0], "{", 2)[0]
+			seen[name]++
 			labels := match[1]
 			assert.Contains(t, labels, `service_name="portrait"`,
 				"selector %q is not scoped to portrait, in %s", match[0], query)
@@ -100,7 +106,52 @@ func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
 				"selector %q does not name which cache, in %s", match[0], query)
 		}
 	}
-	assert.NotZero(t, selectors, "portrait no longer queries the standard cache family at all")
+
+	// Both halves by name, not a bare count: the hit-rate panel divides one
+	// by the sum of both, so a rename that left only the hits selector
+	// standing would keep the count non-zero while the panel silently read a
+	// series nothing writes.
+	assert.NotZero(t, seen["cache_hits_total"], "nothing queries cache_hits_total")
+	assert.NotZero(t, seen["cache_misses_total"], "nothing queries cache_misses_total")
+	assert.Empty(t, mapKeysExcept(seen, "cache_hits_total", "cache_misses_total"),
+		"portrait queries a cache series outside the standard family")
+}
+
+// Every cache selector in the whole registry has to name a service, not just
+// portrait's. registry.go anticipates a second emitter, and an unscoped
+// selector added by one sums every service's caches into that service's
+// panel.
+func TestRegistry_EveryCacheQueryNamesItsService(t *testing.T) {
+	for _, name := range serviceOrder {
+		entry := serviceRegistry[name]
+		queries := make([]string, 0, len(entry.CustomScalars)+len(entry.CustomTimeseries))
+		for _, def := range entry.CustomScalars {
+			queries = append(queries, def.Query)
+		}
+		for _, query := range entry.CustomTimeseries {
+			queries = append(queries, query)
+		}
+		for _, query := range queries {
+			for _, match := range cacheSelectorPattern.FindAllStringSubmatch(query, -1) {
+				assert.Contains(t, match[1], "service_name=",
+					"service %q has an unscoped cache selector %q", name, match[0])
+			}
+		}
+	}
+}
+
+func mapKeysExcept(m map[string]int, except ...string) []string {
+	skip := map[string]bool{}
+	for _, key := range except {
+		skip[key] = true
+	}
+	var rest []string
+	for key := range m {
+		if !skip[key] {
+			rest = append(rest, key)
+		}
+	}
+	return rest
 }
 
 func TestMetricsHandler_GetServiceCatalog(t *testing.T) {

--- a/domains/platform/libs/aura/BUILD.bazel
+++ b/domains/platform/libs/aura/BUILD.bazel
@@ -19,6 +19,31 @@ cc_library(
     ],
 )
 
+# The instrumented cache. Deliberately a separate target from :aura, which
+# pulls the Beast transport in: a service wanting a cache should not inherit
+# a transport, and its tests should not need scripts/make-git-overrides.sh to
+# have been run before they can build.
+cc_library(
+    name = "cache",
+    hdrs = ["cache.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//domains/platform/libs/futility/cache",
+        "//domains/platform/libs/futility/otel:metrics",
+    ],
+)
+
+cc_test(
+    name = "cache_test",
+    size = "small",
+    srcs = ["cache_test.cc"],
+    deps = [
+        ":cache",
+        "//domains/platform/libs/futility/otel:capturing_metrics_recorder",
+        "@googletest//:gtest_main",
+    ],
+)
+
 # Beyoncé Rule contract tests (platform tier): every smithy-cpp behavior the
 # aura chain — and through it every C++ service — depends on, pinned here so
 # a pin bump that changes one fails with a named contract. Non-Beast deps

--- a/domains/platform/libs/aura/BUILD.bazel
+++ b/domains/platform/libs/aura/BUILD.bazel
@@ -21,8 +21,11 @@ cc_library(
 
 # The instrumented cache. Deliberately a separate target from :aura, which
 # pulls the Beast transport in: a service wanting a cache should not inherit
-# a transport, and its tests should not need scripts/make-git-overrides.sh to
-# have been run before they can build.
+# an HTTP transport, and neither should its tests. That keeps Boost out of
+# this target's dep closure, not the sandbox out of the picture entirely —
+# :cache still reaches opentelemetry-cpp through futility/otel, so behind a
+# proxy that 403s GitHub archives it needs scripts/make-git-overrides.sh
+# just like most of the graph.
 cc_library(
     name = "cache",
     hdrs = ["cache.h"],

--- a/domains/platform/libs/aura/README.md
+++ b/domains/platform/libs/aura/README.md
@@ -1,10 +1,22 @@
 # Aura
 
-The serving chain for C++ services on [smithy-cpp](https://github.com/muchq/smithy-cpp):
-observability, health, and optional per-client rate limiting, composed the
-same way in production and in tests.
+The serving-tier components for C++ services on
+[smithy-cpp](https://github.com/muchq/smithy-cpp): observability, health,
+per-client rate limiting, and caching — each one wrapping a `futility`
+primitive so that *using* it emits the standard metric family, instead of
+every service hand-rolling its own counter names.
 
-## What it gives you
+Two targets, deliberately separate:
+
+| Target | Contents | Pulls Beast? |
+|---|---|---|
+| `:aura` | the serving chain (`middleware.h`) | yes |
+| `:cache` | `aura::Cache` (`cache.h`) | no |
+
+A library that wants a cache should not inherit an HTTP transport, and its
+tests should not need `scripts/make-git-overrides.sh` to have been run first.
+
+## What the chain gives you
 
 - **`ProductionChain(ChainOptions, handler)`** — the one entry point:
   - `ServingObservability` outermost, so health probes and 429s are
@@ -46,3 +58,28 @@ options.on_connection_event = aura::ConnectionEventLog();
 Consumers: `//domains/graphics/apis/portrait`, `//domains/games/apis/golf_hub`.
 `HttpMetricsSink` is a virtual seam — tests inject a recording sink instead
 of the OTel-backed one.
+
+## `aura::Cache`
+
+A fixed-capacity LRU cache that counts its own hits and misses, emitting the
+standard `cache_hits_total` / `cache_misses_total{service_name, cache}` family
+([#1209](https://github.com/muchq/MoonBase/issues/1209)). Storage behavior is
+`futility/cache`'s; what aura adds is that the metric arrives by picking this
+type rather than by remembering to count in each branch of a lookup.
+
+```cpp
+#include "domains/platform/libs/aura/cache.h"
+
+aura::Cache<TraceRequest, std::vector<std::uint8_t>> cache_{
+    {.service_name = "portrait", .cache = "trace"}, 50, metrics};
+
+if (auto hit = cache_.get(request)) return *hit;   // counted either way
+```
+
+Share the service's `MetricsRecorder` so cache series carry the same
+`service_name` as its other instruments. Capacity 0 stores nothing and reports
+every lookup as a miss, which turns the cache off without disturbing its call
+sites or leaving a hole in the dashboard.
+
+Counter names are recorded without `_total`; the OTLP exporter appends it, as
+it does for `http_server_requests`.

--- a/domains/platform/libs/aura/README.md
+++ b/domains/platform/libs/aura/README.md
@@ -2,9 +2,8 @@
 
 The serving-tier components for C++ services on
 [smithy-cpp](https://github.com/muchq/smithy-cpp): observability, health,
-per-client rate limiting, and caching — each one wrapping a `futility`
-primitive so that *using* it emits the standard metric family, instead of
-every service hand-rolling its own counter names.
+per-client rate limiting, and caching, composed the same way in production
+and in tests.
 
 Two targets, deliberately separate:
 
@@ -13,8 +12,10 @@ Two targets, deliberately separate:
 | `:aura` | the serving chain (`middleware.h`) | yes |
 | `:cache` | `aura::Cache` (`cache.h`) | no |
 
-A library that wants a cache should not inherit an HTTP transport, and its
-tests should not need `scripts/make-git-overrides.sh` to have been run first.
+A library that wants a cache should not inherit an HTTP transport. That is
+the whole of the split — `:cache` still reaches opentelemetry-cpp via
+`futility/otel`, so it is not a target you can build behind a blocking proxy
+without `scripts/make-git-overrides.sh`.
 
 ## What the chain gives you
 
@@ -70,14 +71,14 @@ type rather than by remembering to count in each branch of a lookup.
 ```cpp
 #include "domains/platform/libs/aura/cache.h"
 
-aura::Cache<TraceRequest, std::vector<std::uint8_t>> cache_{
-    {.service_name = "portrait", .cache = "trace"}, 50, metrics};
+aura::Cache<TraceRequest, std::vector<std::uint8_t>> cache_{"trace", 50, metrics};
 
 if (auto hit = cache_.get(request)) return *hit;   // counted either way
 ```
 
-Share the service's `MetricsRecorder` so cache series carry the same
-`service_name` as its other instruments. Capacity 0 stores nothing and reports
+The `service_name` label comes from the `MetricsRecorder` you pass, not from a
+second argument, so a cache series cannot be labeled for a different service
+than the meter it was recorded through. Capacity 0 stores nothing and reports
 every lookup as a miss, which turns the cache off without disturbing its call
 sites or leaving a hole in the dashboard.
 

--- a/domains/platform/libs/aura/cache.h
+++ b/domains/platform/libs/aura/cache.h
@@ -1,0 +1,85 @@
+#ifndef DOMAINS_PLATFORM_LIBS_AURA_CACHE_H
+#define DOMAINS_PLATFORM_LIBS_AURA_CACHE_H
+
+/// @file cache.h
+/// @brief An LRU cache that reports its own hit rate.
+
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "domains/platform/libs/futility/cache/lru_cache.h"
+#include "domains/platform/libs/futility/otel/metrics.h"
+
+namespace aura {
+
+/// Identifies one cache within one service — the label pair every cache
+/// counter carries.
+///
+/// Both members are static, low-cardinality strings, so a service with
+/// several caches gets one series per cache without cardinality risk. They
+/// are grouped into a type of their own so a call site names them
+/// (`{.service_name = "portrait", .cache = "trace"}`) instead of passing two
+/// interchangeable strings in an order only the header remembers.
+struct CacheId {
+  /// Matches the service_name label on the service's other instruments.
+  std::string service_name;
+  /// Distinguishes this cache from the service's others.
+  std::string cache;
+};
+
+/// A fixed-capacity LRU cache that counts hits and misses.
+///
+/// Wraps futility's cache primitive the way the serving chain wraps
+/// futility's rate-limiter primitive: the storage behavior is entirely the
+/// primitive's, and what aura adds is that *using* it emits the standard
+/// `cache_hits_total` / `cache_misses_total{service_name, cache}` family.
+/// A service gets cache observability by picking this type rather than by
+/// remembering to count in every branch of its own lookup code.
+///
+/// Counter names are recorded without the `_total` suffix; the OTLP
+/// exporter appends it, as it does for `http_server_requests`.
+///
+/// Thread-safe, because the underlying primitive is.
+template <class Key, class Value>
+class Cache {
+ public:
+  /// @param id The service and cache labels for this instance.
+  /// @param capacity Maximum entries. Zero stores nothing, which turns the
+  ///        cache off without disturbing its call sites — the counters keep
+  ///        reporting, so a disabled cache reads as a 0% hit rate rather
+  ///        than as an absent metric.
+  /// @param metrics Where the counters go; share the service's recorder so
+  ///        cache series carry the same service_name as everything else.
+  Cache(CacheId id, std::size_t capacity, std::shared_ptr<futility::otel::MetricsRecorder> metrics)
+      : cache_(capacity),
+        metrics_(std::move(metrics)),
+        labels_{{"service_name", std::move(id.service_name)}, {"cache", std::move(id.cache)}} {}
+
+  /// Looks up a key, counting the outcome, and promotes it on a hit.
+  std::optional<Value> get(const Key& key) {
+    std::optional<Value> found = cache_.get(key);
+    metrics_->RecordCounter(found.has_value() ? "cache_hits" : "cache_misses", 1, labels_);
+    return found;
+  }
+
+  /// Stores a value, evicting the least recently used entry if full. A key
+  /// already present keeps its stored value.
+  void insert(const Key& key, const Value& value) { cache_.insert(key, value); }
+
+  std::size_t size() const { return cache_.size(); }
+  std::size_t capacity() const { return cache_.capacity(); }
+  bool empty() const { return cache_.empty(); }
+
+ private:
+  futility::cache::LRUCache<Key, Value> cache_;
+  std::shared_ptr<futility::otel::MetricsRecorder> metrics_;
+  const std::map<std::string, std::string> labels_;
+};
+
+}  // namespace aura
+
+#endif

--- a/domains/platform/libs/aura/cache.h
+++ b/domains/platform/libs/aura/cache.h
@@ -16,29 +16,13 @@
 
 namespace aura {
 
-/// Identifies one cache within one service — the label pair every cache
-/// counter carries.
-///
-/// Both members are static, low-cardinality strings, so a service with
-/// several caches gets one series per cache without cardinality risk. They
-/// are grouped into a type of their own so a call site names them
-/// (`{.service_name = "portrait", .cache = "trace"}`) instead of passing two
-/// interchangeable strings in an order only the header remembers.
-struct CacheId {
-  /// Matches the service_name label on the service's other instruments.
-  std::string service_name;
-  /// Distinguishes this cache from the service's others.
-  std::string cache;
-};
-
 /// A fixed-capacity LRU cache that counts hits and misses.
 ///
-/// Wraps futility's cache primitive the way the serving chain wraps
-/// futility's rate-limiter primitive: the storage behavior is entirely the
-/// primitive's, and what aura adds is that *using* it emits the standard
-/// `cache_hits_total` / `cache_misses_total{service_name, cache}` family.
-/// A service gets cache observability by picking this type rather than by
-/// remembering to count in every branch of its own lookup code.
+/// Storage behavior is entirely futility's; what aura adds is that *using*
+/// this type emits the standard `cache_hits_total` /
+/// `cache_misses_total{service_name, cache}` family. A service gets cache
+/// observability by picking this type rather than by remembering to count in
+/// every branch of its own lookup code.
 ///
 /// Counter names are recorded without the `_total` suffix; the OTLP
 /// exporter appends it, as it does for `http_server_requests`.
@@ -47,17 +31,21 @@ struct CacheId {
 template <class Key, class Value>
 class Cache {
  public:
-  /// @param id The service and cache labels for this instance.
+  /// @param cache_name Value of the `cache` label, distinguishing this cache
+  ///        from the service's others. Static and low-cardinality.
   /// @param capacity Maximum entries. Zero stores nothing, which turns the
   ///        cache off without disturbing its call sites — the counters keep
   ///        reporting, so a disabled cache reads as a 0% hit rate rather
   ///        than as an absent metric.
-  /// @param metrics Where the counters go; share the service's recorder so
-  ///        cache series carry the same service_name as everything else.
-  Cache(CacheId id, std::size_t capacity, std::shared_ptr<futility::otel::MetricsRecorder> metrics)
+  /// @param metrics Where the counters go. The `service_name` label comes
+  ///        from this recorder rather than from a second argument, so a
+  ///        cache series cannot end up labeled for a different service than
+  ///        the meter it was recorded through.
+  Cache(std::string cache_name, std::size_t capacity,
+        std::shared_ptr<futility::otel::MetricsRecorder> metrics)
       : cache_(capacity),
         metrics_(std::move(metrics)),
-        labels_{{"service_name", std::move(id.service_name)}, {"cache", std::move(id.cache)}} {}
+        labels_{{"service_name", metrics_->service_name()}, {"cache", std::move(cache_name)}} {}
 
   /// Looks up a key, counting the outcome, and promotes it on a hit.
   std::optional<Value> get(const Key& key) {
@@ -69,10 +57,6 @@ class Cache {
   /// Stores a value, evicting the least recently used entry if full. A key
   /// already present keeps its stored value.
   void insert(const Key& key, const Value& value) { cache_.insert(key, value); }
-
-  std::size_t size() const { return cache_.size(); }
-  std::size_t capacity() const { return cache_.capacity(); }
-  bool empty() const { return cache_.empty(); }
 
  private:
   futility::cache::LRUCache<Key, Value> cache_;

--- a/domains/platform/libs/aura/cache_test.cc
+++ b/domains/platform/libs/aura/cache_test.cc
@@ -33,8 +33,7 @@ class AuraCacheTest : public ::testing::Test {
 
   aura::Cache<int, std::string> MakeCache(std::size_t capacity,
                                           const std::string& cache_name = "trace") {
-    return aura::Cache<int, std::string>({.service_name = "portrait", .cache = cache_name},
-                                         capacity, metrics_);
+    return aura::Cache<int, std::string>(cache_name, capacity, metrics_);
   }
 
   std::shared_ptr<CapturingMetricsRecorder> metrics_ =
@@ -119,10 +118,6 @@ TEST_F(AuraCacheTest, StorageBehaviorIsThePrimitivesAndStillReachable) {
   cache.insert(1, "one");
   cache.insert(2, "two");
 
-  EXPECT_EQ(cache.size(), 2u);
-  EXPECT_EQ(cache.capacity(), 2u);
-  EXPECT_FALSE(cache.empty());
-
   // Reading 1 promotes it, so inserting a third entry evicts 2.
   EXPECT_EQ(cache.get(1), "one");
   cache.insert(3, "three");
@@ -136,7 +131,6 @@ TEST_F(AuraCacheTest, ACacheWithNoCapacityStillReportsItsMisses) {
   aura::Cache<int, std::string> cache = MakeCache(0);
   cache.insert(1, "one");
 
-  EXPECT_TRUE(cache.empty());
   EXPECT_FALSE(cache.get(1).has_value());
 
   // A cache turned off by capacity reads as a 0% hit rate, which is a fact

--- a/domains/platform/libs/aura/cache_test.cc
+++ b/domains/platform/libs/aura/cache_test.cc
@@ -1,0 +1,148 @@
+// What aura adds over the futility cache primitive is the standard
+// cache_hits_total / cache_misses_total{service_name, cache} family, so
+// these tests are mostly about the counters: that both outcomes are counted,
+// that each is counted as itself and not as the other, and that the labels
+// are the configured ones. The storage behavior belongs to the primitive and
+// is pinned in //domains/platform/libs/futility/cache:cache_test; only
+// delegation is checked here.
+
+#include "domains/platform/libs/aura/cache.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "domains/platform/libs/futility/otel/capturing_metrics_recorder.h"
+
+namespace {
+
+using futility::otel::CapturingMetricsRecorder;
+
+// The names as recorded. The OTLP exporter appends _total, so recording
+// "cache_hits_total" here would reach Prometheus as cache_hits_total_total.
+constexpr const char* kHits = "cache_hits";
+constexpr const char* kMisses = "cache_misses";
+
+class AuraCacheTest : public ::testing::Test {
+ protected:
+  std::map<std::string, std::string> Labels(const std::string& cache) const {
+    return {{"service_name", "portrait"}, {"cache", cache}};
+  }
+
+  aura::Cache<int, std::string> MakeCache(std::size_t capacity,
+                                          const std::string& cache_name = "trace") {
+    return aura::Cache<int, std::string>({.service_name = "portrait", .cache = cache_name},
+                                         capacity, metrics_);
+  }
+
+  std::shared_ptr<CapturingMetricsRecorder> metrics_ =
+      std::make_shared<CapturingMetricsRecorder>("portrait");
+};
+
+TEST_F(AuraCacheTest, AHitIsCountedAsAHitAndNotAsAMiss) {
+  aura::Cache<int, std::string> cache = MakeCache(4);
+  cache.insert(1, "one");
+
+  EXPECT_EQ(cache.get(1), "one");
+
+  EXPECT_EQ(metrics_->CounterTotal(kHits, Labels("trace")), 1);
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, Labels("trace")), 0) << "a hit also counted as a miss";
+}
+
+TEST_F(AuraCacheTest, AMissIsCountedAsAMissAndNotAsAHit) {
+  aura::Cache<int, std::string> cache = MakeCache(4);
+
+  EXPECT_FALSE(cache.get(99).has_value());
+
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, Labels("trace")), 1);
+  EXPECT_EQ(metrics_->CounterTotal(kHits, Labels("trace")), 0) << "a miss also counted as a hit";
+}
+
+TEST_F(AuraCacheTest, EveryLookupIsCountedExactlyOnce) {
+  aura::Cache<int, std::string> cache = MakeCache(4);
+  cache.insert(1, "one");
+
+  for (int i = 0; i < 3; ++i) {
+    (void)cache.get(1);
+  }
+  for (int i = 0; i < 2; ++i) {
+    (void)cache.get(2);
+  }
+
+  EXPECT_EQ(metrics_->CounterTotal(kHits, Labels("trace")), 3);
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, Labels("trace")), 2);
+}
+
+TEST_F(AuraCacheTest, CountersCarryTheConfiguredLabels) {
+  aura::Cache<int, std::string> cache = MakeCache(4);
+  (void)cache.get(1);
+
+  // CounterTotal matches attributes exactly, so these are the assertions
+  // that give the one above its meaning: a counter emitted bare, or under
+  // some other cache's label, is not this cache's counter.
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, {}), 0) << "recorded without labels";
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, Labels("some-other-cache")), 0);
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, {{"cache", "trace"}}), 0)
+      << "recorded without a service_name";
+}
+
+TEST_F(AuraCacheTest, TheRecordedNamesDoNotCarryTheExporterSuffix) {
+  aura::Cache<int, std::string> cache = MakeCache(4);
+  cache.insert(1, "one");
+  (void)cache.get(1);
+  (void)cache.get(2);
+
+  // The exporter appends _total. Recording it here too would land as
+  // cache_hits_total_total and silently miss every dashboard query.
+  EXPECT_EQ(metrics_->CounterTotal("cache_hits_total", Labels("trace")), 0);
+  EXPECT_EQ(metrics_->CounterTotal("cache_misses_total", Labels("trace")), 0);
+}
+
+TEST_F(AuraCacheTest, TwoCachesInOneServiceCountSeparately) {
+  aura::Cache<int, std::string> scenes = MakeCache(4, "trace");
+  aura::Cache<int, std::string> thumbnails = MakeCache(4, "thumbnail");
+  scenes.insert(1, "one");
+
+  (void)scenes.get(1);      // hit on "trace"
+  (void)thumbnails.get(1);  // miss on "thumbnail"
+
+  EXPECT_EQ(metrics_->CounterTotal(kHits, Labels("trace")), 1);
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, Labels("trace")), 0);
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, Labels("thumbnail")), 1);
+  EXPECT_EQ(metrics_->CounterTotal(kHits, Labels("thumbnail")), 0);
+}
+
+TEST_F(AuraCacheTest, StorageBehaviorIsThePrimitivesAndStillReachable) {
+  aura::Cache<int, std::string> cache = MakeCache(2);
+  cache.insert(1, "one");
+  cache.insert(2, "two");
+
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_EQ(cache.capacity(), 2u);
+  EXPECT_FALSE(cache.empty());
+
+  // Reading 1 promotes it, so inserting a third entry evicts 2.
+  EXPECT_EQ(cache.get(1), "one");
+  cache.insert(3, "three");
+
+  EXPECT_EQ(cache.get(1), "one");
+  EXPECT_FALSE(cache.get(2).has_value());
+  EXPECT_EQ(cache.get(3), "three");
+}
+
+TEST_F(AuraCacheTest, ACacheWithNoCapacityStillReportsItsMisses) {
+  aura::Cache<int, std::string> cache = MakeCache(0);
+  cache.insert(1, "one");
+
+  EXPECT_TRUE(cache.empty());
+  EXPECT_FALSE(cache.get(1).has_value());
+
+  // A cache turned off by capacity reads as a 0% hit rate, which is a fact
+  // about the service; an absent metric reads as a broken exporter.
+  EXPECT_EQ(metrics_->CounterTotal(kMisses, Labels("trace")), 1);
+  EXPECT_EQ(metrics_->CounterTotal(kHits, Labels("trace")), 0);
+}
+
+}  // namespace

--- a/domains/platform/libs/futility/cache/README.md
+++ b/domains/platform/libs/futility/cache/README.md
@@ -14,10 +14,19 @@ Inspired by [boost.compute's LRU cache](https://github.com/boostorg/compute/blob
 - **Automatic eviction**: Removes least recently used items when full
 - **Simple API**: `get()`, `insert()`, `contains()`, `clear()`
 
+## Which one do I want?
+
+This is the bare primitive. A **service** almost always wants
+[`aura::Cache`](../../aura/cache.h) instead, which wraps this and emits the
+standard `cache_hits_total` / `cache_misses_total{service_name, cache}`
+family, so its hit rate shows up on the dashboard without any per-service
+metric code. Reach for the primitive directly only where there is nothing to
+report to — inside another library, or in a tool.
+
 ## Usage
 
 ```cpp
-#include "cpp/futility/cache/lru_cache.h"
+#include "domains/platform/libs/futility/cache/lru_cache.h"
 
 using namespace futility::cache;
 
@@ -40,14 +49,28 @@ return result;
 
 | Method | Description |
 |--------|-------------|
-| `LRUCache(size_t capacity)` | Construct with max capacity |
-| `get(key)` | Get value (updates recency), returns `std::optional` |
+| `LRUCache(size_t capacity)` | Construct with max capacity. Capacity 0 stores nothing |
+| `get(key)` | Get value (makes it most recently used), returns `std::optional` |
 | `insert(key, value)` | Insert (evicts LRU if full), no-op if key exists |
 | `contains(key)` | Check existence (does NOT update recency) |
 | `size()` | Current number of items |
 | `capacity()` | Maximum capacity |
 | `empty()` | True if cache is empty |
 | `clear()` | Remove all items |
+
+There is deliberately no way to remove a single key or to replace the value
+stored under one: `insert` on a key already present keeps the stored value and
+does not refresh its recency. Values are expected to be a pure function of the
+key, so a second insert has nothing new to say.
+
+## Exception safety
+
+`get` moves the existing recency node rather than rebuilding it, so promoting a
+key allocates nothing and cannot fail. `insert` stages its allocations and
+commits them with a non-throwing splice, so a failed insert leaves the cache
+exactly as it was — nothing evicted, no entry half-added. This matters where
+the values are large enough that allocation failure is a real path rather than
+a theoretical one ([#1271](https://github.com/muchq/MoonBase/issues/1271)).
 
 ## Thread Safety
 
@@ -66,7 +89,7 @@ This implementation is **thread-safe**. It uses `std::shared_mutex` internally t
 ## Bazel Target
 
 ```python
-deps = ["//cpp/futility/cache:lru_cache"]
+deps = ["//domains/platform/libs/futility/cache"]
 ```
 
 ## License

--- a/domains/platform/libs/futility/cache/README.md
+++ b/domains/platform/libs/futility/cache/README.md
@@ -65,16 +65,27 @@ key, so a second insert has nothing new to say.
 
 ## Exception safety
 
-`get` moves the existing recency node rather than rebuilding it, so promoting a
-key allocates nothing and cannot fail. `insert` stages its allocations and
-commits them with a non-throwing splice, so a failed insert leaves the cache
-exactly as it was — nothing evicted, no entry half-added. This matters where
-the values are large enough that allocation failure is a real path rather than
-a theoretical one ([#1271](https://github.com/muchq/MoonBase/issues/1271)).
+`get` moves the existing recency node rather than rebuilding it, so the
+promotion itself allocates nothing and cannot fail. (Copying the value into the
+returned `std::optional` still can — but that happens after the relink, with
+both containers already consistent.)
+
+`insert` stages its allocations and commits them with a non-throwing splice, so
+an allocation failure leaves the cache exactly as it was: nothing evicted, no
+entry half-added. Eviction runs after that commit point, because erasing by key
+runs the key's hash and equality and so is not itself non-throwing; a throw
+from there leaves the cache consistent but holding one entry over capacity, for
+good. That overshoot is deliberate rather than drained — see the comment on
+`insert`, since looping the eviction to reclaim it would also hide the symptom
+that makes an inconsistent cache detectable at all.
+
+This matters where the values are large enough that allocation failure is a
+real path rather than a theoretical one
+([#1271](https://github.com/muchq/MoonBase/issues/1271)).
 
 ## Thread Safety
 
-This implementation is **thread-safe**. It uses `std::shared_mutex` internally to allow concurrent read operations while serializing writes.
+This implementation is **thread-safe**. It uses `std::shared_mutex` internally: the observers below share the lock, while anything that mutates state serializes. Note that `get()` is a writer — it updates recency — so concurrent `get()`s on the same cache do not proceed in parallel. `contains()` is the read-only lookup.
 
 | Method | Lock Type | Reason |
 |--------|-----------|--------|

--- a/domains/platform/libs/futility/cache/lru_cache.h
+++ b/domains/platform/libs/futility/cache/lru_cache.h
@@ -105,17 +105,35 @@ class LRUCache {
     }
 
     // Stage the recency node in a list of its own. Both allocations below
-    // can throw, and until the splice at the end neither container has been
-    // touched — so a failure unwinds `staged` and leaves the cache exactly
-    // as it was, rather than half-updated. splice does not allocate and
-    // cannot throw, which is what makes it a commit point.
+    // can throw, and until the splice neither container has been touched —
+    // so a failure unwinds `staged` and leaves the cache exactly as it was,
+    // rather than half-updated. splice does not allocate and cannot throw,
+    // which is what makes it the commit point.
     list_type staged;
     staged.push_front(key);
     m_map.emplace(key, std::make_pair(value, staged.begin()));
+    m_list.splice(m_list.begin(), staged);
+
+    // Only now evict, because eviction is not a non-throwing operation: it
+    // erases by key, which runs the key's hash and equality. Evicting while
+    // the map still pointed into `staged` meant a throw from either left a
+    // map entry referring to a node that unwinding was about to free. The
+    // containers agree from the splice onward, so the worst a throw here can
+    // do is leave the cache one entry over capacity, permanently but
+    // boundedly, since each later insert still evicts one.
+    //
+    // Deliberately an `if` and not a `while`. A loop would drain that
+    // overshoot — but it would equally drain a recency node that no map
+    // entry points at, and that is the visible symptom of every way the two
+    // containers can fall out of step. Measured, not assumed: with a loop
+    // here, deleting the duplicate-key guard above survives the whole suite,
+    // including the 20-thread stress test that otherwise catches it at 98
+    // entries in a cache of 50. A bounded overshoot after an
+    // all-but-unreachable throw is worth less than keeping that class of bug
+    // loud.
     if (m_map.size() > m_capacity) {
       evict();
     }
-    m_list.splice(m_list.begin(), staged);
   }
 
   /// @brief Retrieves a value from the cache.
@@ -133,10 +151,14 @@ class LRUCache {
 
     // splice relinks the existing node: no allocation, no copy of the key,
     // and the stored iterator stays valid and keeps pointing at the same
-    // element. Since nothing here can throw, there is no window where the
-    // map holds an iterator into a node the list has already freed.
-    // Splicing an element in front of itself is defined as a no-op, so the
-    // already-at-front case needs no branch of its own.
+    // element. Splicing an element in front of itself is defined as a no-op,
+    // so the already-at-front case needs no branch of its own.
+    //
+    // Copying the value into the returned optional still can throw — that is
+    // the whole point of #1271, the values here are large. What matters is
+    // that it throws *after* the relink, with both containers already
+    // consistent, so there is no window where the map holds an iterator into
+    // a node the list has freed.
     m_list.splice(m_list.begin(), m_list, i->second.second);
     return i->second.first;
   }

--- a/domains/platform/libs/futility/cache/lru_cache.h
+++ b/domains/platform/libs/futility/cache/lru_cache.h
@@ -86,63 +86,59 @@ class LRUCache {
 
   /// @brief Inserts a key-value pair into the cache.
   ///
-  /// If the key already exists, this is a no-op (the existing value is kept).
-  /// If the cache is at capacity, the least recently used item is evicted first.
+  /// If the key already exists, this is a no-op: the stored value is kept and
+  /// its recency is *not* refreshed. If the cache is at capacity, the least
+  /// recently used item is evicted to make room.
+  ///
+  /// A cache built with capacity 0 stores nothing, and every later get() is a
+  /// miss.
   ///
   /// @param key The key to insert.
   /// @param value The value to associate with the key.
-  /// @note To update an existing key's value, remove it first or use a different pattern.
+  /// @note There is no way to replace the value stored under an existing key.
+  ///       Values here are expected to be a pure function of the key, so a
+  ///       second insert has nothing new to say.
   void insert(const key_type& key, const value_type& value) {
     std::unique_lock lock(mutex_);
-    if (!m_map.contains(key)) {
-      // insert item into the cache, but first check if it is full
-      if (m_map.size() >= m_capacity) {
-        // cache is full, evict the least recently used item
-        evict();
-      }
-
-      // insert the new item
-      m_list.push_front(key);
-      m_map[key] = std::make_pair(value, m_list.begin());
+    if (m_capacity == 0 || m_map.contains(key)) {
+      return;
     }
+
+    // Stage the recency node in a list of its own. Both allocations below
+    // can throw, and until the splice at the end neither container has been
+    // touched — so a failure unwinds `staged` and leaves the cache exactly
+    // as it was, rather than half-updated. splice does not allocate and
+    // cannot throw, which is what makes it a commit point.
+    list_type staged;
+    staged.push_front(key);
+    m_map.emplace(key, std::make_pair(value, staged.begin()));
+    if (m_map.size() > m_capacity) {
+      evict();
+    }
+    m_list.splice(m_list.begin(), staged);
   }
 
   /// @brief Retrieves a value from the cache.
   ///
-  /// If the key exists, it is moved to the front of the recency list,
-  /// making it the most recently used item.
+  /// If the key exists, it becomes the most recently used item.
   ///
   /// @param key The key to look up.
   /// @return The cached value if found, std::nullopt otherwise.
   std::optional<value_type> get(const key_type& key) {
     std::unique_lock lock(mutex_);
-    // lookup value in the cache
-    typename map_type::iterator i = m_map.find(key);
+    const typename map_type::iterator i = m_map.find(key);
     if (i == m_map.end()) {
-      // value not in cache
       return std::nullopt;
     }
 
-    // return the value, but first update its place in the most
-    // recently used list
-    typename list_type::iterator j = i->second.second;
-    if (j != m_list.begin()) {
-      // move item to the front of the most recently used list
-      m_list.erase(j);
-      m_list.push_front(key);
-
-      // update iterator in map
-      j = m_list.begin();
-      const value_type& value = i->second.first;
-      m_map[key] = std::make_pair(value, j);
-
-      // return the value
-      return value;
-    } else {
-      // the item is already at the front of the most recently
-      // used list so just return it
-      return i->second.first;
-    }
+    // splice relinks the existing node: no allocation, no copy of the key,
+    // and the stored iterator stays valid and keeps pointing at the same
+    // element. Since nothing here can throw, there is no window where the
+    // map holds an iterator into a node the list has already freed.
+    // Splicing an element in front of itself is defined as a no-op, so the
+    // already-at-front case needs no branch of its own.
+    m_list.splice(m_list.begin(), m_list, i->second.second);
+    return i->second.first;
   }
 
   /// @brief Removes all items from the cache.
@@ -154,8 +150,10 @@ class LRUCache {
 
  private:
   /// @brief Evicts the least recently used item from the cache.
+  ///
+  /// Only called with the list non-empty: insert() returns early at capacity
+  /// 0, so an over-capacity map always has at least one node to drop.
   void evict() {
-    // evict item from the end of most recently used list
     typename list_type::iterator i = --m_list.end();
     m_map.erase(*i);
     m_list.erase(i);
@@ -163,7 +161,7 @@ class LRUCache {
 
   map_type m_map;                    ///< Hash map for O(1) key lookup
   list_type m_list;                  ///< Doubly-linked list for recency ordering
-  size_t m_capacity;                 ///< Maximum cache capacity
+  const size_t m_capacity;           ///< Maximum cache capacity
   mutable std::shared_mutex mutex_;  ///< Mutex for thread-safe access
 };
 

--- a/domains/platform/libs/futility/cache/lru_cache_test.cc
+++ b/domains/platform/libs/futility/cache/lru_cache_test.cc
@@ -2,11 +2,62 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
 
 using namespace futility::cache;
+
+// A key that counts how often it is copied and can be armed to throw on a
+// chosen future copy.
+//
+// Copying a key is the cache's only allocation-bearing use of one, so "how
+// many copies does this operation make" and "how many chances does it have
+// to fail" are the same question — which is what lets the exception-safety
+// tests below be deterministic instead of depending on a real allocator
+// running out of memory.
+struct ProbeKey {
+  int id = 0;
+
+  ProbeKey() = default;
+  explicit ProbeKey(int key_id) : id(key_id) {}
+
+  ProbeKey(const ProbeKey& other) : id(other.id) { CountCopy(); }
+  ProbeKey& operator=(const ProbeKey& other) {
+    CountCopy();
+    id = other.id;
+    return *this;
+  }
+
+  bool operator==(const ProbeKey& other) const { return id == other.id; }
+
+  static inline int copies = 0;
+  /// The copy ordinal that throws; 0 means no copy ever throws.
+  static inline int throw_on_copy = 0;
+
+  static void Reset() {
+    copies = 0;
+    throw_on_copy = 0;
+  }
+  /// Arms the very next copy, whenever it happens, to fail.
+  static void FailOnNextCopy() { throw_on_copy = copies + 1; }
+
+ private:
+  static void CountCopy() {
+    if (++copies == throw_on_copy) {
+      throw std::runtime_error("ProbeKey copy failed");
+    }
+  }
+};
+
+template <>
+struct std::hash<ProbeKey> {
+  std::size_t operator()(const ProbeKey& key) const noexcept { return std::hash<int>{}(key.id); }
+};
 
 TEST(LRUCache, EmptyCacheReturnsOptionalEmpty) {
   // Arrange
@@ -150,4 +201,199 @@ TEST(LRUCache, ConcurrentEviction) {
 
   // Cache should never exceed capacity
   EXPECT_LE(cache.size(), 10);
+}
+
+// --- Recency semantics -------------------------------------------------
+// EvictionWorks above passes whether or not get() promotes: it reads keys in
+// the same order it inserted them, so the least-recently-used entry is the
+// oldest either way. These make the promotion observable.
+
+TEST(LRUCache, GetPromotesTheKeyItReturns) {
+  LRUCache<int, std::string> cache(2);
+  cache.insert(1, "one");
+  cache.insert(2, "two");
+
+  // 1 is the older entry, so it is next to be evicted — until this read.
+  ASSERT_TRUE(cache.get(1).has_value());
+  cache.insert(3, "three");
+
+  EXPECT_TRUE(cache.get(1).has_value()) << "the promoted key was evicted";
+  EXPECT_FALSE(cache.get(2).has_value()) << "the stale key survived";
+  EXPECT_TRUE(cache.get(3).has_value());
+}
+
+TEST(LRUCache, InsertOnAnExistingKeyKeepsTheStoredValue) {
+  LRUCache<int, std::string> cache(2);
+  cache.insert(1, "first");
+  cache.insert(1, "second");
+
+  EXPECT_EQ(cache.size(), 1u);
+  EXPECT_EQ(cache.get(1), "first");
+}
+
+TEST(LRUCache, InsertOnAnExistingKeyDoesNotPromoteIt) {
+  LRUCache<int, std::string> cache(2);
+  cache.insert(1, "one");
+  cache.insert(2, "two");
+
+  // A no-op insert is a no-op for recency too, so 1 stays next in line.
+  cache.insert(1, "one again");
+  cache.insert(3, "three");
+
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_TRUE(cache.get(2).has_value());
+  EXPECT_TRUE(cache.get(3).has_value());
+}
+
+TEST(LRUCache, ContainsDoesNotPromote) {
+  LRUCache<int, std::string> cache(2);
+  cache.insert(1, "one");
+  cache.insert(2, "two");
+
+  EXPECT_TRUE(cache.contains(1));
+  cache.insert(3, "three");
+
+  EXPECT_FALSE(cache.contains(1)) << "contains() promoted the key it inspected";
+  EXPECT_TRUE(cache.contains(2));
+}
+
+// --- Capacity boundaries -----------------------------------------------
+
+TEST(LRUCache, ZeroCapacityStoresNothing) {
+  // Evicting to make room in an empty cache used to walk off the end of the
+  // recency list.
+  LRUCache<int, std::string> cache(0);
+
+  cache.insert(1, "one");
+
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_TRUE(cache.empty());
+  EXPECT_FALSE(cache.contains(1));
+  EXPECT_FALSE(cache.get(1).has_value());
+}
+
+TEST(LRUCache, CapacityOneHoldsOnlyTheMostRecentKey) {
+  LRUCache<int, std::string> cache(1);
+
+  cache.insert(1, "one");
+  EXPECT_EQ(cache.get(1), "one");
+
+  cache.insert(2, "two");
+  EXPECT_EQ(cache.size(), 1u);
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_EQ(cache.get(2), "two");
+}
+
+TEST(LRUCache, ClearResetsRecencyAsWellAsContents) {
+  LRUCache<int, std::string> cache(2);
+  cache.insert(1, "one");
+  cache.insert(2, "two");
+
+  cache.clear();
+
+  EXPECT_TRUE(cache.empty());
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_FALSE(cache.get(1).has_value());
+
+  // Had clear() emptied only the map, these would queue up behind two stale
+  // recency nodes and the next evictions would free nothing from the map.
+  cache.insert(3, "three");
+  cache.insert(4, "four");
+  cache.insert(5, "five");
+
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_FALSE(cache.get(3).has_value());
+  EXPECT_TRUE(cache.get(4).has_value());
+  EXPECT_TRUE(cache.get(5).has_value());
+}
+
+// --- Exception safety (#1271) ------------------------------------------
+
+TEST(LRUCacheExceptionSafety, PromotingCopiesNoKeySoItCannotFail) {
+  ProbeKey::Reset();
+  LRUCache<ProbeKey, int> cache(4);
+  cache.insert(ProbeKey(1), 10);
+  cache.insert(ProbeKey(2), 20);
+
+  const int copies_before = ProbeKey::copies;
+  ProbeKey::FailOnNextCopy();
+
+  // Promotion relinks the node the cache already owns. Building a fresh node
+  // instead meant copying the key, which is an allocation, which is a way to
+  // fail while the map still held an iterator into the node just erased.
+  std::optional<int> promoted;
+  EXPECT_NO_THROW(promoted = cache.get(ProbeKey(1)));
+  EXPECT_EQ(promoted, 10);
+  EXPECT_EQ(ProbeKey::copies, copies_before) << "promotion copied the key";
+
+  ProbeKey::Reset();
+}
+
+TEST(LRUCacheExceptionSafety, TheCacheIsIntactAfterAnArmedPromotion) {
+  ProbeKey::Reset();
+  LRUCache<ProbeKey, int> cache(2);
+  cache.insert(ProbeKey(1), 10);
+  cache.insert(ProbeKey(2), 20);
+
+  ProbeKey::FailOnNextCopy();
+  EXPECT_NO_THROW((void)cache.get(ProbeKey(1)));
+  ProbeKey::Reset();
+
+  // A promotion that half-completed used to leave the map pointing at a
+  // freed node, so coming back for the same key was undefined rather than
+  // simply correct.
+  EXPECT_EQ(cache.get(ProbeKey(1)), 10);
+  EXPECT_EQ(cache.get(ProbeKey(2)), 20);
+
+  // Recency still tracks reality: 1 was read first, so it goes first.
+  cache.insert(ProbeKey(3), 30);
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_FALSE(cache.get(ProbeKey(1)).has_value());
+  EXPECT_EQ(cache.get(ProbeKey(2)), 20);
+  EXPECT_EQ(cache.get(ProbeKey(3)), 30);
+}
+
+TEST(LRUCacheExceptionSafety, AFailedInsertEvictsNothing) {
+  ProbeKey::Reset();
+  LRUCache<ProbeKey, int> cache(2);
+  cache.insert(ProbeKey(1), 10);
+  cache.insert(ProbeKey(2), 20);
+  ASSERT_EQ(cache.size(), 2u);
+
+  ProbeKey::FailOnNextCopy();
+  EXPECT_THROW(cache.insert(ProbeKey(3), 30), std::runtime_error);
+  ProbeKey::Reset();
+
+  // Making room before knowing the new entry can be built trades a live
+  // entry for one that never arrives.
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_EQ(cache.get(ProbeKey(1)), 10);
+  EXPECT_EQ(cache.get(ProbeKey(2)), 20);
+  EXPECT_FALSE(cache.get(ProbeKey(3)).has_value());
+}
+
+TEST(LRUCacheExceptionSafety, AFailedInsertLeavesNoOrphanedRecencyNode) {
+  ProbeKey::Reset();
+  // Roomy enough that the failing insert evicts nothing, isolating the
+  // orphaned-node failure from the one above.
+  LRUCache<ProbeKey, int> cache(4);
+  cache.insert(ProbeKey(1), 10);
+  cache.insert(ProbeKey(2), 20);
+
+  // Let the recency node be built and fail while inserting the map entry
+  // that is supposed to point at it: the first copy builds the node, the
+  // second builds the map key.
+  ProbeKey::throw_on_copy = ProbeKey::copies + 2;
+  EXPECT_THROW(cache.insert(ProbeKey(3), 30), std::runtime_error);
+  ProbeKey::Reset();
+
+  ASSERT_EQ(cache.size(), 2u);
+
+  // A node in the list that no map entry refers to is invisible until
+  // eviction reaches it — and evicting it frees nothing from the map, so the
+  // cache quietly grows past its capacity.
+  for (int id = 4; id < 12; ++id) {
+    cache.insert(ProbeKey(id), id * 10);
+    EXPECT_LE(cache.size(), cache.capacity()) << "after inserting key " << id;
+  }
 }

--- a/domains/platform/libs/futility/cache/lru_cache_test.cc
+++ b/domains/platform/libs/futility/cache/lru_cache_test.cc
@@ -38,10 +38,14 @@ struct ProbeKey {
   static inline int copies = 0;
   /// The copy ordinal that throws; 0 means no copy ever throws.
   static inline int throw_on_copy = 0;
+  /// Hashing the key with this id throws; -1 disables. Erasing by key runs
+  /// the hash, which is how eviction can fail without allocating anything.
+  static inline int throw_on_hash_of = -1;
 
   static void Reset() {
     copies = 0;
     throw_on_copy = 0;
+    throw_on_hash_of = -1;
   }
   /// Arms the very next copy, whenever it happens, to fail.
   static void FailOnNextCopy() { throw_on_copy = copies + 1; }
@@ -55,8 +59,16 @@ struct ProbeKey {
 };
 
 template <>
+// Deliberately not noexcept: unordered_map does not require it, and a
+// throwing hash is the only way to make erase-by-key — and so eviction —
+// fail without involving the allocator.
 struct std::hash<ProbeKey> {
-  std::size_t operator()(const ProbeKey& key) const noexcept { return std::hash<int>{}(key.id); }
+  std::size_t operator()(const ProbeKey& key) const {
+    if (key.id == ProbeKey::throw_on_hash_of) {
+      throw std::runtime_error("ProbeKey hash failed");
+    }
+    return std::hash<int>{}(key.id);
+  }
 };
 
 TEST(LRUCache, EmptyCacheReturnsOptionalEmpty) {
@@ -231,6 +243,28 @@ TEST(LRUCache, InsertOnAnExistingKeyKeepsTheStoredValue) {
   EXPECT_EQ(cache.get(1), "first");
 }
 
+// The two tests either side of this one both pass against an insert() with
+// its duplicate-key guard removed: m_map.emplace no-ops on a key already
+// present, so the stored value and the recency order stay right. What the
+// guard also prevents is a second recency node for the same key, and that is
+// only visible later — evicting the orphan frees nothing from the map, so
+// the cache creeps past its capacity. Before this test the contract was
+// pinned only by the 20-thread stress test noticing size 98 against a
+// capacity of 50.
+TEST(LRUCache, ARepeatedInsertAddsNoSecondRecencyNode) {
+  LRUCache<int, std::string> cache(2);
+  cache.insert(1, "one");
+  cache.insert(2, "two");
+  cache.insert(1, "one again");
+
+  ASSERT_EQ(cache.size(), 2u);
+
+  for (int key = 3; key < 10; ++key) {
+    cache.insert(key, "v" + std::to_string(key));
+    EXPECT_LE(cache.size(), cache.capacity()) << "after inserting key " << key;
+  }
+}
+
 TEST(LRUCache, InsertOnAnExistingKeyDoesNotPromoteIt) {
   LRUCache<int, std::string> cache(2);
   cache.insert(1, "one");
@@ -370,6 +404,49 @@ TEST(LRUCacheExceptionSafety, AFailedInsertEvictsNothing) {
   EXPECT_EQ(cache.get(ProbeKey(1)), 10);
   EXPECT_EQ(cache.get(ProbeKey(2)), 20);
   EXPECT_FALSE(cache.get(ProbeKey(3)).has_value());
+}
+
+// Eviction is not an allocation-free path to safety: it erases by key, which
+// runs the key's hash and equality. Evicting while the map still pointed at
+// the staged node meant a throw from either left a map entry referring to a
+// node that unwinding was about to free.
+//
+// Honest about what this pins: that corruption is a use-after-free rather
+// than a wrong answer, and .bazelrc configures no sanitizer, so this test
+// cannot see it directly — an ASAN run is what demonstrated it. What is
+// deterministic, and what this asserts, is the shape of the recovery: the
+// entry commits before the eviction is attempted, the overshoot is temporary
+// rather than a permanent rise in effective capacity, and the cache keeps
+// answering correctly afterward.
+TEST(LRUCacheExceptionSafety, AThrowWhileEvictingLeavesTheCacheUsable) {
+  ProbeKey::Reset();
+  LRUCache<ProbeKey, int> cache(2);
+  cache.insert(ProbeKey(1), 10);
+  cache.insert(ProbeKey(2), 20);
+
+  // Key 1 is the least recently used, so it is the one eviction will erase.
+  ProbeKey::throw_on_hash_of = 1;
+  EXPECT_THROW(cache.insert(ProbeKey(3), 30), std::runtime_error);
+  ProbeKey::Reset();
+
+  // The new entry was committed before the eviction that failed. This also
+  // keeps the test from going quietly vacuous: if the throw had come from
+  // somewhere earlier — a rehash inside emplace, say — key 3 would be absent
+  // and the eviction path would never have been reached.
+  EXPECT_TRUE(cache.contains(ProbeKey(3))) << "the insert never reached the eviction";
+
+  // The skipped eviction is not made up later — each subsequent insert still
+  // evicts exactly one — so the cache runs one over capacity from here on.
+  // That is the deliberate trade: draining the overshoot would mean looping
+  // the eviction, and that same loop would quietly absorb orphaned recency
+  // nodes, which is how every list/map disagreement makes itself visible.
+  // Bounded at one, and the cache keeps answering correctly.
+  for (int id = 4; id < 10; ++id) {
+    cache.insert(ProbeKey(id), id * 10);
+  }
+  EXPECT_EQ(cache.size(), cache.capacity() + 1) << "the overshoot is one entry, and stays one";
+  EXPECT_EQ(cache.get(ProbeKey(9)), 90);
+  EXPECT_EQ(cache.get(ProbeKey(8)), 80);
 }
 
 TEST(LRUCacheExceptionSafety, AFailedInsertLeavesNoOrphanedRecencyNode) {

--- a/domains/platform/libs/futility/otel/metrics.cc
+++ b/domains/platform/libs/futility/otel/metrics.cc
@@ -28,7 +28,7 @@ void RecordWithAttributes(const std::map<std::string, std::string>& attributes, 
 
 }  // namespace
 
-MetricsRecorder::MetricsRecorder(const std::string& service_name) {
+MetricsRecorder::MetricsRecorder(const std::string& service_name) : service_name_(service_name) {
   auto provider = opentelemetry::v1::metrics::Provider::GetMeterProvider();
   meter_ = provider->GetMeter(service_name, "1.0.0");
 }

--- a/domains/platform/libs/futility/otel/metrics.h
+++ b/domains/platform/libs/futility/otel/metrics.h
@@ -56,6 +56,14 @@ class MetricsRecorder {
   explicit MetricsRecorder(const std::string& service_name);
   virtual ~MetricsRecorder() = default;
 
+  /// @brief The service this recorder was built for.
+  ///
+  /// Metric families that are labeled by service — the standard http_server_*
+  /// and cache_* blocks — read it from here rather than being handed the name
+  /// a second time, so a series' label cannot disagree with the meter it was
+  /// recorded through.
+  const std::string& service_name() const { return service_name_; }
+
   // The record methods are virtual for exactly one reason: tests wrap a
   // recorder that captures what a service counts — names, values, and
   // labels — and assert on it (including what must never appear in a
@@ -114,6 +122,7 @@ class MetricsRecorder {
   Instrument* FindOrCreate(std::unordered_map<std::string, std::unique_ptr<Instrument>>& cache,
                            const std::string& metric_name, const Factory& make);
 
+  const std::string service_name_;
   std::shared_ptr<opentelemetry::metrics::Meter> meter_;
 
   // Cache metric instruments to avoid recreating them. Recorders are


### PR DESCRIPTION
Closes #1271. Closes #1211. The C++ half of #1209.

Four commits: the cache primitive's exception safety, giving caching a home in aura, a working-agreement change the review panel prompted, and the panel's own findings.

## #1271 was three bugs, not one

The filed one is real. `LRUCache::get` promoted a key by erasing its recency node and pushing a new one at the front; `push_front` allocates a node holding a copy of the key, so it can throw, and when it did the map's stored iterator was left pointing at the node `erase` had just freed. The next `get` on that key called `m_list.erase()` on it — undefined behavior, not a second clean failure.

`splice` moves the existing node instead: no allocation, no key copy, iterator stays valid, `noexcept`. The window is gone rather than narrowed, and the already-at-front branch retires with it.

It is also faster, which wasn't the point but is worth naming: the old path copied the **value** twice per promotion. Portrait's values are whole PNGs, so every cache hit paid for two copies of the payload it was about to return.

Two more of the same shape:

- **`insert` could orphan a recency node.** It built the list node before the map entry, so a throw from the map insert left a node nothing in the map referred to — invisible until eviction reaches the orphan, at which point freeing it frees nothing from the map and the cache creeps past capacity. Both allocations are now staged and committed with a non-throwing splice.
- **`LRUCache(0)` was undefined.** `insert` saw `size() >= capacity`, called `evict`, and did `--m_list.end()` on an empty list. Capacity 0 now stores nothing.

### The suite couldn't have caught any of it

Seven tests, five of them concurrency. `EvictionWorks` reads its keys in the same order it inserted them, so the oldest entry is the least-recently-used either way — **it passes with promotion removed entirely**.

Every #1271 assertion was run against the pre-fix header: two throw, one **crashes the test binary** (that's the UB), one finds size 1 where 2 was expected, one finds size 5 against capacity 4, and zero-capacity aborts.

## #1211: a wrapper, not a relocation

`aura::Cache` wraps futility's primitive and emits the standard `cache_hits_total` / `cache_misses_total{service_name, cache}` family, so a service gets the metric by picking the type rather than by remembering to count in both branches of its own lookup.

Two interface points worth review:

- **`:cache` is a separate `cc_library` from `:aura`.** `:aura` pulls the Beast transport, and `tracer_service` has no transport dependency it should be made to inherit. `deps(:cache_test)` reaches **zero** Boost targets. It does still reach opentelemetry-cpp, so this is not a target that builds behind a blocking proxy without `scripts/make-git-overrides.sh` — an earlier version of this description claimed otherwise and was wrong.
- **The `service_name` label comes off the `MetricsRecorder`**, which already takes a service name and previously dropped it. Asking the caller for it a second time is what the first draft did, and it meant the label could disagree with the meter — which my own tests were quietly doing, building a recorder named `portrait_test` while asserting `portrait`. `MetricsRecorder` now keeps the name, the way `HttpMetricsManager` already does.

Counters record without `_total`; the exporter appends it. Capacity 0 reports every lookup as a miss, so a disabled cache reads as a 0% hit rate rather than an absent metric.

Portrait's two hand-rolled counters are gone, and prom_proxy's queries follow onto the standard family. They stay in portrait's custom block — generalizing them into a standard block parameterized by `service_name` is the prom_proxy half of #1209 and wants a second emitter to generalize against.

## Review panel

Ran, three lenses. It found a defect this branch introduced, two of my tests that passed against the bug they were named for, four claims my comments didn't support, and a type that hadn't earned its place. All fixed in `c83ae93`.

**The defect.** `insert` ran emplace → evict → splice, so between the emplace and the splice the map held an entry pointing into the local `staged` list. `evict` erases by key, which runs the key's hash and equality; a throw from either unwound `staged` and left the map entry pointing at freed memory. Reproduced under ASAN. Unreachable today — portrait's `TraceRequest` hashes via `absl::Hash` over doubles — but this was the commit that added the guarantee it broke.

**And fixing it nearly cost more than it gained.** Draining the resulting overshoot with `while` instead of `if` looked strictly better. It isn't: the same loop drains an orphaned recency node, which is the only visible symptom of the two containers disagreeing. Measured — with the loop, deleting `insert`'s duplicate-key guard survives the **whole suite**, including the 20-thread stress test that otherwise catches it at 98 entries in a cache of 50. So eviction stays a single `if`, a throwing evict leaves the cache permanently one over capacity, and that trade is stated in the comment and pinned by the test.

**Two tests that didn't bite**, both re-derived on a clean tree before fixing and re-run after:

| Test | Mutation that survived |
|---|---|
| `TheBespokeTraceCacheCountersAreGone` | the counter resurrected *with a label* — `CounterTotal` matches attributes exactly, so the bare-name query never saw it |
| prom_proxy registry guard | a half-finished rename to `cache_misses`, or a `cache_evictions_total` nobody emits — the pattern matched neither, so the label checks were skipped entirely |

Also added the deterministic test the duplicate-key guard never had: its two existing tests both pass against its removal, because `emplace` no-ops on a present key. Until now that contract rested entirely on a thread-stress assertion.

**Claims corrected.** Two of these were in earlier versions of this description: that `aura::Cache` "wraps futility's cache primitive the way the serving chain wraps futility's rate-limiter primitive" — the chain takes a `std::function` and the rate_limiter dep is on `middleware_test`, not `:aura` — and the sandbox claim above. Also `get()`'s "nothing here can throw" (the by-value `optional<Value>` copies the payload; the conclusion survives because it throws after the relink), "the `service_name` label on every instrument this service emits" (portrait's others are bare), and a README line claiming the shared_mutex lets reads run concurrently directly above a table showing `get()` takes a unique lock.

## Verification

| | |
|---|---|
| futility, aura, portrait, prom_proxy, golf_hub | 30/30 |
| `bazel build --nobuild //...` | analyses clean |
| `//:buildifier_test`, `scripts/format-all` | green |
| `gazelle --mode=diff` | clean for every package touched |
| Mutation testing | 13 re-run after the panel, all killed — including the three that survived the first time |

**Known coverage gap:** the evict-ordering defect cannot be distinguished by a test without a sanitizer — the buggy and fixed orders both end at `capacity+1` externally, and the difference is a use-after-free. `.bazelrc` configures no ASAN, so the evidence for that one finding is the panel's sanitizer run, not CI. The committed test pins the recovery shape instead, and says so.

`gofmt` and `gazelle` report pre-existing findings elsewhere in the repo; the files in this diff are clean.
