### PR TITLE
Make the live index-request slot exclusive, reclaimable, and bounded

### DIFF
--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -49,9 +49,14 @@ better question, because:
   did. (It would also be worse UX — a request silently disappearing is a poorer
   answer than one labelled "Pruned" — so the signal survives the challenge. But
   that conclusion had to be *reached*, not assumed.)
-- The table has no lifecycle at all. It grows forever, and `listRecent(50)`
-  hides that from the UI, so nothing will ever surface it as a symptom. The
-  feature request pointed straight at a gap that the feature does not close.
+- The table had no lifecycle at all. It grew forever, and `listRecent(50)`
+  hid that from the UI, so nothing would ever have surfaced it as a symptom.
+  The feature request pointed straight at a gap that the feature did not close.
+
+That gap became #1266 and was closed in #1277, which gave the table a 30-day
+window against the data's 7 — long enough that the availability signal above
+still has something to report from, which is the conclusion this example says
+had to be reached rather than assumed.
 
 Raise the alternative in a sentence or two, give a recommendation, and proceed
 — don't stall. If the alternative turns out to be the better design, that is a

--- a/domains/games/apis/mcpserver/README.md
+++ b/domains/games/apis/mcpserver/README.md
@@ -257,7 +257,9 @@ The indexer engine, database, and worker are embedded in this process (Option A 
 - `index_chess_games` — index a player's games. Required: `username`, `platform`
   (`chess.com`), `start_month`/`end_month` (YYYY-MM). Optional: `exclude_bullet`, and
   `skip_cache` to refetch already-indexed months (refreshing stored rows, e.g. backfilling
-  titles/opening names on rows indexed before those columns existed). Single-month requests
+  titles/opening names on rows indexed before those columns existed) — though it returns the
+  in-flight request without refetching if one is already running for the same range.
+  Single-month requests
   complete synchronously; longer ranges return `PENDING` and run in the background.
 - `index_status` — poll an indexing request by `request_id`.
 - `query_chess_games` — ChessQL search over indexed games: `query`, optional `player` (resolves

--- a/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/McpModule.java
+++ b/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/McpModule.java
@@ -99,8 +99,8 @@ public class McpModule {
   }
 
   @Context
-  public IndexingRequestStore indexingRequestStore(Jdbi jdbi) {
-    return new IndexingRequestDao(jdbi);
+  public IndexingRequestStore indexingRequestStore(Jdbi jdbi, Clock clock) {
+    return new IndexingRequestDao(jdbi, clock);
   }
 
   @Context
@@ -194,8 +194,9 @@ public class McpModule {
       IndexingRequestStore requestStore,
       IndexQueue queue,
       IndexWorker worker,
-      DataAvailabilityResolver dataAvailability) {
-    return new IndexRequestService(requestStore, queue, worker::process, dataAvailability);
+      DataAvailabilityResolver dataAvailability,
+      Clock clock) {
+    return new IndexRequestService(requestStore, queue, worker::process, dataAvailability, clock);
   }
 
   @Context

--- a/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/tools/IndexGamesTool.java
+++ b/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/tools/IndexGamesTool.java
@@ -62,7 +62,10 @@ public class IndexGamesTool implements McpTool {
             "description",
             "Refetch every month in the range even if it was already indexed, refreshing stored"
                 + " rows (e.g. to backfill titles and opening names on games indexed before those"
-                + " columns existed). Default false"));
+                + " columns existed). Does not start a second run of a range that is already"
+                + " being indexed: if a request for the same player and months is still"
+                + " PENDING/PROCESSING, that request is returned and nothing is refetched, so"
+                + " wait for it to finish and submit again. Default false"));
     return Map.of(
         "type",
         "object",

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -380,6 +380,7 @@ java_test_suite(
     srcs = [
         "src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java",
         "src/test/java/com/muchq/games/one_d4/worker/OpeningsTest.java",
+        "src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java",
         "src/test/java/com/muchq/games/one_d4/worker/ResultMapperTest.java",
         "src/test/java/com/muchq/games/one_d4/worker/RetentionWorkerTest.java",
     ],

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -511,6 +511,26 @@ java_test_suite(
     ],
 )
 
+# The same hazard on indexing_requests, and a sharper one: staleness is measured
+# over a one-hour window, so a zone leak does not move the boundary, it inverts
+# the predicate — retiring every healthy request or ignoring every strand. Its
+# own target for the same reason as above: the zone has to come from the
+# environment or H2's cached default makes the suite vacuous.
+java_test_suite(
+    name = "request_staleness_timezone_tests",
+    size = "small",
+    srcs = [
+        "src/test/java/com/muchq/games/one_d4/db/RequestStalenessTimeZoneTest.java",
+    ],
+    env = {"TZ": "Pacific/Kiritimati"},
+    deps = [
+        ":db",
+        ":test_db",
+        artifact("org.junit.jupiter:junit-jupiter-api"),
+        artifact("org.assertj:assertj-core"),
+    ],
+)
+
 # Every other DAO suite runs on H2, but Postgres is the deployment target and
 # the aggregate SQL uses two constructs the dialects can disagree on: GROUP BY
 # referencing a SELECT-list alias, and timestamp binds against a

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -309,7 +309,7 @@ On the deployed machine the indexer uses H2 file storage at `/data/indexer` insi
 
 ### Via the API (no direct DB access)
 
-- **Index requests:** `GET http://localhost:8088/v1/index/{id}` — returns `id`, `status`, `gamesIndexed`, `errorMessage` for that request. There is no list-all-requests endpoint; you need the request UUID.
+- **Index requests:** `GET http://localhost:8088/v1/index/{id}` — returns `id`, `status`, `gamesIndexed`, `errorMessage` and a `data` block for that request. `GET http://localhost:8088/v1/index` lists the 50 most recent, newest first, so you do not need the UUID to look around.
 - **Query games:** `POST http://localhost:8088/v1/query` with a ChessQL query (e.g. `white_username = "drawlya"` or `black_username = "drawlya"`) and check the `playedAt` field in the results to see what date ranges are indexed.
 
 ### Direct H2 access (copy DB out)

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -52,7 +52,7 @@ flowchart TB
   end
 
   subgraph Retention["Retention"]
-    RetentionWorker["RetentionWorker\n@Scheduled 1h\n(7-day policy)"]
+    RetentionWorker["RetentionWorker\n@Scheduled 1h\n(7d data / 30d requests)"]
   end
 
   subgraph Store["Stores & DB"]
@@ -97,13 +97,14 @@ flowchart TB
 
   RetentionWorker --> GameStore
   RetentionWorker --> PeriodStore
+  RetentionWorker --> RequestStore
 ```
 
 **Index flow:** Client posts to `POST /v1/index` → request is stored and a message is enqueued. A background thread (IndexWorkerLifecycle) polls the queue; IndexWorker fetches games from Chess.com per month (skipping months already in IndexedPeriodStore), runs FeatureExtractor (PgnParser → GameReplayer → MotifDetectors) on each game, and writes to GameFeatureStore (game_features + motif_occurrences) and IndexedPeriodStore. Fork occurrences are derived inside FeatureExtractor from ATTACK occurrences (same ply + attacker targeting 2+ pieces).
 
 **Query flow:** Client posts a ChessQL string to `POST /v1/query` → Parser and SqlCompiler produce SQL → GameFeatureStore runs the query and loads motif_occurrences for the result set → response returns GameFeatureRow list with per-game occurrences.
 
-**Retention:** RetentionWorker runs hourly and deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days.
+**Retention:** RetentionWorker runs hourly. It deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days, and indexing_requests older than 30 days — games first, so a request and its games clear in one pass. It also retires requests stranded in PENDING/PROCESSING for over an hour, freeing the dedupe slot each one holds.
 
 ## Running Locally (in-memory)
 
@@ -235,7 +236,23 @@ curl -X POST http://localhost:8080/v1/query \
 
 ### Data Retention Policy
 
-The indexer maintains a **7-day retention policy**. Games are automatically deleted 7 days after they are indexed (based on the `indexed_at` timestamp). This policy is enforced by a background worker that runs hourly.
+Two windows, both enforced by a background worker that runs hourly:
+
+| What | Window | Measured from |
+|---|---|---|
+| `game_features` (and `motif_occurrences` via FK cascade), `indexed_periods` | **7 days** | `indexed_at` / `fetched_at` |
+| `indexing_requests` | **30 days** | `created_at` |
+
+Requests outlive their games on purpose. `game_features.request_id` is a foreign key onto
+`indexing_requests(id)`, so a request cannot be deleted while its games remain — and in the gap
+between the two windows the surviving row is what lets `GET /v1/index/{id}` report `EXPIRED`
+("pruned — re-run it") rather than 404. The sweep deletes games before requests so both clear in
+one pass, and skips any request still referenced by a game.
+
+Separately, a PENDING or PROCESSING request whose owner died — a restart with work still queued,
+or an inline dispatch that threw — is retired to FAILED after **1 hour** without progress. Until
+it is, it holds the dedupe slot for its (player, platform, month range), and no new request for
+that range can be created.
 
 ### Available Fields
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
@@ -134,8 +134,8 @@ public class IndexerModule {
   }
 
   @Context
-  public IndexingRequestStore indexingRequestStore(Jdbi jdbi) {
-    return new IndexingRequestDao(jdbi);
+  public IndexingRequestStore indexingRequestStore(Jdbi jdbi, Clock clock) {
+    return new IndexingRequestDao(jdbi, clock);
   }
 
   @Context
@@ -163,8 +163,9 @@ public class IndexerModule {
       IndexingRequestStore requestStore,
       IndexQueue queue,
       IndexWorker worker,
-      DataAvailabilityResolver dataAvailability) {
-    return new IndexRequestService(requestStore, queue, worker::process, dataAvailability);
+      DataAvailabilityResolver dataAvailability,
+      Clock clock) {
+    return new IndexRequestService(requestStore, queue, worker::process, dataAvailability, clock);
   }
 
   @Context

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -1,5 +1,9 @@
 package com.muchq.games.one_d4.db;
 
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -10,6 +14,18 @@ import org.slf4j.LoggerFactory;
 
 public class IndexingRequestDao implements IndexingRequestStore {
   private static final Logger LOG = LoggerFactory.getLogger(IndexingRequestDao.class);
+
+  /**
+   * How many times {@link #createOrAdopt} may lose the race before giving up. A loser normally
+   * adopts on its next pass; it only goes round again if the winner reached a terminal status in
+   * the gap, which frees the key and makes inserting correct again. Bounded because unbounded retry
+   * on a permanently unsatisfiable condition is a hang, not a fix.
+   */
+  private static final int MAX_CLAIM_ATTEMPTS = 5;
+
+  private static final String STRANDED_MESSAGE =
+      "Abandoned: no worker took ownership before the staleness cutoff (orphaned by restart or a"
+          + " failed inline dispatch). Re-submit to try again.";
 
   private static final RowMapper<IndexingRequest> ROW_MAPPER =
       (rs, ctx) ->
@@ -32,25 +48,176 @@ public class IndexingRequestDao implements IndexingRequestStore {
     this.jdbi = jdbi;
   }
 
-  @Override
-  public UUID create(
+  /**
+   * The value stored in {@code dedupe_key} while a request is live. Must render identically to the
+   * SQL backfill in {@link Migration}, or a row migrated from the pre-constraint schema would not
+   * be found by a Java-side lookup.
+   *
+   * <p>Player goes last on purpose. It is the only free-form component — platform is validated
+   * against a closed set, the months are {@code YearMonth}-parsed, and the flag is a boolean — so
+   * putting it at the tail makes the encoding unambiguous without escaping the delimiter, whatever
+   * a username happens to contain.
+   */
+  static String dedupeKey(
       String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
+    return platform + "|" + startMonth + "|" + endMonth + "|" + excludeBullet + "|" + player;
+  }
+
+  @Override
+  public Claim createOrAdopt(
+      String player,
+      String platform,
+      String startMonth,
+      String endMonth,
+      boolean excludeBullet,
+      Duration staleAfter,
+      Instant now) {
+    String key = dedupeKey(player, platform, startMonth, endMonth, excludeBullet);
+
+    // Retire an abandoned holder first, so a dead request cannot keep its replacement out. Without
+    // this the unique constraint would turn #1250's stranded row from "dedupe keeps answering with
+    // it" into "the database refuses the replacement" — the same lockout, enforced harder.
+    reclaimStaleForKey(key, staleAfter, now);
+
+    for (int attempt = 0; attempt < MAX_CLAIM_ATTEMPTS; attempt++) {
+      Optional<IndexingRequest> holder = findByDedupeKey(key);
+      if (holder.isPresent()) {
+        return new Claim(holder.get(), false);
+      }
+      // Each step is its own transaction rather than one enclosing it. On Postgres a constraint
+      // violation aborts the whole transaction, so an insert-then-recover inside a single one
+      // would need a savepoint; separate statements make the recovery path identical on both
+      // engines. The constraint, not the transaction boundary, is what makes this safe: exactly
+      // one racer's insert can succeed.
+      Optional<UUID> inserted =
+          tryInsert(key, player, platform, startMonth, endMonth, excludeBullet);
+      if (inserted.isPresent()) {
+        UUID id = inserted.get();
+        return new Claim(
+            findById(id)
+                .orElseThrow(
+                    () ->
+                        new IllegalStateException(
+                            "inserted request " + id + " vanished before it could be read back")),
+            true);
+      }
+      // Lost the race. Go round: normally the winner is there to adopt, but if it finished in the
+      // gap the key is free again and inserting is the right move.
+    }
+    throw new IllegalStateException(
+        "Could not claim or adopt an indexing request for "
+            + key
+            + " after "
+            + MAX_CLAIM_ATTEMPTS
+            + " attempts");
+  }
+
+  private Optional<UUID> tryInsert(
+      String dedupeKey,
+      String player,
+      String platform,
+      String startMonth,
+      String endMonth,
+      boolean excludeBullet) {
     UUID id = UUID.randomUUID();
-    jdbi.useHandle(
+    try {
+      jdbi.useHandle(
+          h ->
+              h.createUpdate(
+                      """
+                      INSERT INTO indexing_requests
+                        (id, player, platform, start_month, end_month, exclude_bullet, dedupe_key)
+                      VALUES (?, ?, ?, ?, ?, ?, ?)
+                      """)
+                  .bind(0, id)
+                  .bind(1, player)
+                  .bind(2, platform)
+                  .bind(3, startMonth)
+                  .bind(4, endMonth)
+                  .bind(5, excludeBullet)
+                  .bind(6, dedupeKey)
+                  .execute());
+      return Optional.of(id);
+    } catch (RuntimeException e) {
+      if (isUniqueViolation(e)) {
+        return Optional.empty();
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * True when the cause chain carries SQLState class 23 (integrity constraint violation). Matching
+   * on the class rather than the exact code keeps this working across both engines — Postgres and
+   * H2 both raise 23505 for a duplicate key, but only the class is guaranteed by the standard.
+   */
+  private static boolean isUniqueViolation(Throwable e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      if (t instanceof SQLException sqlException) {
+        String state = sqlException.getSQLState();
+        if (state != null && state.startsWith("23")) {
+          return true;
+        }
+      }
+      if (t.getCause() == t) {
+        break;
+      }
+    }
+    return false;
+  }
+
+  private Optional<IndexingRequest> findByDedupeKey(String dedupeKey) {
+    return jdbi.withHandle(
         h ->
-            h.createUpdate(
-                    """
-                    INSERT INTO indexing_requests (id, player, platform, start_month, end_month, exclude_bullet)
-                    VALUES (?, ?, ?, ?, ?, ?)
-                    """)
-                .bind(0, id)
-                .bind(1, player)
-                .bind(2, platform)
-                .bind(3, startMonth)
-                .bind(4, endMonth)
-                .bind(5, excludeBullet)
-                .execute());
-    return id;
+            h.createQuery("SELECT * FROM indexing_requests WHERE dedupe_key = ?")
+                .bind(0, dedupeKey)
+                .map(ROW_MAPPER)
+                .findFirst());
+  }
+
+  private int reclaimStaleForKey(String dedupeKey, Duration staleAfter, Instant now) {
+    return retire("dedupe_key = ?", dedupeKey, staleAfter, now);
+  }
+
+  @Override
+  public int reclaimStale(Duration staleAfter, Instant now) {
+    int reclaimed = retire(null, null, staleAfter, now);
+    if (reclaimed > 0) {
+      LOG.warn(
+          "Retired {} stranded indexing request(s) not updated since {}",
+          reclaimed,
+          now.minus(staleAfter));
+    }
+    return reclaimed;
+  }
+
+  /**
+   * Marks abandoned live requests FAILED and releases the dedupe slot each one holds. {@code
+   * extraPredicate} narrows the sweep to a single key when a submit is trying to reclaim its own
+   * tuple; null sweeps everything.
+   */
+  private int retire(String extraPredicate, String predicateArg, Duration staleAfter, Instant now) {
+    Timestamp cutoff = Timestamp.from(now.minus(staleAfter));
+    String sql =
+        """
+        UPDATE indexing_requests
+        SET status = 'FAILED', error_message = ?, dedupe_key = NULL, updated_at = ?
+        WHERE status IN ('PENDING', 'PROCESSING')
+          AND updated_at < ?
+        """
+            + (extraPredicate == null ? "" : "  AND " + extraPredicate + "\n");
+    return jdbi.withHandle(
+        h -> {
+          var update =
+              h.createUpdate(sql)
+                  .bind(0, STRANDED_MESSAGE)
+                  .bind(1, Timestamp.from(now))
+                  .bind(2, cutoff);
+          if (predicateArg != null) {
+            update.bind(3, predicateArg);
+          }
+          return update.execute();
+        });
   }
 
   @Override
@@ -65,7 +232,13 @@ public class IndexingRequestDao implements IndexingRequestStore {
 
   @Override
   public Optional<IndexingRequest> findExistingRequest(
-      String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
+      String player,
+      String platform,
+      String startMonth,
+      String endMonth,
+      boolean excludeBullet,
+      Duration staleAfter,
+      Instant now) {
     return jdbi.withHandle(
         h ->
             h.createQuery(
@@ -74,6 +247,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
                     WHERE player = ? AND platform = ? AND start_month = ? AND end_month = ?
                       AND exclude_bullet = ?
                       AND status IN ('PENDING', 'PROCESSING')
+                      AND updated_at >= ?
                     ORDER BY created_at ASC
                     LIMIT 1
                     """)
@@ -82,6 +256,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
                 .bind(2, startMonth)
                 .bind(3, endMonth)
                 .bind(4, excludeBullet)
+                .bind(5, Timestamp.from(now.minus(staleAfter)))
                 .map(ROW_MAPPER)
                 .findFirst());
   }
@@ -98,18 +273,52 @@ public class IndexingRequestDao implements IndexingRequestStore {
 
   @Override
   public void updateStatus(UUID id, String status, String errorMessage, int gamesIndexed) {
+    // A terminal status releases the dedupe slot: the same range becomes requestable again the
+    // moment the work stops being in flight. Leaving the key behind would make one COMPLETED
+    // request block that range permanently.
+    boolean terminal = !"PENDING".equals(status) && !"PROCESSING".equals(status);
+    String sql =
+        terminal
+            ? """
+            UPDATE indexing_requests
+            SET status = ?, error_message = ?, games_indexed = ?, updated_at = now(),
+                dedupe_key = NULL
+            WHERE id = ?
+            """
+            : """
+            UPDATE indexing_requests
+            SET status = ?, error_message = ?, games_indexed = ?, updated_at = now()
+            WHERE id = ?
+            """;
     jdbi.useHandle(
         h ->
-            h.createUpdate(
-                    """
-                    UPDATE indexing_requests
-                    SET status = ?, error_message = ?, games_indexed = ?, updated_at = now()
-                    WHERE id = ?
-                    """)
+            h.createUpdate(sql)
                 .bind(0, status)
                 .bind(1, errorMessage)
                 .bind(2, gamesIndexed)
                 .bind(3, id)
                 .execute());
+  }
+
+  @Override
+  public int deleteOlderThan(Instant threshold) {
+    return jdbi.withHandle(
+        h -> {
+          int deleted =
+              h.createUpdate(
+                      """
+                      DELETE FROM indexing_requests
+                      WHERE created_at < ?
+                        AND NOT EXISTS (
+                          SELECT 1 FROM game_features g
+                          WHERE g.request_id = indexing_requests.id)
+                      """)
+                  .bind(0, Timestamp.from(threshold))
+                  .execute();
+          if (deleted > 0) {
+            LOG.debug("Deleted {} indexing requests older than {}", deleted, threshold);
+          }
+          return deleted;
+        });
   }
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -1,9 +1,11 @@
 package com.muchq.games.one_d4.db;
 
 import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -43,9 +45,40 @@ public class IndexingRequestDao implements IndexingRequestStore {
               rs.getBoolean("exclude_bullet"));
 
   private final Jdbi jdbi;
+  private final Clock clock;
 
   public IndexingRequestDao(Jdbi jdbi) {
+    this(jdbi, Clock.systemUTC());
+  }
+
+  /**
+   * @param clock stamps {@code created_at} and {@code updated_at}. Every write goes through it and
+   *     every staleness comparison is made against it, so the table sits on one clock — see {@link
+   *     #toUtcWallClock}.
+   */
+  public IndexingRequestDao(Jdbi jdbi, Clock clock) {
     this.jdbi = jdbi;
+    this.clock = clock;
+  }
+
+  /**
+   * {@code created_at} and {@code updated_at} are TIMESTAMP WITHOUT TIME ZONE, so they hold a wall
+   * clock rather than an instant, and the convention here — as in {@link GameFeatureDao} — is that
+   * the stored wall clock is UTC. Both sides of every comparison are bound through this, so
+   * staleness is measured in one frame of reference.
+   *
+   * <p>This matters more here than it did for {@code game_features}. That column had the same split
+   * — written by the database's {@code now()}, compared against a JVM threshold — and it drifted
+   * with host skew and the server's timezone (#1268). Retention's window there is 7 days, so drift
+   * moved a boundary. {@link RetentionPolicy#STALE_REQUEST} is <em>one hour</em>, and three things
+   * reach that far: clock skew between the app host and the database host, which are different
+   * machines; the documented two-JVM deployment, where REST and MCP write and compare against one
+   * Postgres and a zone difference between them is a straight offset; and DST, where a local wall
+   * clock repeats or skips exactly one hour — exactly the window — so at a boundary the sweep would
+   * either ignore every strand or retire every healthy request. Pinning UTC removes all three.
+   */
+  private static LocalDateTime toUtcWallClock(Instant instant) {
+    return instant.atOffset(ZoneOffset.UTC).toLocalDateTime();
   }
 
   /**
@@ -79,6 +112,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
     // it" into "the database refuses the replacement" — the same lockout, enforced harder.
     reclaimStaleForKey(key, staleAfter, now);
 
+    RuntimeException lastConflict = null;
     for (int attempt = 0; attempt < MAX_CLAIM_ATTEMPTS; attempt++) {
       Optional<IndexingRequest> holder = findByDedupeKey(key);
       if (holder.isPresent()) {
@@ -89,10 +123,8 @@ public class IndexingRequestDao implements IndexingRequestStore {
       // would need a savepoint; separate statements make the recovery path identical on both
       // engines. The constraint, not the transaction boundary, is what makes this safe: exactly
       // one racer's insert can succeed.
-      Optional<UUID> inserted =
-          tryInsert(key, player, platform, startMonth, endMonth, excludeBullet);
-      if (inserted.isPresent()) {
-        UUID id = inserted.get();
+      try {
+        UUID id = insert(key, player, platform, startMonth, endMonth, excludeBullet);
         return new Claim(
             findById(id)
                 .orElseThrow(
@@ -100,19 +132,30 @@ public class IndexingRequestDao implements IndexingRequestStore {
                         new IllegalStateException(
                             "inserted request " + id + " vanished before it could be read back")),
             true);
+      } catch (RuntimeException e) {
+        if (!isUniqueViolation(e)) {
+          throw e;
+        }
+        // Lost the race. Go round: normally the winner is there to adopt, but if it finished in
+        // the gap the key is free again and inserting is the right move.
+        //
+        // Keep the exception. isUniqueViolation matches SQLState class 23 broadly, so a NOT NULL
+        // or check violation lands here too; without the cause, the throw below would blame
+        // contention for what is really a bad column value.
+        lastConflict = e;
       }
-      // Lost the race. Go round: normally the winner is there to adopt, but if it finished in the
-      // gap the key is free again and inserting is the right move.
     }
     throw new IllegalStateException(
         "Could not claim or adopt an indexing request for "
             + key
             + " after "
             + MAX_CLAIM_ATTEMPTS
-            + " attempts");
+            + " attempts",
+        lastConflict);
   }
 
-  private Optional<UUID> tryInsert(
+  /** Throws on conflict; {@link #createOrAdopt} decides whether that is recoverable. */
+  private UUID insert(
       String dedupeKey,
       String player,
       String platform,
@@ -120,30 +163,29 @@ public class IndexingRequestDao implements IndexingRequestStore {
       String endMonth,
       boolean excludeBullet) {
     UUID id = UUID.randomUUID();
-    try {
-      jdbi.useHandle(
-          h ->
-              h.createUpdate(
-                      """
-                      INSERT INTO indexing_requests
-                        (id, player, platform, start_month, end_month, exclude_bullet, dedupe_key)
-                      VALUES (?, ?, ?, ?, ?, ?, ?)
-                      """)
-                  .bind(0, id)
-                  .bind(1, player)
-                  .bind(2, platform)
-                  .bind(3, startMonth)
-                  .bind(4, endMonth)
-                  .bind(5, excludeBullet)
-                  .bind(6, dedupeKey)
-                  .execute());
-      return Optional.of(id);
-    } catch (RuntimeException e) {
-      if (isUniqueViolation(e)) {
-        return Optional.empty();
-      }
-      throw e;
-    }
+    // created_at/updated_at are stamped here rather than left to the column DEFAULT, so they come
+    // from the same clock the staleness predicates compare against.
+    LocalDateTime stamp = toUtcWallClock(clock.instant());
+    jdbi.useHandle(
+        h ->
+            h.createUpdate(
+                    """
+                    INSERT INTO indexing_requests
+                      (id, player, platform, start_month, end_month, exclude_bullet, dedupe_key,
+                       created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """)
+                .bind(0, id)
+                .bind(1, player)
+                .bind(2, platform)
+                .bind(3, startMonth)
+                .bind(4, endMonth)
+                .bind(5, excludeBullet)
+                .bind(6, dedupeKey)
+                .bindByType(7, stamp, LocalDateTime.class)
+                .bindByType(8, stamp, LocalDateTime.class)
+                .execute());
+    return id;
   }
 
   /**
@@ -176,12 +218,12 @@ public class IndexingRequestDao implements IndexingRequestStore {
   }
 
   private int reclaimStaleForKey(String dedupeKey, Duration staleAfter, Instant now) {
-    return retire("dedupe_key = ?", dedupeKey, staleAfter, now);
+    return retire(dedupeKey, staleAfter, now);
   }
 
   @Override
   public int reclaimStale(Duration staleAfter, Instant now) {
-    int reclaimed = retire(null, null, staleAfter, now);
+    int reclaimed = retire(null, staleAfter, now);
     if (reclaimed > 0) {
       LOG.warn(
           "Retired {} stranded indexing request(s) not updated since {}",
@@ -192,29 +234,30 @@ public class IndexingRequestDao implements IndexingRequestStore {
   }
 
   /**
-   * Marks abandoned live requests FAILED and releases the dedupe slot each one holds. {@code
-   * extraPredicate} narrows the sweep to a single key when a submit is trying to reclaim its own
-   * tuple; null sweeps everything.
+   * Marks abandoned live requests FAILED and releases the dedupe slot each one holds. Named
+   * parameters rather than positional ones, and two call sites rather than one with a conditional
+   * predicate: the sweep and the single-key reclaim differ only by one clause, and building that
+   * clause by concatenation meant the caller had to keep a {@code bind(3, ...)} in step with it.
    */
-  private int retire(String extraPredicate, String predicateArg, Duration staleAfter, Instant now) {
-    Timestamp cutoff = Timestamp.from(now.minus(staleAfter));
-    String sql =
-        """
-        UPDATE indexing_requests
-        SET status = 'FAILED', error_message = ?, dedupe_key = NULL, updated_at = ?
-        WHERE status IN ('PENDING', 'PROCESSING')
-          AND updated_at < ?
-        """
-            + (extraPredicate == null ? "" : "  AND " + extraPredicate + "\n");
+  private static final String RETIRE_SQL =
+      """
+      UPDATE indexing_requests
+      SET status = 'FAILED', error_message = :message, dedupe_key = NULL, updated_at = :now
+      WHERE status IN ('PENDING', 'PROCESSING')
+        AND updated_at < :cutoff
+      """;
+
+  private int retire(String keyOrNull, Duration staleAfter, Instant now) {
+    String sql = keyOrNull == null ? RETIRE_SQL : RETIRE_SQL + "  AND dedupe_key = :key\n";
     return jdbi.withHandle(
         h -> {
           var update =
               h.createUpdate(sql)
-                  .bind(0, STRANDED_MESSAGE)
-                  .bind(1, Timestamp.from(now))
-                  .bind(2, cutoff);
-          if (predicateArg != null) {
-            update.bind(3, predicateArg);
+                  .bind("message", STRANDED_MESSAGE)
+                  .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
+                  .bindByType("cutoff", toUtcWallClock(now.minus(staleAfter)), LocalDateTime.class);
+          if (keyOrNull != null) {
+            update.bind("key", keyOrNull);
           }
           return update.execute();
         });
@@ -256,7 +299,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
                 .bind(2, startMonth)
                 .bind(3, endMonth)
                 .bind(4, excludeBullet)
-                .bind(5, Timestamp.from(now.minus(staleAfter)))
+                .bindByType(5, toUtcWallClock(now.minus(staleAfter)), LocalDateTime.class)
                 .map(ROW_MAPPER)
                 .findFirst());
   }
@@ -281,23 +324,46 @@ public class IndexingRequestDao implements IndexingRequestStore {
         terminal
             ? """
             UPDATE indexing_requests
-            SET status = ?, error_message = ?, games_indexed = ?, updated_at = now(),
+            SET status = ?, error_message = ?, games_indexed = ?, updated_at = ?,
                 dedupe_key = NULL
             WHERE id = ?
             """
+            // A non-terminal write may only move a row that is still live. Without the status
+            // guard a retired request can be resurrected: reclaimStale marks a stalled request
+            // FAILED and NULLs its key on the assumption its owner is dead, but nothing fences
+            // that owner, and IndexWorker writes PROCESSING once per month rather than once per
+            // run. The next such write would flip the row back to PROCESSING while leaving
+            // dedupe_key NULL — a live request holding no slot. Its replacement already holds the
+            // key, so the constraint cannot see the violation, and a skipCache submit (which
+            // bypasses the dedupe read) would then start exactly the rival run this change exists
+            // to prevent.
+            //
+            // Restoring the key here instead would be wrong: the replacement holds it, so the
+            // UPDATE would fail on the constraint. Refusing the resurrection is the only shape
+            // that keeps one live row per tuple.
             : """
             UPDATE indexing_requests
-            SET status = ?, error_message = ?, games_indexed = ?, updated_at = now()
-            WHERE id = ?
+            SET status = ?, error_message = ?, games_indexed = ?, updated_at = ?
+            WHERE id = ? AND status IN ('PENDING', 'PROCESSING')
             """;
-    jdbi.useHandle(
-        h ->
-            h.createUpdate(sql)
-                .bind(0, status)
-                .bind(1, errorMessage)
-                .bind(2, gamesIndexed)
-                .bind(3, id)
-                .execute());
+    LocalDateTime stamp = toUtcWallClock(clock.instant());
+    int updated =
+        jdbi.withHandle(
+            h ->
+                h.createUpdate(sql)
+                    .bind(0, status)
+                    .bind(1, errorMessage)
+                    .bind(2, gamesIndexed)
+                    .bindByType(3, stamp, LocalDateTime.class)
+                    .bind(4, id)
+                    .execute());
+    if (updated == 0 && !terminal) {
+      LOG.warn(
+          "Refused to move request {} to {}: it is no longer live, most likely retired as stale."
+              + " A replacement request owns this range now.",
+          id,
+          status);
+    }
   }
 
   @Override
@@ -309,11 +375,12 @@ public class IndexingRequestDao implements IndexingRequestStore {
                       """
                       DELETE FROM indexing_requests
                       WHERE created_at < ?
+                        AND status NOT IN ('PENDING', 'PROCESSING')
                         AND NOT EXISTS (
                           SELECT 1 FROM game_features g
                           WHERE g.request_id = indexing_requests.id)
                       """)
-                  .bind(0, Timestamp.from(threshold))
+                  .bindByType(0, toUtcWallClock(threshold), LocalDateTime.class)
                   .execute();
           if (deleted > 0) {
             LOG.debug("Deleted {} indexing requests older than {}", deleted, threshold);

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -287,7 +287,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
                       AND exclude_bullet = ?
                       AND status IN ('PENDING', 'PROCESSING')
                       AND updated_at >= ?
-                    ORDER BY created_at ASC
+                    ORDER BY created_at ASC, id ASC
                     LIMIT 1
                     """)
                 .bind(0, player)
@@ -315,6 +315,17 @@ public class IndexingRequestDao implements IndexingRequestStore {
     // A terminal status releases the dedupe slot: the same range becomes requestable again the
     // moment the work stops being in flight. Leaving the key behind would make one COMPLETED
     // request block that range permanently.
+    //
+    // Terminal writes are deliberately NOT fenced, unlike the non-terminal ones below, and the
+    // limits of that are worth stating. A worker retired while it was running can still write
+    // COMPLETED over its own FAILED row, so the row can end up describing a run that lost the
+    // range rather than the replacement that owns it. More importantly, nothing here fences the
+    // *data* plane at all: that worker keeps writing game_features and motif_occurrences, so if a
+    // replacement is running the same range concurrently the occurrence delete/insert pair can
+    // still interleave. The heartbeat makes reaching this state much harder, and the non-terminal
+    // guard stops the row itself from flip-flopping, but neither makes a retired worker stop
+    // working. Closing that needs an ownership token the worker carries into every write, which is
+    // a different design from this column and is tracked separately.
     boolean terminal = !"PENDING".equals(status) && !"PROCESSING".equals(status);
     String sql =
         terminal

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -110,7 +110,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
     // Retire an abandoned holder first, so a dead request cannot keep its replacement out. Without
     // this the unique constraint would turn #1250's stranded row from "dedupe keeps answering with
     // it" into "the database refuses the replacement" — the same lockout, enforced harder.
-    reclaimStaleForKey(key, staleAfter, now);
+    retire(key, staleAfter, now);
 
     RuntimeException lastConflict = null;
     for (int attempt = 0; attempt < MAX_CLAIM_ATTEMPTS; attempt++) {
@@ -215,10 +215,6 @@ public class IndexingRequestDao implements IndexingRequestStore {
                 .bind(0, dedupeKey)
                 .map(ROW_MAPPER)
                 .findFirst());
-  }
-
-  private int reclaimStaleForKey(String dedupeKey, Duration staleAfter, Instant now) {
-    return retire(dedupeKey, staleAfter, now);
   }
 
   @Override
@@ -364,6 +360,23 @@ public class IndexingRequestDao implements IndexingRequestStore {
           id,
           status);
     }
+  }
+
+  @Override
+  public boolean heartbeat(UUID id, Instant now) {
+    int touched =
+        jdbi.withHandle(
+            h ->
+                h.createUpdate(
+                        """
+                        UPDATE indexing_requests
+                        SET updated_at = ?
+                        WHERE id = ? AND status IN ('PENDING', 'PROCESSING')
+                        """)
+                    .bindByType(0, toUtcWallClock(now), LocalDateTime.class)
+                    .bind(1, id)
+                    .execute());
+    return touched > 0;
   }
 
   @Override

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
@@ -1,27 +1,82 @@
 package com.muchq.games.one_d4.db;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface IndexingRequestStore {
-  UUID create(
-      String player, String platform, String startMonth, String endMonth, boolean excludeBullet);
+
+  /**
+   * Atomically claims the live slot for this (player, platform, startMonth, endMonth,
+   * excludeBullet), returning either a freshly created request or the one that already holds it.
+   *
+   * <p>This exists instead of a bare {@code create} because dedupe cannot be done as a read
+   * followed by a write. Two identical submits — two REST threads, or REST and MCP, which are two
+   * JVMs against one Postgres whenever {@code INDEXER_DB_URL} is set — can both find nothing and
+   * both insert. {@code game_features} survives that on its {@code game_url} upsert, but {@code
+   * motif_occurrences} does not: its flush deletes and re-inserts under fresh UUIDs in separate
+   * transactions, so interleaved runs leave duplicated occurrence rows and every motif count for
+   * those games reads double.
+   *
+   * <p>The caller must dispatch work only when {@link Claim#created()} is true. Adopting means
+   * another caller already owns the work.
+   *
+   * <p>Implementations also retire rows stranded past {@code staleAfter} as part of the same atomic
+   * step, so an abandoned request cannot hold the slot against its replacement.
+   */
+  Claim createOrAdopt(
+      String player,
+      String platform,
+      String startMonth,
+      String endMonth,
+      boolean excludeBullet,
+      Duration staleAfter,
+      Instant now);
 
   Optional<IndexingRequest> findById(UUID id);
 
   /**
    * Returns an existing request with the same (player, platform, startMonth, endMonth,
-   * excludeBullet) that is PENDING or PROCESSING, if any. Used to avoid creating duplicate indexing
-   * work.
+   * excludeBullet) that is PENDING or PROCESSING and was updated within {@code staleAfter}, if any.
+   * Used to avoid creating duplicate indexing work.
+   *
+   * <p>The age bound is what keeps a request whose owner died from answering for it forever. See
+   * {@link RetentionPolicy#STALE_REQUEST}.
    */
   Optional<IndexingRequest> findExistingRequest(
-      String player, String platform, String startMonth, String endMonth, boolean excludeBullet);
+      String player,
+      String platform,
+      String startMonth,
+      String endMonth,
+      boolean excludeBullet,
+      Duration staleAfter,
+      Instant now);
 
   List<IndexingRequest> listRecent(int limit);
 
   void updateStatus(UUID id, String status, String errorMessage, int gamesIndexed);
+
+  /**
+   * Retires every PENDING/PROCESSING request last updated before {@code now - staleAfter} to
+   * FAILED, freeing the dedupe slot each one holds. Returns the number retired.
+   */
+  int reclaimStale(Duration staleAfter, Instant now);
+
+  /**
+   * Deletes request rows created before {@code threshold} that no {@code game_features} row still
+   * references. Returns the number deleted.
+   *
+   * <p>The reference check is belt and braces on top of sweep ordering: games are deleted first and
+   * on a shorter clock, so by the time a request is old enough to sweep its games are already gone.
+   * Checking anyway means the delete cannot raise a foreign key violation and abort the whole
+   * retention pass even if the two clocks are ever reconfigured into overlap.
+   */
+  int deleteOlderThan(Instant threshold);
+
+  /** The outcome of {@link #createOrAdopt}: the winning row, and whether this caller created it. */
+  record Claim(IndexingRequest request, boolean created) {}
 
   record IndexingRequest(
       UUID id,

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
@@ -65,13 +65,21 @@ public interface IndexingRequestStore {
   int reclaimStale(Duration staleAfter, Instant now);
 
   /**
-   * Deletes request rows created before {@code threshold} that no {@code game_features} row still
-   * references. Returns the number deleted.
+   * Deletes terminal request rows created before {@code threshold} that no {@code game_features}
+   * row still references. Returns the number deleted.
+   *
+   * <p>Two guards, both narrowing what this can destroy rather than relying on the caller.
    *
    * <p>The reference check is belt and braces on top of sweep ordering: games are deleted first and
    * on a shorter clock, so by the time a request is old enough to sweep its games are already gone.
    * Checking anyway means the delete cannot raise a foreign key violation and abort the whole
    * retention pass even if the two clocks are ever reconfigured into overlap.
+   *
+   * <p>The status check stops a PENDING or PROCESSING request from being deleted out from under a
+   * running worker. Today that is unreachable — {@link RetentionPolicy#REQUEST} is thirty days
+   * against a one-hour staleness cutoff, and the worker reclaims stale rows earlier in the same
+   * pass — but it is unreachable because of how the caller is sequenced, which is exactly the kind
+   * of guarantee that evaporates when someone reorders the caller.
    */
   int deleteOlderThan(Instant threshold);
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
@@ -65,6 +65,24 @@ public interface IndexingRequestStore {
   int reclaimStale(Duration staleAfter, Instant now);
 
   /**
+   * Moves a live request's {@code updated_at} forward without touching anything else. Returns true
+   * if the row was still live and was touched.
+   *
+   * <p>This exists because staleness infers liveness from progress, and progress is a bad proxy for
+   * it. {@link IndexWorker} writes status at month boundaries and every hundredth game, so a single
+   * month holding fewer games than that — the common case, since single-month requests run inline —
+   * reports nothing between its first and last write. The archive fetch and the profile lookups
+   * inside that span go through an HTTP client with no request timeout, so the span has no upper
+   * bound, and once it passes {@link RetentionPolicy#STALE_REQUEST} the sweep retires a request
+   * that is running perfectly well and frees the dedupe slot out from under it.
+   *
+   * <p>Returning false rather than throwing when the row is no longer live is deliberate: by then a
+   * replacement may own the range, and the caller's job is to notice and stop, not to fight for it
+   * back.
+   */
+  boolean heartbeat(UUID id, Instant now);
+
+  /**
    * Deletes terminal request rows created before {@code threshold} that no {@code game_features}
    * row still references. Returns the number deleted.
    *

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -246,6 +246,12 @@ public class Migration {
   private static final String ADD_DEDUPE_KEY_COLUMN =
       "ALTER TABLE indexing_requests ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(600)";
 
+  // The (created_at, id) order here is the same one findExistingRequest uses, and they have to stay
+  // that way: this picks which duplicate holds the slot, that picks which one a submit attaches to,
+  // and if they disagree a caller can be handed a row nobody is working on while the keyed row does
+  // the work. created_at alone does not settle it — ties are exactly what duplicate submits
+  // produce.
+  //
   // Backfill before the constraint exists, and only onto the row findExistingRequest would already
   // have returned (oldest non-terminal per group). The pre-constraint schema permitted duplicate
   // live rows, so any group holding several would fail the ADD CONSTRAINT below if they were all

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -295,6 +295,13 @@ public class Migration {
                  OR (o.created_at = r.created_at AND o.id < r.id)))
       """;
 
+  // The retention sweep's anti-join (deleteOlderThan) filters indexing_requests on an hourly
+  // schedule by "does any game still point at me". Without this, EXPLAIN shows a hash anti-join
+  // over a sequential scan of game_features — the largest table in the schema. Neither engine
+  // indexes a foreign key column automatically.
+  private static final String CREATE_IDX_GAME_FEATURES_REQUEST_ID =
+      "CREATE INDEX IF NOT EXISTS idx_game_features_request_id ON game_features(request_id)";
+
   private static final String ADD_DEDUPE_KEY_UNIQUE_H2 =
       "ALTER TABLE indexing_requests ADD CONSTRAINT IF NOT EXISTS indexing_requests_dedupe_unique"
           + " UNIQUE (dedupe_key)";
@@ -375,6 +382,7 @@ public class Migration {
       stmt.execute(ADD_DEDUPE_KEY_COLUMN);
       stmt.execute(BACKFILL_DEDUPE_KEY);
       stmt.execute(useH2 ? ADD_DEDUPE_KEY_UNIQUE_H2 : ADD_DEDUPE_KEY_UNIQUE_PG);
+      stmt.execute(CREATE_IDX_GAME_FEATURES_REQUEST_ID);
 
       LOG.info("Database migration completed successfully (H2={})", useH2);
     } catch (SQLException e) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -232,6 +232,81 @@ public class Migration {
   private static final String ADD_OCC_PIN_TYPE =
       "ALTER TABLE motif_occurrences ADD COLUMN IF NOT EXISTS pin_type VARCHAR(8)";
 
+  // dedupe_key enforces "at most one live request per (player, platform, start_month, end_month,
+  // exclude_bullet)" in the database, closing the check-then-act race in IndexRequestService
+  // (#1249). It carries the composite key while a request is PENDING/PROCESSING and NULL once it
+  // reaches a terminal status — a plain UNIQUE constraint ignores NULLs on both engines, so
+  // terminal rows accumulate freely while live ones cannot collide.
+  //
+  // A Postgres partial unique index would express this more directly, but H2 does not support
+  // one, and H2 is what the default CI suite runs — the pg-backed suites skip silently without
+  // GOLF_HUB_TEST_DB_URL/PG_TEST_DB_URL. A PG-only constraint would leave the race guard
+  // effectively untested on every ordinary PR. One nullable column costs a little schema surface
+  // and buys the same invariant, enforced identically on both engines and exercised by db_tests.
+  private static final String ADD_DEDUPE_KEY_COLUMN =
+      "ALTER TABLE indexing_requests ADD COLUMN IF NOT EXISTS dedupe_key VARCHAR(600)";
+
+  // Backfill before the constraint exists, and only onto the row findExistingRequest would already
+  // have returned (oldest non-terminal per group). The pre-constraint schema permitted duplicate
+  // live rows, so any group holding several would fail the ADD CONSTRAINT below if they were all
+  // keyed. Losers keep dedupe_key NULL: they stay visible and keep their status, they simply hold
+  // no slot, and the staleness reclamation retires them on its own clock.
+  // Keys exactly one live row per group, in a single statement.
+  //
+  // Two details, both learned by watching this fail:
+  //
+  // LOWER(CAST(... AS VARCHAR)) rather than bare concatenation, because H2 renders a BOOLEAN as
+  // 'TRUE' while Postgres and Boolean.toString render 'true'. Left implicit, a backfilled row's
+  // key would not match the one IndexingRequestDao computes in Java on H2, and dedupe would miss
+  // it exactly once.
+  //
+  // And the winner is picked by a total order — (created_at, id), with ids compared by '<' rather
+  // than MIN(id), since Postgres has ordering operators for uuid but no min/max aggregate over it.
+  // Selecting on MIN(created_at) alone is not enough: duplicate submits are precisely the rows
+  // most likely to share a timestamp, a tie makes MIN match every row in the group, and the
+  // statement then tries to write one key onto several rows. Cleaning that up afterwards is too
+  // late — on an upgrade where the constraint already exists the UPDATE itself is rejected, and on
+  // a first run ADD CONSTRAINT is. Either way the migration aborts, so the tiebreak has to be part
+  // of the selection rather than a follow-up pass.
+  //
+  // The IS NULL guards make re-running the migration a no-op.
+  private static final String BACKFILL_DEDUPE_KEY =
+      """
+      UPDATE indexing_requests r
+      SET dedupe_key = r.platform || '|' || r.start_month || '|' || r.end_month || '|'
+                       || LOWER(CAST(r.exclude_bullet AS VARCHAR)) || '|' || r.player
+      WHERE r.status IN ('PENDING', 'PROCESSING')
+        AND r.dedupe_key IS NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM indexing_requests h
+          WHERE h.player = r.player AND h.platform = r.platform
+            AND h.start_month = r.start_month AND h.end_month = r.end_month
+            AND h.exclude_bullet = r.exclude_bullet
+            AND h.status IN ('PENDING', 'PROCESSING')
+            AND h.dedupe_key IS NOT NULL)
+        AND NOT EXISTS (
+          SELECT 1 FROM indexing_requests o
+          WHERE o.player = r.player AND o.platform = r.platform
+            AND o.start_month = r.start_month AND o.end_month = r.end_month
+            AND o.exclude_bullet = r.exclude_bullet
+            AND o.status IN ('PENDING', 'PROCESSING')
+            AND o.dedupe_key IS NULL
+            AND (o.created_at < r.created_at
+                 OR (o.created_at = r.created_at AND o.id < r.id)))
+      """;
+
+  private static final String ADD_DEDUPE_KEY_UNIQUE_H2 =
+      "ALTER TABLE indexing_requests ADD CONSTRAINT IF NOT EXISTS indexing_requests_dedupe_unique"
+          + " UNIQUE (dedupe_key)";
+  private static final String ADD_DEDUPE_KEY_UNIQUE_PG =
+      """
+      DO $$ BEGIN
+        ALTER TABLE indexing_requests ADD CONSTRAINT indexing_requests_dedupe_unique
+          UNIQUE (dedupe_key);
+      EXCEPTION WHEN duplicate_table OR duplicate_object THEN NULL;
+      END $$\
+      """;
+
   // Opening name/family (derived from the chess.com ECOUrl) and player titles. Existing rows get
   // NULL until the affected periods are reindexed.
   private static final String[] ADD_OPENING_AND_TITLE_COLUMNS = {
@@ -294,6 +369,12 @@ public class Migration {
       for (String drop : DROP_HAS_MOTIF_COLUMNS) {
         stmt.execute(drop);
       }
+
+      // Live-request dedupe key. Strictly ordered: the column has to exist before the backfill can
+      // write it, and the data has to be unique before the constraint can be added.
+      stmt.execute(ADD_DEDUPE_KEY_COLUMN);
+      stmt.execute(BACKFILL_DEDUPE_KEY);
+      stmt.execute(useH2 ? ADD_DEDUPE_KEY_UNIQUE_H2 : ADD_DEDUPE_KEY_UNIQUE_PG);
 
       LOG.info("Database migration completed successfully (H2={})", useH2);
     } catch (SQLException e) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
@@ -15,5 +15,49 @@ public final class RetentionPolicy {
   /** Games and indexed periods are deleted once they are older than this. */
   public static final Duration PERIOD = Duration.ofDays(7);
 
+  /**
+   * Request rows are deleted once they are older than this — deliberately longer than {@link
+   * #PERIOD}, for two independent reasons.
+   *
+   * <p>The first is a correctness constraint, not a preference: {@code game_features.request_id} is
+   * a foreign key onto {@code indexing_requests(id)}, so a request may not be deleted while any
+   * game still points at it. Outliving the games it produced is what makes the sweep safe.
+   *
+   * <p>The second is that a request row is the only thing left that can explain its own emptiness.
+   * Once its months are swept, the API reports the request as {@code EXPIRED} rather than dropping
+   * it, which answers "what happened to my index?" with "pruned — re-run it" instead of silence.
+   * Deleting the row on the same clock as the data would throw that answer away at the exact moment
+   * it becomes useful, so the gap between the two windows is the window in which the explanation
+   * exists.
+   */
+  public static final Duration REQUEST = Duration.ofDays(30);
+
+  /**
+   * A PENDING or PROCESSING request whose {@code updated_at} is older than this is presumed
+   * abandoned by a dead owner and retired to FAILED.
+   *
+   * <p>Without a bound, a single stranded row blocks its (player, platform, month range) forever:
+   * dedupe keeps returning it, and the unique constraint on {@code dedupe_key} keeps a replacement
+   * from being created. Rows get stranded by ordinary events — a restart with work still in the
+   * process-local queue, or an inline MCP dispatch that throws before the worker takes ownership —
+   * so "rare" is not the same as "never".
+   *
+   * <p>An hour is far longer than any healthy request takes (a twelve-month range is minutes) while
+   * still being short enough that a user who hits a strand is not locked out for a working day.
+   */
+  public static final Duration STALE_REQUEST = Duration.ofHours(1);
+
+  static {
+    if (REQUEST.compareTo(PERIOD) <= 0) {
+      throw new IllegalStateException(
+          "REQUEST retention ("
+              + REQUEST
+              + ") must exceed PERIOD ("
+              + PERIOD
+              + "): game_features.request_id is a foreign key onto indexing_requests(id), so"
+              + " deleting requests first would be blocked by their own games.");
+    }
+  }
+
   private RetentionPolicy() {}
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
@@ -42,16 +42,19 @@ public final class RetentionPolicy {
    * process-local queue, or an inline MCP dispatch that throws before the worker takes ownership —
    * so "rare" is not the same as "never".
    *
-   * <p>An hour is far longer than a request spends <em>running</em>: {@code IndexWorker} writes
-   * PROCESSING once per month rather than once per run, so a twelve-month range refreshes {@code
-   * updated_at} up to twelve times and cannot age out mid-flight however slow chess.com is.
+   * <p>A running request cannot age out however slow chess.com is, because {@code IndexWorker}
+   * heartbeats it on a timer for as long as it is working — see {@code IndexWorker.startHeartbeat}.
+   * Status writes alone were not enough: they land at month boundaries and every hundredth game, so
+   * a single month under that size reported nothing between its first and last write, and the
+   * archive fetch inside that span goes through an HTTP client with no request timeout.
    *
-   * <p>What the hour does <em>not</em> cover is time spent waiting in the queue. {@code
-   * InMemoryIndexQueue} is drained by a single thread and a queued request's {@code updated_at} is
-   * frozen at insert, so a backlog deeper than an hour would retire work that is owned and about to
-   * run — telling the user to re-submit while the message is still queued. That is tracked
-   * separately rather than papered over here; the fix is a heartbeat on enqueue, not a bigger
-   * number, because raising the window trades one wrong answer for a slower one.
+   * <p>What the hour still does <em>not</em> cover is time spent waiting in the queue. {@code
+   * InMemoryIndexQueue} is drained by a single thread, and a queued message has no worker to
+   * heartbeat for it, so its {@code updated_at} stays frozen at insert. A backlog deeper than an
+   * hour therefore retires work that is owned and about to run, telling the user to re-submit while
+   * the message is still queued. That is tracked separately rather than papered over here; the fix
+   * is to beat on enqueue as well, not a bigger number, because raising the window trades one wrong
+   * answer for a slower one.
    *
    * <p>The invariant that {@link #REQUEST} must exceed {@link #PERIOD} is asserted in {@code
    * IndexE2ETest} alongside the existing check on PERIOD, not in a static initializer here. These

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
@@ -42,22 +42,24 @@ public final class RetentionPolicy {
    * process-local queue, or an inline MCP dispatch that throws before the worker takes ownership —
    * so "rare" is not the same as "never".
    *
-   * <p>An hour is far longer than any healthy request takes (a twelve-month range is minutes) while
-   * still being short enough that a user who hits a strand is not locked out for a working day.
+   * <p>An hour is far longer than a request spends <em>running</em>: {@code IndexWorker} writes
+   * PROCESSING once per month rather than once per run, so a twelve-month range refreshes {@code
+   * updated_at} up to twelve times and cannot age out mid-flight however slow chess.com is.
+   *
+   * <p>What the hour does <em>not</em> cover is time spent waiting in the queue. {@code
+   * InMemoryIndexQueue} is drained by a single thread and a queued request's {@code updated_at} is
+   * frozen at insert, so a backlog deeper than an hour would retire work that is owned and about to
+   * run — telling the user to re-submit while the message is still queued. That is tracked
+   * separately rather than papered over here; the fix is a heartbeat on enqueue, not a bigger
+   * number, because raising the window trades one wrong answer for a slower one.
+   *
+   * <p>The invariant that {@link #REQUEST} must exceed {@link #PERIOD} is asserted in {@code
+   * IndexE2ETest} alongside the existing check on PERIOD, not in a static initializer here. These
+   * are compile-time constants six lines apart, so a violation can only be introduced by editing
+   * this file — and a static block would report it as an {@code ExceptionInInitializerError} during
+   * Micronaut startup rather than as a failing test.
    */
   public static final Duration STALE_REQUEST = Duration.ofHours(1);
-
-  static {
-    if (REQUEST.compareTo(PERIOD) <= 0) {
-      throw new IllegalStateException(
-          "REQUEST retention ("
-              + REQUEST
-              + ") must exceed PERIOD ("
-              + PERIOD
-              + "): game_features.request_id is a foreign key onto indexing_requests(id), so"
-              + " deleting requests first would be blocked by their own games.");
-    }
-  }
 
   private RetentionPolicy() {}
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -32,7 +32,7 @@ Start indexing games for a player over a month range.
 | startMonth    | string | yes      | Start month inclusive, format `YYYY-MM` |
 | endMonth      | string | yes      | End month inclusive, format `YYYY-MM`   |
 | excludeBullet | bool   | no       | Skip bullet games (default false)       |
-| skipCache     | bool   | no       | Refetch every month in the range even if already indexed, refreshing stored rows — e.g. to backfill titles and opening names on rows indexed before those columns existed (default false) |
+| skipCache     | bool   | no       | Refetch every month in the range even if already indexed, refreshing stored rows — e.g. to backfill titles and opening names on rows indexed before those columns existed. Does **not** start a rival run of a range already in flight: if a request for the same player/months is PENDING or PROCESSING, that request is returned and nothing is refetched (default false) |
 
 ### Response (200)
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -97,11 +97,14 @@ Poll the status of an indexing request.
 
 ### The `data` object — is the indexed data still there?
 
-Request rows are kept forever; the games they produced are not. The retention worker deletes
-games and indexed periods once they are older than **7 days**, but never touches
-`indexing_requests` — so without `data`, a request from two weeks ago is indistinguishable from
-one indexed an hour ago. Both say `"status": "COMPLETED", "gamesIndexed": 147`; only one of them
-still has games to query.
+A request row outlives the games it produced. The retention worker deletes games and indexed
+periods once they are older than **7 days**, and the request row itself after **30 days** — so
+without `data`, a request from two weeks ago is indistinguishable from one indexed an hour ago.
+Both say `"status": "COMPLETED", "gamesIndexed": 147`; only one of them still has games to query.
+
+The 23-day gap between the two windows is deliberate. It is the period in which a request can
+still answer "what happened to my index?" with `EXPIRED` — pruned, re-run it — instead of the
+request having vanished too. After 30 days the row is deleted and the id stops resolving.
 
 The key is **absent** until the request reaches COMPLETED — never `"data": null`.
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
@@ -69,7 +69,11 @@ line derived from the chess.com `ECOUrl` (e.g. `Caro Kann Defense Two Knights At
 questions are asked at, e.g. `white.username = "hikaru" AND opening.family = "Caro Kann Defense"`.
 Rows indexed before these columns existed hold NULL until reindexed with `skipCache: true` on
 `POST /v1/index` (or `skip_cache` on the `index_chess_games` MCP tool) — a plain re-request is
-served from the indexed-period cache and does not refetch.
+served from the indexed-period cache and does not refetch. One thing to check when a backfill
+appears to do nothing: `skipCache` will not start a second run over a range that is already being
+indexed. If a request for that player and month range is still PENDING or PROCESSING, the submit
+returns *that* request and refetches nothing, so the NULLs stay. Poll it to COMPLETED, then submit
+the backfill again.
 
 > **Caveat — `opening.family` is not a normalized taxonomy.** Both opening fields are string
 > slices of chess.com's ECO-URL, so near-identical spellings form distinct values and distinct

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/DataAvailabilityResolver.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/DataAvailabilityResolver.java
@@ -19,10 +19,13 @@ import org.jspecify.annotations.Nullable;
 /**
  * Answers "is this request's data still on disk?" for rows in {@code indexing_requests}.
  *
- * <p>Request rows are never swept, but the games and indexed periods they produced are — so a
+ * <p>Request rows outlive the games and indexed periods they produced — 30 days against 7 — so a
  * COMPLETED request from two weeks ago still reads "COMPLETED, 325 games" while querying it returns
- * nothing. This resolver closes that gap by checking each month the request covers against the
- * surviving {@code indexed_periods} rows, which retention deletes on the same clock as the games.
+ * nothing. That gap is deliberate (see {@link com.muchq.games.one_d4.db.RetentionPolicy}), and it
+ * is exactly the window this resolver exists to describe: past 30 days the request is deleted too
+ * and there is nothing left to ask about. This resolver closes that gap by checking each month the
+ * request covers against the surviving {@code indexed_periods} rows, which retention deletes on the
+ * same clock as the games.
  */
 public class DataAvailabilityResolver {
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/IndexRequestService.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/IndexRequestService.java
@@ -176,11 +176,17 @@ public class IndexRequestService {
       } catch (Throwable t) {
         try {
           requestStore.updateStatus(id, "FAILED", "Inline indexing failed: " + t, 0);
-        } catch (RuntimeException suppressed) {
-          // Best effort. The original failure is what the caller needs to see; the staleness
-          // sweep is the backstop for the row.
+        } catch (Throwable suppressed) {
+          // Catch Throwable, not RuntimeException, to match the outer catch. The outer one is
+          // wide precisely because an Error can escape the processor — and if that Error is an
+          // OutOfMemoryError, this recovery allocates a connection, a statement and a message
+          // string, so the likeliest second failure is another Error. Catching only
+          // RuntimeException here would let it replace the original instead of being attached to
+          // it, contradicting the line below.
           t.addSuppressed(suppressed);
         }
+        // The original failure is what the caller needs to see; the staleness sweep is the
+        // backstop for the row if the update above did not land.
         throw t;
       }
       return status(id)

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/IndexRequestService.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/IndexRequestService.java
@@ -2,8 +2,10 @@ package com.muchq.games.one_d4.service;
 
 import com.muchq.games.one_d4.api.dto.IndexResponse;
 import com.muchq.games.one_d4.db.IndexingRequestStore;
+import com.muchq.games.one_d4.db.RetentionPolicy;
 import com.muchq.games.one_d4.queue.IndexMessage;
 import com.muchq.games.one_d4.queue.IndexQueue;
+import java.time.Clock;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -26,6 +28,15 @@ public class IndexRequestService {
   private final IndexQueue queue;
   private final Consumer<IndexMessage> inlineProcessor;
   private final DataAvailabilityResolver dataAvailability;
+  private final Clock clock;
+
+  public IndexRequestService(
+      IndexingRequestStore requestStore,
+      IndexQueue queue,
+      Consumer<IndexMessage> inlineProcessor,
+      DataAvailabilityResolver dataAvailability) {
+    this(requestStore, queue, inlineProcessor, dataAvailability, Clock.systemUTC());
+  }
 
   /**
    * @param inlineProcessor runs a message to completion on the calling thread; used by {@link
@@ -34,21 +45,32 @@ public class IndexRequestService {
    *     request without saying whether its games still exist. When only the REST controller
    *     enriched the response, the MCP {@code index_status} tool told agents "COMPLETED, 325 games"
    *     about a corpus retention had already deleted.
+   * @param clock supplies the "now" that dedupe measures request staleness against, so a test can
+   *     step over the cutoff instead of sleeping through it
    */
   public IndexRequestService(
       IndexingRequestStore requestStore,
       IndexQueue queue,
       Consumer<IndexMessage> inlineProcessor,
-      DataAvailabilityResolver dataAvailability) {
+      DataAvailabilityResolver dataAvailability,
+      Clock clock) {
     this.requestStore = requestStore;
     this.queue = queue;
     this.inlineProcessor = inlineProcessor;
     this.dataAvailability = dataAvailability;
+    this.clock = clock;
   }
 
   /**
-   * @param skipCache bypass the indexed-period cache and request dedupe, refetching every month in
-   *     the range — the backfill path for rows indexed before newer columns existed
+   * @param skipCache refetch every month in the range instead of serving any of them from the
+   *     indexed-period cache, and skip the dedupe read — the backfill path for rows indexed before
+   *     newer columns existed.
+   *     <p>It does not permit a second concurrent run of the same range. If a live request already
+   *     holds that (player, platform, month range, excludeBullet), this returns that request rather
+   *     than starting a rival one: two indexers over the same games interleave {@code
+   *     motif_occurrences} deletes and inserts and leave every motif for those games counted twice.
+   *     The caller can see it was coalesced — the response carries the in-flight request's id and
+   *     its PENDING/PROCESSING status — and re-issuing once that finishes does force the refetch.
    */
   public record Submission(
       String player,
@@ -107,19 +129,32 @@ public class IndexRequestService {
               platform,
               submission.startMonth(),
               submission.endMonth(),
-              submission.excludeBullet());
+              submission.excludeBullet(),
+              RetentionPolicy.STALE_REQUEST,
+              clock.instant());
       if (existing.isPresent()) {
         return toResponse(existing.get());
       }
     }
 
-    UUID id =
-        requestStore.create(
+    // Even on the skipCache path this goes through createOrAdopt rather than a bare insert. The
+    // read above is an optimization — it answers a duplicate submit without touching the write
+    // path — but it cannot be the thing that prevents double-dispatch, because two callers can
+    // both read nothing. The claim is what decides, and only a caller that actually created the
+    // row is allowed to dispatch work for it.
+    IndexingRequestStore.Claim claim =
+        requestStore.createOrAdopt(
             player,
             platform,
             submission.startMonth(),
             submission.endMonth(),
-            submission.excludeBullet());
+            submission.excludeBullet(),
+            RetentionPolicy.STALE_REQUEST,
+            clock.instant());
+    if (!claim.created()) {
+      return toResponse(claim.request());
+    }
+    UUID id = claim.request().id();
     IndexMessage message =
         new IndexMessage(
             id,
@@ -131,7 +166,23 @@ public class IndexRequestService {
             submission.skipCache());
 
     if (inlineSingleMonth && monthSpan <= 1) {
-      inlineProcessor.accept(message);
+      // The inline path has no queue entry and no other owner: if this throws, nothing else will
+      // ever move the row off PENDING, and it holds its dedupe slot until the staleness sweep
+      // notices an hour later. IndexWorker.process already catches Exception and marks FAILED, so
+      // reaching here means its own status write failed or an Error escaped — rare, but the row
+      // is stranded either way. Retire it on the way out so the range frees immediately.
+      try {
+        inlineProcessor.accept(message);
+      } catch (Throwable t) {
+        try {
+          requestStore.updateStatus(id, "FAILED", "Inline indexing failed: " + t, 0);
+        } catch (RuntimeException suppressed) {
+          // Best effort. The original failure is what the caller needs to see; the staleness
+          // sweep is the backstop for the row.
+          t.addSuppressed(suppressed);
+        }
+        throw t;
+      }
       return status(id)
           .orElse(
               new IndexResponse(

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -9,6 +9,7 @@ import com.muchq.games.one_d4.api.dto.GameFeature;
 import com.muchq.games.one_d4.db.GameFeatureStore;
 import com.muchq.games.one_d4.db.IndexedPeriodStore;
 import com.muchq.games.one_d4.db.IndexingRequestStore;
+import com.muchq.games.one_d4.db.RetentionPolicy;
 import com.muchq.games.one_d4.engine.FeatureExtractor;
 import com.muchq.games.one_d4.engine.model.GameFeatures;
 import com.muchq.games.one_d4.engine.model.Motif;
@@ -31,9 +32,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -63,6 +70,14 @@ public class IndexWorker {
   private final IndexedPeriodStore periodStore;
   private final ExecutorService extractionExecutor;
   private final Clock clock;
+  private final Duration heartbeatInterval;
+  private final ScheduledExecutorService heartbeatScheduler;
+
+  /**
+   * A quarter of the staleness cutoff, so three consecutive beats can be lost before the request
+   * looks abandoned.
+   */
+  static final Duration DEFAULT_HEARTBEAT_INTERVAL = RetentionPolicy.STALE_REQUEST.dividedBy(4);
 
   public IndexWorker(
       ChessClient chessClient,
@@ -81,12 +96,6 @@ public class IndexWorker {
         Clock.systemUTC());
   }
 
-  /**
-   * @param clock the source for {@code indexed_periods.fetched_at}, which retention compares
-   *     against. Injected so a test can advance time across the retention boundary instead of
-   *     backdating rows, which only ever exercises {@code deleteOlderThan} and never the window
-   *     arithmetic that decides what "old" means.
-   */
   public IndexWorker(
       ChessClient chessClient,
       FeatureExtractor featureExtractor,
@@ -95,6 +104,36 @@ public class IndexWorker {
       IndexedPeriodStore periodStore,
       ExecutorService extractionExecutor,
       Clock clock) {
+    this(
+        chessClient,
+        featureExtractor,
+        requestStore,
+        gameFeatureStore,
+        periodStore,
+        extractionExecutor,
+        clock,
+        DEFAULT_HEARTBEAT_INTERVAL);
+  }
+
+  /**
+   * @param clock the source for {@code indexed_periods.fetched_at}, which retention compares
+   *     against. Injected so a test can advance time across the retention boundary instead of
+   *     backdating rows, which only ever exercises {@code deleteOlderThan} and never the window
+   *     arithmetic that decides what "old" means.
+   * @param heartbeatInterval how often an in-flight request's {@code updated_at} is refreshed.
+   *     Injected only so a test can observe a beat without waiting a quarter of an hour for one —
+   *     the heartbeat runs on wall-clock time, not on {@code clock}, because its job is to prove
+   *     this process is still alive and a fake clock proves nothing about that.
+   */
+  public IndexWorker(
+      ChessClient chessClient,
+      FeatureExtractor featureExtractor,
+      IndexingRequestStore requestStore,
+      GameFeatureStore gameFeatureStore,
+      IndexedPeriodStore periodStore,
+      ExecutorService extractionExecutor,
+      Clock clock,
+      Duration heartbeatInterval) {
     this.chessClient = chessClient;
     this.featureExtractor = featureExtractor;
     this.requestStore = requestStore;
@@ -102,6 +141,15 @@ public class IndexWorker {
     this.periodStore = periodStore;
     this.extractionExecutor = extractionExecutor;
     this.clock = clock;
+    this.heartbeatInterval = heartbeatInterval;
+    this.heartbeatScheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "index-request-heartbeat");
+              // Daemon: a heartbeat must never be the reason a JVM refuses to exit.
+              t.setDaemon(true);
+              return t;
+            });
   }
 
   public void process(IndexMessage message) {
@@ -111,6 +159,7 @@ public class IndexWorker {
         message.player(),
         message.platform());
 
+    ScheduledFuture<?> heartbeat = startHeartbeat(message.requestId());
     try {
       requestStore.updateStatus(message.requestId(), "PROCESSING", null, 0);
 
@@ -241,7 +290,49 @@ public class IndexWorker {
       LOG.error("Failed to process index request {}", message.requestId(), e);
       requestStore.updateStatus(
           message.requestId(), "FAILED", "Indexing failed due to an internal error", 0);
+    } finally {
+      heartbeat.cancel(false);
     }
+  }
+
+  /**
+   * Keeps {@code updated_at} moving for as long as this request is being worked on, so the
+   * staleness sweep can tell "running slowly" from "abandoned".
+   *
+   * <p>On a timer rather than at checkpoints, because the spans that need covering are exactly the
+   * ones with no checkpoint in them: a single archive fetch, a run of profile lookups, the
+   * extraction of a month holding fewer than {@link #BATCH_SIZE} games. The interval is a quarter
+   * of the cutoff, so three consecutive beats can be lost — to a paused GC, a blocked pool, a
+   * database blip — before the request looks abandoned.
+   *
+   * <p>A beat that comes back false means the row is no longer live: something already retired it
+   * and a replacement may own the range. The heartbeat stops rather than reasserting itself, and
+   * the run finishes against a row whose terminal write will be refused. That is the honest outcome
+   * — this worker lost the range while it was not looking.
+   */
+  private ScheduledFuture<?> startHeartbeat(UUID requestId) {
+    long everyMillis = Math.max(1, heartbeatInterval.toMillis());
+    return heartbeatScheduler.scheduleWithFixedDelay(
+        () -> {
+          try {
+            if (!requestStore.heartbeat(requestId, clock.instant())) {
+              LOG.warn(
+                  "Request {} is no longer live; another owner has taken this range. Stopping"
+                      + " heartbeat.",
+                  requestId);
+              throw new CancellationException("request no longer live");
+            }
+          } catch (CancellationException e) {
+            throw e;
+          } catch (RuntimeException e) {
+            // A missed beat is survivable — the interval leaves room for three. Logging and
+            // continuing beats killing the schedule on one transient database error.
+            LOG.warn("Heartbeat failed for request {}", requestId, e);
+          }
+        },
+        everyMillis,
+        everyMillis,
+        TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/RetentionWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/RetentionWorker.java
@@ -2,6 +2,7 @@ package com.muchq.games.one_d4.worker;
 
 import com.muchq.games.one_d4.db.GameFeatureStore;
 import com.muchq.games.one_d4.db.IndexedPeriodStore;
+import com.muchq.games.one_d4.db.IndexingRequestStore;
 import com.muchq.games.one_d4.db.RetentionPolicy;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.scheduling.annotation.Scheduled;
@@ -17,12 +18,19 @@ public class RetentionWorker {
   private static final Logger LOG = LoggerFactory.getLogger(RetentionWorker.class);
   private static final Duration RETENTION_PERIOD = RetentionPolicy.PERIOD;
 
+  private static final Duration REQUEST_RETENTION_PERIOD = RetentionPolicy.REQUEST;
+  private static final Duration STALE_REQUEST_PERIOD = RetentionPolicy.STALE_REQUEST;
+
   private final GameFeatureStore gameFeatureStore;
   private final IndexedPeriodStore indexedPeriodStore;
+  private final IndexingRequestStore indexingRequestStore;
   private final Clock clock;
 
-  public RetentionWorker(GameFeatureStore gameFeatureStore, IndexedPeriodStore indexedPeriodStore) {
-    this(gameFeatureStore, indexedPeriodStore, Clock.systemUTC());
+  public RetentionWorker(
+      GameFeatureStore gameFeatureStore,
+      IndexedPeriodStore indexedPeriodStore,
+      IndexingRequestStore indexingRequestStore) {
+    this(gameFeatureStore, indexedPeriodStore, indexingRequestStore, Clock.systemUTC());
   }
 
   /**
@@ -33,22 +41,54 @@ public class RetentionWorker {
    */
   @Inject
   public RetentionWorker(
-      GameFeatureStore gameFeatureStore, IndexedPeriodStore indexedPeriodStore, Clock clock) {
+      GameFeatureStore gameFeatureStore,
+      IndexedPeriodStore indexedPeriodStore,
+      IndexingRequestStore indexingRequestStore,
+      Clock clock) {
     this.gameFeatureStore = gameFeatureStore;
     this.indexedPeriodStore = indexedPeriodStore;
+    this.indexingRequestStore = indexingRequestStore;
     this.clock = clock;
     LOG.info(
-        "RetentionWorker initialized (retention={} days, interval=1h)", RETENTION_PERIOD.toDays());
+        "RetentionWorker initialized (games/periods={} days, requests={} days, stale requests={},"
+            + " interval=1h)",
+        RETENTION_PERIOD.toDays(),
+        REQUEST_RETENTION_PERIOD.toDays(),
+        STALE_REQUEST_PERIOD);
   }
 
   @Scheduled(fixedDelay = "1h", initialDelay = "1m")
   public void runRetention() {
-    LOG.info("Running game retention policy ({} days)", RETENTION_PERIOD.toDays());
-    Instant threshold = clock.instant().minus(RETENTION_PERIOD);
+    LOG.info(
+        "Running retention policy (games/periods={} days, requests={} days)",
+        RETENTION_PERIOD.toDays(),
+        REQUEST_RETENTION_PERIOD.toDays());
+    Instant now = clock.instant();
+    Instant threshold = now.minus(RETENTION_PERIOD);
     try {
+      // Retire abandoned requests before deleting anything. A stranded PENDING row holds its
+      // dedupe slot until something retires it, and the submit path only reclaims the one tuple
+      // being submitted — a strand nobody re-submits would otherwise sit there until it aged out
+      // of the request window entirely.
+      int reclaimed = indexingRequestStore.reclaimStale(STALE_REQUEST_PERIOD, now);
+
+      // Games before requests, because game_features.request_id is a foreign key onto
+      // indexing_requests(id). The delete itself is guarded — deleteOlderThan skips any request
+      // still referenced — so reversing these would not corrupt anything or raise a violation; it
+      // would just leave a qualifying request behind for a later pass, once its games had gone.
+      // Ordering is what lets a request and the games it owns clear in the same pass rather than
+      // over two.
       int games = gameFeatureStore.deleteOlderThan(threshold);
       int periods = indexedPeriodStore.deleteOlderThan(threshold);
-      LOG.info("Retention cleanup complete: deleted {} games, {} periods", games, periods);
+      int requests = indexingRequestStore.deleteOlderThan(now.minus(REQUEST_RETENTION_PERIOD));
+
+      LOG.info(
+          "Retention cleanup complete: deleted {} games, {} periods, {} requests; retired {}"
+              + " stranded requests",
+          games,
+          periods,
+          requests,
+          reclaimed);
     } catch (Exception e) {
       LOG.error("Failed to run retention policy", e);
     }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
@@ -436,6 +436,11 @@ public class IndexControllerTest {
     }
 
     @Override
+    public boolean heartbeat(UUID id, Instant now) {
+      return true;
+    }
+
+    @Override
     public int deleteOlderThan(Instant threshold) {
       return 0;
     }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
@@ -144,7 +144,25 @@ public class IndexControllerTest {
   }
 
   @Test
-  public void createIndex_skipCachePropagatesAndBypassesDedupe() {
+  public void createIndex_skipCachePropagatesTheFlag() {
+    IndexResponse response =
+        controller.createIndex(
+            new IndexRequest("hikaru", "CHESS_COM", "2024-01", "2024-01", null, true));
+
+    assertThat(response.id()).isNotNull();
+    assertThat(requestStore.createCallCount()).isEqualTo(1);
+    assertThat(queue.enqueued()).hasSize(1);
+    assertThat(queue.enqueued().get(0).skipCache()).isTrue();
+  }
+
+  /**
+   * skip_cache forces a refetch, but it cannot start a second run of a range that is already in
+   * flight: concurrent indexers over the same games interleave the motif_occurrences delete and
+   * insert and leave every motif for those games counted twice. The caller gets the in-flight
+   * request back and can see from its status that it was coalesced.
+   */
+  @Test
+  public void createIndex_skipCacheCoalescesOntoAnInFlightRequest() {
     UUID existingId = UUID.randomUUID();
     requestStore.setExistingRequest(
         new IndexingRequestStore.IndexingRequest(
@@ -164,11 +182,9 @@ public class IndexControllerTest {
         controller.createIndex(
             new IndexRequest("hikaru", "CHESS_COM", "2024-01", "2024-01", null, true));
 
-    // skip_cache means "force a refetch" — reusing the existing request would defeat that
-    assertThat(response.id()).isNotEqualTo(existingId);
-    assertThat(requestStore.createCallCount()).isEqualTo(1);
-    assertThat(queue.enqueued()).hasSize(1);
-    assertThat(queue.enqueued().get(0).skipCache()).isTrue();
+    assertThat(response.id()).isEqualTo(existingId);
+    assertThat(requestStore.createCallCount()).isZero();
+    assertThat(queue.enqueued()).isEmpty();
   }
 
   @Test
@@ -371,15 +387,57 @@ public class IndexControllerTest {
     }
 
     @Override
-    public UUID create(
-        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
+    public Claim createOrAdopt(
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        Duration staleAfter,
+        Instant now) {
+      // Mirrors the schema's exclusivity: if a live request is already registered for this tuple,
+      // the caller adopts it rather than creating a rival.
+      Optional<IndexingRequestStore.IndexingRequest> holder =
+          existingRequest.filter(
+              r ->
+                  r.player().equals(player)
+                      && r.platform().equals(platform)
+                      && r.startMonth().equals(startMonth)
+                      && r.endMonth().equals(endMonth)
+                      && r.excludeBullet() == excludeBullet);
+      if (holder.isPresent()) {
+        return new Claim(holder.get(), false);
+      }
       createCallCount++;
-      return UUID.randomUUID();
+      return new Claim(
+          new IndexingRequestStore.IndexingRequest(
+              UUID.randomUUID(),
+              player,
+              platform,
+              startMonth,
+              endMonth,
+              "PENDING",
+              now,
+              now,
+              null,
+              0,
+              excludeBullet),
+          true);
     }
 
     @Override
     public Optional<IndexingRequestStore.IndexingRequest> findById(UUID id) {
       return findByIdResponse.filter(r -> r.id().equals(id));
+    }
+
+    @Override
+    public int reclaimStale(Duration staleAfter, Instant now) {
+      return 0;
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
     }
 
     @Override
@@ -392,7 +450,13 @@ public class IndexControllerTest {
 
     @Override
     public Optional<IndexingRequestStore.IndexingRequest> findExistingRequest(
-        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        Duration staleAfter,
+        Instant now) {
       return existingRequest.filter(
           r ->
               r.player().equals(player)

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
@@ -1,6 +1,7 @@
 package com.muchq.games.one_d4.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -278,6 +279,115 @@ public class IndexingRequestDaoTest {
     assertThat(dao.findById(fresh.request().id()).orElseThrow().status()).isEqualTo("PENDING");
   }
 
+  /**
+   * A worker that marked its request PROCESSING and then died is the likelier strand than one that
+   * never started, and the README promises both are handled. Narrowing {@code retire}'s predicate
+   * to PENDING alone left every other reclamation test green, because they all strand a row that
+   * never left PENDING.
+   */
+  @Test
+  public void reclaimStale_retiresAStrandedProcessingRow() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("halfdone", "CHESS_COM", "2025-07", "2025-07", false, STALE_AFTER, now);
+    dao.updateStatus(claim.request().id(), "PROCESSING", null, 4);
+    backdateUpdatedAt(claim.request().id(), now.minus(Duration.ofHours(3)));
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now)).isEqualTo(1);
+
+    IndexingRequestStore.IndexingRequest retired = dao.findById(claim.request().id()).orElseThrow();
+    assertThat(retired.status()).isEqualTo("FAILED");
+    assertThat(retired.gamesIndexed()).as("progress so far is preserved").isEqualTo(4);
+
+    IndexingRequestStore.Claim replacement =
+        dao.createOrAdopt("halfdone", "CHESS_COM", "2025-07", "2025-07", false, STALE_AFTER, now);
+    assertThat(replacement.created()).isTrue();
+  }
+
+  @Test
+  public void createOrAdopt_reclaimsAStrandedProcessingHolder() {
+    IndexingRequestStore.Claim stranded =
+        dao.createOrAdopt("halfdone2", "CHESS_COM", "2025-08", "2025-08", false, STALE_AFTER, now);
+    dao.updateStatus(stranded.request().id(), "PROCESSING", null, 2);
+    backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(3)));
+
+    IndexingRequestStore.Claim replacement =
+        dao.createOrAdopt("halfdone2", "CHESS_COM", "2025-08", "2025-08", false, STALE_AFTER, now);
+
+    assertThat(replacement.created()).isTrue();
+    assertThat(replacement.request().id()).isNotEqualTo(stranded.request().id());
+  }
+
+  /**
+   * The dead worker is not fenced, so it keeps writing. Its next per-month PROCESSING heartbeat
+   * must not resurrect the row it no longer owns: that would produce a live request holding no
+   * dedupe slot, and the replacement already holds the key, so the constraint could not see the
+   * second live row.
+   */
+  @Test
+  public void updateStatus_cannotResurrectARetiredRequest() {
+    IndexingRequestStore.Claim stranded =
+        dao.createOrAdopt("zombie", "CHESS_COM", "2025-09", "2025-09", false, STALE_AFTER, now);
+    UUID strandedId = stranded.request().id();
+    backdateUpdatedAt(strandedId, now.minus(Duration.ofHours(3)));
+    dao.reclaimStale(STALE_AFTER, now);
+
+    IndexingRequestStore.Claim replacement =
+        dao.createOrAdopt("zombie", "CHESS_COM", "2025-09", "2025-09", false, STALE_AFTER, now);
+    assertThat(replacement.created()).isTrue();
+
+    // The dead worker's next heartbeat.
+    dao.updateStatus(strandedId, "PROCESSING", null, 9);
+
+    assertThat(dao.findById(strandedId).orElseThrow().status())
+        .as("a retired request stays retired")
+        .isEqualTo("FAILED");
+    assertThat(countLiveRowsFor("zombie"))
+        .as("exactly one live row per tuple, always")
+        .isEqualTo(1);
+  }
+
+  /** A terminal write is still allowed to land on a retired row — it does not un-retire it. */
+  @Test
+  public void updateStatus_terminalWriteOnARetiredRequestStillRecordsTheOutcome() {
+    IndexingRequestStore.Claim stranded =
+        dao.createOrAdopt("late", "CHESS_COM", "2025-10", "2025-10", false, STALE_AFTER, now);
+    UUID strandedId = stranded.request().id();
+    backdateUpdatedAt(strandedId, now.minus(Duration.ofHours(3)));
+    dao.reclaimStale(STALE_AFTER, now);
+
+    dao.updateStatus(strandedId, "COMPLETED", null, 11);
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(strandedId).orElseThrow();
+    assertThat(row.status()).isEqualTo("COMPLETED");
+    assertThat(row.gamesIndexed()).isEqualTo(11);
+  }
+
+  /**
+   * Every other test reaches the constraint only through {@code findByDedupeKey}, which short
+   * circuits before the insert. This drives the constraint itself, so removing it from the
+   * migration fails deterministically rather than only under a thread interleaving.
+   */
+  @Test
+  public void schema_rejectsASecondRowWithTheSameDedupeKey() {
+    create("constrained", "2025-11", "2025-11", false);
+    String key =
+        IndexingRequestDao.dedupeKey("constrained", "CHESS_COM", "2025-11", "2025-11", false);
+
+    assertThatThrownBy(() -> insertRawWithDedupeKey(key))
+        .as("the database, not the application, is what makes the slot exclusive")
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  public void schema_allowsManyTerminalRowsForOneTuple() {
+    for (int i = 0; i < 3; i++) {
+      IndexingRequestStore.Claim claim =
+          dao.createOrAdopt("recycled", "CHESS_COM", "2025-12", "2025-12", false, STALE_AFTER, now);
+      dao.updateStatus(claim.request().id(), "COMPLETED", null, i);
+    }
+    assertThat(countRequests()).isEqualTo(3);
+  }
+
   @Test
   public void reclaimStale_leavesTerminalRowsAlone() {
     IndexingRequestStore.Claim completed =
@@ -314,12 +424,31 @@ public class IndexingRequestDaoTest {
         dao.createOrAdopt("old", "CHESS_COM", "2025-04", "2025-04", false, STALE_AFTER, now);
     IndexingRequestStore.Claim recent =
         dao.createOrAdopt("recent", "CHESS_COM", "2025-05", "2025-05", false, STALE_AFTER, now);
+    dao.updateStatus(old.request().id(), "COMPLETED", null, 5);
+    dao.updateStatus(recent.request().id(), "COMPLETED", null, 5);
     backdateCreatedAt(old.request().id(), now.minus(Duration.ofDays(40)));
 
     assertThat(dao.deleteOlderThan(now.minus(Duration.ofDays(30)))).isEqualTo(1);
 
     assertThat(dao.findById(old.request().id())).isEmpty();
     assertThat(dao.findById(recent.request().id())).isPresent();
+  }
+
+  /**
+   * Age alone is not licence to delete. A request only reaches this age while still live if the
+   * staleness reclamation never ran, and deleting it would take the row out from under a worker
+   * that is still writing against its id — losing the FK's protection and the user's status.
+   * Unreachable through {@code RetentionWorker}, which reclaims first, but the guard belongs on the
+   * delete rather than in the caller's ordering.
+   */
+  @Test
+  public void deleteOlderThan_refusesToSweepALiveRequestHoweverOldItIs() {
+    IndexingRequestStore.Claim pending =
+        dao.createOrAdopt("ancient", "CHESS_COM", "2025-04", "2025-04", false, STALE_AFTER, now);
+    backdateCreatedAt(pending.request().id(), now.minus(Duration.ofDays(400)));
+
+    assertThat(dao.deleteOlderThan(now.minus(Duration.ofDays(30)))).isEqualTo(0);
+    assertThat(dao.findById(pending.request().id())).isPresent();
   }
 
   @Test
@@ -382,6 +511,37 @@ public class IndexingRequestDaoTest {
       ps.setObject(2, requestId);
       ps.setString(3, gameUrl);
       ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void insertRawWithDedupeKey(String dedupeKey) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " dedupe_key) VALUES (?, 'constrained', 'CHESS_COM', '2025-11', '2025-11',"
+                    + " ?)")) {
+      ps.setObject(1, UUID.randomUUID());
+      ps.setString(2, dedupeKey);
+      ps.executeUpdate();
+    } catch (java.sql.SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private int countLiveRowsFor(String player) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "SELECT COUNT(*) FROM indexing_requests WHERE player = ? AND status IN"
+                    + " ('PENDING', 'PROCESSING')")) {
+      ps.setString(1, player);
+      try (var rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getInt(1);
+      }
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
@@ -2,33 +2,61 @@ package com.muchq.games.one_d4.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class IndexingRequestDaoTest {
 
+  private static final Duration STALE_AFTER = Duration.ofHours(1);
+
   private IndexingRequestDao dao;
+  private DataSource dataSource;
+  private Instant now;
 
   @BeforeEach
   public void setUp() {
-    dao = new IndexingRequestDao(TestDb.create("index_req_test").jdbi());
+    TestDb testDb = TestDb.create("index_req_test");
+    dataSource = testDb.dataSource();
+    dao = new IndexingRequestDao(testDb.jdbi());
+    now = Instant.parse("2026-07-01T12:00:00Z");
+  }
+
+  private IndexingRequestStore.IndexingRequest create(
+      String player, String start, String end, boolean excludeBullet) {
+    return dao.createOrAdopt(player, "CHESS_COM", start, end, excludeBullet, STALE_AFTER, now)
+        .request();
+  }
+
+  private Optional<IndexingRequestStore.IndexingRequest> find(
+      String player, String start, String end, boolean excludeBullet) {
+    return dao.findExistingRequest(
+        player, "CHESS_COM", start, end, excludeBullet, STALE_AFTER, now);
   }
 
   @Test
   public void findExistingRequest_returnsEmptyWhenNoRequests() {
-    Optional<IndexingRequestStore.IndexingRequest> result =
-        dao.findExistingRequest("player1", "CHESS_COM", "2024-01", "2024-01", false);
-    assertThat(result).isEmpty();
+    assertThat(find("player1", "2024-01", "2024-01", false)).isEmpty();
   }
 
   @Test
   public void findExistingRequest_returnsPendingRequestWithMatchingParams() {
-    UUID id = dao.create("player1", "CHESS_COM", "2024-01", "2024-03", false);
+    UUID id = create("player1", "2024-01", "2024-03", false).id();
     Optional<IndexingRequestStore.IndexingRequest> result =
-        dao.findExistingRequest("player1", "CHESS_COM", "2024-01", "2024-03", false);
+        find("player1", "2024-01", "2024-03", false);
     assertThat(result).isPresent();
     assertThat(result.get().id()).isEqualTo(id);
     assertThat(result.get().status()).isEqualTo("PENDING");
@@ -40,10 +68,10 @@ public class IndexingRequestDaoTest {
 
   @Test
   public void findExistingRequest_returnsProcessingRequest() {
-    UUID id = dao.create("player2", "CHESS_COM", "2024-02", "2024-02", false);
+    UUID id = create("player2", "2024-02", "2024-02", false).id();
     dao.updateStatus(id, "PROCESSING", null, 5);
     Optional<IndexingRequestStore.IndexingRequest> result =
-        dao.findExistingRequest("player2", "CHESS_COM", "2024-02", "2024-02", false);
+        find("player2", "2024-02", "2024-02", false);
     assertThat(result).isPresent();
     assertThat(result.get().id()).isEqualTo(id);
     assertThat(result.get().status()).isEqualTo("PROCESSING");
@@ -52,85 +80,321 @@ public class IndexingRequestDaoTest {
 
   @Test
   public void findExistingRequest_ignoresCompletedRequest() {
-    UUID id = dao.create("player3", "CHESS_COM", "2024-03", "2024-03", false);
+    UUID id = create("player3", "2024-03", "2024-03", false).id();
     dao.updateStatus(id, "COMPLETED", null, 10);
-    Optional<IndexingRequestStore.IndexingRequest> result =
-        dao.findExistingRequest("player3", "CHESS_COM", "2024-03", "2024-03", false);
-    assertThat(result).isEmpty();
+    assertThat(find("player3", "2024-03", "2024-03", false)).isEmpty();
   }
 
   @Test
   public void findExistingRequest_ignoresFailedRequest() {
-    UUID id = dao.create("player4", "CHESS_COM", "2024-04", "2024-04", false);
+    UUID id = create("player4", "2024-04", "2024-04", false).id();
     dao.updateStatus(id, "FAILED", "Network error", 0);
-    Optional<IndexingRequestStore.IndexingRequest> result =
-        dao.findExistingRequest("player4", "CHESS_COM", "2024-04", "2024-04", false);
-    assertThat(result).isEmpty();
+    assertThat(find("player4", "2024-04", "2024-04", false)).isEmpty();
   }
 
   @Test
-  public void findExistingRequest_returnsOldestWhenMultiplePending() {
-    UUID first = dao.create("same", "CHESS_COM", "2024-01", "2024-01", false);
-    dao.create("same", "CHESS_COM", "2024-01", "2024-01", false);
-    Optional<IndexingRequestStore.IndexingRequest> result =
-        dao.findExistingRequest("same", "CHESS_COM", "2024-01", "2024-01", false);
-    assertThat(result).isPresent();
-    assertThat(result.get().id()).isEqualTo(first);
+  public void findExistingRequest_returnsEmptyWhenParamsDiffer() {
+    create("player5", "2024-01", "2024-01", false);
+    assertThat(find("player5", "2024-02", "2024-02", false)).isEmpty();
   }
+
+  @Test
+  public void findExistingRequest_distinguishesByExcludeBullet() {
+    UUID id = create("player6", "2024-05", "2024-05", true).id();
+
+    Optional<IndexingRequestStore.IndexingRequest> match =
+        find("player6", "2024-05", "2024-05", true);
+    assertThat(match).isPresent();
+    assertThat(match.get().id()).isEqualTo(id);
+    assertThat(match.get().excludeBullet()).isTrue();
+
+    assertThat(find("player6", "2024-05", "2024-05", false)).isEmpty();
+  }
+
+  // --- #1249: the live slot is exclusive ------------------------------------------------------
+
+  @Test
+  public void createOrAdopt_secondIdenticalSubmitAdoptsTheFirstInsteadOfCreating() {
+    IndexingRequestStore.Claim first =
+        dao.createOrAdopt("same", "CHESS_COM", "2024-01", "2024-01", false, STALE_AFTER, now);
+    IndexingRequestStore.Claim second =
+        dao.createOrAdopt("same", "CHESS_COM", "2024-01", "2024-01", false, STALE_AFTER, now);
+
+    assertThat(first.created()).isTrue();
+    assertThat(second.created()).isFalse();
+    assertThat(second.request().id()).isEqualTo(first.request().id());
+    assertThat(countRequests()).isEqualTo(1);
+  }
+
+  /**
+   * The whole point of the constraint: concurrent identical submits must produce exactly one unit
+   * of work. Two of them double every motif count for the games they share, because the occurrence
+   * flush deletes and re-inserts under fresh UUIDs in separate transactions.
+   */
+  @Test
+  public void createOrAdopt_concurrentIdenticalSubmitsProduceExactlyOneRequest() throws Exception {
+    int threads = 8;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch startLine = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threads);
+    AtomicInteger createdCount = new AtomicInteger();
+    Set<UUID> claimedIds = ConcurrentHashMap.newKeySet();
+    AtomicInteger failures = new AtomicInteger();
+
+    for (int i = 0; i < threads; i++) {
+      pool.submit(
+          () -> {
+            try {
+              startLine.await();
+              IndexingRequestStore.Claim claim =
+                  dao.createOrAdopt(
+                      "racer", "CHESS_COM", "2024-06", "2024-06", false, STALE_AFTER, now);
+              claimedIds.add(claim.request().id());
+              if (claim.created()) {
+                createdCount.incrementAndGet();
+              }
+            } catch (Exception e) {
+              failures.incrementAndGet();
+            } finally {
+              done.countDown();
+            }
+          });
+    }
+
+    startLine.countDown();
+    assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+    pool.shutdownNow();
+
+    assertThat(failures.get()).isEqualTo(0);
+    assertThat(createdCount.get()).isEqualTo(1);
+    assertThat(claimedIds).hasSize(1);
+    assertThat(countRequests()).isEqualTo(1);
+  }
+
+  @Test
+  public void createOrAdopt_terminalStatusFreesTheSlotForANewRequest() {
+    IndexingRequestStore.Claim first =
+        dao.createOrAdopt("done", "CHESS_COM", "2024-07", "2024-07", false, STALE_AFTER, now);
+    dao.updateStatus(first.request().id(), "COMPLETED", null, 12);
+
+    IndexingRequestStore.Claim second =
+        dao.createOrAdopt("done", "CHESS_COM", "2024-07", "2024-07", false, STALE_AFTER, now);
+
+    assertThat(second.created()).isTrue();
+    assertThat(second.request().id()).isNotEqualTo(first.request().id());
+    assertThat(countRequests()).isEqualTo(2);
+  }
+
+  @Test
+  public void createOrAdopt_failedStatusAlsoFreesTheSlot() {
+    IndexingRequestStore.Claim first =
+        dao.createOrAdopt("retry", "CHESS_COM", "2024-08", "2024-08", false, STALE_AFTER, now);
+    dao.updateStatus(first.request().id(), "FAILED", "boom", 0);
+
+    IndexingRequestStore.Claim second =
+        dao.createOrAdopt("retry", "CHESS_COM", "2024-08", "2024-08", false, STALE_AFTER, now);
+
+    assertThat(second.created()).isTrue();
+    assertThat(second.request().id()).isNotEqualTo(first.request().id());
+  }
+
+  /** PROCESSING is still in flight, so it must keep holding the slot. */
+  @Test
+  public void createOrAdopt_processingStatusKeepsHoldingTheSlot() {
+    IndexingRequestStore.Claim first =
+        dao.createOrAdopt("busy", "CHESS_COM", "2024-09", "2024-09", false, STALE_AFTER, now);
+    dao.updateStatus(first.request().id(), "PROCESSING", null, 3);
+
+    IndexingRequestStore.Claim second =
+        dao.createOrAdopt("busy", "CHESS_COM", "2024-09", "2024-09", false, STALE_AFTER, now);
+
+    assertThat(second.created()).isFalse();
+    assertThat(second.request().id()).isEqualTo(first.request().id());
+  }
+
+  @Test
+  public void createOrAdopt_differentTuplesDoNotCollide() {
+    assertThat(create("a", "2024-01", "2024-01", false).id())
+        .isNotEqualTo(create("b", "2024-01", "2024-01", false).id());
+    assertThat(create("a", "2024-02", "2024-02", false).id()).isNotNull();
+    assertThat(create("a", "2024-01", "2024-01", true).id()).isNotNull();
+    assertThat(countRequests()).isEqualTo(4);
+  }
+
+  // --- #1250: a stranded holder must not lock the range out forever ---------------------------
+
+  @Test
+  public void createOrAdopt_reclaimsAStrandedHolderAndCreatesAReplacement() {
+    IndexingRequestStore.Claim stranded =
+        dao.createOrAdopt("ghost", "CHESS_COM", "2024-10", "2024-10", false, STALE_AFTER, now);
+    backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(3)));
+
+    IndexingRequestStore.Claim replacement =
+        dao.createOrAdopt("ghost", "CHESS_COM", "2024-10", "2024-10", false, STALE_AFTER, now);
+
+    assertThat(replacement.created()).isTrue();
+    assertThat(replacement.request().id()).isNotEqualTo(stranded.request().id());
+
+    IndexingRequestStore.IndexingRequest retired =
+        dao.findById(stranded.request().id()).orElseThrow();
+    assertThat(retired.status()).isEqualTo("FAILED");
+    assertThat(retired.errorMessage()).contains("Abandoned");
+  }
+
+  @Test
+  public void createOrAdopt_doesNotReclaimAHolderThatIsStillFresh() {
+    IndexingRequestStore.Claim live =
+        dao.createOrAdopt("alive", "CHESS_COM", "2024-11", "2024-11", false, STALE_AFTER, now);
+    backdateUpdatedAt(live.request().id(), now.minus(Duration.ofMinutes(30)));
+
+    IndexingRequestStore.Claim second =
+        dao.createOrAdopt("alive", "CHESS_COM", "2024-11", "2024-11", false, STALE_AFTER, now);
+
+    assertThat(second.created()).isFalse();
+    assertThat(second.request().id()).isEqualTo(live.request().id());
+    assertThat(dao.findById(live.request().id()).orElseThrow().status()).isEqualTo("PENDING");
+  }
+
+  @Test
+  public void findExistingRequest_ignoresAStrandedRow() {
+    IndexingRequestStore.Claim stranded =
+        dao.createOrAdopt("ghost2", "CHESS_COM", "2024-12", "2024-12", false, STALE_AFTER, now);
+    backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(5)));
+
+    assertThat(find("ghost2", "2024-12", "2024-12", false)).isEmpty();
+  }
+
+  @Test
+  public void reclaimStale_retiresStrandedRowsAndLeavesFreshOnes() {
+    IndexingRequestStore.Claim old =
+        dao.createOrAdopt("p1", "CHESS_COM", "2025-01", "2025-01", false, STALE_AFTER, now);
+    IndexingRequestStore.Claim fresh =
+        dao.createOrAdopt("p2", "CHESS_COM", "2025-01", "2025-01", false, STALE_AFTER, now);
+    backdateUpdatedAt(old.request().id(), now.minus(Duration.ofHours(2)));
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now)).isEqualTo(1);
+
+    assertThat(dao.findById(old.request().id()).orElseThrow().status()).isEqualTo("FAILED");
+    assertThat(dao.findById(fresh.request().id()).orElseThrow().status()).isEqualTo("PENDING");
+  }
+
+  @Test
+  public void reclaimStale_leavesTerminalRowsAlone() {
+    IndexingRequestStore.Claim completed =
+        dao.createOrAdopt("p3", "CHESS_COM", "2025-02", "2025-02", false, STALE_AFTER, now);
+    dao.updateStatus(completed.request().id(), "COMPLETED", null, 7);
+    backdateUpdatedAt(completed.request().id(), now.minus(Duration.ofDays(2)));
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now)).isEqualTo(0);
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(completed.request().id()).orElseThrow();
+    assertThat(row.status()).isEqualTo("COMPLETED");
+    assertThat(row.gamesIndexed()).isEqualTo(7);
+  }
+
+  /** Reclaiming has to release the slot, not just relabel the row. */
+  @Test
+  public void reclaimStale_freesTheSlotSoTheRangeCanBeRequestedAgain() {
+    IndexingRequestStore.Claim stranded =
+        dao.createOrAdopt("p4", "CHESS_COM", "2025-03", "2025-03", false, STALE_AFTER, now);
+    backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(4)));
+
+    dao.reclaimStale(STALE_AFTER, now);
+
+    IndexingRequestStore.Claim replacement =
+        dao.createOrAdopt("p4", "CHESS_COM", "2025-03", "2025-03", false, STALE_AFTER, now);
+    assertThat(replacement.created()).isTrue();
+  }
+
+  // --- #1266: the table is bounded -------------------------------------------------------------
+
+  @Test
+  public void deleteOlderThan_removesRequestsPastTheThreshold() {
+    IndexingRequestStore.Claim old =
+        dao.createOrAdopt("old", "CHESS_COM", "2025-04", "2025-04", false, STALE_AFTER, now);
+    IndexingRequestStore.Claim recent =
+        dao.createOrAdopt("recent", "CHESS_COM", "2025-05", "2025-05", false, STALE_AFTER, now);
+    backdateCreatedAt(old.request().id(), now.minus(Duration.ofDays(40)));
+
+    assertThat(dao.deleteOlderThan(now.minus(Duration.ofDays(30)))).isEqualTo(1);
+
+    assertThat(dao.findById(old.request().id())).isEmpty();
+    assertThat(dao.findById(recent.request().id())).isPresent();
+  }
+
+  @Test
+  public void deleteOlderThan_leavesRequestsThatStillOwnGames() {
+    IndexingRequestStore.Claim owner =
+        dao.createOrAdopt("owner", "CHESS_COM", "2025-06", "2025-06", false, STALE_AFTER, now);
+    backdateCreatedAt(owner.request().id(), now.minus(Duration.ofDays(40)));
+    insertGame(owner.request().id(), "https://chess.com/still-here");
+
+    assertThat(dao.deleteOlderThan(now.minus(Duration.ofDays(30)))).isEqualTo(0);
+    assertThat(dao.findById(owner.request().id())).isPresent();
+  }
+
+  // --- unchanged surface -----------------------------------------------------------------------
 
   @Test
   public void listRecent_returnsEmptyWhenNoRequests() {
-    List<IndexingRequestStore.IndexingRequest> results = dao.listRecent(10);
-    assertThat(results).isEmpty();
-  }
-
-  @Test
-  public void listRecent_returnsRequestsOrderedByCreatedAtDesc() {
-    UUID first = dao.create("playerA", "CHESS_COM", "2024-01", "2024-01", false);
-    UUID second = dao.create("playerB", "CHESS_COM", "2024-02", "2024-02", false);
-    UUID third = dao.create("playerC", "CHESS_COM", "2024-03", "2024-03", false);
-
-    List<IndexingRequestStore.IndexingRequest> results = dao.listRecent(10);
-
-    assertThat(results).hasSize(3);
-    assertThat(results.get(0).id()).isEqualTo(third);
-    assertThat(results.get(1).id()).isEqualTo(second);
-    assertThat(results.get(2).id()).isEqualTo(first);
+    assertThat(dao.listRecent(10)).isEmpty();
   }
 
   @Test
   public void listRecent_respectsLimit() {
-    dao.create("playerA", "CHESS_COM", "2024-01", "2024-01", false);
-    dao.create("playerB", "CHESS_COM", "2024-02", "2024-02", false);
-    dao.create("playerC", "CHESS_COM", "2024-03", "2024-03", false);
+    create("playerA", "2024-01", "2024-01", false);
+    create("playerB", "2024-02", "2024-02", false);
+    create("playerC", "2024-03", "2024-03", false);
 
     List<IndexingRequestStore.IndexingRequest> results = dao.listRecent(2);
 
     assertThat(results).hasSize(2);
   }
 
-  @Test
-  public void findExistingRequest_returnsEmptyWhenParamsDiffer() {
-    dao.create("player5", "CHESS_COM", "2024-01", "2024-01", false);
-    Optional<IndexingRequestStore.IndexingRequest> result =
-        dao.findExistingRequest("player5", "CHESS_COM", "2024-02", "2024-02", false);
-    assertThat(result).isEmpty();
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private void backdateUpdatedAt(UUID id, Instant updatedAt) {
+    execute("UPDATE indexing_requests SET updated_at = ? WHERE id = ?", updatedAt, id);
   }
 
-  @Test
-  public void findExistingRequest_distinguishesByExcludeBullet() {
-    UUID id = dao.create("player6", "CHESS_COM", "2024-05", "2024-05", true);
+  private void backdateCreatedAt(UUID id, Instant createdAt) {
+    execute("UPDATE indexing_requests SET created_at = ? WHERE id = ?", createdAt, id);
+  }
 
-    // Same params, same excludeBullet → match
-    Optional<IndexingRequestStore.IndexingRequest> match =
-        dao.findExistingRequest("player6", "CHESS_COM", "2024-05", "2024-05", true);
-    assertThat(match).isPresent();
-    assertThat(match.get().id()).isEqualTo(id);
-    assertThat(match.get().excludeBullet()).isTrue();
+  private void execute(String sql, Instant timestamp, UUID id) {
+    try (var conn = dataSource.getConnection();
+        var ps = conn.prepareStatement(sql)) {
+      ps.setTimestamp(1, Timestamp.from(timestamp));
+      ps.setObject(2, id);
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-    // Same params, different excludeBullet → no match
-    Optional<IndexingRequestStore.IndexingRequest> noMatch =
-        dao.findExistingRequest("player6", "CHESS_COM", "2024-05", "2024-05", false);
-    assertThat(noMatch).isEmpty();
+  private void insertGame(UUID requestId, String gameUrl) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "INSERT INTO game_features (id, request_id, game_url, platform) VALUES (?, ?, ?,"
+                    + " 'CHESS_COM')")) {
+      ps.setObject(1, UUID.randomUUID());
+      ps.setObject(2, requestId);
+      ps.setString(3, gameUrl);
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private int countRequests() {
+    try (var conn = dataSource.getConnection();
+        var ps = conn.prepareStatement("SELECT COUNT(*) FROM indexing_requests");
+        var rs = ps.executeQuery()) {
+      rs.next();
+      return rs.getInt(1);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -173,6 +173,43 @@ public class MigrationTest {
     assertThat(keyed).as("exactly one duplicate may hold the slot").isEqualTo(1);
   }
 
+  /**
+   * The backfill decides which duplicate holds the slot; {@code findExistingRequest} decides which
+   * one a later submit attaches to. They have to be the same row. Ordering by created_at alone
+   * settles it only when the timestamps differ — and duplicate submits are precisely what produces
+   * ties — so a tie is where the two can disagree and hand a caller a row nobody is working on
+   * while the keyed row does the work.
+   */
+  @Test
+  public void run_theBackfillWinnerIsTheRowASubsequentLookupReturns() throws Exception {
+    new Migration(dataSource, true).run();
+
+    Instant sameInstant = Instant.parse("2026-06-01T00:00:00Z");
+    for (int i = 0; i < 3; i++) {
+      insertLegacyRequest("tied", "2024-05", "2024-05", false, "PENDING", sameInstant);
+    }
+    clearDedupeKeys();
+
+    new Migration(dataSource, true).run();
+
+    IndexingRequestDao dao = new IndexingRequestDao(org.jdbi.v3.core.Jdbi.create(dataSource));
+    UUID found =
+        dao.findExistingRequest(
+                "tied",
+                "CHESS_COM",
+                "2024-05",
+                "2024-05",
+                false,
+                java.time.Duration.ofDays(3650),
+                Instant.parse("2026-06-01T01:00:00Z"))
+            .orElseThrow()
+            .id();
+
+    assertThat(dedupeKeyOf(found))
+        .as("the row a submit attaches to must be the row that holds the slot")
+        .isNotNull();
+  }
+
   private UUID insertLegacyRequest(
       String player, String startMonth, String endMonth, boolean excludeBullet, String status)
       throws Exception {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -6,6 +6,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.time.Instant;
 import java.util.UUID;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,6 +102,127 @@ public class MigrationTest {
       assertThat(rs.getInt("move_number")).isEqualTo(3);
       assertThat(rs.getString("description")).isEqualTo("Check at move 3");
       assertThat(rs.next()).isFalse();
+    }
+  }
+
+  /**
+   * The backfill renders the dedupe key in SQL while {@link IndexingRequestDao} renders it in Java,
+   * and the two have to agree exactly or a migrated row is invisible to dedupe. H2 spells a BOOLEAN
+   * 'TRUE' where Java and Postgres spell it 'true', so the excludeBullet=true case is the one that
+   * catches a missing LOWER(CAST(...)) — the false case passes either way.
+   */
+  @Test
+  public void run_backfillsDedupeKeyMatchingTheJavaRendering() throws Exception {
+    new Migration(dataSource, true).run();
+
+    UUID pending = insertLegacyRequest("hikaru", "2024-01", "2024-03", true, "PENDING");
+    UUID completed = insertLegacyRequest("magnus", "2024-01", "2024-01", false, "COMPLETED");
+    clearDedupeKeys();
+
+    new Migration(dataSource, true).run();
+
+    assertThat(dedupeKeyOf(pending))
+        .isEqualTo(IndexingRequestDao.dedupeKey("hikaru", "CHESS_COM", "2024-01", "2024-03", true));
+    assertThat(dedupeKeyOf(completed)).as("terminal rows hold no slot").isNull();
+
+    // The proof that the rendering agrees: a fresh submit for the same tuple adopts the migrated
+    // row rather than trying to create a second one.
+    IndexingRequestDao dao = new IndexingRequestDao(org.jdbi.v3.core.Jdbi.create(dataSource));
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt(
+            "hikaru",
+            "CHESS_COM",
+            "2024-01",
+            "2024-03",
+            true,
+            java.time.Duration.ofHours(1),
+            java.time.Instant.now());
+    assertThat(claim.created()).isFalse();
+    assertThat(claim.request().id()).isEqualTo(pending);
+  }
+
+  /**
+   * The pre-constraint schema allowed several live rows per tuple, so the backfill has to key at
+   * most one of them or ADD CONSTRAINT fails and the whole migration aborts.
+   *
+   * <p>All three rows are given the <em>same</em> created_at deliberately. The backfill picks the
+   * group's MIN(created_at), which on distinct timestamps already selects one row and hides the
+   * problem; a tie is what makes MIN match every row at once, and a tie is exactly what a coarse
+   * clock produces when duplicate submits land in the same instant — which is the situation that
+   * created these duplicates in the first place.
+   */
+  @Test
+  public void run_backfillKeysOnlyOneOfSeveralLiveRequestsCreatedInTheSameInstant()
+      throws Exception {
+    new Migration(dataSource, true).run();
+
+    Instant sameInstant = Instant.parse("2026-06-01T00:00:00Z");
+    UUID first = insertLegacyRequest("dupe", "2024-05", "2024-05", false, "PENDING", sameInstant);
+    UUID second = insertLegacyRequest("dupe", "2024-05", "2024-05", false, "PENDING", sameInstant);
+    UUID third =
+        insertLegacyRequest("dupe", "2024-05", "2024-05", false, "PROCESSING", sameInstant);
+    clearDedupeKeys();
+
+    new Migration(dataSource, true).run();
+
+    long keyed =
+        java.util.stream.Stream.of(first, second, third)
+            .filter(id -> dedupeKeyOf(id) != null)
+            .count();
+    assertThat(keyed).as("exactly one duplicate may hold the slot").isEqualTo(1);
+  }
+
+  private UUID insertLegacyRequest(
+      String player, String startMonth, String endMonth, boolean excludeBullet, String status)
+      throws Exception {
+    return insertLegacyRequest(player, startMonth, endMonth, excludeBullet, status, null);
+  }
+
+  private UUID insertLegacyRequest(
+      String player,
+      String startMonth,
+      String endMonth,
+      boolean excludeBullet,
+      String status,
+      Instant createdAt)
+      throws Exception {
+    UUID id = UUID.randomUUID();
+    try (Connection conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " exclude_bullet, status, created_at) VALUES (?, ?, 'CHESS_COM', ?, ?, ?, ?,"
+                    + " ?)")) {
+      ps.setObject(1, id);
+      ps.setString(2, player);
+      ps.setString(3, startMonth);
+      ps.setString(4, endMonth);
+      ps.setBoolean(5, excludeBullet);
+      ps.setString(6, status);
+      ps.setTimestamp(7, java.sql.Timestamp.from(createdAt == null ? Instant.now() : createdAt));
+      ps.executeUpdate();
+    }
+    return id;
+  }
+
+  /** Simulates rows written before the column existed, so the backfill has work to do. */
+  private void clearDedupeKeys() throws Exception {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("UPDATE indexing_requests SET dedupe_key = NULL");
+    }
+  }
+
+  private String dedupeKeyOf(UUID id) {
+    try (Connection conn = dataSource.getConnection();
+        var ps = conn.prepareStatement("SELECT dedupe_key FROM indexing_requests WHERE id = ?")) {
+      ps.setObject(1, id);
+      try (ResultSet rs = ps.executeQuery()) {
+        assertThat(rs.next()).isTrue();
+        return rs.getString("dedupe_key");
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -145,11 +145,12 @@ public class MigrationTest {
    * The pre-constraint schema allowed several live rows per tuple, so the backfill has to key at
    * most one of them or ADD CONSTRAINT fails and the whole migration aborts.
    *
-   * <p>All three rows are given the <em>same</em> created_at deliberately. The backfill picks the
-   * group's MIN(created_at), which on distinct timestamps already selects one row and hides the
-   * problem; a tie is what makes MIN match every row at once, and a tie is exactly what a coarse
-   * clock produces when duplicate submits land in the same instant — which is the situation that
-   * created these duplicates in the first place.
+   * <p>All three rows are given the <em>same</em> created_at deliberately. The backfill orders
+   * candidates by (created_at, id); on distinct timestamps created_at alone decides and the id
+   * tiebreak never runs, so a fixture with distinct timestamps would pass against a backfill that
+   * omitted it. A tie is what forces the tiebreak to do the work — and a tie is exactly what a
+   * coarse clock produces when duplicate submits land in the same instant, which is the situation
+   * that created these duplicates in the first place.
    */
   @Test
   public void run_backfillKeysOnlyOneOfSeveralLiveRequestsCreatedInTheSameInstant()

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/RequestStalenessTimeZoneTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/RequestStalenessTimeZoneTest.java
@@ -1,0 +1,152 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code indexing_requests.created_at} and {@code updated_at} are TIMESTAMP columns with no zone on
+ * both H2 and Postgres, and {@link RetentionPolicy#STALE_REQUEST} measures against them across a
+ * window of one hour. That window is short enough that a zone leak does not shift a boundary — it
+ * inverts the predicate, retiring every healthy request or ignoring every stranded one.
+ *
+ * <p>This is the same hazard {@code game_features.indexed_at} had (#1268), so this suite is the
+ * counterpart to {@link PlayedAtTimeZoneTest} and exists for the same reason its javadoc gives:
+ * <b>a symmetric write/read pair cancels the offset out within one process.</b> Every test in
+ * {@code IndexingRequestDaoTest} writes its fixture with the same JVM conversion the DAO reads
+ * with, so all of them would pass against a DAO that stored local time. The assertions here look at
+ * the wall clock actually on disk, and at a threshold computed independently of the DAO.
+ *
+ * <p>This is not hypothetical for this table in particular. {@code createOrAdopt}'s own javadoc
+ * describes REST and MCP as two JVMs against one Postgres; if they disagreed about the stored
+ * convention, one would systematically mis-measure the other's requests.
+ *
+ * <p>The zone comes from the Bazel target's {@code env = {"TZ": ...}} rather than {@code
+ * TimeZone.setDefault} in a {@code @BeforeEach}: H2 caches the default zone globally the first time
+ * it converts a value, so a zone changed mid-JVM would not reach the driver and this would pass
+ * vacuously.
+ */
+public class RequestStalenessTimeZoneTest {
+
+  /** UTC+14 with no DST — the largest offset in the tz database, so any zone leak shows up. */
+  private static final String EXPECTED_ZONE = "Pacific/Kiritimati";
+
+  private static final Instant NOW = Instant.parse("2026-07-01T12:00:00Z");
+  private static final Duration STALE_AFTER = Duration.ofHours(1);
+
+  private IndexingRequestDao dao;
+  private DataSource dataSource;
+
+  @BeforeEach
+  public void setUp() {
+    TestDb testDb = TestDb.create("request_staleness_tz");
+    dataSource = testDb.dataSource();
+    dao = new IndexingRequestDao(testDb.jdbi(), Clock.fixed(NOW, ZoneOffset.UTC));
+  }
+
+  @Test
+  public void sanityTheTargetActuallyRunsUnderTheNonUtcZone() {
+    assertThat(TimeZone.getDefault().getID())
+        .as("the Bazel target must set TZ, or every assertion here is vacuous")
+        .isEqualTo(EXPECTED_ZONE);
+  }
+
+  /**
+   * The load-bearing assertion: the value on disk is the UTC wall clock, not the JVM-local one. A
+   * DAO that bound through the default zone would store 2026-07-02T02:00 here (UTC+14).
+   */
+  @Test
+  public void storedTimestampsAreUtcWallClocksNotJvmLocal() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("tz", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+
+    LocalDateTime expected = LocalDateTime.of(2026, 7, 1, 12, 0, 0);
+    assertThat(rawTimestamp(claim.request().id(), "created_at")).isEqualTo(expected);
+    assertThat(rawTimestamp(claim.request().id(), "updated_at")).isEqualTo(expected);
+  }
+
+  @Test
+  public void updateStatusAlsoStampsAUtcWallClock() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("tz2", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+    dao.updateStatus(claim.request().id(), "PROCESSING", null, 1);
+
+    assertThat(rawTimestamp(claim.request().id(), "updated_at"))
+        .as("updated_at must not come from a different clock than created_at")
+        .isEqualTo(LocalDateTime.of(2026, 7, 1, 12, 0, 0));
+  }
+
+  /**
+   * Staleness measured against a row whose timestamp this test wrote itself, in UTC, without going
+   * through the DAO — so the DAO cannot cancel its own error out.
+   */
+  @Test
+  public void stalenessIsMeasuredInUtcRegardlessOfTheJvmZone() {
+    IndexingRequestStore.Claim fresh =
+        dao.createOrAdopt("tz3", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+    IndexingRequestStore.Claim stale =
+        dao.createOrAdopt("tz4", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+
+    // 30 minutes old and 3 hours old, written as UTC wall clocks by hand.
+    writeUtcWallClock(fresh.request().id(), LocalDateTime.of(2026, 7, 1, 11, 30));
+    writeUtcWallClock(stale.request().id(), LocalDateTime.of(2026, 7, 1, 9, 0));
+
+    assertThat(dao.reclaimStale(STALE_AFTER, NOW)).isEqualTo(1);
+
+    assertThat(dao.findById(stale.request().id()).orElseThrow().status()).isEqualTo("FAILED");
+    assertThat(dao.findById(fresh.request().id()).orElseThrow().status()).isEqualTo("PENDING");
+  }
+
+  /**
+   * The same boundary through the dedupe read. Under a UTC+14 leak the 30-minute-old row would look
+   * 14 hours stale and dedupe would stop seeing it, which is what silently disables #1249's guard.
+   */
+  @Test
+  public void findExistingRequestStillSeesAFreshRowUnderANonUtcZone() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("tz5", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+    writeUtcWallClock(claim.request().id(), LocalDateTime.of(2026, 7, 1, 11, 30));
+
+    assertThat(
+            dao.findExistingRequest(
+                "tz5", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW))
+        .isPresent();
+  }
+
+  private LocalDateTime rawTimestamp(UUID id, String column) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement("SELECT " + column + " FROM indexing_requests WHERE id = ?")) {
+      ps.setObject(1, id);
+      try (var rs = ps.executeQuery()) {
+        assertThat(rs.next()).isTrue();
+        // getObject(LocalDateTime.class) reads the stored wall clock with no zone conversion —
+        // getTimestamp would reintroduce the JVM zone and hide exactly what this is checking.
+        return rs.getObject(column, LocalDateTime.class);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void writeUtcWallClock(UUID id, LocalDateTime utcWallClock) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement("UPDATE indexing_requests SET updated_at = ? WHERE id = ?")) {
+      ps.setObject(1, utcWallClock);
+      ps.setObject(2, id);
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
@@ -257,6 +257,35 @@ public class IndexE2ETest {
   }
 
   /**
+   * Same contract, the other two windows. Both are published in prose that nothing else gates —
+   * API.md's "**30 days**" and its "23-day gap" paragraph, the README retention table, and the web
+   * app's panel note. Behavior alone pins these only loosely: the worker suite's fixtures are 10
+   * and 40 days old, so anything in between would keep it green while falsifying every one of those
+   * sentences.
+   */
+  @Test
+  public void requestRetentionWindowIsThirtyDays() {
+    assertThat(RetentionPolicy.REQUEST).isEqualTo(Duration.ofDays(30));
+  }
+
+  @Test
+  public void strandedRequestCutoffIsOneHour() {
+    assertThat(RetentionPolicy.STALE_REQUEST).isEqualTo(Duration.ofHours(1));
+  }
+
+  /**
+   * Not a style preference — a correctness constraint. {@code game_features.request_id} is a
+   * foreign key onto {@code indexing_requests(id)}, so a request must outlive the games it produced
+   * or the sweep would be deleting rows its own children still reference. Asserted here rather than
+   * in a static initializer on RetentionPolicy, where a violation would surface as an
+   * ExceptionInInitializerError during Micronaut startup instead of as a failing test.
+   */
+  @Test
+  public void requestsAreRetainedLongerThanTheGamesTheyProduced() {
+    assertThat(RetentionPolicy.REQUEST).isGreaterThan(RetentionPolicy.PERIOD);
+  }
+
+  /**
    * A clock parked {@code offset} into the future. RetentionWorker subtracts RetentionPolicy.PERIOD
    * from it, so the resulting threshold sits {@code offset - PERIOD} either side of "now" — which
    * is what puts the rows just written on one side of the boundary or the other.

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
@@ -158,7 +158,8 @@ public class IndexE2ETest {
     // deleteOlderThan with a hand-made threshold would only test the DELETE; this exercises
     // RetentionWorker's own `clock.instant().minus(RETENTION_PERIOD)` arithmetic, so changing
     // RetentionPolicy.PERIOD now breaks a test instead of silently changing behaviour.
-    new RetentionWorker(gameFeatureStore, periodStore, clockOffsetBy(RETENTION_PLUS_MARGIN))
+    new RetentionWorker(
+            gameFeatureStore, periodStore, requestStore, clockOffsetBy(RETENTION_PLUS_MARGIN))
         .runRetention();
 
     IndexResponse swept = controller.getIndex(created.id());
@@ -189,7 +190,8 @@ public class IndexE2ETest {
         controller.createIndex(new IndexRequest(PLAYER, PLATFORM, "2024-03", "2024-03", null));
     processQueueUntilIdle();
 
-    new RetentionWorker(gameFeatureStore, periodStore, clockOffsetBy(RETENTION_MINUS_MARGIN))
+    new RetentionWorker(
+            gameFeatureStore, periodStore, requestStore, clockOffsetBy(RETENTION_MINUS_MARGIN))
         .runRetention();
 
     assertThat(controller.getIndex(created.id()).data().status()).isEqualTo("AVAILABLE");

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
@@ -8,8 +8,10 @@ import com.muchq.games.one_d4.db.IndexedPeriodStore;
 import com.muchq.games.one_d4.db.IndexingRequestStore;
 import com.muchq.games.one_d4.queue.IndexMessage;
 import com.muchq.games.one_d4.queue.IndexQueue;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -21,6 +23,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class IndexRequestServiceTest {
+
+  private static final Instant NOW = Instant.parse("2026-07-01T12:00:00Z");
 
   private InMemoryRequestStore requestStore;
   private RecordingQueue queue;
@@ -40,7 +44,8 @@ public class IndexRequestServiceTest {
               inlineProcessed.add(message);
               requestStore.updateStatus(message.requestId(), "COMPLETED", null, 42);
             },
-            noPeriods());
+            noPeriods(),
+            Clock.fixed(NOW, ZoneOffset.UTC));
   }
 
   /** No period rows: availability resolves to EXPIRED, which these tests don't assert on. */
@@ -108,8 +113,41 @@ public class IndexRequestServiceTest {
   }
 
   @Test
-  public void submit_skipCacheBypassesDedupeAndPropagates() {
-    service.submit(submission("hikaru", "CHESS_COM"));
+  public void submit_skipCachePropagatesTheFlagWhenNothingIsInFlight() {
+    IndexResponse forced =
+        service.submit(
+            new IndexRequestService.Submission(
+                "hikaru", "CHESS_COM", "2024-01", "2024-03", false, true));
+
+    assertThat(queue.enqueued).hasSize(1);
+    assertThat(queue.enqueued.get(0).skipCache()).isTrue();
+    assertThat(forced.status()).isEqualTo("PENDING");
+  }
+
+  /**
+   * skipCache forces a refetch; it does not license a second concurrent run of the same range. Two
+   * indexers over one set of games interleave the occurrence delete/insert and double every motif
+   * count, so the forced submit coalesces onto the in-flight request instead.
+   */
+  @Test
+  public void submit_skipCacheDoesNotStartARivalRunWhileOneIsInFlight() {
+    IndexResponse first = service.submit(submission("hikaru", "CHESS_COM"));
+
+    IndexResponse forced =
+        service.submit(
+            new IndexRequestService.Submission(
+                "hikaru", "CHESS_COM", "2024-01", "2024-03", false, true));
+
+    assertThat(queue.enqueued).hasSize(1);
+    assertThat(forced.id()).isEqualTo(first.id());
+    assertThat(forced.status()).isEqualTo("PENDING");
+  }
+
+  /** Once the in-flight run reaches a terminal status the force works normally. */
+  @Test
+  public void submit_skipCacheForcesAFreshRunOnceTheInFlightOneFinishes() {
+    IndexResponse first = service.submit(submission("hikaru", "CHESS_COM"));
+    requestStore.updateStatus(first.id(), "COMPLETED", null, 30);
 
     IndexResponse forced =
         service.submit(
@@ -118,7 +156,49 @@ public class IndexRequestServiceTest {
 
     assertThat(queue.enqueued).hasSize(2);
     assertThat(queue.enqueued.get(1).skipCache()).isTrue();
-    assertThat(forced.status()).isEqualTo("PENDING");
+    assertThat(forced.id()).isNotEqualTo(first.id());
+  }
+
+  /**
+   * #1249: two callers that both see nothing must still produce one unit of work. The service's
+   * dedupe read cannot prevent this — only the claim can — so this drives the path where the read
+   * is bypassed entirely.
+   */
+  @Test
+  public void submit_secondCallerAdoptsRatherThanDispatchingASecondTime() {
+    IndexResponse first = service.submit(submission("hikaru", "CHESS_COM"));
+    IndexResponse second = service.submit(submission("hikaru", "CHESS_COM"));
+
+    assertThat(second.id()).isEqualTo(first.id());
+    assertThat(queue.enqueued).hasSize(1);
+  }
+
+  /**
+   * #1250: a request whose owner died must not hold its range hostage. Before the age bound, the
+   * stranded row answered every later submit forever and the only escape was skipCache.
+   */
+  @Test
+  public void submit_strandedRequestIsRetiredAndReplacedOnTheNextSubmit() {
+    IndexResponse stranded = service.submit(submission("hikaru", "CHESS_COM"));
+    requestStore.strand(stranded.id(), NOW.minus(Duration.ofHours(6)));
+
+    IndexResponse replacement = service.submit(submission("hikaru", "CHESS_COM"));
+
+    assertThat(replacement.id()).isNotEqualTo(stranded.id());
+    assertThat(replacement.status()).isEqualTo("PENDING");
+    assertThat(queue.enqueued).hasSize(2);
+    assertThat(requestStore.findById(stranded.id()).orElseThrow().status()).isEqualTo("FAILED");
+  }
+
+  @Test
+  public void submit_aFreshInFlightRequestIsStillReusedNotReplaced() {
+    IndexResponse first = service.submit(submission("hikaru", "CHESS_COM"));
+    requestStore.strand(first.id(), NOW.minus(Duration.ofMinutes(20)));
+
+    IndexResponse second = service.submit(submission("hikaru", "CHESS_COM"));
+
+    assertThat(second.id()).isEqualTo(first.id());
+    assertThat(queue.enqueued).hasSize(1);
   }
 
   @Test
@@ -189,10 +269,13 @@ public class IndexRequestServiceTest {
     assertThat(response.errorMessage()).isEqualTo("chess.com 429");
   }
 
+  /**
+   * The inline path owns its row outright — no queue entry, no worker to pick it up — so an
+   * exception escaping the processor used to leave it PENDING forever, holding the range against
+   * every later submit. The failure still reaches the caller; the row no longer outlives it.
+   */
   @Test
-  public void submitHybrid_inlineProcessorThrowingPropagatesAndLeavesRowPending() {
-    // Pins current behavior: an exception escaping the inline processor reaches the caller and the
-    // row stays PENDING (dedupe will keep matching it — tracked as a known gap in the service).
+  public void submitHybrid_inlineProcessorThrowingPropagatesAndRetiresTheRow() {
     IndexRequestService throwing =
         new IndexRequestService(
             requestStore,
@@ -200,7 +283,8 @@ public class IndexRequestServiceTest {
             message -> {
               throw new RuntimeException("boom");
             },
-            noPeriods());
+            noPeriods(),
+            Clock.fixed(NOW, ZoneOffset.UTC));
 
     assertThatThrownBy(
             () ->
@@ -210,10 +294,44 @@ public class IndexRequestServiceTest {
         .isInstanceOf(RuntimeException.class)
         .hasMessage("boom");
 
-    Optional<IndexingRequestStore.IndexingRequest> row =
-        requestStore.findExistingRequest("hikaru", "CHESS_COM", "2024-01", "2024-01", false);
-    assertThat(row).isPresent();
-    assertThat(row.get().status()).isEqualTo("PENDING");
+    assertThat(
+            requestStore.findExistingRequest(
+                "hikaru", "CHESS_COM", "2024-01", "2024-01", false, Duration.ofHours(1), NOW))
+        .as("the range must not stay locked by a row nothing will ever finish")
+        .isEmpty();
+
+    IndexingRequestStore.IndexingRequest row =
+        requestStore.listRecent(10).stream().findFirst().orElseThrow();
+    assertThat(row.status()).isEqualTo("FAILED");
+    assertThat(row.errorMessage()).contains("boom");
+  }
+
+  /** A retired inline failure frees the slot, so the caller can immediately try again. */
+  @Test
+  public void submitHybrid_rangeIsRequestableAgainAfterAnInlineFailure() {
+    IndexRequestService throwing =
+        new IndexRequestService(
+            requestStore,
+            queue,
+            message -> {
+              throw new RuntimeException("boom");
+            },
+            noPeriods(),
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThatThrownBy(
+            () ->
+                throwing.submitHybrid(
+                    new IndexRequestService.Submission(
+                        "hikaru", "CHESS_COM", "2024-01", "2024-01", false, false)))
+        .isInstanceOf(RuntimeException.class);
+
+    IndexResponse retry =
+        service.submitHybrid(
+            new IndexRequestService.Submission(
+                "hikaru", "CHESS_COM", "2024-01", "2024-01", false, false));
+
+    assertThat(retry.status()).isEqualTo("COMPLETED");
   }
 
   @Test
@@ -291,37 +409,20 @@ public class IndexRequestServiceTest {
     assertThat(service.status(UUID.randomUUID())).isEmpty();
   }
 
+  /**
+   * Models the constraint the real schema enforces: at most one live row per dedupe tuple, and a
+   * terminal status releases it. A fake that lets two live rows coexist would let double-dispatch
+   * tests pass here and fail against Postgres.
+   */
   private static final class InMemoryRequestStore implements IndexingRequestStore {
     private final Map<UUID, IndexingRequest> rows = new HashMap<>();
+    private Instant clock = Instant.parse("2026-07-01T12:00:00Z");
 
-    @Override
-    public UUID create(
-        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
-      UUID id = UUID.randomUUID();
-      rows.put(
-          id,
-          new IndexingRequest(
-              id,
-              player,
-              platform,
-              startMonth,
-              endMonth,
-              "PENDING",
-              Instant.now(),
-              Instant.now(),
-              null,
-              0,
-              excludeBullet));
-      return id;
+    private static boolean live(IndexingRequest r) {
+      return r.status().equals("PENDING") || r.status().equals("PROCESSING");
     }
 
-    @Override
-    public Optional<IndexingRequest> findById(UUID id) {
-      return Optional.ofNullable(rows.get(id));
-    }
-
-    @Override
-    public Optional<IndexingRequest> findExistingRequest(
+    private Optional<IndexingRequest> liveHolder(
         String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
       return rows.values().stream()
           .filter(
@@ -331,8 +432,60 @@ public class IndexRequestServiceTest {
                       && r.startMonth().equals(startMonth)
                       && r.endMonth().equals(endMonth)
                       && r.excludeBullet() == excludeBullet
-                      && (r.status().equals("PENDING") || r.status().equals("PROCESSING")))
+                      && live(r))
           .findFirst();
+    }
+
+    @Override
+    public Claim createOrAdopt(
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        Duration staleAfter,
+        Instant now) {
+      reclaimStale(staleAfter, now);
+      Optional<IndexingRequest> holder =
+          liveHolder(player, platform, startMonth, endMonth, excludeBullet);
+      if (holder.isPresent()) {
+        return new Claim(holder.get(), false);
+      }
+      UUID id = UUID.randomUUID();
+      IndexingRequest created =
+          new IndexingRequest(
+              id,
+              player,
+              platform,
+              startMonth,
+              endMonth,
+              "PENDING",
+              now,
+              now,
+              null,
+              0,
+              excludeBullet);
+      rows.put(id, created);
+      return new Claim(created, true);
+    }
+
+    @Override
+    public Optional<IndexingRequest> findById(UUID id) {
+      return Optional.ofNullable(rows.get(id));
+    }
+
+    @Override
+    public Optional<IndexingRequest> findExistingRequest(
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        Duration staleAfter,
+        Instant now) {
+      Instant cutoff = now.minus(staleAfter);
+      return liveHolder(player, platform, startMonth, endMonth, excludeBullet)
+          .filter(r -> !r.updatedAt().isBefore(cutoff));
     }
 
     @Override
@@ -353,10 +506,64 @@ public class IndexRequestServiceTest {
               row.endMonth(),
               status,
               row.createdAt(),
-              Instant.now(),
+              clock,
               errorMessage,
               gamesIndexed,
               row.excludeBullet()));
+    }
+
+    @Override
+    public int reclaimStale(Duration staleAfter, Instant now) {
+      Instant cutoff = now.minus(staleAfter);
+      List<IndexingRequest> stranded =
+          rows.values().stream().filter(r -> live(r) && r.updatedAt().isBefore(cutoff)).toList();
+      for (IndexingRequest r : stranded) {
+        rows.put(
+            r.id(),
+            new IndexingRequest(
+                r.id(),
+                r.player(),
+                r.platform(),
+                r.startMonth(),
+                r.endMonth(),
+                "FAILED",
+                r.createdAt(),
+                now,
+                "Abandoned",
+                r.gamesIndexed(),
+                r.excludeBullet()));
+      }
+      return stranded.size();
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      List<UUID> doomed =
+          rows.values().stream()
+              .filter(r -> r.createdAt().isBefore(threshold))
+              .map(IndexingRequest::id)
+              .toList();
+      doomed.forEach(rows::remove);
+      return doomed.size();
+    }
+
+    /** Backdates a row's updatedAt so a test can strand it without waiting an hour. */
+    void strand(UUID id, Instant updatedAt) {
+      IndexingRequest r = rows.get(id);
+      rows.put(
+          id,
+          new IndexingRequest(
+              r.id(),
+              r.player(),
+              r.platform(),
+              r.startMonth(),
+              r.endMonth(),
+              r.status(),
+              r.createdAt(),
+              updatedAt,
+              r.errorMessage(),
+              r.gamesIndexed(),
+              r.excludeBullet()));
     }
   }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
@@ -513,6 +513,16 @@ public class IndexRequestServiceTest {
     }
 
     @Override
+    public boolean heartbeat(UUID id, Instant now) {
+      IndexingRequest r = rows.get(id);
+      if (r == null || !live(r)) {
+        return false;
+      }
+      strand(id, now);
+      return true;
+    }
+
+    @Override
     public int reclaimStale(Duration staleAfter, Instant now) {
       Instant cutoff = now.minus(staleAfter);
       List<IndexingRequest> stranded =

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -689,14 +689,43 @@ public class IndexWorkerTest {
     }
 
     @Override
-    public UUID create(
-        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
-      return UUID.randomUUID();
+    public Claim createOrAdopt(
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        java.time.Duration staleAfter,
+        Instant now) {
+      return new Claim(
+          new IndexingRequestStore.IndexingRequest(
+              UUID.randomUUID(),
+              player,
+              platform,
+              startMonth,
+              endMonth,
+              "PENDING",
+              now,
+              now,
+              null,
+              0,
+              excludeBullet),
+          true);
     }
 
     @Override
     public Optional<IndexingRequestStore.IndexingRequest> findById(UUID id) {
       return Optional.empty();
+    }
+
+    @Override
+    public int reclaimStale(java.time.Duration staleAfter, Instant now) {
+      return 0;
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
     }
 
     @Override
@@ -713,7 +742,13 @@ public class IndexWorkerTest {
 
     @Override
     public Optional<IndexingRequestStore.IndexingRequest> findExistingRequest(
-        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        java.time.Duration staleAfter,
+        Instant now) {
       return Optional.empty();
     }
   }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -724,6 +724,11 @@ public class IndexWorkerTest {
     }
 
     @Override
+    public boolean heartbeat(UUID id, Instant now) {
+      return true;
+    }
+
+    @Override
     public int deleteOlderThan(Instant threshold) {
       return 0;
     }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -143,6 +143,35 @@ public class RequestLivenessTest {
         .isTrue();
   }
 
+  /**
+   * Characterizes the hole the heartbeat does <em>not</em> close, so it cannot drift silently.
+   *
+   * <p>A message waiting in the queue has no worker running for it, so nothing beats on its behalf
+   * and {@code updated_at} stays frozen at insert. A backlog deeper than the cutoff therefore
+   * retires work that is owned and about to run, and tells the user to re-submit while the message
+   * is still queued.
+   *
+   * <p>This asserts the current, wrong-ish behaviour on purpose. When someone beats on enqueue —
+   * the actual fix, rather than a larger cutoff — this test should fail and be rewritten to assert
+   * the opposite. That failure is the notification.
+   */
+  @Test
+  public void queuedButUnstartedWorkIsStillRetired_knownGap() {
+    TestDb testDb = TestDb.create("liveness_backlog");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID queued = claim(dao).request().id();
+
+    // No worker has picked the message up yet; the backlog outlasts the cutoff.
+    clock.advance(SLOW_FETCH);
+    dao.reclaimStale(STALE_AFTER, clock.instant());
+
+    assertThat(dao.findById(queued).orElseThrow().status())
+        .as(
+            "known gap: queued-but-unstarted work is indistinguishable from abandoned work,"
+                + " because only a running worker heartbeats. Fix is to beat on enqueue.")
+        .isEqualTo("FAILED");
+  }
+
   /** A beat must not resurrect a request someone else already took. */
   @Test
   public void aHeartbeatDoesNotReviveARequestThatWasAlreadyRetired() {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -1,0 +1,482 @@
+package com.muchq.games.one_d4.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.muchq.games.chess_com_client.ChessClient;
+import com.muchq.games.chess_com_client.GamesResponse;
+import com.muchq.games.chess_com_client.Player;
+import com.muchq.games.one_d4.api.dto.AggregateRow;
+import com.muchq.games.one_d4.api.dto.GameFeature;
+import com.muchq.games.one_d4.api.dto.OccurrenceRow;
+import com.muchq.games.one_d4.db.GameFeatureStore;
+import com.muchq.games.one_d4.db.IndexedPeriodStore;
+import com.muchq.games.one_d4.db.IndexingRequestDao;
+import com.muchq.games.one_d4.db.IndexingRequestStore;
+import com.muchq.games.one_d4.db.RetentionPolicy;
+import com.muchq.games.one_d4.db.TestDb;
+import com.muchq.games.one_d4.engine.FeatureExtractor;
+import com.muchq.games.one_d4.engine.GameReplayer;
+import com.muchq.games.one_d4.engine.PgnParser;
+import com.muchq.games.one_d4.engine.model.GameFeatures;
+import com.muchq.games.one_d4.engine.model.Motif;
+import com.muchq.games.one_d4.motifs.CheckDetector;
+import com.muchq.games.one_d4.queue.IndexMessage;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Liveness of an in-flight indexing request: can a request that is being worked on right now be
+ * mistaken for an abandoned one?
+ *
+ * <p>{@link RetentionPolicy#STALE_REQUEST} retires a PENDING/PROCESSING request whose {@code
+ * updated_at} has not moved in an hour, on the theory that its owner is dead. That theory is only
+ * as good as the worker's heartbeat, and status writes alone are not one: {@link IndexWorker} wrote
+ * PROCESSING at the start of a run and again at each month boundary, cache hit, empty archive and
+ * 100-game batch flush, leaving everything between two of those points unobserved.
+ *
+ * <p>The gap that mattered most was the ordinary one. A single-month request holding fewer than
+ * {@code BATCH_SIZE} games flushes exactly once, at the end, so the whole month — the archive
+ * fetch, one profile lookup per distinct opponent, and the extraction of every game — sat between
+ * two writes. {@code ChessClient} sets no request timeout, so a chess.com call that hangs has no
+ * bound at all, and single-month requests are the common case since {@code submitHybrid} runs them
+ * inline.
+ *
+ * <p>Crossing the cutoff is not just a wrong label. Retirement clears {@code dedupe_key}, which is
+ * the whole mechanism keeping one live request per range, so a resubmit creates a replacement and
+ * two workers index the same games concurrently — interleaving the {@code motif_occurrences}
+ * delete/insert pair and doubling every motif count. That is precisely the failure #1249 exists to
+ * prevent, reached by a different road.
+ *
+ * <p>These tests were written against the defect and observed failing before the timer-based
+ * heartbeat that now satisfies them. What they pin is the invariant, not the fix: any future change
+ * that lets a running request go unobserved for longer than the cutoff breaks them.
+ *
+ * <p>One case is deliberately <em>not</em> covered here, because it is out of the heartbeat's
+ * reach: a message still waiting in the queue has no worker to beat for it, so a backlog deeper
+ * than the cutoff still retires work that is owned but not yet started. See {@link
+ * RetentionPolicy#STALE_REQUEST}.
+ */
+public class RequestLivenessTest {
+
+  private static final String PLAYER = "liveness";
+  private static final String PLATFORM = "CHESS_COM";
+  private static final String MONTH = "2024-01";
+  private static final Instant START = Instant.parse("2026-07-01T12:00:00Z");
+  private static final Duration STALE_AFTER = RetentionPolicy.STALE_REQUEST;
+
+  /** Comfortably past the cutoff, and well within what an unbounded HTTP call can take. */
+  private static final Duration SLOW_FETCH = Duration.ofMinutes(90);
+
+  private MutableClock clock;
+  private ExecutorService extractionExecutor;
+  private ExecutorService workerExecutor;
+
+  @BeforeEach
+  public void setUp() {
+    clock = new MutableClock(START);
+    extractionExecutor = Executors.newFixedThreadPool(2);
+    workerExecutor = Executors.newSingleThreadExecutor();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    extractionExecutor.shutdownNow();
+    workerExecutor.shutdownNow();
+  }
+
+  /**
+   * The property, stated directly: a request must be touched while it is inside the archive fetch,
+   * not only on either side of it. That span has no checkpoint and no HTTP timeout bounding it, so
+   * if nothing writes during it, "stale" means "slow" as well as "dead".
+   *
+   * <p>Wall-clock, not the injected clock. Advancing a fake clock proves the arithmetic; it cannot
+   * prove that something in this process is still running, which is the only thing a heartbeat is
+   * for. The interval is shrunk to milliseconds so a beat is observable without waiting a quarter
+   * of an hour for one.
+   */
+  @Test
+  @Timeout(30)
+  public void theRequestIsTouchedWhileTheWorkerIsInsideASlowArchiveFetch() throws Exception {
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    CountDownLatch beatDuringFetch = new CountDownLatch(1);
+
+    HeartbeatRecorder recorder = new HeartbeatRecorder(beatDuringFetch);
+    IndexWorker worker =
+        newWorker(
+            new ClockJumpingChessClient(clock, null, insideFetch, releaseFetch),
+            recorder,
+            Duration.ofMillis(20));
+
+    workerExecutor.submit(() -> worker.process(message(UUID.randomUUID())));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS))
+        .as("worker should have reached the archive fetch")
+        .isTrue();
+
+    boolean touched = beatDuringFetch.await(10, TimeUnit.SECONDS);
+    releaseFetch.countDown();
+
+    assertThat(touched)
+        .as(
+            "nothing refreshed the request while the worker sat in the archive fetch — that span"
+                + " is unbounded, so a healthy worker crosses the %s cutoff and is retired mid-run",
+            STALE_AFTER)
+        .isTrue();
+  }
+
+  /** A beat must not resurrect a request someone else already took. */
+  @Test
+  public void aHeartbeatDoesNotReviveARequestThatWasAlreadyRetired() {
+    TestDb testDb = TestDb.create("liveness_fenced");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    clock.advance(SLOW_FETCH);
+    dao.reclaimStale(STALE_AFTER, clock.instant());
+
+    assertThat(dao.heartbeat(requestId, clock.instant()))
+        .as("a retired request is not this worker's to keep alive")
+        .isFalse();
+    assertThat(dao.findById(requestId).orElseThrow().status()).isEqualTo("FAILED");
+  }
+
+  /**
+   * The same thing observed from the sweep's side, against a real database and a worker genuinely
+   * parked inside {@code fetchGames}. A request being worked on must survive a retention pass.
+   */
+  @Test
+  @Timeout(30)
+  public void aRequestIsNotRetiredWhileItsWorkerIsMidFlight() throws Exception {
+    TestDb testDb = TestDb.create("liveness_midflight");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    IndexWorker worker = blockingWorker(dao, insideFetch, releaseFetch);
+
+    workerExecutor.submit(() -> worker.process(message(requestId)));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS))
+        .as("worker should have reached the archive fetch")
+        .isTrue();
+
+    // The fetch is hanging and an hour and a half of it goes by. In production the heartbeat has
+    // beaten dozens of times by now; here we wait for one so the assertion is about the sweep's
+    // decision rather than about scheduler timing.
+    clock.advance(SLOW_FETCH);
+    boolean beat = awaitHeartbeatAtOrAfter(dao, requestId, clock.instant());
+
+    dao.reclaimStale(STALE_AFTER, clock.instant());
+    IndexingRequestStore.IndexingRequest row = dao.findById(requestId).orElseThrow();
+    releaseFetch.countDown();
+
+    assertThat(beat).as("no heartbeat landed during the hanging fetch").isTrue();
+    assertThat(row.status())
+        .as("a request whose worker is still running must not be retired as abandoned")
+        .isIn("PENDING", "PROCESSING");
+  }
+
+  /**
+   * The consequence, and the reason the label matters. Retirement frees the dedupe slot; if it can
+   * happen to a live request, a resubmit starts a rival worker over the same games and the
+   * occurrence delete/insert pair interleaves — the doubled motif counts this whole change exists
+   * to prevent.
+   */
+  @Test
+  @Timeout(30)
+  public void theDedupeSlotIsNotFreedWhileAWorkerIsMidFlight() throws Exception {
+    TestDb testDb = TestDb.create("liveness_slot");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    IndexWorker worker = blockingWorker(dao, insideFetch, releaseFetch);
+
+    workerExecutor.submit(() -> worker.process(message(requestId)));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS)).isTrue();
+
+    clock.advance(SLOW_FETCH);
+    awaitHeartbeatAtOrAfter(dao, requestId, clock.instant());
+    dao.reclaimStale(STALE_AFTER, clock.instant());
+
+    IndexingRequestStore.Claim resubmit = claim(dao);
+    releaseFetch.countDown();
+
+    assertThat(resubmit.created())
+        .as(
+            "resubmitting a range that is actively being indexed must adopt the running request,"
+                + " not start a rival one over the same games")
+        .isFalse();
+    assertThat(resubmit.request().id()).isEqualTo(requestId);
+  }
+
+  // --- wiring ---------------------------------------------------------------------------------
+
+  private IndexingRequestStore.Claim claim(IndexingRequestDao dao) {
+    return dao.createOrAdopt(PLAYER, PLATFORM, MONTH, MONTH, false, STALE_AFTER, clock.instant());
+  }
+
+  private IndexMessage message(UUID requestId) {
+    return new IndexMessage(requestId, PLAYER, PLATFORM, MONTH, MONTH, false);
+  }
+
+  /** A worker that parks inside the archive fetch until released. */
+  private IndexWorker blockingWorker(
+      IndexingRequestStore store, CountDownLatch entered, CountDownLatch release) {
+    return newWorker(
+        new ClockJumpingChessClient(clock, null, entered, release), store, Duration.ofMillis(20));
+  }
+
+  private IndexWorker newWorker(
+      ChessClient client, IndexingRequestStore store, Duration heartbeatInterval) {
+    FeatureExtractor extractor =
+        new FeatureExtractor(new PgnParser(), new GameReplayer(), List.of(new CheckDetector()));
+    return new IndexWorker(
+        client,
+        extractor,
+        store,
+        new NoOpGameFeatureStore(),
+        new NoOpPeriodStore(),
+        extractionExecutor,
+        clock,
+        heartbeatInterval);
+  }
+
+  /** Polls until the stored row has been refreshed to at least {@code at}, or gives up. */
+  private boolean awaitHeartbeatAtOrAfter(IndexingRequestDao dao, UUID id, Instant at)
+      throws InterruptedException {
+    for (int i = 0; i < 200; i++) {
+      Optional<IndexingRequestStore.IndexingRequest> row = dao.findById(id);
+      if (row.isPresent() && !row.get().updatedAt().isBefore(at)) {
+        return true;
+      }
+      Thread.sleep(25);
+    }
+    return false;
+  }
+
+  /** A clock a test can move, shared by the worker, the DAO, and the assertions. */
+  private static final class MutableClock extends Clock {
+    private final AtomicReference<Instant> now;
+
+    MutableClock(Instant start) {
+      this.now = new AtomicReference<>(start);
+    }
+
+    void advance(Duration by) {
+      now.updateAndGet(current -> current.plus(by));
+    }
+
+    @Override
+    public Instant instant() {
+      return now.get();
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+  }
+
+  /**
+   * Stands in for a chess.com call that is slow rather than broken: it either jumps the clock to a
+   * fixed instant, or blocks until a latch is released. `ChessClient` has no request timeout, so
+   * neither shape is bounded in production.
+   */
+  private static final class ClockJumpingChessClient extends ChessClient {
+    private final MutableClock clock;
+    private final Instant returnAt;
+    private final CountDownLatch entered;
+    private final CountDownLatch release;
+
+    ClockJumpingChessClient(
+        MutableClock clock, Instant returnAt, CountDownLatch entered, CountDownLatch release) {
+      super(null, new ObjectMapper());
+      this.clock = clock;
+      this.returnAt = returnAt;
+      this.entered = entered;
+      this.release = release;
+    }
+
+    @Override
+    public Optional<GamesResponse> fetchGames(String player, YearMonth yearMonth) {
+      if (entered != null) {
+        entered.countDown();
+        try {
+          release.await(20, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+      if (returnAt != null) {
+        clock.now.set(returnAt);
+      }
+      // The archive is empty: the month still counts as indexed, and the worker takes its
+      // no-games path. What is under test is the silence before this returns, not the payload.
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Player> fetchPlayer(String player) {
+      return Optional.empty();
+    }
+  }
+
+  /** Trips a latch the first time anything refreshes the request. */
+  private static final class HeartbeatRecorder implements IndexingRequestStore {
+    private final CountDownLatch touched;
+
+    HeartbeatRecorder(CountDownLatch touched) {
+      this.touched = touched;
+    }
+
+    @Override
+    public boolean heartbeat(UUID id, Instant now) {
+      touched.countDown();
+      return true;
+    }
+
+    @Override
+    public void updateStatus(UUID id, String status, String errorMessage, int gamesIndexed) {}
+
+    @Override
+    public Claim createOrAdopt(
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        Duration staleAfter,
+        Instant now) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<IndexingRequest> findById(UUID id) {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<IndexingRequest> findExistingRequest(
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        Duration staleAfter,
+        Instant now) {
+      return Optional.empty();
+    }
+
+    @Override
+    public List<IndexingRequest> listRecent(int limit) {
+      return List.of();
+    }
+
+    @Override
+    public int reclaimStale(Duration staleAfter, Instant now) {
+      return 0;
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
+    }
+  }
+
+  private static final class NoOpPeriodStore implements IndexedPeriodStore {
+    @Override
+    public Optional<IndexedPeriod> findCompletePeriod(
+        String player, String platform, String month, boolean excludeBullet) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void upsertPeriod(
+        String player,
+        String platform,
+        String month,
+        Instant fetchedAt,
+        boolean isComplete,
+        int gamesCount,
+        boolean excludeBullet) {}
+
+    @Override
+    public List<IndexedPeriod> findPeriodsForPlayers(Collection<String> players) {
+      return List.of();
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
+    }
+  }
+
+  private static final class NoOpGameFeatureStore implements GameFeatureStore {
+    @Override
+    public void insertBatch(List<GameFeature> features) {}
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
+    }
+
+    @Override
+    public void insertOccurrencesBatch(
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {}
+
+    @Override
+    public void deleteOccurrencesByGameUrls(List<String> gameUrls) {}
+
+    @Override
+    public List<GameFeature> query(Object compiledQuery, int limit, int offset) {
+      return List.of();
+    }
+
+    @Override
+    public List<AggregateRow> aggregate(
+        Object compiledQuery, List<String> groupColumns, int limit) {
+      return List.of();
+    }
+
+    @Override
+    public AggregateTotals aggregateTotals(Object compiledQuery) {
+      return new AggregateTotals(0, 0);
+    }
+
+    @Override
+    public Map<String, Map<String, List<OccurrenceRow>>> queryOccurrences(List<String> gameUrls) {
+      return Map.of();
+    }
+
+    @Override
+    public List<GameForReanalysis> fetchForReanalysis(int limit, int offset) {
+      return List.of();
+    }
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RetentionWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RetentionWorkerTest.java
@@ -7,6 +7,7 @@ import com.muchq.games.chessql.parser.Parser;
 import com.muchq.games.one_d4.api.dto.GameFeature;
 import com.muchq.games.one_d4.db.GameFeatureDao;
 import com.muchq.games.one_d4.db.IndexedPeriodDao;
+import com.muchq.games.one_d4.db.IndexingRequestDao;
 import com.muchq.games.one_d4.db.TestDb;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 public class RetentionWorkerTest {
   private GameFeatureDao dao;
   private IndexedPeriodDao periodDao;
+  private IndexingRequestDao requestDao;
   private RetentionWorker worker;
   private UUID requestId;
   private DataSource dataSource;
@@ -30,7 +32,8 @@ public class RetentionWorkerTest {
 
     dao = new GameFeatureDao(testDb.jdbi(), true);
     periodDao = new IndexedPeriodDao(testDb.jdbi(), true);
-    worker = new RetentionWorker(dao, periodDao);
+    requestDao = new IndexingRequestDao(testDb.jdbi());
+    worker = new RetentionWorker(dao, periodDao, requestDao);
     requestId = UUID.randomUUID();
 
     // Create a dummy indexing request to satisfy foreign key constraint
@@ -83,6 +86,150 @@ public class RetentionWorkerTest {
     assertThat(periodDao.findCompletePeriod("p", "CHESS_COM", "2024-02", false)).isEmpty();
   }
 
+  /**
+   * The acceptance case for #1266's foreign key constraint: a request old enough to sweep that
+   * still owns games at the moment the pass starts. Games are deleted first, which is what lets the
+   * request delete succeed — reverse the two and the FK refuses and the whole pass aborts.
+   */
+  @Test
+  public void runRetention_deletesAnOldRequestAndItsGamesInForeignKeyOrder() {
+    UUID oldRequest = insertRequest("COMPLETED", Instant.now().minus(40, ChronoUnit.DAYS));
+    dao.insertBatch(List.of(createGame("https://chess.com/owned", oldRequest)));
+    updateIndexedAt("https://chess.com/owned", Instant.now().minus(8, ChronoUnit.DAYS));
+
+    assertThat(countGames()).isEqualTo(1);
+    assertThat(countRequests()).isEqualTo(2);
+
+    worker.runRetention();
+
+    assertThat(countGames()).isEqualTo(0);
+    assertThat(requestDao.findById(oldRequest)).isEmpty();
+    // The fixture's own request is recent, so it stays.
+    assertThat(requestDao.findById(requestId)).isPresent();
+  }
+
+  /**
+   * The mirror case: the request has aged out but its games have not. Deleting it would violate the
+   * foreign key, so it has to survive this pass and go on the next one after its games do.
+   */
+  @Test
+  public void runRetention_keepsAnOldRequestWhoseGamesAreStillFresh() {
+    UUID oldRequest = insertRequest("COMPLETED", Instant.now().minus(40, ChronoUnit.DAYS));
+    dao.insertBatch(List.of(createGame("https://chess.com/fresh-game", oldRequest)));
+
+    worker.runRetention();
+
+    assertThat(countGames()).isEqualTo(1);
+    assertThat(requestDao.findById(oldRequest)).isPresent();
+  }
+
+  /**
+   * A request between the two windows — past the 7-day game clock, short of the 30-day request
+   * clock — must survive. This is the gap in which the row is the only thing left that can tell a
+   * user their data was pruned rather than never indexed, so sweeping requests on the games'
+   * threshold would delete exactly the explanation the API is built to give.
+   */
+  @Test
+  public void runRetention_keepsARequestThatIsPastTheGameWindowButNotTheRequestWindow() {
+    UUID midLife = insertRequest("COMPLETED", Instant.now().minus(10, ChronoUnit.DAYS));
+
+    worker.runRetention();
+
+    assertThat(requestDao.findById(midLife)).isPresent();
+  }
+
+  @Test
+  public void runRetention_retiresStrandedRequestsAndFreesTheirSlot() {
+    UUID stranded = insertRequest("PENDING", Instant.now());
+    // Exact rendering is IndexingRequestDao's business and is pinned in MigrationTest; here it
+    // only has to be non-null so that clearing it is observable.
+    setDedupeKey(stranded, "CHESS_COM|2024-01|2024-01|false|p2");
+    updateRequestUpdatedAt(stranded, Instant.now().minus(6, ChronoUnit.HOURS));
+
+    worker.runRetention();
+
+    var retired = requestDao.findById(stranded).orElseThrow();
+    assertThat(retired.status()).isEqualTo("FAILED");
+    assertThat(retired.errorMessage()).contains("Abandoned");
+    assertThat(dedupeKeyOf(stranded)).isNull();
+  }
+
+  @Test
+  public void runRetention_leavesAFreshPendingRequestRunning() {
+    UUID live = insertRequest("PENDING", Instant.now());
+
+    worker.runRetention();
+
+    assertThat(requestDao.findById(live).orElseThrow().status()).isEqualTo("PENDING");
+  }
+
+  private UUID insertRequest(String status, Instant createdAt) {
+    UUID id = UUID.randomUUID();
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " status, created_at, updated_at) VALUES (?, 'p2', 'CHESS_COM', '2024-01',"
+                    + " '2024-01', ?, ?, ?)")) {
+      ps.setObject(1, id);
+      ps.setString(2, status);
+      ps.setTimestamp(3, java.sql.Timestamp.from(createdAt));
+      ps.setTimestamp(4, java.sql.Timestamp.from(createdAt));
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return id;
+  }
+
+  private void setDedupeKey(UUID id, String key) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement("UPDATE indexing_requests SET dedupe_key = ? WHERE id = ?")) {
+      ps.setString(1, key);
+      ps.setObject(2, id);
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String dedupeKeyOf(UUID id) {
+    try (var conn = dataSource.getConnection();
+        var ps = conn.prepareStatement("SELECT dedupe_key FROM indexing_requests WHERE id = ?")) {
+      ps.setObject(1, id);
+      try (var rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getString("dedupe_key");
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void updateRequestUpdatedAt(UUID id, Instant updatedAt) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement("UPDATE indexing_requests SET updated_at = ? WHERE id = ?")) {
+      ps.setTimestamp(1, java.sql.Timestamp.from(updatedAt));
+      ps.setObject(2, id);
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private int countRequests() {
+    try (var conn = dataSource.getConnection();
+        var ps = conn.prepareStatement("SELECT COUNT(*) FROM indexing_requests");
+        var rs = ps.executeQuery()) {
+      rs.next();
+      return rs.getInt(1);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private void updateIndexedAt(String url, Instant indexedAt) {
     try (var conn = dataSource.getConnection();
         var ps =
@@ -131,9 +278,13 @@ public class RetentionWorkerTest {
   }
 
   private GameFeature createGame(String url) {
+    return createGame(url, requestId);
+  }
+
+  private GameFeature createGame(String url, UUID owningRequest) {
     return new GameFeature(
         null,
-        requestId,
+        owningRequest,
         url,
         "CHESS_COM",
         "w",

--- a/domains/games/apps/1d4_web/src/__tests__/IndexView.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/IndexView.test.tsx
@@ -152,11 +152,14 @@ describe('IndexView', () => {
     expect(silentRow.cells[4].querySelector('.data-badge')).toBeNull();
   });
 
-  it('explains the retention window so a pruned row is not a mystery', async () => {
+  it('explains both retention windows so a pruned row is not a mystery', async () => {
     setup();
     await waitFor(() =>
       expect(screen.getByText(/kept for 7 days/)).toBeInTheDocument()
     );
+    // The second window matters as much as the first: without it the note promises the row
+    // stays "after that" indefinitely, and a user who comes back in a month finds it gone.
+    expect(screen.getByText(/removed after 30 days/)).toBeInTheDocument();
   });
 
   it('lets a wide status table scroll instead of overflowing the panel', async () => {

--- a/domains/games/apps/1d4_web/src/types.ts
+++ b/domains/games/apps/1d4_web/src/types.ts
@@ -32,8 +32,10 @@ export interface GameRow {
 /**
  * Whether a request's indexed games are still stored. Request rows outlive the
  * games they produced — the retention worker sweeps games and indexed periods
- * on a 7-day clock but never touches `indexing_requests` — so "COMPLETED, 325
- * games" keeps rendering long after querying it would return nothing.
+ * on a 7-day clock and the request rows themselves on a 30-day one — so
+ * "COMPLETED, 325 games" keeps rendering long after querying it would return
+ * nothing. The gap between the two windows is where this field earns its keep:
+ * the request is still there to say EXPIRED rather than having vanished.
  */
 export interface DataAvailability {
   status: 'AVAILABLE' | 'PARTIAL' | 'EXPIRED' | 'UNKNOWN';

--- a/domains/games/apps/1d4_web/src/views/IndexView.tsx
+++ b/domains/games/apps/1d4_web/src/views/IndexView.tsx
@@ -209,6 +209,7 @@ export default function IndexView() {
           <p className="panel-note">
             Indexed games are kept for 7 days, then deleted. A request stays in this list
             after that, marked <strong>Pruned</strong> — re-run it to index the games again.
+            The request itself is removed after 30 days.
           </p>
         )}
       </div>


### PR DESCRIPTION
Closes #1249. Closes #1250. Closes #1266.

Three defects on one table, fixed together — #1266 says as much in its own constraints section, and the fix for either of the first two makes the other worse on its own.

## The exclusive slot (#1249)

Dedupe was a read followed by a write. Two identical submits — two REST threads, or REST and MCP, which are **two JVMs against one Postgres** whenever `INDEXER_DB_URL` is set — could both find nothing and both insert.

`game_features` survives that on its `game_url` upsert. `motif_occurrences` does not: `IndexWorker.flushBatch` deletes then inserts under fresh UUIDs in separate transactions, so interleaving leaves duplicated occurrence rows. The visible symptom is **every motif for those games counted twice** in query results.

A new `dedupe_key` column carries the composite key while a request is live and is NULL once terminal, under a plain `UNIQUE` constraint — NULLs don't collide on either engine, so terminal rows accumulate freely while live ones can't. `create` becomes `createOrAdopt`: insert, and on conflict adopt the winner. Only a caller that actually created the row dispatches work.

**Why a column and not a Postgres partial index.** A partial unique index says this more directly, but H2 has none, and H2 is what the default CI suite runs — the pg-backed suites skip silently without `PG_TEST_DB_URL`. A PG-only guard would leave the race guard untested on every ordinary PR, which is the specific trap `CLAUDE.md` warns about. One nullable column buys the same invariant on both engines, enforced identically, exercised by `db_tests`.

## Reclaiming what was stranded (#1250)

`findExistingRequest` matched PENDING/PROCESSING with no age cutoff, and nothing reconciled rows whose owner died. One strand locked its range forever; `skipCache` was the only way out.

Adding the constraint above would have made that **worse** — not just "dedupe keeps answering with it" but "the database refuses the replacement". So the age bound retires rather than ignores: a live row older than `RetentionPolicy.STALE_REQUEST` (1h) becomes FAILED with a message saying so, which releases its slot. That runs for the submitted tuple inside `createOrAdopt`, and fleet-wide in the retention worker.

The inline MCP path also retires its own row when the processor throws — the cheapest source of strands, and the one `IndexRequestServiceTest` previously pinned as known-broken.

## Bounding the table (#1266)

`RetentionWorker` never touched `indexing_requests`, and `listRecent(50)` meant unbounded growth had no symptom. It now sweeps them on a **30-day** clock against the games' **7 days**: games first so a request and its games clear in one pass, and the delete skips any request still referenced (and any request still live) so neither the foreign key nor a running worker can be disrupted by a pass.

The 23-day gap is the point, not a rounding choice — it's the window in which a swept request still reports `EXPIRED` ("pruned — re-run it") instead of having vanished. Both windows, and the invariant that `REQUEST > PERIOD`, are pinned in `IndexE2ETest` beside the existing check on `PERIOD`.

## Behaviour change worth knowing

**`skipCache` no longer starts a rival run of a range already in flight.** That is precisely the double-dispatch above. It coalesces onto the in-flight request and returns it — the caller sees the existing id and its PENDING/PROCESSING status — and forces normally once that finishes. Two tests previously pinned the old behaviour at the service and controller layers; both are rewritten to state what now holds and why, and the four places that document the flag (including the MCP tool description an agent reads) now say so.

## The review panel ran, and found two real defects

Three read-only agents on three lenses. It ran *after* the first commit was already pushed rather than before it, which is the wrong order — that is why this is two commits rather than one.

**A clock split, and a regression of #1268.** `updated_at` was written by the database's `now()` and compared against a JVM `Timestamp.from(...)`. `game_features.indexed_at` had exactly this split and it was fixed in #1268. Sharper here: retention's window is 7 days so drift moves a boundary, but `STALE_REQUEST` is one hour, so drift **inverts** the predicate. Three things reach an hour — skew between the app host and the database host, the two-JVM deployment disagreeing on a zone, and DST repeating or skipping exactly one hour. Any of them retires every healthy request mid-run and makes `createOrAdopt` retire the row it is about to adopt, silently disabling the guard this PR exists to add. The table is now on one injected `Clock` and one UTC wall-clock convention.

None of the existing tests could see it — they write fixtures with the same JVM conversion the DAO reads with, so the offset cancels inside one process, which is the trap `PlayedAtTimeZoneTest`'s javadoc names. `RequestStalenessTimeZoneTest` is its counterpart, TZ-pinned to UTC+14 by its own target.

**A retired request could come back to life.** `updateStatus`'s non-terminal branch had no status guard, and `IndexWorker` writes PROCESSING once per *month*, not once per run — so a request retired as stale was flipped back to PROCESSING by its own worker's next heartbeat with `dedupe_key` still NULL: a live row holding no slot, invisible to the constraint because its replacement holds the key.

Also from the panel: `deleteOlderThan` could delete a live request; `game_features.request_id` had no index, so the hourly anti-join sequential-scanned the largest table in the schema; a swallowed `SQLException` turned a NOT NULL violation into a causeless "after 5 attempts"; an inner `catch (RuntimeException)` inside a `catch (Throwable)` could let an Error replace the original failure; and three behaviours had no test — a stranded **PROCESSING** row (every reclamation test used PENDING, so narrowing the predicate left the suite green), the constraint's own existence, and the retention constants.

One surviving finding is **not** fixed here: a queue backlog deeper than an hour would retire work that is queued but owned, because `updated_at` is frozen while a message waits. The honest fix is a heartbeat on enqueue, not a larger number, so `RetentionPolicy` now documents the limit precisely instead of implying a guarantee it does not have.

## Verification

| | |
|---|---|
| `//domains/games/apis/one_d4/...`, `//domains/games/apis/mcpserver/...`, `//:buildifier_test` | 56/56 |
| `1d4_web` | 104/104 |
| Mutation checking — `Migration`, `IndexingRequestDao`, `RetentionWorker`, `IndexRequestService` | every mutation killed |
| `scripts/format-all` | clean |
| Postgres | **verified.** See below. |

Four mutations earned their keep by failing first:

- **Rendering `exclude_bullet` without `LOWER(CAST(... AS VARCHAR))`.** H2 spells a BOOLEAN `'TRUE'` where Java and Postgres spell it `'true'`, so a backfilled row would be invisible to a Java-side lookup exactly once.
- **Picking the backfill winner on `MIN(created_at)` alone.** Duplicate submits are the rows most likely to share a timestamp; a tie makes MIN match the whole group and the statement writes one key onto several rows. Cleaning up afterwards is too late — the UPDATE is rejected on an upgrade where the constraint already exists, and `ADD CONSTRAINT` is on a first run. The tiebreak had to move into the selection, and the test now ties three rows on purpose.
- **A DAO binding through the system default zone** — dies in the TZ-pinned target, which is the whole point of that target existing.
- **Dropping the resurrection guard** — dies on the second live row.

**On Postgres specifically.** The dialect-sensitive SQL was verified three ways: a panel agent stood up real PostgreSQL 16 and H2 2.4.240 and executed the statements against both, refuting every concern I had flagged (`CAST(boolean AS VARCHAR)` renders `true`/`false` on both, `UPDATE t r` parses, uuid `<` works, the `DO $$ … EXCEPTION` block catches `42P07`, and re-running against dirty data is idempotent); CI's pg-backed suites went green on both commits; and pgjdbc sets the session `TimeZone` from the JVM default, which is why the surviving clock concern is skew and DST rather than a zone mismatch.

---
_Generated by [Claude Code](https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA)_