### PR TITLE
Run the C++ suites under ASan, UBSan and TSan, and fix the first two things they found

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -74,6 +74,56 @@ common --test_output=errors
 # don't block on remote-cache uploads
 common --bes_upload_mode=fully_async
 
+# Sanitizers (#1273). Off by default and never implied by another config:
+# they change codegen, and a sanitized binary is not what we ship.
+#
+# The point of these is the class of bug whose symptom is undefined behavior
+# rather than a wrong answer, which no assertion can see. #1272 shipped a
+# use-after-free fix whose test could only pin the recovery shape, because
+# the buggy and correct orderings are indistinguishable from outside.
+#
+# compilation_mode=dbg deliberately overrides the repo-wide opt above: a
+# report whose stack has been inlined away names the wrong function, which
+# is the difference between a lead and a shrug.
+build:sanitizer --compilation_mode=dbg
+build:sanitizer --strip=never
+build:sanitizer --copt=-g
+build:sanitizer --copt=-fno-omit-frame-pointer
+build:sanitizer --copt=-fno-optimize-sibling-calls
+# Sanitized runs are slow enough to trip the default small/medium timeouts
+# on tests that pass comfortably under opt.
+build:sanitizer --test_timeout=120,600,1800,3600
+# Targets with a known finding that has an issue and no fix yet. Each one
+# carries the issue number at its tags= line; removing the tag is that
+# issue's acceptance test. Pass --test_tag_filters= to see them anyway.
+test:sanitizer --test_tag_filters=-no-sanitize
+
+build:asan --config=sanitizer
+build:asan --copt=-fsanitize=address
+build:asan --linkopt=-fsanitize=address
+test:asan --test_env=ASAN_OPTIONS=detect_stack_use_after_return=1:strict_string_checks=1
+
+build:ubsan --config=sanitizer
+build:ubsan --copt=-fsanitize=undefined
+build:ubsan --linkopt=-fsanitize=undefined
+# Everything except the vptr check, which is the one UBSan check that needs
+# the C++-specific runtime (libclang_rt.ubsan_standalone_cxx). The toolchain
+# links through clang rather than clang++, so leaving it on fails at link
+# with undefined __ubsan_vptr_type_cache rather than finding anything. The
+# checks that carry the weight here — signed overflow, shifts, alignment,
+# null deref, bogus bool/enum loads, float casts — are all still on.
+build:ubsan --copt=-fno-sanitize=vptr
+build:ubsan --linkopt=-fno-sanitize=vptr
+# UBSan diagnoses and keeps going by default, so a finding scrolls past
+# inside a test that still reports green. Make it fatal.
+build:ubsan --copt=-fno-sanitize-recover=all
+test:ubsan --test_env=UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
+
+build:tsan --config=sanitizer
+build:tsan --copt=-fsanitize=thread
+build:tsan --linkopt=-fsanitize=thread
+test:tsan --test_env=TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1
+
 # Platform-specific configurations
 build:macos --features=-module_maps
 

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -168,12 +168,22 @@ jobs:
   # Beast, opentelemetry-cpp and Postgres targets do build and pass under
   # ASan; they just add a full instrumented -c dbg rebuild of boost and otel
   # to a runner that has to free disk before it can build at all. Widening
-  # this, and adding the tsan config that already exists in .bazelrc, are
-  # runner-budget calls rather than technical ones.
+  # that is a runner-budget call rather than a technical one.
+  #
+  # A matrix rather than three steps in one job, for two reasons. The three
+  # configs share no build output — each is a distinct object tree, so
+  # sequential steps would serialize three full builds for nothing — and
+  # fail-fast is off so one sanitizer's finding does not hide the other two.
+  # ASan and TSan are mutually exclusive at link time anyway.
   sanitize:
+    name: sanitize (${{ matrix.sanitizer }})
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/muchq/moonbase/ci-base:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [asan, ubsan, tsan]
 
     steps:
       - uses: actions/checkout@v7
@@ -190,10 +200,11 @@ jobs:
       - uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
-          # Its own disk-cache key: these are -c dbg and instrumented, so
-          # sharing build-and-test's cache would evict the opt artifacts that
-          # job depends on for every one of these it stores.
-          disk-cache: ${{ github.workflow }}-sanitize
+          # A key per sanitizer. Separate from build-and-test's because these
+          # are -c dbg and instrumented, and separate from each other's
+          # because the three configs share no object tree — one key would
+          # just have them evicting each other on every run.
+          disk-cache: ${{ github.workflow }}-sanitize-${{ matrix.sanitizer }}
           repository-cache: true
           bazelrc: |
             build --local_resources=cpu=4
@@ -215,11 +226,8 @@ jobs:
           echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
           echo "Sanitizing: $TARGETS"
 
-      - name: AddressSanitizer
-        run: bazel test --config=asan ${{ steps.targets.outputs.targets }}
-
-      - name: UndefinedBehaviorSanitizer
-        run: bazel test --config=ubsan ${{ steps.targets.outputs.targets }}
+      - name: Test under ${{ matrix.sanitizer }}
+        run: bazel test --config=${{ matrix.sanitizer }} ${{ steps.targets.outputs.targets }}
 
   # Metal GPU training requires macOS; run microgpt tests on Apple Silicon when relevant files change.
   test-microgpt-metal:

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -153,6 +153,74 @@ jobs:
         run: |
           ./scripts/diff-build origin/main
 
+  # Sanitizers (#1273). The class of bug these catch — use-after-free, leaks,
+  # signed overflow — has no symptom an assertion can see, so before this job
+  # existed CI was blind to all of it. #1272 shipped a use-after-free fix
+  # whose test could only pin the recovery shape, and #1274 was a leak on
+  # portrait's render path that 22 green tests walked straight past.
+  #
+  # Its own job rather than more flags on build-and-test: that one is already
+  # the long pole, and a sanitized build is a separate configuration with its
+  # own object tree, not an extra flag on an existing one.
+  #
+  # Scope is the first-party C++ tests whose dependency closure is also
+  # first-party. That is a build-cost line, not a compatibility one — the
+  # Beast, opentelemetry-cpp and Postgres targets do build and pass under
+  # ASan; they just add a full instrumented -c dbg rebuild of boost and otel
+  # to a runner that has to free disk before it can build at all. Widening
+  # this, and adding the tsan config that already exists in .bazelrc, are
+  # runner-budget calls rather than technical ones.
+  sanitize:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/muchq/moonbase/ci-base:latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Free up disk space
+        run: |
+          df -h
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+          rm -rf "/usr/local/share/boost"
+          rm -rf "$AGENT_TOOLSDIRECTORY"
+          df -h
+
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          # Its own disk-cache key: these are -c dbg and instrumented, so
+          # sharing build-and-test's cache would evict the opt artifacts that
+          # job depends on for every one of these it stores.
+          disk-cache: ${{ github.workflow }}-sanitize
+          repository-cache: true
+          bazelrc: |
+            build --local_resources=cpu=4
+            build --local_resources=memory=12288
+
+      - name: Resolve target set
+        id: targets
+        run: |
+          TARGETS=$(bazel query 'kind(cc_test, //domains/...) except (
+            //domains/games/apis/golf_hub/... union
+            //domains/platform/libs/pg/... union
+            //domains/platform/libs/aura/... union
+            //domains/platform/libs/futility/otel/... union
+            //domains/graphics/apis/portrait/...)' | tr '\n' ' ')
+          if [ -z "$TARGETS" ]; then
+            echo "target query matched nothing; refusing to report a vacuous pass"
+            exit 1
+          fi
+          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
+          echo "Sanitizing: $TARGETS"
+
+      - name: AddressSanitizer
+        run: bazel test --config=asan ${{ steps.targets.outputs.targets }}
+
+      - name: UndefinedBehaviorSanitizer
+        run: bazel test --config=ubsan ${{ steps.targets.outputs.targets }}
+
   # Metal GPU training requires macOS; run microgpt tests on Apple Silicon when relevant files change.
   test-microgpt-metal:
     runs-on: macos-26

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,9 +80,11 @@ suite reported green on:
   never ran (#1274). All 22 tests in that suite passed; the leak report came
   after them.
 
-The CI `sanitize` job runs ASan and UBSan over the first-party C++ tests whose
-dependency closure is also first-party — a build-cost boundary, not a
-compatibility one. Running a heavier target locally is just the flag above.
+The CI `sanitize` job runs all three, one matrix leg each, over the first-party
+C++ tests whose dependency closure is also first-party — a build-cost boundary,
+not a compatibility one. Running a heavier target locally is just the flag
+above. The legs don't fail fast, because one sanitizer's finding shouldn't hide
+the other two, and ASan and TSan can't be linked into the same binary anyway.
 
 When a finding has an issue but no fix yet, its target carries
 `tags = ["no-sanitize"]` with the issue number at the tag; the config filters

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -51,6 +51,43 @@ Two real examples from `prom_proxy`:
   and "keep the last row" gave the same answer. It passed against an
   implementation that had no dedup logic at all.
 
+## Some bugs have no wrong answer to assert on
+
+Mutation checking assumes the bug produces an observable difference. A whole
+class of C++ defect doesn't: use-after-free, leaks, signed overflow, misaligned
+access. The program is wrong and the assertions still pass — or it crashes
+somewhere unrelated and you go looking in the wrong file.
+
+```bash
+bazel test --config=asan  //some/cc:target   # use-after-free, leaks
+bazel test --config=ubsan //some/cc:target   # overflow, shifts, alignment
+bazel test --config=tsan  //some/cc:target   # data races
+```
+
+These override the repo-wide `-c opt` with `-c dbg`, because a report whose
+stack has been inlined away names the wrong function.
+
+Two findings from the day these configs landed, both of which the ordinary
+suite reported green on:
+
+- `LRUCache::insert` mutated its map before its commit point, so a throw out
+  of eviction left a map entry pointing into a freed list node (#1272). With
+  the fix reverted, the ordinary build **segfaults with no gtest verdict at
+  all**; ASan names it `heap-use-after-free` with both stacks, UBSan calls it
+  a misaligned access.
+- `png_plusplus` leaked the libpng struct on every failed encode, because its
+  error handler threw across libpng's C frames and the constructor's cleanup
+  never ran (#1274). All 22 tests in that suite passed; the leak report came
+  after them.
+
+The CI `sanitize` job runs ASan and UBSan over the first-party C++ tests whose
+dependency closure is also first-party — a build-cost boundary, not a
+compatibility one. Running a heavier target locally is just the flag above.
+
+When a finding has an issue but no fix yet, its target carries
+`tags = ["no-sanitize"]` with the issue number at the tag; the config filters
+those out, and removing the tag is that issue's acceptance test.
+
 ## Bazel `srcs` are explicit
 
 `BUILD.bazel` lists sources by name rather than globbing, and CI runs bazel

--- a/domains/graphics/libs/png_plusplus/png_plusplus.h
+++ b/domains/graphics/libs/png_plusplus/png_plusplus.h
@@ -21,6 +21,34 @@ class PngException : public std::runtime_error {
   explicit PngException(const std::string& msg) : std::runtime_error(msg) {}
 };
 
+namespace detail {
+
+/// Whatever libpng handed the error handler before jumping, or `fallback`
+/// when the jump arrived without a message.
+inline std::string ErrorText(const std::string& recorded, const char* fallback) {
+  return recorded.empty() ? std::string(fallback) : recorded;
+}
+
+}  // namespace detail
+
+// How errors get out of libpng, and why it looks like this (#1274).
+//
+// libpng is C. Its error handler is required not to return — it calls
+// abort() if one does — so the way back to C++ is the longjmp that
+// png_jmpbuf sets up. Throwing from the handler instead unwinds through
+// libpng's own frames, which are compiled without unwind tables: undefined
+// behavior, and it strands every allocation libpng was holding, including
+// the png struct the C++ object had not finished adopting yet.
+//
+// So the handlers below record the message and longjmp, and the exception
+// is thrown from the C++ side of the jump, where unwinding is defined.
+//
+// The second half of the rule matters just as much: longjmp runs no
+// destructors. Anything owning memory has to be constructed in a frame the
+// jump lands *below*, never between the setjmp and the libpng call that
+// might jump. That is why the row buffers are built by the caller and the
+// setjmp sits in a small helper holding nothing but a pointer.
+
 class PngWriter {
  public:
   PngWriter(const std::string& filename, int width, int height)
@@ -43,10 +71,13 @@ class PngWriter {
       throw PngException("Failed to create PNG info struct");
     }
 
-    // Set up error handling with setjmp
+    // Where errorHandler's longjmp lands. Nothing with a destructor is live
+    // in this frame, so the jump skips nothing.
     if (setjmp(png_jmpbuf(png_))) {
+      const std::string message =
+          detail::ErrorText(error_message_, "PNG error during initialization");
       cleanup();
-      throw PngException("PNG error during initialization");
+      throw PngException(message);
     }
 
     png_init_io(png_, file_);
@@ -99,10 +130,8 @@ class PngWriter {
       throw PngException("Image dimensions don't match writer dimensions");
     }
 
-    if (setjmp(png_jmpbuf(png_))) {
-      throw PngException("PNG error during write");
-    }
-
+    // Built before the jump target is armed, so they belong to this frame
+    // and are destroyed on the way out however writeRows leaves.
     std::vector<png_bytep> row_pointers(height_);
     std::vector<png_byte> row_data(width_ * 3 * height_);
 
@@ -115,8 +144,7 @@ class PngWriter {
       }
     }
 
-    png_write_image(png_, row_pointers.data());
-    png_write_end(png_, nullptr);
+    writeRows(row_pointers.data());
   }
 
   int getWidth() const { return width_; }
@@ -124,6 +152,18 @@ class PngWriter {
   const std::string& getFilename() const { return filename_; }
 
  private:
+  /// The only frame that calls libpng with a jump target armed. It holds
+  /// nothing but its argument on purpose: longjmp runs no destructors, so
+  /// anything owning memory has to live in the caller's frame instead.
+  void writeRows(png_bytep* rows) {
+    if (setjmp(png_jmpbuf(png_))) {
+      throw PngException(detail::ErrorText(error_message_, "PNG error during write"));
+    }
+
+    png_write_image(png_, rows);
+    png_write_end(png_, nullptr);
+  }
+
   void cleanup() {
     if (png_ || info_) {
       png_destroy_write_struct(png_ ? &png_ : nullptr, info_ ? &info_ : nullptr);
@@ -136,9 +176,15 @@ class PngWriter {
     }
   }
 
+  /// Records the message and jumps; never returns. libpng aborts the
+  /// process if an error handler returns, and throwing from here would
+  /// unwind through its C frames.
   static void errorHandler(png_structp png, png_const_charp msg) {
-    (void)png;  // Unused
-    throw PngException(std::string("PNG Error: ") + msg);
+    auto* self = static_cast<PngWriter*>(png_get_error_ptr(png));
+    if (self != nullptr) {
+      self->error_message_ = std::string("PNG Error: ") + (msg != nullptr ? msg : "unknown");
+    }
+    longjmp(png_jmpbuf(png), 1);
   }
 
   static void warningHandler(png_structp png, png_const_charp msg) {
@@ -153,6 +199,8 @@ class PngWriter {
   int width_;
   int height_;
   std::string filename_;
+  /// Written by errorHandler before it jumps, read on the far side.
+  std::string error_message_;
 };
 
 // Convenience function for simple image writing
@@ -266,10 +314,13 @@ class MemoryPngWriter {
       throw PngException("Failed to create PNG info struct");
     }
 
-    // Set up error handling with setjmp
+    // Where errorHandler's longjmp lands. Nothing with a destructor is live
+    // in this frame, so the jump skips nothing.
     if (setjmp(png_jmpbuf(png_))) {
+      const std::string message =
+          detail::ErrorText(error_message_, "PNG error during initialization");
       cleanup();
-      throw PngException("PNG error during initialization");
+      throw PngException(message);
     }
 
     png_set_write_fn(png_, this, &MemoryPngWriter::writeData, nullptr);
@@ -325,10 +376,8 @@ class MemoryPngWriter {
       throw PngException("Image dimensions don't match writer dimensions");
     }
 
-    if (setjmp(png_jmpbuf(png_))) {
-      throw PngException("PNG error during write");
-    }
-
+    // Built before the jump target is armed, so they belong to this frame
+    // and are destroyed on the way out however writeRows leaves.
     std::vector<png_bytep> row_pointers(height_);
     std::vector<png_byte> row_data(width_ * 3 * height_);
 
@@ -341,8 +390,7 @@ class MemoryPngWriter {
       }
     }
 
-    png_write_image(png_, row_pointers.data());
-    png_write_end(png_, nullptr);
+    writeRows(row_pointers.data());
   }
 
   const std::vector<unsigned char>& getBuffer() const { return buffer_; }
@@ -365,14 +413,32 @@ class MemoryPngWriter {
     writer->buffer_.insert(writer->buffer_.end(), data, data + length);
   }
 
+  /// Records the message and jumps; never returns. libpng aborts the
+  /// process if an error handler returns, and throwing from here would
+  /// unwind through its C frames.
   static void errorHandler(png_structp png, png_const_charp msg) {
-    (void)png;  // Unused
-    throw PngException(std::string("PNG Error: ") + msg);
+    auto* self = static_cast<MemoryPngWriter*>(png_get_error_ptr(png));
+    if (self != nullptr) {
+      self->error_message_ = std::string("PNG Error: ") + (msg != nullptr ? msg : "unknown");
+    }
+    longjmp(png_jmpbuf(png), 1);
   }
 
   static void warningHandler(png_structp png, png_const_charp msg) {
     (void)png;  // Unused
     (void)msg;  // Could log warnings here if desired
+  }
+
+  /// The only frame that calls libpng with a jump target armed. It holds
+  /// nothing but its argument on purpose: longjmp runs no destructors, so
+  /// anything owning memory has to live in the caller's frame instead.
+  void writeRows(png_bytep* rows) {
+    if (setjmp(png_jmpbuf(png_))) {
+      throw PngException(detail::ErrorText(error_message_, "PNG error during write"));
+    }
+
+    png_write_image(png_, rows);
+    png_write_end(png_, nullptr);
   }
 
   png_structp png_ = nullptr;
@@ -381,6 +447,8 @@ class MemoryPngWriter {
   int height_;
   int compression_level_;
   std::vector<unsigned char> buffer_;
+  /// Written by errorHandler before it jumps, read on the far side.
+  std::string error_message_;
 };
 
 // Memory-based PNG reader for reading from in-memory buffers

--- a/domains/graphics/libs/png_plusplus/png_plusplus_test.cc
+++ b/domains/graphics/libs/png_plusplus/png_plusplus_test.cc
@@ -577,6 +577,27 @@ TEST_F(PngPlusPlusTest, EmptyImageHandling) {
       PngException);
 }
 
+// Errors leave libpng by longjmp now, not by throwing across its C frames
+// (#1274), so the diagnostic has to survive that trip: the handler records
+// it on the far side of a jump that runs no destructors and copies nothing.
+// Get that wrong and the caller still sees a PngException — just the generic
+// fallback, with libpng's actual objection gone. The tests above assert only
+// that *something* throws, so nothing else would notice.
+TEST_F(PngPlusPlusTest, LibpngsOwnMessageSurvivesTheJump) {
+  image_core::Image<image_core::RGB_Double> empty_image(0, 0);
+
+  try {
+    imageToPng(empty_image);
+    FAIL() << "expected imageToPng to throw";
+  } catch (const PngException& e) {
+    const std::string message = e.what();
+    EXPECT_NE(message.find("PNG Error: "), std::string::npos)
+        << "the recorded message never reached the caller: " << message;
+    EXPECT_EQ(message.find("PNG error during initialization"), std::string::npos)
+        << "fell back to the generic text, so nothing was recorded: " << message;
+  }
+}
+
 TEST_F(PngPlusPlusTest, InvalidPngBufferHandling) {
   // Test with invalid PNG data
   std::vector<unsigned char> invalid_buffer = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};

--- a/domains/platform/libs/futility/cache/lru_cache_test.cc
+++ b/domains/platform/libs/futility/cache/lru_cache_test.cc
@@ -435,6 +435,15 @@ TEST(LRUCacheExceptionSafety, AThrowWhileEvictingLeavesTheCacheUsable) {
   // and the eviction path would never have been reached.
   EXPECT_TRUE(cache.contains(ProbeKey(3))) << "the insert never reached the eviction";
 
+  // Reading it back is the assertion that needs a sanitizer to mean
+  // anything. contains() only looks in the map; get() follows the stored
+  // iterator into the recency list, which is the pointer the older
+  // evict-before-commit ordering left dangling. Under --config=asan this
+  // line is a heap-use-after-free against that ordering; in an ordinary
+  // build it quietly returns the right answer anyway, which is exactly why
+  // #1273 exists.
+  EXPECT_EQ(cache.get(ProbeKey(3)), 30);
+
   // The skipped eviction is not made up later — each subsequent insert still
   // evicts exactly one — so the cache runs one over capacity from here on.
   // That is the deliberate trade: draining the overshoot would mean looping


### PR DESCRIPTION
Closes #1273. Closes #1274.

MoonBase configured no sanitizer anywhere, so a whole class of C++ defect was invisible to CI — the ones whose symptom is undefined behavior rather than a wrong answer. Mutation checking can't reach them: it assumes the bug produces an observable difference, and these produce a crash somewhere unrelated, or nothing.

## The configs

`--config=asan`, `--config=ubsan`, `--config=tsan` in `.bazelrc`, none implied by anything else. All three override the repo-wide `-c opt` with `-c dbg` — a report whose stack has been inlined away names the wrong function.

Two flags worth explaining rather than just reading:

- **`-fno-sanitize-recover=all`** on UBSan. It diagnoses and keeps going by default, so a finding would scroll past inside a test that still reports green.
- **`-fno-sanitize=vptr`**, the one check needing `libclang_rt.ubsan_standalone_cxx`. The toolchain links through `clang`, not `clang++`, so leaving it on fails at link with undefined `__ubsan_vptr_type_cache` rather than finding anything. Everything that carries the weight — signed overflow, shifts, alignment, null deref, bogus bool/enum loads, float casts — is still on.

## The CI job

Its own job, not more flags on `build-and-test`: that one is already the long pole, and a sanitized build is a separate configuration with its own object tree. Its own disk-cache keys too — these artifacts are `-c dbg` and instrumented, so sharing would evict the opt ones `build-and-test` depends on.

**All three sanitizers run, as a matrix.** The configs share no build output, so sequential steps would serialize three full builds for no reuse; ASan and TSan can't be linked into the same binary regardless. `fail-fast` is off so one sanitizer's finding doesn't hide the other two, and each leg reports its own pass/fail. Disk cache is keyed per sanitizer so the legs don't evict each other.

**Scope is a build-cost line, not a compatibility one**, and I measured it both ways rather than assuming. The light set (first-party tests whose closure is also first-party) is 16 targets: ~110s under UBSan, 137s under TSan. golf_hub's race tests and portrait's suite *also* build and pass under ASan — they just add a full instrumented rebuild of boost and opentelemetry-cpp. My first attempt at the full set reported `FAILED TO BUILD`, which turned out to be **this sandbox running out of disk**, not the sanitizer. Worth chasing down before it became a false rationale in a comment.

## What it found in its first two minutes: #1274

`png_plusplus`'s error handler threw a C++ exception from inside libpng's C frames. libpng requires that handler not to return and provides `longjmp` for the purpose; throwing instead unwinds frames compiled without unwind tables and strands everything libpng held. `MemoryPngWriter`'s constructor allocates the png struct then throws before finishing, so the destructor never runs and `cleanup()` never happens.

**All 22 tests in that suite pass.** The leak report arrives after them. And it's on portrait's render path — `TracerService::trace` catches `PngException` out of `imageToPng`, and that catch is load-bearing (#1267, #1271), so every render failing inside libpng took this path.

Both writers now record the message and `longjmp`, throwing from the C++ side of the jump where unwinding is defined.

**The second half wasn't in the issue and is subtler:** `longjmp` runs no destructors. `writeImage` built its row buffers *after* the `setjmp`, so a jump out of `png_write_image` skipped those too. Buffers are now built by the caller, with the `setjmp` in a small `writeRows` helper holding nothing but a pointer — the jump lands *below* the owning frame instead of past it.

`LibpngsOwnMessageSurvivesTheJump` pins that libpng's diagnostic still reaches the caller. Nothing else would notice it going missing: the existing tests assert only that *something* throws, so a handler that recorded nothing would hand back the generic fallback and stay green.

The two *readers* are untouched. They pass `nullptr` for the error function, so they use libpng's default handler and never had this bug. They do share the destructor-skip hazard, but only on a read failure after the row buffers are allocated, and fixing it properly needs RAII around the raw `png_structp`/`FILE*` — a separate change.

## And the one that motivated #1273

`AThrowWhileEvictingLeavesTheCacheUsable` gained the assertion it couldn't carry before. `contains()` only looks in the map; `get()` follows the stored iterator into the recency list — the pointer the pre-#1272 ordering left dangling. Against that ordering:

| Build | Result |
|---|---|
| ordinary | **segfault, no gtest verdict, no diagnosis** (5 runs, 5 crashes) |
| `--config=asan` | `heap-use-after-free`, both stacks |
| `--config=ubsan` | member access within misaligned address |
| `--config=tsan` | `heap-use-after-free` |

Note the first row, because it corrects something I wrote in #1272's description: the new assertion makes the bug *detectable* without a sanitizer, just only as a mystery crash. What the sanitizers add is the **diagnosis** — plus the cases where UB doesn't happen to crash at all.

## Verification

| | |
|---|---|
| 16 first-party targets — ASan, UBSan, TSan | green on all three |
| png_plusplus, portrait, futility, aura — ordinary build | 16/16 |
| golf_hub race tests under ASan | pass (built locally, out of CI scope for cost) |
| `//:buildifier_test`, `scripts/format-all` | green |
| `branch.yml` | parses; matrix expands to asan/ubsan/tsan, `fail-fast: false` |
| Mutation testing | png fix killed 3 ways — reverting `longjmp` to a throw dies under ASan; clearing the recorded message or hardcoding the fallback both die in the ordinary build |

The job fails loudly if the target query matches nothing, so a mis-edited query reports a build error rather than a vacuous pass.

**The review panel did not run on this change.**
