### PR TITLE
one_d4: give a worker an explicit claim on a request, and fence every write on it

### DIFF
--- a/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/tools/IndexerFacadeAggregateTest.java
+++ b/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/tools/IndexerFacadeAggregateTest.java
@@ -85,6 +85,17 @@ public class IndexerFacadeAggregateTest {
     @Override
     public void insertBatch(List<GameFeature> features) {}
 
+    /** Not part of the aggregate surface: only the indexer's worker flushes. */
+    @Override
+    public boolean flushOwned(
+        java.util.UUID requestId,
+        String ownerId,
+        Instant now,
+        List<GameFeature> features,
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+      throw new UnsupportedOperationException("aggregate tests never flush");
+    }
+
     @Override
     public int deleteOlderThan(Instant threshold) {
       return 0;

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -533,16 +533,20 @@ java_test_suite(
     ],
 )
 
-# Every other DAO suite runs on H2, but Postgres is the deployment target and
-# the aggregate SQL uses two constructs the dialects can disagree on: GROUP BY
-# referencing a SELECT-list alias, and timestamp binds against a
-# TIMESTAMP-without-zone column. Real postgres via PG_TEST_DB_URL (which CI's
-# build-and-test job exports); skips otherwise.
+# Every other DAO suite runs on H2, but Postgres is the deployment target, and
+# some claims are only true — or only falsifiable — there. The aggregate SQL uses
+# two constructs the dialects can disagree on: GROUP BY referencing a SELECT-list
+# alias, and timestamp binds against a TIMESTAMP-without-zone column. The
+# concurrent-write suite covers guarantees about READ COMMITTED behaviour that
+# H2's MVStore does not reproduce, so asserting them on H2 would pass either way.
+# Real postgres via PG_TEST_DB_URL (which CI's build-and-test job exports);
+# skips otherwise.
 java_test_suite(
     name = "pg_db_tests",
     size = "small",
     srcs = [
         "src/test/java/com/muchq/games/one_d4/db/PostgresAggregateCompatTest.java",
+        "src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java",
     ],
     env_inherit = ["PG_TEST_DB_URL"],
     # One shared scratch database: concurrent DB tests drop each other's schemas.
@@ -553,6 +557,7 @@ java_test_suite(
     deps = [
         ":db",
         ":dto",
+        ":model",
         "//domains/games/libs/chessql:compiler",
         "//domains/games/libs/chessql:parser",
         artifact("org.assertj:assertj-core"),

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -469,6 +469,7 @@ java_test_suite(
     name = "db_tests",
     size = "small",
     srcs = [
+        "src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java",
         "src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java",
         "src/test/java/com/muchq/games/one_d4/db/IndexedPeriodDaoTest.java",
         "src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java",

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -104,7 +104,7 @@ flowchart TB
 
 **Query flow:** Client posts a ChessQL string to `POST /v1/query` → Parser and SqlCompiler produce SQL → GameFeatureStore runs the query and loads motif_occurrences for the result set → response returns GameFeatureRow list with per-game occurrences.
 
-**Retention:** RetentionWorker runs hourly. It deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days, and indexing_requests older than 30 days — games first, so a request and its games clear in one pass. It also retires requests stranded in PENDING/PROCESSING for over an hour, freeing the dedupe slot each one holds.
+**Retention:** RetentionWorker runs hourly. It deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days, and indexing_requests older than 30 days — games first, so a request and its games clear in one pass. It also retires live requests nobody is working on — a claimed one five minutes after its owner stops renewing its lease, an unclaimed one an hour after it was created — freeing the dedupe slot each one holds.
 
 ## Running Locally (in-memory)
 
@@ -249,10 +249,25 @@ between the two windows the surviving row is what lets `GET /v1/index/{id}` repo
 ("pruned — re-run it") rather than 404. The sweep deletes games before requests so both clear in
 one pass, and skips any request still referenced by a game.
 
-Separately, a PENDING or PROCESSING request whose owner died — a restart with work still queued,
-or an inline dispatch that threw — is retired to FAILED after **1 hour** without progress. Until
-it is, it holds the dedupe slot for its (player, platform, month range), and no new request for
-that range can be created.
+Separately, a live request that nobody is working on is retired to FAILED, which frees the dedupe
+slot it holds for its (player, platform, month range). Two different questions, on two clocks:
+
+| Situation | Retired after | Why that clock |
+|---|---|---|
+| Claimed, but the owner stopped renewing | **5 minutes** (`LEASE`) | The owner reports in every 75 seconds. Three missed renewals and it is presumed gone. |
+| Never claimed by anyone | **1 hour** (`STALE_REQUEST`) | There is no owner whose silence could be measured, so the only evidence is the age of the row. |
+
+A worker takes an explicit lease on a request before it writes anything: `owner_id` names the
+process, and every subsequent write — progress, the terminal status, and the batched game and
+occurrence writes — is conditioned on the row still naming it. A worker that has lost its lease
+stops rather than reasserting itself, because something has already handed its range to a
+replacement and two writers over the same games would corrupt the occurrence counts.
+
+Renewal says "the owner is still here", not "progress was made", so a request can run for hours
+against a slow archive without looking abandoned. The hour above still misses one case: a message
+waiting in the in-memory queue has no worker to renew for it, so a backlog deeper than an hour
+retires work that is owned and about to run. Closing that means dispatch claiming from the table
+rather than from a process-local queue.
 
 ### Available Fields
 

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -104,7 +104,7 @@ flowchart TB
 
 **Query flow:** Client posts a ChessQL string to `POST /v1/query` → Parser and SqlCompiler produce SQL → GameFeatureStore runs the query and loads motif_occurrences for the result set → response returns GameFeatureRow list with per-game occurrences.
 
-**Retention:** RetentionWorker runs hourly. It deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days, and indexing_requests older than 30 days — games first, so a request and its games clear in one pass. It also retires live requests nobody is working on — a claimed one five minutes after its owner stops renewing its lease, an unclaimed one an hour after it was created — freeing the dedupe slot each one holds.
+**Retention:** RetentionWorker runs hourly. It deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days, and indexing_requests older than 30 days — games first, so a request and its games clear in one pass. It also retires live requests nobody is working on — a claimed one whose owner has stopped renewing its five-minute lease, an unclaimed one over an hour old — freeing the dedupe slot each one holds. Since the sweep is hourly, those windows say when a request becomes eligible, not when it is retired.
 
 ## Running Locally (in-memory)
 
@@ -252,22 +252,31 @@ one pass, and skips any request still referenced by a game.
 Separately, a live request that nobody is working on is retired to FAILED, which frees the dedupe
 slot it holds for its (player, platform, month range). Two different questions, on two clocks:
 
-| Situation | Retired after | Why that clock |
+| Situation | Eligible for retirement after | Why that clock |
 |---|---|---|
-| Claimed, but the owner stopped renewing | **5 minutes** (`LEASE`) | The owner reports in every 75 seconds. Three missed renewals and it is presumed gone. |
+| Claimed, but the owner stopped renewing | **5 minutes** (`LEASE`) | The owner reports in every 75 seconds. Three missed renewals are survivable; expiry lands on the fourth. |
 | Never claimed by anyone | **1 hour** (`STALE_REQUEST`) | There is no owner whose silence could be measured, so the only evidence is the age of the row. |
+
+*Eligible*, not retired — the distinction matters. Reclamation is only as prompt as its caller, and
+the caller is the hourly `RetentionWorker`; the one faster path is a resubmit for the same range,
+which retires the key it is about to claim. And retiring frees the range rather than handing it
+over: nothing scans for expired leases and nothing re-dispatches, so the user resubmits. Making
+another worker pick the range up is [#1279](https://github.com/muchq/MoonBase/issues/1279).
 
 A worker takes an explicit lease on a request before it writes anything: `owner_id` names the
 process, and every subsequent write — progress, the terminal status, and the batched game and
-occurrence writes — is conditioned on the row still naming it. A worker that has lost its lease
-stops rather than reasserting itself, because something has already handed its range to a
-replacement and two writers over the same games would corrupt the occurrence counts.
+occurrence writes — is conditioned on the row still naming it. A worker whose row has changed
+hands stops rather than reasserting itself; a lease that merely lapsed with nobody taking it is
+renewed and the run continues, because abandoning work no one else wants helps nobody.
 
 Renewal says "the owner is still here", not "progress was made", so a request can run for hours
-against a slow archive without looking abandoned. The hour above still misses one case: a message
-waiting in the in-memory queue has no worker to renew for it, so a backlog deeper than an hour
-retires work that is owned and about to run. Closing that means dispatch claiming from the table
-rather than from a process-local queue.
+against a slow archive without looking abandoned. The hour above still misses one case, and
+ownership made its cost worse: a message waiting in the in-memory queue has no worker to renew for
+it, so a backlog deeper than an hour retires it — and the worker that eventually dequeues it finds
+a retired row, declines it, and indexes nothing. Previously it carried on and recorded a result,
+which is how the range could end up with two writers. Closing this properly means dispatch claiming
+from the table rather than from a process-local queue
+([#1279](https://github.com/muchq/MoonBase/issues/1279)).
 
 ### Available Fields
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
@@ -229,6 +229,13 @@ public class IndexerModule {
     return Executors.newFixedThreadPool(threads, tf);
   }
 
+  /**
+   * @param clock the same bean every other lease participant gets. The worker was the one holdout,
+   *     falling back to {@code Clock.systemUTC()} inside its no-clock constructor. Both resolve to
+   *     the same thing today, so nothing was broken — but the worker now stamps {@code
+   *     lease_expires_at} and {@code reclaimStale} compares against it, so a divergence that used
+   *     to nudge a seven-day retention boundary would decide ownership on a five-minute window.
+   */
   @Context
   public IndexWorker indexWorker(
       ChessClient chessClient,
@@ -236,14 +243,16 @@ public class IndexerModule {
       IndexingRequestStore requestStore,
       GameFeatureStore gameFeatureStore,
       IndexedPeriodStore periodStore,
-      @jakarta.inject.Named("indexExtraction") ExecutorService indexExtractionExecutor) {
+      @jakarta.inject.Named("indexExtraction") ExecutorService indexExtractionExecutor,
+      Clock clock) {
     return new IndexWorker(
         chessClient,
         featureExtractor,
         requestStore,
         gameFeatureStore,
         periodStore,
-        indexExtractionExecutor);
+        indexExtractionExecutor,
+        clock);
   }
 
   @Context

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/AdminController.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/AdminController.java
@@ -80,8 +80,12 @@ public class AdminController {
         }
       }
 
-      gameFeatureStore.deleteOccurrencesByGameUrls(gameUrlsToDelete);
-      gameFeatureStore.insertOccurrencesBatch(occurrencesBatch);
+      // One transaction. A delete that commits separately from its insert leaves a window in
+      // which an indexing worker flushing a live request over one of these games can insert its
+      // own occurrences and have both copies survive — the doubling ConcurrentFlushTest
+      // demonstrates. Being single-threaded inside this loop does not help; the other writer is
+      // in another thread.
+      gameFeatureStore.replaceOccurrences(gameUrlsToDelete, occurrencesBatch);
 
       offset += BATCH_SIZE;
       LOG.debug(

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,42 +155,47 @@ public class GameFeatureDao implements GameFeatureStore {
   @Override
   public void insertBatch(List<GameFeature> features) {
     if (features.isEmpty()) return;
+    jdbi.useHandle(h -> insertFeatures(h, features));
+  }
+
+  private void insertFeatures(org.jdbi.v3.core.Handle h, List<GameFeature> features) {
     String sql = useH2 ? H2_INSERT : PG_INSERT;
-    jdbi.useHandle(
-        h -> {
-          var batch = h.prepareBatch(sql);
-          for (GameFeature row : features) {
-            // bindByType, not bind: played_at is nullable, and only the typed form carries
-            // Types.TIMESTAMP into setNull. Plain bind() would fall back to JDBI's untyped-null
-            // default (Types.OTHER) — accepted by both drivers today, but not the column's type.
-            batch
-                .bind(0, row.requestId())
-                .bind(1, row.gameUrl())
-                .bind(2, row.platform())
-                .bind(3, row.whiteUsername())
-                .bind(4, row.blackUsername())
-                .bind(5, (Integer) row.whiteElo())
-                .bind(6, (Integer) row.blackElo())
-                .bind(7, row.whiteTitle())
-                .bind(8, row.blackTitle())
-                .bind(9, row.timeClass())
-                .bind(10, row.eco())
-                .bind(11, row.openingName())
-                .bind(12, row.openingFamily())
-                .bind(13, row.result())
-                .bindByType(14, toUtcWallClock(row.playedAt()), LocalDateTime.class)
-                .bind(15, (Integer) row.numMoves())
-                // Never null: the column is NOT NULL, and a row that slipped through without a
-                // stamp would be undeletable, since `NULL < threshold` is unknown.
-                .bindByType(
-                    16,
-                    toUtcWallClock(row.indexedAt() == null ? clock.instant() : row.indexedAt()),
-                    LocalDateTime.class)
-                .bind(17, row.pgn())
-                .add();
-          }
-          batch.execute();
-        });
+    {
+      {
+        var batch = h.prepareBatch(sql);
+        for (GameFeature row : features) {
+          // bindByType, not bind: played_at is nullable, and only the typed form carries
+          // Types.TIMESTAMP into setNull. Plain bind() would fall back to JDBI's untyped-null
+          // default (Types.OTHER) — accepted by both drivers today, but not the column's type.
+          batch
+              .bind(0, row.requestId())
+              .bind(1, row.gameUrl())
+              .bind(2, row.platform())
+              .bind(3, row.whiteUsername())
+              .bind(4, row.blackUsername())
+              .bind(5, (Integer) row.whiteElo())
+              .bind(6, (Integer) row.blackElo())
+              .bind(7, row.whiteTitle())
+              .bind(8, row.blackTitle())
+              .bind(9, row.timeClass())
+              .bind(10, row.eco())
+              .bind(11, row.openingName())
+              .bind(12, row.openingFamily())
+              .bind(13, row.result())
+              .bindByType(14, toUtcWallClock(row.playedAt()), LocalDateTime.class)
+              .bind(15, (Integer) row.numMoves())
+              // Never null: the column is NOT NULL, and a row that slipped through without a
+              // stamp would be undeletable, since `NULL < threshold` is unknown.
+              .bindByType(
+                  16,
+                  toUtcWallClock(row.indexedAt() == null ? clock.instant() : row.indexedAt()),
+                  LocalDateTime.class)
+              .bind(17, row.pgn())
+              .add();
+        }
+        batch.execute();
+      }
+    }
   }
 
   /**
@@ -217,38 +223,93 @@ public class GameFeatureDao implements GameFeatureStore {
   }
 
   @Override
+  public boolean flushOwned(
+      UUID requestId,
+      String ownerId,
+      Instant now,
+      List<GameFeature> features,
+      Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+    if (features.isEmpty() && occurrencesByGame.isEmpty()) {
+      return true;
+    }
+    // Game urls in a stable order. Two flushes that touch an overlapping set take row locks in the
+    // same sequence, so they queue behind each other instead of deadlocking half way through.
+    List<String> gameUrls = new ArrayList<>(occurrencesByGame.keySet());
+    Collections.sort(gameUrls);
+
+    return jdbi.inTransaction(
+        h -> {
+          int stillOwner =
+              h.createQuery(
+                      """
+                      SELECT COUNT(*) FROM indexing_requests
+                      WHERE id = ? AND owner_id = ?
+                        AND status IN ('PENDING', 'PROCESSING')
+                        AND lease_expires_at > ?
+                      """)
+                  .bind(0, requestId)
+                  .bind(1, ownerId)
+                  .bindByType(2, toUtcWallClock(now), LocalDateTime.class)
+                  .mapTo(Integer.class)
+                  .one();
+          if (stillOwner == 0) {
+            return false;
+          }
+          if (!features.isEmpty()) {
+            insertFeatures(h, features);
+          }
+          if (!gameUrls.isEmpty()) {
+            var deletes = h.prepareBatch(DELETE_OCCURRENCES_BY_GAME_URL);
+            for (String gameUrl : gameUrls) {
+              deletes.bind(0, gameUrl).add();
+            }
+            deletes.execute();
+            insertOccurrences(h, occurrencesByGame);
+          }
+          return true;
+        });
+  }
+
+  @Override
   public void insertOccurrencesBatch(
       Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
     if (occurrencesByGame.isEmpty()) return;
-    jdbi.useHandle(
-        h -> {
-          var batch = h.prepareBatch(INSERT_OCCURRENCE);
-          for (var gameEntry : occurrencesByGame.entrySet()) {
-            String gameUrl = gameEntry.getKey();
-            for (var motifEntry : gameEntry.getValue().entrySet()) {
-              String motifName = motifEntry.getKey().name();
-              for (GameFeatures.MotifOccurrence occ : motifEntry.getValue()) {
-                if (occ.ply() <= 0) continue;
-                batch
-                    .bind(0, UUID.randomUUID().toString())
-                    .bind(1, gameUrl)
-                    .bind(2, motifName)
-                    .bind(3, occ.ply())
-                    .bind(4, occ.side())
-                    .bind(5, occ.moveNumber())
-                    .bind(6, occ.description())
-                    .bind(7, occ.movedPiece())
-                    .bind(8, occ.attacker())
-                    .bind(9, occ.target())
-                    .bind(10, occ.isDiscovered())
-                    .bind(11, occ.isMate())
-                    .bind(12, occ.pinType())
-                    .add();
-              }
+    jdbi.useHandle(h -> insertOccurrences(h, occurrencesByGame));
+  }
+
+  private void insertOccurrences(
+      org.jdbi.v3.core.Handle h,
+      Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+    {
+      {
+        var batch = h.prepareBatch(INSERT_OCCURRENCE);
+        for (var gameEntry : occurrencesByGame.entrySet()) {
+          String gameUrl = gameEntry.getKey();
+          for (var motifEntry : gameEntry.getValue().entrySet()) {
+            String motifName = motifEntry.getKey().name();
+            for (GameFeatures.MotifOccurrence occ : motifEntry.getValue()) {
+              if (occ.ply() <= 0) continue;
+              batch
+                  .bind(0, UUID.randomUUID().toString())
+                  .bind(1, gameUrl)
+                  .bind(2, motifName)
+                  .bind(3, occ.ply())
+                  .bind(4, occ.side())
+                  .bind(5, occ.moveNumber())
+                  .bind(6, occ.description())
+                  .bind(7, occ.movedPiece())
+                  .bind(8, occ.attacker())
+                  .bind(9, occ.target())
+                  .bind(10, occ.isDiscovered())
+                  .bind(11, occ.isMate())
+                  .bind(12, occ.pinType())
+                  .add();
             }
           }
-          batch.execute();
-        });
+        }
+        batch.execute();
+      }
+    }
   }
 
   @Override

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
@@ -14,10 +14,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jspecify.annotations.Nullable;
@@ -222,6 +224,40 @@ public class GameFeatureDao implements GameFeatureStore {
         });
   }
 
+  /**
+   * Takes the {@code game_features} row locks for these games, in the given order, before their
+   * occurrences are rewritten.
+   *
+   * <p>Making each writer's delete-and-insert one transaction is necessary and not sufficient.
+   * Nothing sets an isolation level, so both engines run READ COMMITTED, and under that a {@code
+   * DELETE} that blocks on another transaction's uncommitted delete re-evaluates the rows it was
+   * blocked on — but not rows that transaction <em>inserted</em>, which are outside its statement
+   * snapshot. Two transactional writers over one game therefore still interleave as delete, delete,
+   * insert, insert and both sets survive: exactly the doubling {@code ConcurrentFlushTest}
+   * demonstrates, one isolation level up.
+   *
+   * <p>What removes it is a lock both writers must take first. {@code game_features.game_url} is
+   * UNIQUE and every occurrence belongs to a game, so that row is the natural serialization point.
+   * A flush already takes it implicitly — its feature upsert conflicts on {@code game_url} — but
+   * only for games it is also writing features for, and the reanalysis path writes no features at
+   * all. Taking it explicitly in both places is what makes the two paths safe against each other
+   * rather than only against themselves.
+   *
+   * <p>Sorted, because two writers over an overlapping set that take these locks in different
+   * orders deadlock instead of queueing.
+   */
+  private static void lockGames(Handle h, List<String> sortedGameUrls) {
+    if (sortedGameUrls.isEmpty()) {
+      return;
+    }
+    h.createQuery(
+            "SELECT game_url FROM game_features WHERE game_url IN (<urls>)"
+                + " ORDER BY game_url FOR UPDATE")
+        .bindList("urls", sortedGameUrls)
+        .mapTo(String.class)
+        .list();
+  }
+
   @Override
   public boolean flushOwned(
       UUID requestId,
@@ -229,36 +265,51 @@ public class GameFeatureDao implements GameFeatureStore {
       Instant now,
       List<GameFeature> features,
       Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
-    if (features.isEmpty() && occurrencesByGame.isEmpty()) {
-      return true;
-    }
-    // Game urls in a stable order. Two flushes that touch an overlapping set take row locks in the
-    // same sequence, so they queue behind each other instead of deadlocking half way through.
+    // Everything this transaction locks, in one deterministic order, so two flushes over an
+    // overlapping set queue behind each other rather than deadlocking half way through. Both
+    // phases matter and only sorting one of them is worthless: the feature upsert runs first and
+    // takes an index-tuple lock per game_url on Postgres, so an inverted pair deadlocks there
+    // before it ever reaches the ordered deletes.
+    List<GameFeature> orderedFeatures = new ArrayList<>(features);
+    orderedFeatures.sort(Comparator.comparing(GameFeature::gameUrl));
     List<String> gameUrls = new ArrayList<>(occurrencesByGame.keySet());
     Collections.sort(gameUrls);
 
     return jdbi.inTransaction(
         h -> {
-          int stillOwner =
+          // SELECT ... FOR UPDATE, not a bare read. Nothing sets an isolation level, so both
+          // engines run READ COMMITTED, and under that a plain SELECT is a snapshot rather than a
+          // claim: a concurrent takeover can commit between this statement and the writes below,
+          // and then this transaction commits rows against a request it no longer owns. The
+          // window is the whole flush — up to a hundred upserts, a hundred deletes, and the
+          // occurrence batch — not an instant. Taking the row lock makes a rival claim() block
+          // until this commits or rolls back, which is what "checked in the same transaction that
+          // writes" has to mean to be worth anything.
+          //
+          // Selecting id rather than COUNT(*): Postgres rejects FOR UPDATE alongside an aggregate.
+          boolean stillOwner =
               h.createQuery(
                       """
-                      SELECT COUNT(*) FROM indexing_requests
+                      SELECT id FROM indexing_requests
                       WHERE id = ? AND owner_id = ?
                         AND status IN ('PENDING', 'PROCESSING')
                         AND lease_expires_at > ?
+                      FOR UPDATE
                       """)
                   .bind(0, requestId)
                   .bind(1, ownerId)
                   .bindByType(2, toUtcWallClock(now), LocalDateTime.class)
-                  .mapTo(Integer.class)
-                  .one();
-          if (stillOwner == 0) {
+                  .mapTo(String.class)
+                  .findFirst()
+                  .isPresent();
+          if (!stillOwner) {
             return false;
           }
-          if (!features.isEmpty()) {
-            insertFeatures(h, features);
+          if (!orderedFeatures.isEmpty()) {
+            insertFeatures(h, orderedFeatures);
           }
           if (!gameUrls.isEmpty()) {
+            lockGames(h, gameUrls);
             var deletes = h.prepareBatch(DELETE_OCCURRENCES_BY_GAME_URL);
             for (String gameUrl : gameUrls) {
               deletes.bind(0, gameUrl).add();
@@ -267,6 +318,39 @@ public class GameFeatureDao implements GameFeatureStore {
             insertOccurrences(h, occurrencesByGame);
           }
           return true;
+        });
+  }
+
+  /**
+   * Replaces the occurrences for a set of games as one unit, without an ownership check.
+   *
+   * <p>For the reanalysis path, which recomputes motifs for games it does not own a request for.
+   * The atomicity is the same requirement as {@link #flushOwned}'s and for the same reason: a
+   * delete that commits separately from its insert leaves a window in which another writer — an
+   * indexing worker flushing a live request that covers one of these games — can delete nothing,
+   * insert its own rows, and let both copies survive. Being single-threaded within its own loop
+   * does not help, because the other writer is in another thread.
+   */
+  @Override
+  public void replaceOccurrences(
+      List<String> gameUrlsToClear,
+      Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+    if (gameUrlsToClear.isEmpty() && occurrencesByGame.isEmpty()) {
+      return;
+    }
+    List<String> merged = new ArrayList<>(gameUrlsToClear);
+    merged.addAll(occurrencesByGame.keySet());
+    List<String> gameUrls = merged.stream().distinct().sorted().toList();
+    final List<String> locked = gameUrls;
+    jdbi.useTransaction(
+        h -> {
+          lockGames(h, locked);
+          var deletes = h.prepareBatch(DELETE_OCCURRENCES_BY_GAME_URL);
+          for (String gameUrl : locked) {
+            deletes.bind(0, gameUrl).add();
+          }
+          deletes.execute();
+          insertOccurrences(h, occurrencesByGame);
         });
   }
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureStore.java
@@ -13,6 +13,33 @@ import java.util.UUID;
 public interface GameFeatureStore {
   void insertBatch(List<GameFeature> features);
 
+  /**
+   * Writes a batch of games and their occurrences as one unit, only if {@code ownerId} still holds
+   * the lease on {@code requestId}. Returns false without writing anything if it does not.
+   *
+   * <p>This replaces the three separate calls a flush used to make, and the single transaction is
+   * the point rather than a tidy-up. Occurrences are written by deleting a game's existing rows and
+   * inserting the new ones, and {@code motif_occurrences} has no uniqueness beyond a random UUID
+   * primary key. Split across transactions, two writers over the same game interleave as delete,
+   * delete, insert, insert and both sets survive — every motif for that game then reads double.
+   * That is reproducible in a test, not a worry; the delete and the insert have to be indivisible.
+   *
+   * <p>Two live requests can legitimately cover the same game: a game has two players, so indexing
+   * each of them reaches it. Dedupe cannot prevent that overlap because the requests are for
+   * different ranges, which is why the atomicity has to live here rather than in a lock on the
+   * request row.
+   *
+   * <p>The ownership check is the second, separate guarantee — it stops a worker that has lost its
+   * lease from continuing to write against a range someone else now owns. Because it happens inside
+   * the same transaction as the write, there is no window between checking and writing.
+   */
+  boolean flushOwned(
+      UUID requestId,
+      String ownerId,
+      Instant now,
+      List<GameFeature> features,
+      Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame);
+
   int deleteOlderThan(Instant threshold);
 
   void insertOccurrencesBatch(

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureStore.java
@@ -15,7 +15,9 @@ public interface GameFeatureStore {
 
   /**
    * Writes a batch of games and their occurrences as one unit, only if {@code ownerId} still holds
-   * the lease on {@code requestId}. Returns false without writing anything if it does not.
+   * the lease on {@code requestId}. Returns false without writing anything if it does not — which
+   * includes the case where there is nothing to write, so a caller can use an empty batch purely to
+   * ask whether it still owns the request.
    *
    * <p>This replaces the three separate calls a flush used to make, and the single transaction is
    * the point rather than a tidy-up. Occurrences are written by deleting a game's existing rows and
@@ -30,8 +32,9 @@ public interface GameFeatureStore {
    * request row.
    *
    * <p>The ownership check is the second, separate guarantee — it stops a worker that has lost its
-   * lease from continuing to write against a range someone else now owns. Because it happens inside
-   * the same transaction as the write, there is no window between checking and writing.
+   * lease from continuing to write against a range someone else now owns. It has to take a row
+   * lock, not merely run inside the same transaction: nothing sets an isolation level, so a plain
+   * read is a snapshot that a concurrent takeover can invalidate before this transaction commits.
    */
   boolean flushOwned(
       UUID requestId,
@@ -39,6 +42,25 @@ public interface GameFeatureStore {
       Instant now,
       List<GameFeature> features,
       Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame);
+
+  /**
+   * Replaces the occurrences for a set of games as one unit. For callers that recompute motifs for
+   * games without holding a request lease — reanalysis — and therefore have no token to present.
+   *
+   * <p>{@code gameUrls} is the full set to clear, which is not the same as the map's key set: a
+   * game whose reanalysis found no motifs must still lose the occurrences it had.
+   *
+   * <p>The default composes the two primitives and is <em>not</em> atomic. It exists so test fakes
+   * need not reimplement a transaction they do not have; any store backed by a real database must
+   * override it, because the whole hazard is that a delete committing separately from its insert
+   * lets a concurrent writer's rows survive alongside the new ones.
+   */
+  default void replaceOccurrences(
+      List<String> gameUrls,
+      Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+    deleteOccurrencesByGameUrls(gameUrls);
+    insertOccurrencesBatch(occurrencesByGame);
+  }
 
   int deleteOlderThan(Instant threshold);
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -25,9 +25,20 @@ public class IndexingRequestDao implements IndexingRequestStore {
    */
   private static final int MAX_CLAIM_ATTEMPTS = 5;
 
-  private static final String STRANDED_MESSAGE =
+  /** For the unclaimed arm: nobody ever picked this up. */
+  private static final String NEVER_CLAIMED_MESSAGE =
       "Abandoned: no worker took ownership before the staleness cutoff (orphaned by restart or a"
           + " failed inline dispatch). Re-submit to try again.";
+
+  /**
+   * For the lease arm. A different sentence because it describes a different event, and this text
+   * is not internal — it reaches the user as {@code IndexResponse.errorMessage} and is rendered in
+   * the web app. Telling someone whose worker crashed mid-run that nobody ever picked their request
+   * up sends them looking for a dispatch problem that is not there.
+   */
+  private static final String OWNER_GONE_MESSAGE =
+      "Abandoned: the worker indexing this request stopped responding and its lease expired."
+          + " Re-submit to try again.";
 
   private static final RowMapper<IndexingRequest> ROW_MAPPER =
       (rs, ctx) ->
@@ -221,9 +232,14 @@ public class IndexingRequestDao implements IndexingRequestStore {
   public int reclaimStale(Duration staleAfter, Instant now) {
     int reclaimed = retire(null, staleAfter, now);
     if (reclaimed > 0) {
+      // Deliberately vague about which arm fired: one statement covers both, and saying "not
+      // updated since <cutoff>" for a row retired on a five-minute lease — whose updated_at is
+      // minutes old — was simply false.
       LOG.warn(
-          "Retired {} stranded indexing request(s) not updated since {}",
+          "Retired {} indexing request(s) nobody is working on: leases expired as of {}, or never"
+              + " claimed and untouched since {}",
           reclaimed,
+          now,
           now.minus(staleAfter));
     }
     return reclaimed;
@@ -238,7 +254,11 @@ public class IndexingRequestDao implements IndexingRequestStore {
   private static final String RETIRE_SQL =
       """
       UPDATE indexing_requests
-      SET status = 'FAILED', error_message = :message, dedupe_key = NULL, updated_at = :now,
+      SET status = 'FAILED',
+          error_message = CASE WHEN owner_id IS NULL
+                            THEN CAST(:neverClaimed AS VARCHAR)
+                            ELSE CAST(:ownerGone AS VARCHAR) END,
+          dedupe_key = NULL, updated_at = :now,
           owner_id = NULL, lease_expires_at = NULL
       WHERE status IN ('PENDING', 'PROCESSING')
         AND ((owner_id IS NOT NULL
@@ -253,7 +273,8 @@ public class IndexingRequestDao implements IndexingRequestStore {
         h -> {
           var update =
               h.createUpdate(sql)
-                  .bind("message", STRANDED_MESSAGE)
+                  .bind("neverClaimed", NEVER_CLAIMED_MESSAGE)
+                  .bind("ownerGone", OWNER_GONE_MESSAGE)
                   .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
                   .bindByType("cutoff", toUtcWallClock(now.minus(staleAfter)), LocalDateTime.class);
           if (keyOrNull != null) {
@@ -287,19 +308,24 @@ public class IndexingRequestDao implements IndexingRequestStore {
             h.createQuery(
                     """
                     SELECT * FROM indexing_requests
-                    WHERE player = ? AND platform = ? AND start_month = ? AND end_month = ?
-                      AND exclude_bullet = ?
+                    WHERE player = :player AND platform = :platform
+                      AND start_month = :startMonth AND end_month = :endMonth
+                      AND exclude_bullet = :excludeBullet
                       AND status IN ('PENDING', 'PROCESSING')
-                      AND updated_at >= ?
+                      AND ((owner_id IS NOT NULL
+                            AND lease_expires_at IS NOT NULL
+                            AND lease_expires_at > :now)
+                           OR (owner_id IS NULL AND updated_at >= :cutoff))
                     ORDER BY created_at ASC, id ASC
                     LIMIT 1
                     """)
-                .bind(0, player)
-                .bind(1, platform)
-                .bind(2, startMonth)
-                .bind(3, endMonth)
-                .bind(4, excludeBullet)
-                .bindByType(5, toUtcWallClock(now.minus(staleAfter)), LocalDateTime.class)
+                .bind("player", player)
+                .bind("platform", platform)
+                .bind("startMonth", startMonth)
+                .bind("endMonth", endMonth)
+                .bind("excludeBullet", excludeBullet)
+                .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
+                .bindByType("cutoff", toUtcWallClock(now.minus(staleAfter)), LocalDateTime.class)
                 .map(ROW_MAPPER)
                 .findFirst());
   }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -238,9 +238,13 @@ public class IndexingRequestDao implements IndexingRequestStore {
   private static final String RETIRE_SQL =
       """
       UPDATE indexing_requests
-      SET status = 'FAILED', error_message = :message, dedupe_key = NULL, updated_at = :now
+      SET status = 'FAILED', error_message = :message, dedupe_key = NULL, updated_at = :now,
+          owner_id = NULL, lease_expires_at = NULL
       WHERE status IN ('PENDING', 'PROCESSING')
-        AND updated_at < :cutoff
+        AND ((owner_id IS NOT NULL
+              AND lease_expires_at IS NOT NULL
+              AND lease_expires_at <= :now)
+             OR (owner_id IS NULL AND updated_at < :cutoff))
       """;
 
   private int retire(String keyOrNull, Duration staleAfter, Instant now) {
@@ -316,23 +320,17 @@ public class IndexingRequestDao implements IndexingRequestStore {
     // moment the work stops being in flight. Leaving the key behind would make one COMPLETED
     // request block that range permanently.
     //
-    // Terminal writes are deliberately NOT fenced, unlike the non-terminal ones below, and the
-    // limits of that are worth stating. A worker retired while it was running can still write
-    // COMPLETED over its own FAILED row, so the row can end up describing a run that lost the
-    // range rather than the replacement that owns it. More importantly, nothing here fences the
-    // *data* plane at all: that worker keeps writing game_features and motif_occurrences, so if a
-    // replacement is running the same range concurrently the occurrence delete/insert pair can
-    // still interleave. The heartbeat makes reaching this state much harder, and the non-terminal
-    // guard stops the row itself from flip-flopping, but neither makes a retired worker stop
-    // working. Closing that needs an ownership token the worker carries into every write, which is
-    // a different design from this column and is tracked separately.
-    boolean terminal = !"PENDING".equals(status) && !"PROCESSING".equals(status);
+    // Nothing here is fenced on ownership, so this is the unowned path: it is for callers writing
+    // about a request no worker ever claimed — the inline-dispatch failure in IndexRequestService,
+    // and tests. A worker presents its token and goes through updateStatusOwned instead, which is
+    // what stops a lapsed owner from stamping COMPLETED over a range someone else now holds.
+    boolean terminal = isTerminal(status);
     String sql =
         terminal
             ? """
             UPDATE indexing_requests
             SET status = ?, error_message = ?, games_indexed = ?, updated_at = ?,
-                dedupe_key = NULL
+                dedupe_key = NULL, owner_id = NULL, lease_expires_at = NULL
             WHERE id = ?
             """
             // A non-terminal write may only move a row that is still live. Without the status
@@ -373,21 +371,119 @@ public class IndexingRequestDao implements IndexingRequestStore {
     }
   }
 
+  private static boolean isTerminal(String status) {
+    return !"PENDING".equals(status) && !"PROCESSING".equals(status);
+  }
+
   @Override
-  public boolean heartbeat(UUID id, Instant now) {
-    int touched =
+  public boolean updateStatusOwned(
+      UUID id, String ownerId, String status, String errorMessage, int gamesIndexed, Instant now) {
+    // The lease is checked in the same statement that writes, so there is no window between
+    // establishing ownership and using it. Requiring an unexpired lease and not merely a matching
+    // owner_id is the stricter of the two available readings, and the right one: past expiry the
+    // system has already licensed a takeover, so a write from the old owner is racing a claim it
+    // cannot see. Recovering from a hiccup is renewLease's job, not this one's.
+    String sql =
+        isTerminal(status)
+            ? """
+            UPDATE indexing_requests
+            SET status = :status, error_message = :message, games_indexed = :games,
+                updated_at = :now, dedupe_key = NULL, owner_id = NULL, lease_expires_at = NULL
+            WHERE id = :id AND owner_id = :owner
+              AND status IN ('PENDING', 'PROCESSING')
+              AND lease_expires_at > :now
+            """
+            : """
+            UPDATE indexing_requests
+            SET status = :status, error_message = :message, games_indexed = :games,
+                updated_at = :now
+            WHERE id = :id AND owner_id = :owner
+              AND status IN ('PENDING', 'PROCESSING')
+              AND lease_expires_at > :now
+            """;
+    int updated =
+        jdbi.withHandle(
+            h ->
+                h.createUpdate(sql)
+                    .bind("status", status)
+                    .bind("message", errorMessage)
+                    .bind("games", gamesIndexed)
+                    .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
+                    .bind("id", id)
+                    .bind("owner", ownerId)
+                    .execute());
+    if (updated == 0) {
+      LOG.warn(
+          "Refused to move request {} to {}: {} no longer holds the lease.", id, status, ownerId);
+    }
+    return updated > 0;
+  }
+
+  @Override
+  public boolean claim(UUID id, String ownerId, Duration lease, Instant now) {
+    // Unclaimed, or claimed by a lease that has run out. Expressed as one conditional UPDATE so
+    // two instances racing for the same request cannot both win: the row lock decides it, and the
+    // loser's WHERE no longer matches.
+    int taken =
         jdbi.withHandle(
             h ->
                 h.createUpdate(
                         """
                         UPDATE indexing_requests
-                        SET updated_at = ?
-                        WHERE id = ? AND status IN ('PENDING', 'PROCESSING')
+                        SET owner_id = :owner, lease_expires_at = :expires, updated_at = :now
+                        WHERE id = :id
+                          AND status IN ('PENDING', 'PROCESSING')
+                          AND (owner_id IS NULL
+                               OR owner_id = :owner
+                               OR lease_expires_at IS NULL
+                               OR lease_expires_at <= :now)
                         """)
-                    .bindByType(0, toUtcWallClock(now), LocalDateTime.class)
-                    .bind(1, id)
+                    .bind("owner", ownerId)
+                    .bindByType("expires", toUtcWallClock(now.plus(lease)), LocalDateTime.class)
+                    .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
+                    .bind("id", id)
                     .execute());
-    return touched > 0;
+    return taken > 0;
+  }
+
+  @Override
+  public boolean renewLease(UUID id, String ownerId, Duration lease, Instant now) {
+    int renewed =
+        jdbi.withHandle(
+            h ->
+                h.createUpdate(
+                        """
+                        UPDATE indexing_requests
+                        SET lease_expires_at = :expires, updated_at = :now
+                        WHERE id = :id
+                          AND owner_id = :owner
+                          AND status IN ('PENDING', 'PROCESSING')
+                        """)
+                    .bindByType("expires", toUtcWallClock(now.plus(lease)), LocalDateTime.class)
+                    .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
+                    .bind("id", id)
+                    .bind("owner", ownerId)
+                    .execute());
+    return renewed > 0;
+  }
+
+  @Override
+  public boolean holdsLease(UUID id, String ownerId, Instant now) {
+    return jdbi.withHandle(
+        h ->
+            h.createQuery(
+                        """
+                        SELECT COUNT(*) FROM indexing_requests
+                        WHERE id = ? AND owner_id = ?
+                          AND status IN ('PENDING', 'PROCESSING')
+                          AND lease_expires_at > ?
+                        """)
+                    .bind(0, id)
+                    .bind(1, ownerId)
+                    .bindByType(2, toUtcWallClock(now), LocalDateTime.class)
+                    .mapTo(Integer.class)
+                    .one()
+                > 0);
   }
 
   @Override

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
@@ -38,12 +38,15 @@ public interface IndexingRequestStore {
   Optional<IndexingRequest> findById(UUID id);
 
   /**
-   * Returns an existing request with the same (player, platform, startMonth, endMonth,
-   * excludeBullet) that is PENDING or PROCESSING and was updated within {@code staleAfter}, if any.
-   * Used to avoid creating duplicate indexing work.
+   * Returns the live request with the same (player, platform, startMonth, endMonth, excludeBullet),
+   * if there is one. Used to avoid creating duplicate indexing work.
    *
-   * <p>The age bound is what keeps a request whose owner died from answering for it forever. See
-   * {@link RetentionPolicy#STALE_REQUEST}.
+   * <p>"Live" here must mean exactly what it means to {@link #reclaimStale} — the same two arms,
+   * negated. A claimed request is live while its lease holds; an unclaimed one is live until {@code
+   * staleAfter}. Answering that question two different ways on one submit is a bug with a long
+   * tail: this read runs first and short-circuits, so a laxer predicate here silently overrides the
+   * stricter reclamation behind it, and a request whose worker was killed keeps being handed back
+   * to callers for the full hour instead of the lease's few minutes.
    */
   Optional<IndexingRequest> findExistingRequest(
       String player,
@@ -77,10 +80,15 @@ public interface IndexingRequestStore {
    * request being worked on now renews, and renewal is a claim about the owner rather than about
    * progress, so it stays alive however long a month takes.
    *
-   * <p>The unclaimed arm still has the gap it always had. A message waiting in a process-local
-   * queue has no owner to renew for it and is indistinguishable from one whose queue died with its
-   * process, so a backlog deeper than {@code staleAfter} still retires work that is owned and about
-   * to run. Closing that means dispatch pulling from this table instead of an in-memory queue.
+   * <p>Retiring makes a request reclaimable; it does not hand it to anyone. There is no scanner for
+   * expired leases and no re-dispatch — the row goes FAILED, the range becomes requestable, and the
+   * user resubmits. Actual takeover is #1279.
+   *
+   * <p>The unclaimed arm still has the gap it always had, and ownership made its consequence worse:
+   * a message waiting in a process-local queue has no owner to renew for it, so a backlog deeper
+   * than {@code staleAfter} retires work that is owned and about to run — and the worker that
+   * eventually reaches it now declines the retired row instead of indexing it anyway. Closing that
+   * means dispatch pulling from this table instead of an in-memory queue (#1279).
    */
   int reclaimStale(Duration staleAfter, Instant now);
 
@@ -99,16 +107,30 @@ public interface IndexingRequestStore {
   boolean claim(UUID id, String ownerId, Duration lease, Instant now);
 
   /**
-   * Extends this owner's lease. Returns false if the request is no longer live or is no longer held
-   * by {@code ownerId} — meaning someone else has taken it, and the caller should stop.
+   * Extends this owner's lease. Returns false if the request is no longer live, or if {@code
+   * owner_id} no longer names this caller — someone else has taken it, and the caller should stop.
    *
-   * <p>Failing rather than re-taking is the point. A worker that lost its lease has, by definition,
-   * been presumed dead by something that has already handed its range to a replacement; reasserting
-   * itself would put two writers on the same games.
+   * <p>Deliberately lenient about expiry, and that is not an oversight: a lease that has lapsed but
+   * still names this owner has not been taken by anyone, so renewing it is recovery rather than a
+   * second claim. A paused GC or a stalled connection pool can outlast a lease without anything
+   * being wrong, and the alternative — abandoning a run nobody else wants — throws away work and
+   * leaves the row stranded until the sweep.
+   *
+   * <p>What it will not do is re-take. Once {@code owner_id} has changed this returns false, and it
+   * cannot race a takeover: both are single conditional UPDATEs on one row, so the row lock orders
+   * them and the rival always wins. Refusing there is the point — the replacement is already
+   * indexing that range, and reasserting would put two writers on the same games.
    */
   boolean renewLease(UUID id, String ownerId, Duration lease, Instant now);
 
-  /** True if {@code ownerId} still holds a live, unexpired lease on this request. */
+  /**
+   * True if {@code ownerId} still holds a live, unexpired lease on this request.
+   *
+   * <p>Has no production caller, and should not acquire one: asking this before a write would be a
+   * check-then-act with a window in it, which is exactly what {@link #updateStatusOwned} and {@link
+   * GameFeatureStore#flushOwned} exist to avoid by folding the question into the write. It is here
+   * for tests and for diagnostics.
+   */
   boolean holdsLease(UUID id, String ownerId, Instant now);
 
   /**

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
@@ -59,28 +59,75 @@ public interface IndexingRequestStore {
   void updateStatus(UUID id, String status, String errorMessage, int gamesIndexed);
 
   /**
-   * Retires every PENDING/PROCESSING request last updated before {@code now - staleAfter} to
-   * FAILED, freeing the dedupe slot each one holds. Returns the number retired.
+   * Retires live requests nobody is working on, freeing the dedupe slot and the lease each one
+   * holds. Returns the number retired.
+   *
+   * <p>Two different questions, deliberately kept apart:
+   *
+   * <ul>
+   *   <li><b>Claimed, lease expired.</b> Someone took this and stopped renewing, so the owner is
+   *       gone. Decided by {@link RetentionPolicy#LEASE}, in minutes.
+   *   <li><b>Never claimed, and old.</b> Nobody ever picked it up. Decided by {@code staleAfter},
+   *       in hours, because there is no owner whose silence could be measured — only the age of the
+   *       row itself.
+   * </ul>
+   *
+   * <p>Conflating those two is what made a slow request indistinguishable from a dead one: a
+   * running worker that simply had nothing to report for an hour was retired underneath itself. A
+   * request being worked on now renews, and renewal is a claim about the owner rather than about
+   * progress, so it stays alive however long a month takes.
+   *
+   * <p>The unclaimed arm still has the gap it always had. A message waiting in a process-local
+   * queue has no owner to renew for it and is indistinguishable from one whose queue died with its
+   * process, so a backlog deeper than {@code staleAfter} still retires work that is owned and about
+   * to run. Closing that means dispatch pulling from this table instead of an in-memory queue.
    */
   int reclaimStale(Duration staleAfter, Instant now);
 
   /**
-   * Moves a live request's {@code updated_at} forward without touching anything else. Returns true
-   * if the row was still live and was touched.
+   * Takes ownership of a request for {@code lease}, if it is live and either unclaimed or held by a
+   * lease that has already expired. Returns true if this caller now owns it.
    *
-   * <p>This exists because staleness infers liveness from progress, and progress is a bad proxy for
-   * it. {@link IndexWorker} writes status at month boundaries and every hundredth game, so a single
-   * month holding fewer games than that — the common case, since single-month requests run inline —
-   * reports nothing between its first and last write. The archive fetch and the profile lookups
-   * inside that span go through an HTTP client with no request timeout, so the span has no upper
-   * bound, and once it passes {@link RetentionPolicy#STALE_REQUEST} the sweep retires a request
-   * that is running perfectly well and frees the dedupe slot out from under it.
+   * <p>Claiming is how a worker earns the right to write. Before this, liveness was inferred from
+   * whether {@code updated_at} had moved recently, which cannot distinguish a worker that is slow
+   * from one that is dead, and gives nothing to check a later write against.
    *
-   * <p>Returning false rather than throwing when the row is no longer live is deliberate: by then a
-   * replacement may own the range, and the caller's job is to notice and stop, not to fight for it
-   * back.
+   * <p>{@code ownerId} identifies the <em>process</em>, not the thread or the run. It is the
+   * fencing token every subsequent write is conditioned on, so it has to stay stable while a worker
+   * holds the request and be unique across the instances competing for it.
    */
-  boolean heartbeat(UUID id, Instant now);
+  boolean claim(UUID id, String ownerId, Duration lease, Instant now);
+
+  /**
+   * Extends this owner's lease. Returns false if the request is no longer live or is no longer held
+   * by {@code ownerId} — meaning someone else has taken it, and the caller should stop.
+   *
+   * <p>Failing rather than re-taking is the point. A worker that lost its lease has, by definition,
+   * been presumed dead by something that has already handed its range to a replacement; reasserting
+   * itself would put two writers on the same games.
+   */
+  boolean renewLease(UUID id, String ownerId, Duration lease, Instant now);
+
+  /** True if {@code ownerId} still holds a live, unexpired lease on this request. */
+  boolean holdsLease(UUID id, String ownerId, Instant now);
+
+  /**
+   * Writes a status, but only if {@code ownerId} still holds the lease. Returns false without
+   * writing if it does not — the caller has lost the request and should stop.
+   *
+   * <p>The fenced counterpart to {@link #updateStatus}. A worker holds a token, so every write it
+   * makes is conditioned on that token, and this is the request row's half of the same rule {@link
+   * GameFeatureStore#flushOwned} applies to the data plane. Without it a worker whose lease lapsed
+   * could still stamp COMPLETED — and a terminal write clears {@code dedupe_key} and the lease, so
+   * it would free the slot out from under whoever legitimately owns the range now, and report the
+   * dead run's game count as the answer.
+   *
+   * <p>Non-owner callers keep using {@link #updateStatus}: the inline-dispatch failure path in
+   * {@code IndexRequestService} writes on behalf of a request no worker ever claimed, and has no
+   * token to present.
+   */
+  boolean updateStatusOwned(
+      UUID id, String ownerId, String status, String errorMessage, int gamesIndexed, Instant now);
 
   /**
    * Deletes terminal request rows created before {@code threshold} that no {@code game_features}

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -301,6 +301,26 @@ public class Migration {
                  OR (o.created_at = r.created_at AND o.id < r.id)))
       """;
 
+  // Explicit ownership, replacing the inference that a request whose updated_at has not moved must
+  // be abandoned. owner_id names the worker that holds the request; lease_expires_at is how long
+  // that claim is good for without renewal. Both NULL means nobody has claimed it yet — which is a
+  // different state from "claimed and gone quiet", and the sweep now has to tell them apart.
+  //
+  // Nullable with no backfill on purpose. Rows already in flight when this deploys have no owner,
+  // so they read as unclaimed and fall to the orphan clock, which is exactly how they were being
+  // handled before this column existed. Anything else would mean inventing an owner for a worker
+  // this process cannot see.
+  private static final String[] ADD_LEASE_COLUMNS = {
+    "ALTER TABLE indexing_requests ADD COLUMN IF NOT EXISTS owner_id VARCHAR(128)",
+    "ALTER TABLE indexing_requests ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMP",
+  };
+
+  // The reclaim sweep looks for live rows whose lease has run out, and the orphan sweep for live
+  // rows that never had one. Both filter on status plus a lease column every hour.
+  private static final String CREATE_IDX_REQUESTS_LEASE =
+      "CREATE INDEX IF NOT EXISTS idx_indexing_requests_lease"
+          + " ON indexing_requests(status, lease_expires_at)";
+
   // The retention sweep's anti-join (deleteOlderThan) filters indexing_requests on an hourly
   // schedule by "does any game still point at me". Without this, EXPLAIN shows a hash anti-join
   // over a sequential scan of game_features — the largest table in the schema. Neither engine
@@ -389,6 +409,12 @@ public class Migration {
       stmt.execute(BACKFILL_DEDUPE_KEY);
       stmt.execute(useH2 ? ADD_DEDUPE_KEY_UNIQUE_H2 : ADD_DEDUPE_KEY_UNIQUE_PG);
       stmt.execute(CREATE_IDX_GAME_FEATURES_REQUEST_ID);
+
+      // Ownership leases.
+      for (String add : ADD_LEASE_COLUMNS) {
+        stmt.execute(add);
+      }
+      stmt.execute(CREATE_IDX_REQUESTS_LEASE);
 
       LOG.info("Database migration completed successfully (H2={})", useH2);
     } catch (SQLException e) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
@@ -33,8 +33,8 @@ public final class RetentionPolicy {
   public static final Duration REQUEST = Duration.ofDays(30);
 
   /**
-   * A PENDING or PROCESSING request whose {@code updated_at} is older than this is presumed
-   * abandoned by a dead owner and retired to FAILED.
+   * How long a live request that <em>nobody has claimed</em> may sit before it is presumed orphaned
+   * and retired to FAILED.
    *
    * <p>Without a bound, a single stranded row blocks its (player, platform, month range) forever:
    * dedupe keeps returning it, and the unique constraint on {@code dedupe_key} keeps a replacement
@@ -42,27 +42,55 @@ public final class RetentionPolicy {
    * process-local queue, or an inline MCP dispatch that throws before the worker takes ownership —
    * so "rare" is not the same as "never".
    *
-   * <p>A running request cannot age out however slow chess.com is, because {@code IndexWorker}
-   * heartbeats it on a timer for as long as it is working — see {@code IndexWorker.startHeartbeat}.
-   * Status writes alone were not enough: they land at month boundaries and every hundredth game, so
-   * a single month under that size reported nothing between its first and last write, and the
-   * archive fetch inside that span goes through an HTTP client with no request timeout.
+   * <p>This is measured in hours because it is the wrong question asked of an unanswerable
+   * situation. There is no owner whose silence could be measured, so the only evidence is the age
+   * of the row, and the row's age says nothing about whether the work is about to start. For a
+   * request that <em>has</em> been claimed there is a better question and a much shorter clock: see
+   * {@link #LEASE}.
    *
-   * <p>What the hour still does <em>not</em> cover is time spent waiting in the queue. {@code
-   * InMemoryIndexQueue} is drained by a single thread, and a queued message has no worker to
-   * heartbeat for it, so its {@code updated_at} stays frozen at insert. A backlog deeper than an
-   * hour therefore retires work that is owned and about to run, telling the user to re-submit while
-   * the message is still queued. That is tracked separately rather than papered over here; the fix
-   * is to beat on enqueue as well, not a bigger number, because raising the window trades one wrong
-   * answer for a slower one.
+   * <p>What the hour still does not cover is time spent waiting in the queue. {@code
+   * InMemoryIndexQueue} is drained by a single thread, and a queued message has no worker to hold a
+   * lease for it, so its {@code updated_at} stays frozen at insert. A backlog deeper than an hour
+   * therefore retires work that is owned and about to run, telling the user to re-submit while the
+   * message is still queued. That is tracked separately rather than papered over here; the fix is
+   * for dispatch to claim from this table instead of an in-memory queue, not a bigger number,
+   * because raising the window trades one wrong answer for a slower one.
    *
    * <p>The invariant that {@link #REQUEST} must exceed {@link #PERIOD} is asserted in {@code
    * IndexE2ETest} alongside the existing check on PERIOD, not in a static initializer here. These
-   * are compile-time constants six lines apart, so a violation can only be introduced by editing
+   * are compile-time constants a few lines apart, so a violation can only be introduced by editing
    * this file — and a static block would report it as an {@code ExceptionInInitializerError} during
    * Micronaut startup rather than as a failing test.
    */
   public static final Duration STALE_REQUEST = Duration.ofHours(1);
+
+  /**
+   * How long a worker's claim on a request is good for without renewal.
+   *
+   * <p>Deliberately far shorter than {@link #STALE_REQUEST}, because it answers a different
+   * question. The hour above asks "did anyone ever pick this up?" — a question about a request
+   * nobody owns. This asks "is the owner still there?", and once ownership is explicit that can be
+   * answered quickly and safely: the holder renews every {@link #LEASE_RENEWAL} and a holder that
+   * stops renewing has its work taken over in minutes rather than an hour.
+   *
+   * <p>Five minutes is four renewal intervals, so three consecutive misses are survivable, and
+   * short enough that a crashed instance does not strand a range for longer than a user is willing
+   * to wait before resubmitting. It is not a timeout on the work: a request can run for hours,
+   * renewing throughout.
+   *
+   * <p>{@code IndexWorker.DEFAULT_HEARTBEAT_INTERVAL} must stay below this, and the relationship is
+   * asserted in {@code IndexE2ETest} rather than left to inspection — an interval longer than the
+   * lease means every lease lapses between beats, which does not fail loudly. It shows up as work
+   * being reclaimed out from under healthy workers.
+   */
+  public static final Duration LEASE = Duration.ofMinutes(5);
+
+  /**
+   * How often the holder renews. A quarter of {@link #LEASE}, so three consecutive renewals can be
+   * lost — to a paused GC, a saturated pool, a brief database blip — before anyone else may take
+   * the request.
+   */
+  public static final Duration LEASE_RENEWAL = LEASE.dividedBy(4);
 
   private RetentionPolicy() {}
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
@@ -48,13 +48,18 @@ public final class RetentionPolicy {
    * request that <em>has</em> been claimed there is a better question and a much shorter clock: see
    * {@link #LEASE}.
    *
-   * <p>What the hour still does not cover is time spent waiting in the queue. {@code
-   * InMemoryIndexQueue} is drained by a single thread, and a queued message has no worker to hold a
-   * lease for it, so its {@code updated_at} stays frozen at insert. A backlog deeper than an hour
-   * therefore retires work that is owned and about to run, telling the user to re-submit while the
-   * message is still queued. That is tracked separately rather than papered over here; the fix is
-   * for dispatch to claim from this table instead of an in-memory queue, not a bigger number,
-   * because raising the window trades one wrong answer for a slower one.
+   * <p>What the hour still does not cover is time spent waiting in the queue, and the cost of that
+   * went <em>up</em> when ownership arrived. {@code InMemoryIndexQueue} is drained by a single
+   * thread, and a queued message has no worker holding a lease for it, so its {@code updated_at}
+   * stays frozen at insert and a backlog deeper than an hour retires work that is owned and about
+   * to run. The worker then reaches the message, fails to claim a retired row, and declines: the
+   * indexing does not happen at all. Before ownership it carried on and its unfenced terminal write
+   * landed, so the user got their games — at the cost of exactly the concurrent-writer corruption
+   * this design prevents, since the freed dedupe slot may already have started a replacement.
+   *
+   * <p>Neither answer is right, and a bigger number only makes the wrong one slower. The fix is for
+   * queued work not to be invisible: dispatch claiming from this table instead of from memory,
+   * tracked as #1279.
    *
    * <p>The invariant that {@link #REQUEST} must exceed {@link #PERIOD} is asserted in {@code
    * IndexE2ETest} alongside the existing check on PERIOD, not in a static initializer here. These
@@ -69,14 +74,24 @@ public final class RetentionPolicy {
    *
    * <p>Deliberately far shorter than {@link #STALE_REQUEST}, because it answers a different
    * question. The hour above asks "did anyone ever pick this up?" — a question about a request
-   * nobody owns. This asks "is the owner still there?", and once ownership is explicit that can be
-   * answered quickly and safely: the holder renews every {@link #LEASE_RENEWAL} and a holder that
-   * stops renewing has its work taken over in minutes rather than an hour.
+   * nobody owns. This asks "is the owner still there?", which the owner itself answers by renewing
+   * every {@link #LEASE_RENEWAL}, so it can be decided in minutes rather than an hour.
    *
-   * <p>Five minutes is four renewal intervals, so three consecutive misses are survivable, and
-   * short enough that a crashed instance does not strand a range for longer than a user is willing
-   * to wait before resubmitting. It is not a timeout on the work: a request can run for hours,
-   * renewing throughout.
+   * <p>What "decided" means today is narrower than it sounds, and worth stating rather than
+   * implying. A lapsed lease makes the request <em>reclaimable</em>; nothing picks it up. {@code
+   * IndexWorker.process} is the only caller of {@code claim}, and it runs on a dispatched message,
+   * so there is no scanner looking for expired leases and no re-dispatch. The row is retired to
+   * FAILED and the range becomes requestable again — the user resubmits. Reclamation itself is only
+   * as prompt as its caller: {@code RetentionWorker} is on an hourly schedule, and the only faster
+   * path is {@code createOrAdopt}, which retires the key it is about to claim. So the five minutes
+   * bounds when a lapse <em>may</em> be acted on, not when it is. Actually handing the range to
+   * another worker is #1279.
+   *
+   * <p>Five minutes is four renewal intervals: three consecutive misses are survivable and expiry
+   * lands on the fourth. Short enough that a crashed instance does not strand a range for longer
+   * than a user will wait before resubmitting. It is not a timeout on the work — a request can run
+   * for hours, renewing throughout — and a lease that lapses without anyone taking it is renewed
+   * rather than abandoned, so a stalled pool costs a warning and not a run.
    *
    * <p>{@code IndexWorker.DEFAULT_HEARTBEAT_INTERVAL} must stay below this, and the relationship is
    * asserted in {@code IndexE2ETest} rather than left to inspection — an interval longer than the

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
@@ -151,6 +151,10 @@ com.muchq.indexer/
 | updated_at    | TIMESTAMP    | Updated on status change       |
 | error_message | TEXT         | Populated on FAILED            |
 | games_indexed | INT          | Running count during processing|
+| exclude_bullet | BOOLEAN     | Part of the dedupe tuple       |
+| dedupe_key    | VARCHAR      | UNIQUE. Held while live, NULLed on a terminal status — one live request per (player, platform, range, exclude_bullet) |
+| owner_id      | VARCHAR(128) | The worker process holding the lease; the fencing token every write is conditioned on |
+| lease_expires_at | TIMESTAMP | Renewed every 75s while the owner is alive. Past this the request is reclaimable |
 
 ### game_features
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -359,16 +359,25 @@ public class IndexWorker {
       LOG.warn("Abandoning request {}: {}", message.requestId(), e.getMessage());
     } catch (Exception e) {
       LOG.error("Failed to process index request {}", message.requestId(), e);
-      if (!requestStore.updateStatusOwned(
+      // Through fenced(), like every other write in the run. This is the write most likely to be
+      // refused for a reason unrelated to what it is reporting — the database problem that throws
+      // out of a run is the same one that stalls the heartbeat — and it is the only write that can
+      // explain the failure. Refused, it leaves the row PROCESSING holding its dedupe slot, so the
+      // range stays blocked until the hourly sweep retires it under a message about an owner that
+      // stopped responding, which is not what happened.
+      if (!fenced(
           message.requestId(),
-          ownerId,
-          "FAILED",
-          "Indexing failed due to an internal error",
-          0,
-          clock.instant())) {
-        // Worth its own line: the failure is now recorded nowhere, and the row waits for the
-        // sweep. Reachable when the exception that landed here is itself the database problem
-        // that lapsed the lease.
+          () ->
+              requestStore.updateStatusOwned(
+                  message.requestId(),
+                  ownerId,
+                  "FAILED",
+                  "Indexing failed due to an internal error",
+                  0,
+                  clock.instant()),
+          "the failure could be recorded")) {
+        // Only reachable now when the range has genuinely moved on, in which case the replacement
+        // owns the outcome and this run has nothing to report.
         LOG.error(
             "Could not record FAILED for request {}: the lease is gone. The row will be reclaimed"
                 + " rather than reporting this error.",

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -74,10 +74,35 @@ public class IndexWorker {
   private final ScheduledExecutorService heartbeatScheduler;
 
   /**
-   * A quarter of the staleness cutoff, so three consecutive beats can be lost before the request
-   * looks abandoned.
+   * Identifies this worker as the holder of a lease. Stable for the life of the process and unique
+   * across the instances competing for the same table, which is what makes it usable as a fencing
+   * token: every write this worker makes is conditioned on the request still naming it. The host
+   * and pid are carried for the sake of whoever reads the column while debugging a stuck range.
    */
-  static final Duration DEFAULT_HEARTBEAT_INTERVAL = RetentionPolicy.STALE_REQUEST.dividedBy(4);
+  private final String ownerId = buildOwnerId();
+
+  private static String buildOwnerId() {
+    String host;
+    try {
+      host = java.net.InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      host = "unknown-host";
+    }
+    return host + "/" + ProcessHandle.current().pid() + "/" + UUID.randomUUID();
+  }
+
+  /** Visible so a test can assert which worker holds a request. */
+  public String ownerId() {
+    return ownerId;
+  }
+
+  /**
+   * How often the lease is renewed. Paced against {@link RetentionPolicy#LEASE}, not against {@link
+   * RetentionPolicy#STALE_REQUEST}: the hour is how long an <em>unclaimed</em> row may sit before
+   * it is presumed orphaned, and beating on that schedule against a five-minute lease would let
+   * every lease lapse between beats.
+   */
+  public static final Duration DEFAULT_HEARTBEAT_INTERVAL = RetentionPolicy.LEASE_RENEWAL;
 
   public IndexWorker(
       ChessClient chessClient,
@@ -120,10 +145,10 @@ public class IndexWorker {
    *     against. Injected so a test can advance time across the retention boundary instead of
    *     backdating rows, which only ever exercises {@code deleteOlderThan} and never the window
    *     arithmetic that decides what "old" means.
-   * @param heartbeatInterval how often an in-flight request's {@code updated_at} is refreshed.
-   *     Injected only so a test can observe a beat without waiting a quarter of an hour for one —
-   *     the heartbeat runs on wall-clock time, not on {@code clock}, because its job is to prove
-   *     this process is still alive and a fake clock proves nothing about that.
+   * @param heartbeatInterval how often an in-flight request's lease is renewed. Injected only so a
+   *     test can observe a beat without waiting out a renewal interval — the heartbeat is scheduled
+   *     on wall-clock time, not on {@code clock}, because its job is to prove this process is still
+   *     alive and a fake clock proves nothing about that.
    */
   public IndexWorker(
       ChessClient chessClient,
@@ -159,9 +184,16 @@ public class IndexWorker {
         message.player(),
         message.platform());
 
+    if (!requestStore.claim(message.requestId(), ownerId, RetentionPolicy.LEASE, clock.instant())) {
+      // Someone else holds a live lease on this request. That is not an error: it means the work
+      // is already owned, and doing it again would put two writers on the same games.
+      LOG.info("Skipping request {}: another worker holds the lease", message.requestId());
+      return;
+    }
+
     ScheduledFuture<?> heartbeat = startHeartbeat(message.requestId());
     try {
-      requestStore.updateStatus(message.requestId(), "PROCESSING", null, 0);
+      progress(message.requestId(), 0);
 
       YearMonth start = YearMonth.parse(message.startMonth(), MONTH_FORMAT);
       YearMonth end = YearMonth.parse(message.endMonth(), MONTH_FORMAT);
@@ -194,7 +226,7 @@ public class IndexWorker {
                 message.platform(),
                 monthStr,
                 count);
-            requestStore.updateStatus(message.requestId(), "PROCESSING", null, totalIndexed);
+            progress(message.requestId(), totalIndexed);
             continue;
           }
         }
@@ -208,7 +240,7 @@ public class IndexWorker {
           // period cache miss forever, refetching an empty archive on every request.
           LOG.warn("No games found for player={} month={}", message.player(), month);
           upsertPeriod(message, monthStr, month, fetchedAt, 0, false);
-          requestStore.updateStatus(message.requestId(), "PROCESSING", null, totalIndexed);
+          progress(message.requestId(), totalIndexed);
           continue;
         }
 
@@ -269,11 +301,11 @@ public class IndexWorker {
           monthCount++;
           totalIndexed++;
           if (featureBatch.size() >= BATCH_SIZE) {
-            flushBatch(featureBatch, occurrencesBatch);
-            requestStore.updateStatus(message.requestId(), "PROCESSING", null, totalIndexed);
+            flushBatch(message.requestId(), featureBatch, occurrencesBatch);
+            progress(message.requestId(), totalIndexed);
           }
         }
-        flushBatch(featureBatch, occurrencesBatch);
+        flushBatch(message.requestId(), featureBatch, occurrencesBatch);
         if (titleResolution.degraded()) {
           LOG.warn(
               "Title enrichment degraded for player={} month={}; period stored incomplete",
@@ -281,41 +313,54 @@ public class IndexWorker {
               monthStr);
         }
         upsertPeriod(message, monthStr, month, fetchedAt, monthCount, titleResolution.degraded());
-        requestStore.updateStatus(message.requestId(), "PROCESSING", null, totalIndexed);
+        progress(message.requestId(), totalIndexed);
       }
 
-      requestStore.updateStatus(message.requestId(), "COMPLETED", null, totalIndexed);
+      requestStore.updateStatusOwned(
+          message.requestId(), ownerId, "COMPLETED", null, totalIndexed, clock.instant());
       LOG.info("Completed indexing request {} with {} games", message.requestId(), totalIndexed);
+    } catch (LeaseLostException e) {
+      // Not a failure of the work, and deliberately not written down. The row belongs to someone
+      // else now; a FAILED here would clear their dedupe slot and their lease. Leaving it alone is
+      // the whole point of carrying a token.
+      LOG.warn("Abandoning request {}: {}", message.requestId(), e.getMessage());
     } catch (Exception e) {
       LOG.error("Failed to process index request {}", message.requestId(), e);
-      requestStore.updateStatus(
-          message.requestId(), "FAILED", "Indexing failed due to an internal error", 0);
+      requestStore.updateStatusOwned(
+          message.requestId(),
+          ownerId,
+          "FAILED",
+          "Indexing failed due to an internal error",
+          0,
+          clock.instant());
     } finally {
       heartbeat.cancel(false);
     }
   }
 
   /**
-   * Keeps {@code updated_at} moving for as long as this request is being worked on, so the
-   * staleness sweep can tell "running slowly" from "abandoned".
+   * Renews this worker's lease for as long as the request is being worked on, so reclamation can
+   * tell "running slowly" from "abandoned".
    *
    * <p>On a timer rather than at checkpoints, because the spans that need covering are exactly the
    * ones with no checkpoint in them: a single archive fetch, a run of profile lookups, the
    * extraction of a month holding fewer than {@link #BATCH_SIZE} games. The interval is a quarter
-   * of the cutoff, so three consecutive beats can be lost — to a paused GC, a blocked pool, a
-   * database blip — before the request looks abandoned.
+   * of the lease, so three consecutive beats can be lost — to a paused GC, a blocked pool, a
+   * database blip — before anyone else may take the request.
    *
-   * <p>A beat that comes back false means the row is no longer live: something already retired it
-   * and a replacement may own the range. The heartbeat stops rather than reasserting itself, and
-   * the run finishes against a row whose terminal write will be refused. That is the honest outcome
-   * — this worker lost the range while it was not looking.
+   * <p>Renewal asserts that this owner is still here; it says nothing about progress, which is why
+   * a request can run for hours without looking abandoned. A beat that comes back false means the
+   * row no longer names this worker as owner, so something has already handed the range to a
+   * replacement. The heartbeat stops rather than reasserting itself — retaking it would put two
+   * writers on the same games — and the run unwinds at its next fenced write.
    */
   private ScheduledFuture<?> startHeartbeat(UUID requestId) {
     long everyMillis = Math.max(1, heartbeatInterval.toMillis());
     return heartbeatScheduler.scheduleWithFixedDelay(
         () -> {
           try {
-            if (!requestStore.heartbeat(requestId, clock.instant())) {
+            if (!requestStore.renewLease(
+                requestId, ownerId, RetentionPolicy.LEASE, clock.instant())) {
               LOG.warn(
                   "Request {} is no longer live; another owner has taken this range. Stopping"
                       + " heartbeat.",
@@ -472,15 +517,50 @@ public class IndexWorker {
     return titles.get(playerResult.username().toLowerCase());
   }
 
+  /**
+   * Writes a batch under this worker's lease, as one transaction.
+   *
+   * <p>It used to be three calls — insert games, delete the games' occurrences, insert the new ones
+   * — and the middle two are a read-modify-write on rows keyed by nothing but a random UUID. Two
+   * workers over the same game could interleave as delete, delete, insert, insert, and both inserts
+   * survive: every motif for that game then counts double. Two live requests reaching one game is
+   * ordinary, not exotic — a game has two players — so the fix has to be atomicity here rather than
+   * exclusion upstream.
+   */
   private void flushBatch(
+      UUID requestId,
       List<GameFeature> featureBatch,
       Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesBatch) {
     if (featureBatch.isEmpty()) return;
-    gameFeatureStore.insertBatch(featureBatch);
-    gameFeatureStore.deleteOccurrencesByGameUrls(new ArrayList<>(occurrencesBatch.keySet()));
-    gameFeatureStore.insertOccurrencesBatch(occurrencesBatch);
+    if (!gameFeatureStore.flushOwned(
+        requestId, ownerId, clock.instant(), featureBatch, occurrencesBatch)) {
+      throw new LeaseLostException(requestId, "the lease was lost before a batch could be written");
+    }
     featureBatch.clear();
     occurrencesBatch.clear();
+  }
+
+  /**
+   * Reports progress under the lease. A refused write means this worker no longer owns the range,
+   * so it unwinds the run rather than carrying on producing rows nobody will read.
+   */
+  private void progress(UUID requestId, int totalIndexed) {
+    if (!requestStore.updateStatusOwned(
+        requestId, ownerId, "PROCESSING", null, totalIndexed, clock.instant())) {
+      throw new LeaseLostException(
+          requestId, "the lease was lost before progress could be recorded");
+    }
+  }
+
+  /**
+   * Thrown to unwind a run whose lease has gone. Distinct from an ordinary failure because the
+   * outcome is different: there is no row left for this worker to write to, and pretending
+   * otherwise would corrupt the replacement's.
+   */
+  private static final class LeaseLostException extends RuntimeException {
+    LeaseLostException(UUID requestId, String detail) {
+      super("Request " + requestId + ": " + detail);
+    }
   }
 
   private String determineResult(PlayedGame game) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -185,9 +185,22 @@ public class IndexWorker {
         message.platform());
 
     if (!requestStore.claim(message.requestId(), ownerId, RetentionPolicy.LEASE, clock.instant())) {
-      // Someone else holds a live lease on this request. That is not an error: it means the work
-      // is already owned, and doing it again would put two writers on the same games.
-      LOG.info("Skipping request {}: another worker holds the lease", message.requestId());
+      // Three causes, and the message must not pick one: a live rival holds the lease, the row
+      // reached a terminal status, or it is gone. Only the first is benign — it means the work is
+      // already owned and doing it again would put two writers on the same games.
+      //
+      // The second is not benign and is the known cost of dispatching from a process-local queue.
+      // A message that waits longer than the unclaimed cutoff has its row retired underneath it,
+      // and this worker then declines the work rather than doing it: the dedupe slot is free, so a
+      // replacement may already be running the range. Before ownership existed the worker carried
+      // on and its unfenced terminal write landed, so the user got their games — at the cost of
+      // exactly the concurrent-writer corruption this change prevents. Neither answer is right;
+      // the fix is for queued work not to be retired at all, which needs dispatch to claim from
+      // the table rather than from memory (#1279).
+      LOG.warn(
+          "Declining request {}: it is not available to claim (already held, or retired while"
+              + " queued). No games will be indexed for it.",
+          message.requestId());
       return;
     }
 
@@ -239,8 +252,14 @@ public class IndexWorker {
           // swept (DataAvailabilityResolver reads a missing row as "gone"), and would make the
           // period cache miss forever, refetching an empty archive on every request.
           LOG.warn("No games found for player={} month={}", message.player(), month);
-          upsertPeriod(message, monthStr, month, fetchedAt, 0, false);
+          // Ownership first. upsertPeriod is the one write in a run that carries no token —
+          // indexed_periods is keyed by (player, platform, month) and has no request to fence
+          // against — so the only protection it can have is not reaching it after the lease is
+          // gone. Writing an empty period for a month a replacement has already indexed properly
+          // would make the period cache report zero games and skip that month until retention
+          // sweeps it.
           progress(message.requestId(), totalIndexed);
+          upsertPeriod(message, monthStr, month, fetchedAt, 0, false);
           continue;
         }
 
@@ -316,23 +335,45 @@ public class IndexWorker {
         progress(message.requestId(), totalIndexed);
       }
 
-      requestStore.updateStatusOwned(
-          message.requestId(), ownerId, "COMPLETED", null, totalIndexed, clock.instant());
-      LOG.info("Completed indexing request {} with {} games", message.requestId(), totalIndexed);
+      final int finalCount = totalIndexed;
+      if (fenced(
+          message.requestId(),
+          () ->
+              requestStore.updateStatusOwned(
+                  message.requestId(), ownerId, "COMPLETED", null, finalCount, clock.instant()),
+          "the run could be completed")) {
+        LOG.info("Completed indexing request {} with {} games", message.requestId(), totalIndexed);
+      } else {
+        // Logging the count unconditionally read as success whatever the row said. The games are
+        // on disk either way; what is lost is the record that this run produced them.
+        LOG.warn(
+            "Indexed {} games for request {} but could not record COMPLETED: the lease is gone.",
+            totalIndexed,
+            message.requestId());
+      }
     } catch (LeaseLostException e) {
-      // Not a failure of the work, and deliberately not written down. The row belongs to someone
-      // else now; a FAILED here would clear their dedupe slot and their lease. Leaving it alone is
-      // the whole point of carrying a token.
+      // No terminal write is attempted, and that is the whole difference from an ordinary failure.
+      // It is not that a FAILED here would damage the replacement's row — that write is fenced
+      // too, and would simply be refused. It is that attempting it would log a spurious error for
+      // a run that did not fail: it was stopped, correctly, because the range moved.
       LOG.warn("Abandoning request {}: {}", message.requestId(), e.getMessage());
     } catch (Exception e) {
       LOG.error("Failed to process index request {}", message.requestId(), e);
-      requestStore.updateStatusOwned(
+      if (!requestStore.updateStatusOwned(
           message.requestId(),
           ownerId,
           "FAILED",
           "Indexing failed due to an internal error",
           0,
-          clock.instant());
+          clock.instant())) {
+        // Worth its own line: the failure is now recorded nowhere, and the row waits for the
+        // sweep. Reachable when the exception that landed here is itself the database problem
+        // that lapsed the lease.
+        LOG.error(
+            "Could not record FAILED for request {}: the lease is gone. The row will be reclaimed"
+                + " rather than reporting this error.",
+            message.requestId());
+      }
     } finally {
       heartbeat.cancel(false);
     }
@@ -531,9 +572,16 @@ public class IndexWorker {
       UUID requestId,
       List<GameFeature> featureBatch,
       Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesBatch) {
-    if (featureBatch.isEmpty()) return;
-    if (!gameFeatureStore.flushOwned(
-        requestId, ownerId, clock.instant(), featureBatch, occurrencesBatch)) {
+    // No early return on an empty batch. An empty flush writes nothing but still asks the question,
+    // and the answer is what gates everything after it — including upsertPeriod, which is not
+    // itself fenced. A month whose games were all bullet-filtered, or whose count is an exact
+    // multiple of BATCH_SIZE, arrives here empty, and skipping the check there was a hole.
+    if (!fenced(
+        requestId,
+        () ->
+            gameFeatureStore.flushOwned(
+                requestId, ownerId, clock.instant(), featureBatch, occurrencesBatch),
+        "a batch could be written")) {
       throw new LeaseLostException(requestId, "the lease was lost before a batch could be written");
     }
     featureBatch.clear();
@@ -545,11 +593,47 @@ public class IndexWorker {
    * so it unwinds the run rather than carrying on producing rows nobody will read.
    */
   private void progress(UUID requestId, int totalIndexed) {
-    if (!requestStore.updateStatusOwned(
-        requestId, ownerId, "PROCESSING", null, totalIndexed, clock.instant())) {
+    if (!fenced(
+        requestId,
+        () ->
+            requestStore.updateStatusOwned(
+                requestId, ownerId, "PROCESSING", null, totalIndexed, clock.instant()),
+        "progress could be recorded")) {
       throw new LeaseLostException(
           requestId, "the lease was lost before progress could be recorded");
     }
+  }
+
+  /**
+   * Runs a fenced write, and retries it once if the only thing wrong was that our own lease had
+   * lapsed.
+   *
+   * <p>A refusal has three causes and they do not deserve the same response: someone else took the
+   * request, the row reached a terminal status, or this worker's lease expired with nobody taking
+   * it. The last is recoverable and not rare — the renewal interval is 75 seconds against a
+   * five-minute lease, but a stalled connection pool can outlast both, and the heartbeat shares one
+   * scheduler thread with every other in-flight request on this instance. Treating it as a loss
+   * abandons a run nobody else wants, mid-way, leaving the row PROCESSING and still holding its
+   * dedupe slot until the sweep retires it with a message about an owner that never existed.
+   *
+   * <p>{@link IndexingRequestStore#renewLease} is exactly the discriminator: it is keyed on {@code
+   * owner_id}, so it succeeds when the row still names us and fails when it does not. No separate
+   * read is needed, and there is no window — a rival claim and a late renewal are two conditional
+   * updates on one row, so the row lock orders them and the rival always wins.
+   */
+  private boolean fenced(UUID requestId, java.util.function.BooleanSupplier write, String what) {
+    if (write.getAsBoolean()) {
+      return true;
+    }
+    if (!requestStore.renewLease(requestId, ownerId, RetentionPolicy.LEASE, clock.instant())) {
+      return false;
+    }
+    LOG.warn(
+        "Lease on request {} had lapsed before {}, but no one else took it. Renewed and"
+            + " continuing.",
+        requestId,
+        what);
+    return write.getAsBoolean();
   }
 
   /**

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AdminControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AdminControllerTest.java
@@ -155,6 +155,18 @@ public class AdminControllerTest {
   }
 
   private static class FakeGameFeatureStore implements GameFeatureStore {
+
+    /** Not part of the AdminController surface: only the worker flushes. */
+    @Override
+    public boolean flushOwned(
+        java.util.UUID requestId,
+        String ownerId,
+        Instant now,
+        List<GameFeature> features,
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+      throw new UnsupportedOperationException("AdminController tests never flush");
+    }
+
     private final List<GameForReanalysis> games = new ArrayList<>();
     private final Map<String, Integer> deleteCount = new HashMap<>();
     private final Map<String, Integer> insertCount = new HashMap<>();

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AggregateControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AggregateControllerTest.java
@@ -216,6 +216,18 @@ public class AggregateControllerTest {
   }
 
   private static final class RecordingStore implements GameFeatureStore {
+
+    /** Not part of the AggregateController surface: only the worker flushes. */
+    @Override
+    public boolean flushOwned(
+        java.util.UUID requestId,
+        String ownerId,
+        Instant now,
+        List<GameFeature> features,
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+      throw new UnsupportedOperationException("AggregateController tests never flush");
+    }
+
     List<AggregateRow> rows = List.of();
     AggregateTotals totals = new AggregateTotals(0, 0);
     Object lastCompiled;

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
@@ -436,7 +436,28 @@ public class IndexControllerTest {
     }
 
     @Override
-    public boolean heartbeat(UUID id, Instant now) {
+    public boolean claim(UUID id, String ownerId, Duration lease, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean renewLease(UUID id, String ownerId, Duration lease, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean holdsLease(UUID id, String ownerId, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean updateStatusOwned(
+        UUID id,
+        String ownerId,
+        String status,
+        String errorMessage,
+        int gamesIndexed,
+        Instant now) {
       return true;
     }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/QueryControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/QueryControllerTest.java
@@ -185,6 +185,18 @@ public class QueryControllerTest {
   }
 
   private static final class FakeGameFeatureStore implements GameFeatureStore {
+
+    /** Not part of the QueryController surface: only the worker flushes. */
+    @Override
+    public boolean flushOwned(
+        java.util.UUID requestId,
+        String ownerId,
+        Instant now,
+        List<GameFeature> features,
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+      throw new UnsupportedOperationException("QueryController tests never flush");
+    }
+
     private List<GameFeature> queryResult = List.of();
     private Map<String, Map<String, List<OccurrenceRow>>> occurrencesResult = Map.of();
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java
@@ -1,0 +1,390 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.muchq.games.one_d4.api.dto.GameFeature;
+import com.muchq.games.one_d4.engine.model.GameFeatures;
+import com.muchq.games.one_d4.engine.model.Motif;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The write path's own safety, independent of who is allowed to run it.
+ *
+ * <p>#1249 named this as the harm behind the whole dedupe mechanism. A flush inserts features,
+ * deletes the occurrences for those games, then re-inserts them. Run as three separate
+ * transactions, two writers over the same game can interleave as delete, delete, insert, insert,
+ * and {@code motif_occurrences} has no uniqueness beyond a random UUID primary key, so nothing
+ * rejects the second copy: every motif for that game then reads double.
+ *
+ * <p>Until #1278 that was prevented only by making the overlap unreachable — one live request per
+ * range, and a heartbeat so a running request is not retired underneath its worker. Those are good
+ * defences and they are why this has not bitten, but they are defences in the control plane against
+ * a defect in the data plane, and scale-out puts more processes in a position to test them. Two
+ * live requests can also reach one game entirely legitimately: a game has two players, so indexing
+ * each of them covers it, and dedupe cannot rule that out because the two requests differ.
+ *
+ * <p>Three properties are pinned here, in the order they build on each other: the hazard is real
+ * when the delete and the insert are separate transactions; it is gone when they are one; and a
+ * flush from a worker that no longer owns the request writes nothing at all.
+ */
+public class ConcurrentFlushTest {
+
+  private static final String GAME_URL = "https://chess.com/game/contended";
+
+  /** A game with no {@code game_features} row. Its occurrences violate the foreign key. */
+  private static final String UNBACKED_URL = "https://chess.com/game/absent";
+
+  private static final String OWNER_A = "host-a/1/aaaa";
+  private static final String OWNER_B = "host-b/2/bbbb";
+  private static final Instant NOW = Instant.parse("2026-07-01T12:00:00Z");
+
+  /**
+   * Enough flushes for a concurrent reader to land inside one, if landing inside one is possible.
+   */
+  private static final int ROUNDS = 200;
+
+  private TestDb testDb;
+  private DataSource dataSource;
+  private GameFeatureDao store;
+  private UUID requestId;
+  private ExecutorService pool;
+
+  @BeforeEach
+  public void setUp() {
+    testDb = TestDb.create("concurrent_flush");
+    dataSource = testDb.dataSource();
+    store = new GameFeatureDao(testDb.jdbi(), true);
+    requestId = insertRequest(OWNER_A, NOW.plus(Duration.ofMinutes(5)));
+    pool = Executors.newFixedThreadPool(2);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    pool.shutdownNow();
+  }
+
+  /**
+   * The hazard, stated as a fact rather than an argument. Driven through the separate public
+   * primitives with the interleaving forced by a latch, doubling is not a race that might happen
+   * but the guaranteed outcome of an ordering the API permits.
+   *
+   * <p>Those primitives are still public and still correct for their remaining caller — {@code
+   * AdminController}'s reanalysis path pairs them, single-threaded — so the constraint on their use
+   * needs somewhere to live. If a later change routes concurrent writers back through them, this is
+   * the explanation waiting.
+   */
+  @Test
+  @Timeout(30)
+  public void theSeparateDeleteAndInsertPrimitivesAreNotSafeToPairUnderConcurrency()
+      throws Exception {
+    CountDownLatch bothDeleted = new CountDownLatch(2);
+    CountDownLatch go = new CountDownLatch(1);
+
+    Runnable flush =
+        () -> {
+          store.insertBatch(List.of(gameFeature()));
+          store.deleteOccurrencesByGameUrls(List.of(GAME_URL));
+          bothDeleted.countDown();
+          try {
+            // Hold here until the other writer has also deleted. This is the interleaving the
+            // separate transactions allow; the latch only makes it deterministic.
+            go.await(15, TimeUnit.SECONDS);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          store.insertOccurrencesBatch(Map.of(GAME_URL, occurrences()));
+        };
+
+    pool.submit(flush);
+    pool.submit(flush);
+
+    assertThat(bothDeleted.await(15, TimeUnit.SECONDS)).isTrue();
+    go.countDown();
+    pool.shutdown();
+    assertThat(pool.awaitTermination(20, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(countOccurrences())
+        .as("both inserts survived because neither delete could see the other's rows")
+        .isEqualTo(4);
+  }
+
+  /**
+   * The property that removes it, observed from outside: while a flush is in progress, nobody can
+   * see the game with its occurrences deleted. The gap the interleaving needs is the same gap a
+   * reader can see, so a reader that never sees one is evidence there is none to exploit.
+   *
+   * <p>This fails against the three-call sequence — the reader lands on a count of zero within a
+   * few rounds — which is what makes it worth running rather than a loop that passes either way.
+   */
+  @Test
+  @Timeout(60)
+  public void aReaderNeverSeesAGameWithItsOccurrencesMissing() throws Exception {
+    store.flushOwned(
+        requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+
+    AtomicBoolean done = new AtomicBoolean(false);
+    AtomicInteger lowest = new AtomicInteger(Integer.MAX_VALUE);
+
+    Future<?> reader =
+        pool.submit(
+            () -> {
+              while (!done.get()) {
+                lowest.getAndUpdate(m -> Math.min(m, countOccurrences()));
+              }
+            });
+    Future<?> writer =
+        pool.submit(
+            () -> {
+              for (int i = 0; i < ROUNDS; i++) {
+                store.flushOwned(
+                    requestId,
+                    OWNER_A,
+                    NOW,
+                    List.of(gameFeature()),
+                    Map.of(GAME_URL, occurrences()));
+              }
+              done.set(true);
+            });
+
+    writer.get(45, TimeUnit.SECONDS);
+    reader.get(45, TimeUnit.SECONDS);
+
+    assertThat(lowest.get())
+        .as("a reader observed a flush half applied, so another writer could have too")
+        .isEqualTo(2);
+  }
+
+  /**
+   * The same property from the other side, and deterministically: a flush that fails part way
+   * through leaves the game exactly as it was. If the delete were its own transaction it would have
+   * committed by the time the insert failed, and the game would be left with no occurrences at all
+   * — the state a concurrent writer needs to duplicate into.
+   *
+   * <p>The failure is a real one rather than a stub: {@code motif_occurrences.game_url} is a
+   * foreign key onto {@code game_features}, so occurrences for a game the batch does not also
+   * insert cannot be written.
+   */
+  @Test
+  public void aFlushThatFailsPartWayThroughLeavesThePreviousOccurrencesIntact() {
+    store.flushOwned(
+        requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+    assertThat(countOccurrences()).isEqualTo(2);
+
+    assertThatThrownBy(
+            () ->
+                store.flushOwned(
+                    requestId,
+                    OWNER_A,
+                    NOW,
+                    List.of(gameFeature()),
+                    Map.of(GAME_URL, occurrences(), UNBACKED_URL, occurrences())))
+        .isInstanceOf(RuntimeException.class);
+
+    assertThat(countOccurrences())
+        .as("the delete outlived the insert that was supposed to replace it")
+        .isEqualTo(2);
+  }
+
+  /** The fence: a worker whose lease has been taken writes nothing at all. */
+  @Test
+  public void aFlushIsRefusedOnceTheLeaseHasMovedToAnotherOwner() {
+    setOwner(OWNER_B, NOW.plus(Duration.ofMinutes(5)));
+
+    boolean wrote =
+        store.flushOwned(
+            requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+
+    assertThat(wrote).isFalse();
+    assertThat(countOccurrences()).isZero();
+    assertThat(countFeatures()).isZero();
+  }
+
+  /**
+   * An expired lease is refused too, even though {@code owner_id} still names this worker. Past
+   * expiry the system has already licensed a takeover, so writing would be racing a claim this
+   * worker cannot see. Recovering from a lapse is the heartbeat's job, not the flush's.
+   */
+  @Test
+  public void aFlushIsRefusedOnceTheLeaseHasExpired() {
+    setOwner(OWNER_A, NOW.minusSeconds(1));
+
+    boolean wrote =
+        store.flushOwned(
+            requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+
+    assertThat(wrote).isFalse();
+    assertThat(countOccurrences()).isZero();
+  }
+
+  /** And once the request is no longer live, whoever owned it may not keep writing to it. */
+  @Test
+  public void aFlushIsRefusedOnceTheRequestHasBeenRetired() {
+    execute(
+        "UPDATE indexing_requests SET status = 'FAILED', owner_id = NULL,"
+            + " lease_expires_at = NULL WHERE id = '"
+            + requestId
+            + "'");
+
+    boolean wrote =
+        store.flushOwned(
+            requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+
+    assertThat(wrote).isFalse();
+    assertThat(countOccurrences()).isZero();
+  }
+
+  /**
+   * The status guard on its own, with {@code owner_id} deliberately left in place. Today every path
+   * that ends a request also clears the owner, so this is unreachable — but it is unreachable
+   * because of how the callers happen to be sequenced, which is exactly the kind of guarantee that
+   * evaporates when someone adds a path. A finished request is not writable by anyone.
+   */
+  @Test
+  public void aFlushIsRefusedOnATerminalRequestEvenIfItStillNamesTheWorker() {
+    execute("UPDATE indexing_requests SET status = 'COMPLETED' WHERE id = '" + requestId + "'");
+
+    boolean wrote =
+        store.flushOwned(
+            requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+
+    assertThat(wrote).isFalse();
+    assertThat(countOccurrences()).isZero();
+  }
+
+  /** The happy path, so the refusals above are not passing for want of a working write. */
+  @Test
+  public void aFlushUnderALiveLeaseWritesBothGamesAndOccurrences() {
+    boolean wrote =
+        store.flushOwned(
+            requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+
+    assertThat(wrote).isTrue();
+    assertThat(countFeatures()).isEqualTo(1);
+    assertThat(countOccurrences()).isEqualTo(2);
+  }
+
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private Map<Motif, List<GameFeatures.MotifOccurrence>> occurrences() {
+    return Map.of(
+        Motif.CHECK,
+        List.of(
+            new GameFeatures.MotifOccurrence(
+                5, 3, "white", "check", null, null, null, false, false, null),
+            new GameFeatures.MotifOccurrence(
+                9, 5, "black", "check", null, null, null, false, false, null)));
+  }
+
+  private GameFeature gameFeature() {
+    return new GameFeature(
+        null,
+        requestId,
+        GAME_URL,
+        "CHESS_COM",
+        "w",
+        "b",
+        1500,
+        1500,
+        null,
+        null,
+        "blitz",
+        "B00",
+        null,
+        null,
+        "1-0",
+        Instant.parse("2024-01-15T00:00:00Z"),
+        20,
+        Instant.parse("2024-01-16T00:00:00Z"),
+        "pgn");
+  }
+
+  private UUID insertRequest(String ownerId, Instant leaseExpiresAt) {
+    UUID id = UUID.randomUUID();
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " status, owner_id, lease_expires_at) VALUES (?, 'p', 'CHESS_COM', '2024-01',"
+                    + " '2024-01', 'PROCESSING', ?, ?)")) {
+      ps.setObject(1, id);
+      ps.setString(2, ownerId);
+      ps.setObject(3, utcWallClock(leaseExpiresAt));
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return id;
+  }
+
+  private void setOwner(String ownerId, Instant leaseExpiresAt) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "UPDATE indexing_requests SET owner_id = ?, lease_expires_at = ? WHERE id = ?")) {
+      ps.setString(1, ownerId);
+      ps.setObject(2, utcWallClock(leaseExpiresAt));
+      ps.setObject(3, requestId);
+      ps.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * The lease column is TIMESTAMP WITHOUT TIME ZONE and the convention across these tables is that
+   * it holds a UTC wall clock, so a fixture writing it directly has to say so rather than letting
+   * the JVM's default zone decide.
+   */
+  private static LocalDateTime utcWallClock(Instant instant) {
+    return instant.atOffset(ZoneOffset.UTC).toLocalDateTime();
+  }
+
+  private void execute(String sql) {
+    try (var conn = dataSource.getConnection();
+        var st = conn.createStatement()) {
+      st.executeUpdate(sql);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private int countOccurrences() {
+    return count("SELECT COUNT(*) FROM motif_occurrences WHERE game_url = ?");
+  }
+
+  private int countFeatures() {
+    return count("SELECT COUNT(*) FROM game_features WHERE game_url = ?");
+  }
+
+  private int count(String sql) {
+    try (var conn = dataSource.getConnection();
+        var ps = conn.prepareStatement(sql)) {
+      ps.setString(1, GAME_URL);
+      try (var rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getInt(1);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java
@@ -62,6 +62,13 @@ public class ConcurrentFlushTest {
    */
   private static final int ROUNDS = 200;
 
+  /**
+   * How long the rival in {@code aTakeoverThatCommitsDuringAFlushStillStopsIt} holds its row lock.
+   * Long enough that the flush is certainly inside its ownership probe, short enough to stay under
+   * H2's one-second default lock timeout so the blocked probe waits rather than erroring.
+   */
+  private static final long RIVAL_HOLD_MILLIS = 600;
+
   private TestDb testDb;
   private DataSource dataSource;
   private GameFeatureDao store;
@@ -87,10 +94,11 @@ public class ConcurrentFlushTest {
    * primitives with the interleaving forced by a latch, doubling is not a race that might happen
    * but the guaranteed outcome of an ordering the API permits.
    *
-   * <p>Those primitives are still public and still correct for their remaining caller — {@code
-   * AdminController}'s reanalysis path pairs them, single-threaded — so the constraint on their use
-   * needs somewhere to live. If a later change routes concurrent writers back through them, this is
-   * the explanation waiting.
+   * <p>Those primitives are still public, and "single-threaded within its own loop" is not a
+   * defence: {@code AdminController}'s reanalysis used to pair them, and the writer it races is an
+   * indexing worker on another thread, not a second admin call. It now goes through {@code
+   * replaceOccurrences}. This test is what the constraint on their use rests on — if a later change
+   * routes any concurrent writer back through the pair, the explanation is waiting here.
    */
   @Test
   @Timeout(30)
@@ -204,6 +212,55 @@ public class ConcurrentFlushTest {
         .isEqualTo(2);
   }
 
+  /**
+   * The other writer of {@code motif_occurrences}: reanalysis, which rewrites a game's motifs
+   * without holding any request lease. It has to be safe against a worker flushing a live request
+   * that covers the same game, and being a transaction is not enough on its own.
+   *
+   * <p>Under READ COMMITTED a {@code DELETE} blocked on another transaction's uncommitted delete
+   * re-checks the rows it was blocked on, but not rows that transaction inserted — those are
+   * outside its statement snapshot. So two transactional writers still interleave as delete,
+   * delete, insert, insert unless they first contend for something in common. Both now take the
+   * {@code game_features} row for the game.
+   *
+   * <p>Driven the same way as the takeover test: the admin side opens its transaction and holds it
+   * while the flush runs, which is the ordering that produces the doubling if nothing serializes
+   * them.
+   */
+  @Test
+  @Timeout(30)
+  public void reanalysisAndAWorkerFlushOverOneGameDoNotDuplicateOccurrences() throws Exception {
+    store.flushOwned(
+        requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+    assertThat(countOccurrences()).isEqualTo(2);
+
+    CountDownLatch reanalysisStarted = new CountDownLatch(1);
+
+    Future<?> reanalysis =
+        pool.submit(
+            () -> {
+              reanalysisStarted.countDown();
+              store.replaceOccurrences(List.of(GAME_URL), Map.of(GAME_URL, occurrences()));
+            });
+    assertThat(reanalysisStarted.await(15, TimeUnit.SECONDS)).isTrue();
+    Future<Boolean> flush =
+        pool.submit(
+            () ->
+                store.flushOwned(
+                    requestId,
+                    OWNER_A,
+                    NOW,
+                    List.of(gameFeature()),
+                    Map.of(GAME_URL, occurrences())));
+
+    reanalysis.get(20, TimeUnit.SECONDS);
+    assertThat(flush.get(20, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(countOccurrences())
+        .as("reanalysis and an indexing flush left two copies of every motif for this game")
+        .isEqualTo(2);
+  }
+
   /** The fence: a worker whose lease has been taken writes nothing at all. */
   @Test
   public void aFlushIsRefusedOnceTheLeaseHasMovedToAnotherOwner() {
@@ -222,10 +279,16 @@ public class ConcurrentFlushTest {
    * An expired lease is refused too, even though {@code owner_id} still names this worker. Past
    * expiry the system has already licensed a takeover, so writing would be racing a claim this
    * worker cannot see. Recovering from a lapse is the heartbeat's job, not the flush's.
+   *
+   * <p>Asserted <em>at</em> the expiry instant, not a second past it. {@code claim} hands the row
+   * over at {@code lease_expires_at <= now} while this predicate authorizes writing at {@code >
+   * now}; they are complementary, and the only instant where that could break is the one they
+   * share. Relaxing this to {@code >=} puts the replacement and the old owner on the same games for
+   * that instant, and a test a second either side of the boundary would not notice.
    */
   @Test
-  public void aFlushIsRefusedOnceTheLeaseHasExpired() {
-    setOwner(OWNER_A, NOW.minusSeconds(1));
+  public void aFlushIsRefusedAtTheExactInstantTheLeaseExpires() {
+    setOwner(OWNER_A, NOW);
 
     boolean wrote =
         store.flushOwned(
@@ -233,6 +296,69 @@ public class ConcurrentFlushTest {
 
     assertThat(wrote).isFalse();
     assertThat(countOccurrences()).isZero();
+  }
+
+  /**
+   * A takeover that commits <em>during</em> a flush, rather than before one.
+   *
+   * <p>This is the case a check-then-write cannot survive without a row lock. Nothing sets an
+   * isolation level, so both engines run READ COMMITTED and a plain {@code SELECT} inside the
+   * transaction is a snapshot, not a claim: the rival's {@code claim} commits in the gap and the
+   * flush goes on to write rows for a request it no longer owns. The window is the whole flush.
+   *
+   * <p>Driven from the other side, because a test cannot pause the DAO mid-transaction: the rival
+   * takes the lease first and holds its transaction open, then the flush runs. With {@code FOR
+   * UPDATE} on the probe the flush blocks on the rival's uncommitted row and, once released, reads
+   * the new owner and refuses. Without it the probe reads the pre-takeover snapshot and writes.
+   */
+  @Test
+  @Timeout(30)
+  public void aTakeoverThatCommitsDuringAFlushStillStopsIt() throws Exception {
+    CountDownLatch rivalHoldsRow = new CountDownLatch(1);
+    // Never counted down. The rival holds its row lock for the whole timeout, which has to outlast
+    // the flush reaching its ownership probe — otherwise the rival commits first, the probe reads
+    // the new owner from a committed snapshot, and the test passes whether or not it took a lock.
+    CountDownLatch neverReleased = new CountDownLatch(1);
+
+    Future<?> rival =
+        pool.submit(
+            () -> {
+              try (var conn = dataSource.getConnection()) {
+                conn.setAutoCommit(false);
+                try (var ps =
+                    conn.prepareStatement(
+                        "UPDATE indexing_requests SET owner_id = ?, lease_expires_at = ?"
+                            + " WHERE id = ?")) {
+                  ps.setString(1, OWNER_B);
+                  ps.setObject(2, utcWallClock(NOW.plus(Duration.ofMinutes(5))));
+                  ps.setObject(3, requestId);
+                  ps.executeUpdate();
+                }
+                rivalHoldsRow.countDown();
+                neverReleased.await(RIVAL_HOLD_MILLIS, TimeUnit.MILLISECONDS);
+                conn.commit();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    assertThat(rivalHoldsRow.await(15, TimeUnit.SECONDS)).isTrue();
+    Future<Boolean> flush =
+        pool.submit(
+            () ->
+                store.flushOwned(
+                    requestId,
+                    OWNER_A,
+                    NOW,
+                    List.of(gameFeature()),
+                    Map.of(GAME_URL, occurrences())));
+
+    assertThat(flush.get(20, TimeUnit.SECONDS))
+        .as("the flush committed against a request that had already changed hands")
+        .isFalse();
+    rival.get(20, TimeUnit.SECONDS);
+    assertThat(countOccurrences()).isZero();
+    assertThat(countFeatures()).isZero();
   }
 
   /** And once the request is no longer live, whoever owned it may not keep writing to it. */

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java
@@ -69,6 +69,15 @@ public class ConcurrentFlushTest {
    */
   private static final long RIVAL_HOLD_MILLIS = 600;
 
+  /**
+   * How long a writer must fail to finish for us to call it blocked. Generously above what an
+   * unblocked flush of one game takes, so the assertion cannot fire on a slow machine.
+   */
+  private static final long BLOCKED_WINDOW_MILLIS = 1500;
+
+  /** Rounds of reanalysis against a flush. A race, not a proof — see the test that says so. */
+  private static final int CONTENTION_ROUNDS = 60;
+
   private TestDb testDb;
   private DataSource dataSource;
   private GameFeatureDao store;
@@ -213,51 +222,146 @@ public class ConcurrentFlushTest {
   }
 
   /**
-   * The other writer of {@code motif_occurrences}: reanalysis, which rewrites a game's motifs
-   * without holding any request lease. It has to be safe against a worker flushing a live request
-   * that covers the same game, and being a transaction is not enough on its own.
+   * The mechanism that makes reanalysis and an indexing flush safe against each other, asserted
+   * directly rather than raced for.
    *
-   * <p>Under READ COMMITTED a {@code DELETE} blocked on another transaction's uncommitted delete
-   * re-checks the rows it was blocked on, but not rows that transaction inserted — those are
-   * outside its statement snapshot. So two transactional writers still interleave as delete,
-   * delete, insert, insert unless they first contend for something in common. Both now take the
-   * {@code game_features} row for the game.
+   * <p>Both rewrite a game's occurrences, and both being a transaction is not what saves them:
+   * under READ COMMITTED a {@code DELETE} blocked on another transaction's uncommitted delete
+   * re-checks the rows it blocked on but not the rows that transaction <em>inserted</em>, so they
+   * still interleave as delete, delete, insert, insert. What saves them is contending for something
+   * shared first, and the only thing they share is the game's {@code game_features} row.
    *
-   * <p>Driven the same way as the takeover test: the admin side opens its transaction and holds it
-   * while the flush runs, which is the ordering that produces the doubling if nothing serializes
-   * them.
+   * <p>Racing two writers cannot prove that — whichever finishes first, the count is right, so the
+   * test passes with or without the lock. Holding the row from outside can: if a writer takes it,
+   * it blocks; if it does not, it sails through. Delete either {@code lockGames} call and the
+   * corresponding case fails immediately.
    */
   @Test
   @Timeout(30)
+  public void bothOccurrenceWritersTakeTheGamesFeatureRowBeforeRewritingIt() throws Exception {
+    store.flushOwned(
+        requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+
+    assertBlocksWhileTheGameRowIsHeld(
+        "reanalysis",
+        () -> store.replaceOccurrences(List.of(GAME_URL), Map.of(GAME_URL, occurrences())));
+    assertBlocksWhileTheGameRowIsHeld(
+        "an indexing flush",
+        () ->
+            store.flushOwned(
+                requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences())));
+    // The shape where the explicit lock is the only lock. A flush that writes features takes the
+    // row implicitly — its upsert conflicts on the UNIQUE game_url — so deleting lockGames from
+    // that path changes nothing observable and the case above passes either way. Occurrences
+    // without features is reachable through the interface and rewrites the same rows with nothing
+    // to conflict on, which is precisely what the explicit lock is for.
+    assertBlocksWhileTheGameRowIsHeld(
+        "a flush of occurrences alone",
+        () ->
+            store.flushOwned(requestId, OWNER_A, NOW, List.of(), Map.of(GAME_URL, occurrences())));
+  }
+
+  /**
+   * Runs {@code writer} while another connection holds the game's {@code game_features} row, and
+   * asserts it makes no progress until that is released.
+   *
+   * <p>The negative half is the load-bearing one and it is sound in the direction that matters: a
+   * writer that takes the row lock <em>cannot</em> finish inside the window, so completing is proof
+   * it never asked for it. The window is generous, so the converse — a writer slow for unrelated
+   * reasons — cannot fail it.
+   */
+  private void assertBlocksWhileTheGameRowIsHeld(String what, Runnable writer) throws Exception {
+    CountDownLatch rowHeld = new CountDownLatch(1);
+    CountDownLatch releaseRow = new CountDownLatch(1);
+
+    Future<?> holder =
+        pool.submit(
+            () -> {
+              try (var conn = dataSource.getConnection()) {
+                conn.setAutoCommit(false);
+                try (var ps =
+                    conn.prepareStatement(
+                        "SELECT game_url FROM game_features WHERE game_url = ? FOR UPDATE")) {
+                  ps.setString(1, GAME_URL);
+                  ps.executeQuery().close();
+                }
+                rowHeld.countDown();
+                releaseRow.await(20, TimeUnit.SECONDS);
+                conn.commit();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    assertThat(rowHeld.await(15, TimeUnit.SECONDS)).isTrue();
+    Future<?> blocked = pool.submit(writer);
+    try {
+      blocked.get(BLOCKED_WINDOW_MILLIS, TimeUnit.MILLISECONDS);
+      throw new AssertionError(
+          what + " rewrote the game's occurrences without taking its game_features row first");
+    } catch (java.util.concurrent.TimeoutException expected) {
+      // Blocked, which is the point.
+    }
+
+    releaseRow.countDown();
+    blocked.get(20, TimeUnit.SECONDS);
+    holder.get(20, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Both writers, run against each other repeatedly with a barrier per round.
+   *
+   * <p>This is a race and says so: it cannot force the delete/delete/insert/insert order, because
+   * neither {@code flushOwned} nor {@code replaceOccurrences} can be paused mid-transaction from
+   * outside. What it adds over the deterministic test above is coverage of orderings nobody thought
+   * to write down. Treat a failure as real and a pass as weak evidence — the lock itself is pinned
+   * by {@code bothOccurrenceWritersTakeTheGamesFeatureRowBeforeRewritingIt}, and the Postgres
+   * behaviour that makes it necessary by {@code PostgresConcurrentWriteTest}.
+   */
+  @Test
+  @Timeout(60)
   public void reanalysisAndAWorkerFlushOverOneGameDoNotDuplicateOccurrences() throws Exception {
     store.flushOwned(
         requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
     assertThat(countOccurrences()).isEqualTo(2);
 
-    CountDownLatch reanalysisStarted = new CountDownLatch(1);
+    java.util.concurrent.CyclicBarrier round = new java.util.concurrent.CyclicBarrier(2);
+    Runnable sync =
+        () -> {
+          try {
+            round.await(20, TimeUnit.SECONDS);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        };
 
     Future<?> reanalysis =
         pool.submit(
             () -> {
-              reanalysisStarted.countDown();
-              store.replaceOccurrences(List.of(GAME_URL), Map.of(GAME_URL, occurrences()));
+              for (int i = 0; i < CONTENTION_ROUNDS; i++) {
+                sync.run();
+                store.replaceOccurrences(List.of(GAME_URL), Map.of(GAME_URL, occurrences()));
+              }
             });
-    assertThat(reanalysisStarted.await(15, TimeUnit.SECONDS)).isTrue();
-    Future<Boolean> flush =
+    Future<?> flush =
         pool.submit(
-            () ->
+            () -> {
+              for (int i = 0; i < CONTENTION_ROUNDS; i++) {
+                sync.run();
                 store.flushOwned(
                     requestId,
                     OWNER_A,
                     NOW,
                     List.of(gameFeature()),
-                    Map.of(GAME_URL, occurrences())));
+                    Map.of(GAME_URL, occurrences()));
+              }
+            });
 
-    reanalysis.get(20, TimeUnit.SECONDS);
-    assertThat(flush.get(20, TimeUnit.SECONDS)).isTrue();
+    reanalysis.get(45, TimeUnit.SECONDS);
+    flush.get(45, TimeUnit.SECONDS);
 
     assertThat(countOccurrences())
-        .as("reanalysis and an indexing flush left two copies of every motif for this game")
+        .as("reanalysis and an indexing flush left duplicated motif rows for this game")
         .isEqualTo(2);
   }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
@@ -318,10 +318,14 @@ public class IndexingRequestDaoTest {
   }
 
   /**
-   * The dead worker is not fenced, so it keeps writing. Its next per-month PROCESSING heartbeat
-   * must not resurrect the row it no longer owns: that would produce a live request holding no
-   * dedupe slot, and the replacement already holds the key, so the constraint could not see the
-   * second live row.
+   * The unfenced write path, which is still reachable: {@code IndexRequestService}'s
+   * inline-dispatch failure handler has no lease to present, and neither do the tests below. A
+   * status write with no token behind it must not resurrect a row that was already retired — that
+   * would produce a live request holding no dedupe slot, and since the replacement already holds
+   * the key the constraint could not see the second live row.
+   *
+   * <p>A worker cannot reach this state at all now: its writes go through {@code updateStatusOwned}
+   * and are refused outright. This guard covers everything that is not a worker.
    */
   @Test
   public void updateStatus_cannotResurrectARetiredRequest() {
@@ -335,7 +339,7 @@ public class IndexingRequestDaoTest {
         dao.createOrAdopt("zombie", "CHESS_COM", "2025-09", "2025-09", false, STALE_AFTER, now);
     assertThat(replacement.created()).isTrue();
 
-    // The dead worker's next heartbeat.
+    // An unfenced status write landing after the fact.
     dao.updateStatus(strandedId, "PROCESSING", null, 9);
 
     assertThat(dao.findById(strandedId).orElseThrow().status())
@@ -481,6 +485,262 @@ public class IndexingRequestDaoTest {
   }
 
   // --- helpers ---------------------------------------------------------------------------------
+
+  // --- ownership leases (#1278) -----------------------------------------------------------------
+
+  private static final Duration LEASE = Duration.ofMinutes(5);
+  private static final String WORKER_A = "host-a/1/aaaa";
+  private static final String WORKER_B = "host-b/2/bbbb";
+
+  @Test
+  public void claim_takesAnUnclaimedLiveRequest() {
+    UUID id = create("lease1", "2025-01", "2025-01", false).id();
+
+    assertThat(dao.claim(id, WORKER_A, LEASE, now)).isTrue();
+    assertThat(dao.holdsLease(id, WORKER_A, now)).isTrue();
+    assertThat(dao.holdsLease(id, WORKER_B, now)).isFalse();
+  }
+
+  @Test
+  public void claim_isRefusedWhileAnotherOwnersLeaseIsLive() {
+    UUID id = create("lease2", "2025-02", "2025-02", false).id();
+    assertThat(dao.claim(id, WORKER_A, LEASE, now)).isTrue();
+
+    assertThat(dao.claim(id, WORKER_B, LEASE, now.plus(Duration.ofMinutes(4))))
+        .as("a live lease is not available to take")
+        .isFalse();
+    assertThat(dao.holdsLease(id, WORKER_A, now.plus(Duration.ofMinutes(4)))).isTrue();
+  }
+
+  @Test
+  public void claim_takesOverOnceTheOtherOwnersLeaseHasExpired() {
+    UUID id = create("lease3", "2025-03", "2025-03", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant afterExpiry = now.plus(LEASE).plusSeconds(1);
+    assertThat(dao.claim(id, WORKER_B, LEASE, afterExpiry)).isTrue();
+    assertThat(dao.holdsLease(id, WORKER_A, afterExpiry))
+        .as("the old owner is out the moment the new one is in")
+        .isFalse();
+  }
+
+  /**
+   * The expiry boundary, pinned because two predicates have to agree on it and nothing else makes
+   * them. At the exact instant a lease expires it is no longer held ({@code lease_expires_at > now}
+   * is false), so it must also be available to take. A strict {@code <} in the claim predicate
+   * would leave one instant in which nobody holds the lease and nobody may take it.
+   */
+  @Test
+  public void claim_takesOverAtTheExactInstantTheLeaseExpires() {
+    UUID id = create("boundary", "2025-13", "2025-13", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant atExpiry = now.plus(LEASE);
+    assertThat(dao.holdsLease(id, WORKER_A, atExpiry))
+        .as("the lease is over at its expiry, not one instant later")
+        .isFalse();
+    assertThat(dao.claim(id, WORKER_B, LEASE, atExpiry))
+        .as("and what nobody holds must be available to take")
+        .isTrue();
+  }
+
+  /** The same boundary on the sweep's side, so the two predicates cannot drift apart. */
+  @Test
+  public void reclaimStale_retiresALeaseAtTheExactInstantItExpires() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("boundary2", "CHESS_COM", "2025-14", "2025-14", false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now.plus(LEASE))).isEqualTo(1);
+    assertThat(dao.findById(id).orElseThrow().status()).isEqualTo("FAILED");
+  }
+
+  /**
+   * Re-claiming as the same owner extends rather than fails. A worker restarted mid-request with a
+   * stable id, or one whose claim call is retried after a timeout, must not lock itself out.
+   */
+  @Test
+  public void claim_isIdempotentForTheSameOwner() {
+    UUID id = create("lease4", "2025-04", "2025-04", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant later = now.plus(Duration.ofMinutes(4));
+    assertThat(dao.claim(id, WORKER_A, LEASE, later)).isTrue();
+    assertThat(dao.holdsLease(id, WORKER_A, later.plus(Duration.ofMinutes(4))))
+        .as("the second claim extended the lease rather than leaving the first one's expiry")
+        .isTrue();
+  }
+
+  @Test
+  public void claim_isRefusedOnceTheRequestIsTerminal() {
+    UUID id = create("lease5", "2025-05", "2025-05", false).id();
+    dao.updateStatus(id, "COMPLETED", null, 3);
+
+    assertThat(dao.claim(id, WORKER_A, LEASE, now))
+        .as("finished work is not there to be picked up")
+        .isFalse();
+  }
+
+  @Test
+  public void renewLease_failsOnceAnotherOwnerHasTakenTheRequest() {
+    UUID id = create("lease6", "2025-06", "2025-06", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant afterExpiry = now.plus(LEASE).plusSeconds(1);
+    dao.claim(id, WORKER_B, LEASE, afterExpiry);
+
+    assertThat(dao.renewLease(id, WORKER_A, LEASE, afterExpiry))
+        .as("a worker that lost its lease must stop, not reassert itself over the replacement")
+        .isFalse();
+    assertThat(dao.holdsLease(id, WORKER_B, afterExpiry)).isTrue();
+  }
+
+  /**
+   * Renewal is deliberately lenient about expiry: while {@code owner_id} still names this worker,
+   * nobody else has taken the request, so a lapse caused by a paused GC or a database blip is
+   * recoverable. Only a change of owner ends a claim.
+   */
+  @Test
+  public void renewLease_recoversFromALapseNobodyElseTook() {
+    UUID id = create("lease7", "2025-07", "2025-07", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant afterExpiry = now.plus(LEASE).plusSeconds(1);
+    assertThat(dao.holdsLease(id, WORKER_A, afterExpiry)).isFalse();
+    assertThat(dao.renewLease(id, WORKER_A, LEASE, afterExpiry)).isTrue();
+    assertThat(dao.holdsLease(id, WORKER_A, afterExpiry)).isTrue();
+  }
+
+  /**
+   * The lease arm of reclamation: a crashed owner is reclaimable in minutes, without waiting out
+   * the hour that governs work nobody ever picked up. That is the whole point of asking "is the
+   * owner there?" instead of "has anything happened lately?".
+   */
+  @Test
+  public void reclaimStale_takesAnExpiredLeaseWithoutWaitingForTheStalenessCutoff() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("crashed", "CHESS_COM", "2025-11", "2025-11", false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant sixMinutesLater = now.plus(Duration.ofMinutes(6));
+    assertThat(dao.reclaimStale(STALE_AFTER, sixMinutesLater))
+        .as("six minutes is nowhere near the one-hour cutoff, but the lease is gone")
+        .isEqualTo(1);
+    assertThat(dao.findById(id).orElseThrow().status()).isEqualTo("FAILED");
+
+    IndexingRequestStore.Claim replacement =
+        dao.createOrAdopt(
+            "crashed", "CHESS_COM", "2025-11", "2025-11", false, STALE_AFTER, sixMinutesLater);
+    assertThat(replacement.created()).as("and the range is free again").isTrue();
+  }
+
+  /**
+   * The other arm, and the reason they are separate. A request whose owner is renewing must not be
+   * retired for being quiet, however long it has been quiet: renewal is a claim about the owner,
+   * not about progress, and an indexing run can legitimately produce nothing for hours.
+   *
+   * <p>Collapsing the two — judging a claimed row by {@code updated_at} — is what made a slow
+   * request indistinguishable from a dead one.
+   */
+  @Test
+  public void reclaimStale_leavesAClaimedRequestAloneEvenWhenItHasBeenQuietForHours() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("patient", "CHESS_COM", "2025-12", "2025-12", false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+    backdateUpdatedAt(id, now.minus(Duration.ofHours(3)));
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now))
+        .as("the hour is for work nobody owns; this one has an owner and a live lease")
+        .isZero();
+    assertThat(dao.findById(id).orElseThrow().status()).isIn("PENDING", "PROCESSING");
+  }
+
+  @Test
+  public void updateStatusOwned_isRefusedForAWorkerThatLostTheLease() {
+    UUID id = create("fenced1", "2026-01", "2026-01", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+    Instant afterExpiry = now.plus(LEASE).plusSeconds(1);
+    dao.claim(id, WORKER_B, LEASE, afterExpiry);
+
+    assertThat(dao.updateStatusOwned(id, WORKER_A, "COMPLETED", null, 99, afterExpiry)).isFalse();
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(id).orElseThrow();
+    assertThat(row.status()).as("the replacement's row is untouched").isEqualTo("PENDING");
+    assertThat(row.gamesIndexed()).isZero();
+    assertThat(dao.holdsLease(id, WORKER_B, afterExpiry))
+        .as("and the replacement still holds the lease the refused write would have cleared")
+        .isTrue();
+  }
+
+  /** An expired lease is refused too, even with {@code owner_id} unchanged. */
+  @Test
+  public void updateStatusOwned_isRefusedOnceTheLeaseHasExpired() {
+    UUID id = create("fenced2", "2026-02", "2026-02", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    assertThat(
+            dao.updateStatusOwned(
+                id, WORKER_A, "PROCESSING", null, 5, now.plus(LEASE).plusSeconds(1)))
+        .isFalse();
+  }
+
+  @Test
+  public void updateStatusOwned_terminalWriteReleasesTheLeaseAndTheDedupeSlot() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt("released", "CHESS_COM", "2026-03", "2026-03", false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    assertThat(dao.updateStatusOwned(id, WORKER_A, "COMPLETED", null, 12, now)).isTrue();
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(id).orElseThrow();
+    assertThat(row.status()).isEqualTo("COMPLETED");
+    assertThat(row.gamesIndexed()).isEqualTo(12);
+    // Read straight off the row. holdsLease would answer false for a COMPLETED request whatever
+    // the columns say, so it cannot tell a released lease from a stale one left behind.
+    assertThat(columnOf(id, "owner_id")).as("the lease is released, not just unusable").isNull();
+    assertThat(columnOf(id, "lease_expires_at")).isNull();
+    assertThat(dao.holdsLease(id, WORKER_A, now)).isFalse();
+    assertThat(
+            dao.createOrAdopt(
+                    "released", "CHESS_COM", "2026-03", "2026-03", false, STALE_AFTER, now)
+                .created())
+        .as("the range is requestable again the moment the work stops being in flight")
+        .isTrue();
+  }
+
+  @Test
+  public void updateStatusOwned_recordsProgressForTheHolder() {
+    UUID id = create("holder", "2026-04", "2026-04", false).id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    assertThat(dao.updateStatusOwned(id, WORKER_A, "PROCESSING", null, 7, now)).isTrue();
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(id).orElseThrow();
+    assertThat(row.status()).isEqualTo("PROCESSING");
+    assertThat(row.gamesIndexed()).isEqualTo(7);
+    assertThat(dao.holdsLease(id, WORKER_A, now))
+        .as("a progress write must not release the lease it was made under")
+        .isTrue();
+  }
+
+  /** Reads a column the {@code IndexingRequest} record does not carry. */
+  private Object columnOf(UUID id, String column) {
+    try (var conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement("SELECT " + column + " FROM indexing_requests WHERE id = ?")) {
+      ps.setObject(1, id);
+      try (var rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getObject(1);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   private void backdateUpdatedAt(UUID id, Instant updatedAt) {
     execute("UPDATE indexing_requests SET updated_at = ? WHERE id = ?", updatedAt, id);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
@@ -675,16 +675,95 @@ public class IndexingRequestDaoTest {
         .isTrue();
   }
 
-  /** An expired lease is refused too, even with {@code owner_id} unchanged. */
+  /**
+   * An expired lease is refused too, even with {@code owner_id} unchanged — and asserted
+   * <em>at</em> the expiry instant rather than a second past it.
+   *
+   * <p>Five predicates have to agree on this boundary, not two. {@code claim} and the reclamation
+   * sweep hand the row over at {@code lease_expires_at <= now}; {@code holdsLease}, this, and the
+   * flush's ownership probe authorize at {@code > now}. A second either side of the boundary tests
+   * nothing about the boundary: relax any of the write-authorizing three to {@code >=} and there is
+   * one instant where the replacement owns the row and the old owner may still write to it, which
+   * is the state this whole change exists to prevent.
+   */
   @Test
-  public void updateStatusOwned_isRefusedOnceTheLeaseHasExpired() {
+  public void updateStatusOwned_isRefusedAtTheExactInstantTheLeaseExpires() {
     UUID id = create("fenced2", "2026-02", "2026-02", false).id();
     dao.claim(id, WORKER_A, LEASE, now);
 
-    assertThat(
-            dao.updateStatusOwned(
-                id, WORKER_A, "PROCESSING", null, 5, now.plus(LEASE).plusSeconds(1)))
+    assertThat(dao.updateStatusOwned(id, WORKER_A, "PROCESSING", null, 5, now.plus(LEASE)))
         .isFalse();
+  }
+
+  /**
+   * Dedupe must answer "is this alive?" the same way reclamation does. This read runs first on
+   * every submit and short-circuits, so a laxer predicate here silently overrides the stricter
+   * reclamation behind it.
+   *
+   * <p>The case that exposed it: a worker claims, then is killed. Its lease lapses in minutes and
+   * the row is reclaimable — but {@code updated_at} was bumped by its last renewal, so a predicate
+   * that asks only about age keeps handing the dead request back to callers for the full hour. The
+   * README's "five minutes" was delivered nowhere a user could reach.
+   */
+  @Test
+  public void findExistingRequest_doesNotAnswerWithARequestWhoseLeaseHasLapsed() {
+    dao.createOrAdopt("killed", "CHESS_COM", "2026-05", "2026-05", false, STALE_AFTER, now);
+    UUID id = find("killed", "2026-05", "2026-05", false).orElseThrow().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant afterLapse = now.plus(LEASE).plusSeconds(1);
+    assertThat(
+            dao.findExistingRequest(
+                "killed", "CHESS_COM", "2026-05", "2026-05", false, STALE_AFTER, afterLapse))
+        .as("a request whose owner is gone must not keep answering for the range")
+        .isEmpty();
+    // The boundary itself. reclaimStale takes the row at exactly this instant, so dedupe must
+    // already have stopped offering it — otherwise there is a moment where the row is both
+    // reclaimable and reported as the live holder.
+    assertThat(
+            dao.findExistingRequest(
+                "killed", "CHESS_COM", "2026-05", "2026-05", false, STALE_AFTER, now.plus(LEASE)))
+        .isEmpty();
+  }
+
+  /** The converse: a claimed request with a live lease is still the answer, however quiet it is. */
+  @Test
+  public void findExistingRequest_stillAnswersWithAClaimedRequestThatIsRenewing() {
+    dao.createOrAdopt("busy", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, now);
+    UUID id = find("busy", "2026-06", "2026-06", false).orElseThrow().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+    backdateUpdatedAt(id, now.minus(Duration.ofHours(3)));
+    dao.renewLease(id, WORKER_A, LEASE, now);
+
+    assertThat(
+            dao.findExistingRequest(
+                "busy", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, now))
+        .as("an owner that is renewing owns the range no matter how long the work takes")
+        .isPresent();
+  }
+
+  /**
+   * The two arms report different things to the user. {@code error_message} is surfaced by the API
+   * and rendered in the web app, so telling someone whose worker crashed mid-run that nobody ever
+   * picked their request up sends them looking for a dispatch problem that is not there.
+   */
+  @Test
+  public void reclaimStale_saysWhichArmRetiredTheRequest() {
+    IndexingRequestStore.Claim claimed =
+        dao.createOrAdopt("crashed2", "CHESS_COM", "2026-07", "2026-07", false, STALE_AFTER, now);
+    dao.claim(claimed.request().id(), WORKER_A, LEASE, now);
+
+    IndexingRequestStore.Claim neverClaimed =
+        dao.createOrAdopt("orphan", "CHESS_COM", "2026-08", "2026-08", false, STALE_AFTER, now);
+    backdateUpdatedAt(neverClaimed.request().id(), now.minus(Duration.ofHours(3)));
+
+    dao.reclaimStale(STALE_AFTER, now.plus(Duration.ofMinutes(6)));
+
+    assertThat(dao.findById(claimed.request().id()).orElseThrow().errorMessage())
+        .contains("stopped responding")
+        .doesNotContain("no worker took ownership");
+    assertThat(dao.findById(neverClaimed.request().id()).orElseThrow().errorMessage())
+        .contains("no worker took ownership");
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
@@ -1,0 +1,316 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.muchq.games.one_d4.api.dto.GameFeature;
+import com.muchq.games.one_d4.engine.model.GameFeatures;
+import com.muchq.games.one_d4.engine.model.Motif;
+import java.io.Closeable;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.sql.DataSource;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The concurrency guarantees behind {@code motif_occurrences} writes, against the engine they are
+ * guarantees about.
+ *
+ * <p>{@link ConcurrentFlushTest} covers what H2 can show: that the delete and insert are one
+ * transaction, and that a reader never sees a half-applied flush. Two of the properties this change
+ * relies on are not observable there, because they are statements about PostgreSQL's READ COMMITTED
+ * behaviour and H2's MVStore does not reproduce them. Asserting them on H2 would produce tests that
+ * pass whether or not the code is right — the same vacuity trap this suite exists to avoid.
+ *
+ * <ul>
+ *   <li><b>The ownership probe must take a row lock.</b> Nothing sets an isolation level, so a
+ *       plain {@code SELECT} inside the flush transaction is a snapshot, not a claim: a concurrent
+ *       takeover commits in the gap and the flush writes rows for a request it no longer owns. The
+ *       window is the whole flush, not an instant.
+ *   <li><b>Being transactional is not enough to make two writers safe against each other.</b> A
+ *       {@code DELETE} blocked on another transaction's uncommitted delete re-checks the rows it
+ *       blocked on, but not rows that transaction <em>inserted</em> — those fall outside its
+ *       statement snapshot. So two transactional writers over one game still interleave as delete,
+ *       delete, insert, insert unless they first contend for something shared. Both take the game's
+ *       {@code game_features} row.
+ * </ul>
+ *
+ * <p>Runs against the real postgres CI provides via {@code PG_TEST_DB_URL}; skips when that is
+ * unset. A skipped run proves nothing about either property — say so rather than reporting green.
+ */
+public class PostgresConcurrentWriteTest {
+
+  private static final String DB_URL_ENV = "PG_TEST_DB_URL";
+  private static final String SCHEMA = "one_d4_pg_concurrent_test";
+  private static final String GAME_URL = "https://chess.com/game/pg-contended";
+  private static final String OWNER_A = "host-a/1/aaaa";
+  private static final String OWNER_B = "host-b/2/bbbb";
+  private static final Instant NOW = Instant.parse("2026-07-01T12:00:00Z");
+
+  /**
+   * How long a writer holds its transaction open while the other one runs. Long enough that the
+   * second writer is certainly past the point where it would read a stale snapshot.
+   */
+  private static final long HOLD_MILLIS = 750;
+
+  private DataSource dataSource;
+  private GameFeatureDao dao;
+  private UUID requestId;
+  private ExecutorService pool;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    String rawUrl = System.getenv(DB_URL_ENV);
+    assumeTrue(
+        rawUrl != null && !rawUrl.isBlank(),
+        DB_URL_ENV + " is not set; skipping the real-postgres concurrency suite");
+
+    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+      stmt.execute("CREATE SCHEMA " + SCHEMA);
+    }
+
+    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl, SCHEMA));
+    new Migration(dataSource, false).run();
+    dao = new GameFeatureDao(Jdbi.create(dataSource), false);
+    requestId = insertClaimedRequest();
+    pool = Executors.newFixedThreadPool(2);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (pool != null) {
+      pool.shutdownNow();
+    }
+    if (dataSource instanceof Closeable closeable) {
+      closeable.close();
+    }
+    String rawUrl = System.getenv(DB_URL_ENV);
+    if (rawUrl == null || rawUrl.isBlank()) {
+      return;
+    }
+    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+    }
+  }
+
+  /**
+   * A takeover that commits while a flush is in flight. Without {@code FOR UPDATE} on the probe the
+   * flush reads its pre-takeover snapshot, believes it still owns the request, and commits rows
+   * against a range someone else is indexing.
+   */
+  @Test
+  @Timeout(60)
+  public void aFlushCannotCommitAgainstARequestThatChangedHandsWhileItRan() throws Exception {
+    CountDownLatch rivalHoldsRow = new CountDownLatch(1);
+    CountDownLatch neverReleased = new CountDownLatch(1);
+
+    Future<?> rival =
+        pool.submit(
+            () -> {
+              try (Connection conn = dataSource.getConnection()) {
+                conn.setAutoCommit(false);
+                try (var ps =
+                    conn.prepareStatement(
+                        "UPDATE indexing_requests SET owner_id = ?, lease_expires_at = ?"
+                            + " WHERE id = ?")) {
+                  ps.setString(1, OWNER_B);
+                  ps.setObject(2, utcWallClock(NOW.plus(Duration.ofMinutes(5))));
+                  ps.setObject(3, requestId);
+                  ps.executeUpdate();
+                }
+                rivalHoldsRow.countDown();
+                neverReleased.await(HOLD_MILLIS, TimeUnit.MILLISECONDS);
+                conn.commit();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
+    assertThat(rivalHoldsRow.await(20, TimeUnit.SECONDS)).isTrue();
+    Future<Boolean> flush =
+        pool.submit(
+            () ->
+                dao.flushOwned(
+                    requestId,
+                    OWNER_A,
+                    NOW,
+                    List.of(gameFeature()),
+                    Map.of(GAME_URL, occurrences())));
+
+    assertThat(flush.get(30, TimeUnit.SECONDS))
+        .as("the flush committed against a request that had already changed hands")
+        .isFalse();
+    rival.get(30, TimeUnit.SECONDS);
+    assertThat(countOccurrences()).isZero();
+  }
+
+  /**
+   * Reanalysis and an indexing flush over the same game. Each is a transaction; that is not what
+   * makes them safe against each other, and this is the engine where the difference shows.
+   */
+  @Test
+  @Timeout(60)
+  public void reanalysisAndAFlushOverOneGameDoNotDuplicateOccurrences() throws Exception {
+    assertThat(
+            dao.flushOwned(
+                requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences())))
+        .isTrue();
+    assertThat(countOccurrences()).isEqualTo(2);
+
+    CountDownLatch bothStarted = new CountDownLatch(2);
+
+    Future<?> reanalysis =
+        pool.submit(
+            () -> {
+              await(bothStarted);
+              dao.replaceOccurrences(List.of(GAME_URL), Map.of(GAME_URL, occurrences()));
+            });
+    Future<?> flush =
+        pool.submit(
+            () -> {
+              await(bothStarted);
+              dao.flushOwned(
+                  requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+            });
+
+    reanalysis.get(30, TimeUnit.SECONDS);
+    flush.get(30, TimeUnit.SECONDS);
+
+    assertThat(countOccurrences())
+        .as("reanalysis and an indexing flush left two copies of every motif for this game")
+        .isEqualTo(2);
+  }
+
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private static void await(CountDownLatch latch) {
+    latch.countDown();
+    try {
+      latch.await(20, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static LocalDateTime utcWallClock(Instant instant) {
+    return instant.atOffset(ZoneOffset.UTC).toLocalDateTime();
+  }
+
+  private Map<Motif, List<GameFeatures.MotifOccurrence>> occurrences() {
+    return Map.of(
+        Motif.CHECK,
+        List.of(
+            new GameFeatures.MotifOccurrence(
+                5, 3, "white", "check", null, null, null, false, false, null),
+            new GameFeatures.MotifOccurrence(
+                9, 5, "black", "check", null, null, null, false, false, null)));
+  }
+
+  private GameFeature gameFeature() {
+    return new GameFeature(
+        null,
+        requestId,
+        GAME_URL,
+        "CHESS_COM",
+        "w",
+        "b",
+        1500,
+        1500,
+        null,
+        null,
+        "blitz",
+        "B00",
+        null,
+        null,
+        "1-0",
+        Instant.parse("2024-01-15T00:00:00Z"),
+        20,
+        Instant.parse("2024-01-16T00:00:00Z"),
+        "pgn");
+  }
+
+  private UUID insertClaimedRequest() throws Exception {
+    UUID id = UUID.randomUUID();
+    try (Connection conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " status, owner_id, lease_expires_at) VALUES (?, 'p', 'CHESS_COM', '2024-01',"
+                    + " '2024-01', 'PROCESSING', ?, ?)")) {
+      ps.setObject(1, id);
+      ps.setString(2, OWNER_A);
+      ps.setObject(3, utcWallClock(NOW.plus(Duration.ofMinutes(5))));
+      ps.executeUpdate();
+    }
+    return id;
+  }
+
+  private int countOccurrences() {
+    try (Connection conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement("SELECT COUNT(*) FROM motif_occurrences WHERE game_url = ?")) {
+      ps.setString(1, GAME_URL);
+      try (var rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getInt(1);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Same shape as {@link PostgresAggregateCompatTest}: a scratch database, one schema per suite.
+   */
+  private static String jdbcUrl(String rawUrl, String schema) {
+    URI uri = URI.create(rawUrl.startsWith("jdbc:") ? rawUrl.substring("jdbc:".length()) : rawUrl);
+    String userInfo = uri.getUserInfo();
+    StringBuilder sb = new StringBuilder("jdbc:postgresql://");
+    sb.append(uri.getHost());
+    if (uri.getPort() > 0) {
+      sb.append(':').append(uri.getPort());
+    }
+    sb.append(uri.getPath() == null || uri.getPath().isEmpty() ? "/postgres" : uri.getPath());
+    StringBuilder params = new StringBuilder();
+    if (userInfo != null && !userInfo.isEmpty()) {
+      String[] parts = userInfo.split(":", 2);
+      params.append("user=").append(URLEncoder.encode(parts[0], StandardCharsets.UTF_8));
+      if (parts.length > 1) {
+        params.append("&password=").append(URLEncoder.encode(parts[1], StandardCharsets.UTF_8));
+      }
+    }
+    if (schema != null) {
+      if (params.length() > 0) {
+        params.append('&');
+      }
+      params.append("currentSchema=").append(schema);
+    }
+    if (params.length() > 0) {
+      sb.append('?').append(params);
+    }
+    return sb.toString();
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
@@ -55,6 +55,14 @@ import org.junit.jupiter.api.Timeout;
  *       {@code game_features} row.
  * </ul>
  *
+ * <p>The two tests are not equally strong and should not be read as if they were. The takeover case
+ * forces its interleaving with a held row lock and proves what it claims. The reanalysis case is a
+ * race: neither production method can be paused mid-transaction from outside, so the order that
+ * produces the doubling cannot be forced through the API, and a pass is corroboration rather than
+ * proof. That the shared lock is taken at all is pinned deterministically in {@code
+ * ConcurrentFlushTest.bothOccurrenceWritersTakeTheGamesFeatureRowBeforeRewritingIt}, which holds
+ * the row from outside and asserts both writers block on it.
+ *
  * <p>Runs against the real postgres CI provides via {@code PG_TEST_DB_URL}; skips when that is
  * unset. A skipped run proves nothing about either property — say so rather than reporting green.
  */
@@ -72,6 +80,9 @@ public class PostgresConcurrentWriteTest {
    * second writer is certainly past the point where it would read a stale snapshot.
    */
   private static final long HOLD_MILLIS = 750;
+
+  /** Rounds of reanalysis against a flush. A race, not a proof — see the test that says so. */
+  private static final int CONTENTION_ROUNDS = 60;
 
   private DataSource dataSource;
   private GameFeatureDao dao;
@@ -168,11 +179,23 @@ public class PostgresConcurrentWriteTest {
   }
 
   /**
-   * Reanalysis and an indexing flush over the same game. Each is a transaction; that is not what
-   * makes them safe against each other, and this is the engine where the difference shows.
+   * Reanalysis and an indexing flush over the same game, raced repeatedly on the engine whose READ
+   * COMMITTED semantics make the hazard real.
+   *
+   * <p>Stated plainly: this is a race, not a proof. Neither {@code flushOwned} nor {@code
+   * replaceOccurrences} can be paused mid-transaction from outside, so the delete/delete/insert/
+   * insert order cannot be forced through the production API — a single round passes whichever
+   * writer happens to finish first. Rounds buy coverage of orderings nobody thought to write down,
+   * and on Postgres the window is wide (a feature upsert, a delete batch and an occurrence batch),
+   * so a missing lock has a real chance of showing here.
+   *
+   * <p>The deterministic half lives in {@code
+   * ConcurrentFlushTest.bothOccurrenceWritersTakeTheGamesFeatureRowBeforeRewritingIt}, which holds
+   * the shared row from outside and asserts both writers block on it. Treat a failure here as real
+   * and a pass as corroboration.
    */
   @Test
-  @Timeout(60)
+  @Timeout(120)
   public void reanalysisAndAFlushOverOneGameDoNotDuplicateOccurrences() throws Exception {
     assertThat(
             dao.flushOwned(
@@ -180,40 +203,47 @@ public class PostgresConcurrentWriteTest {
         .isTrue();
     assertThat(countOccurrences()).isEqualTo(2);
 
-    CountDownLatch bothStarted = new CountDownLatch(2);
+    java.util.concurrent.CyclicBarrier round = new java.util.concurrent.CyclicBarrier(2);
+    Runnable sync =
+        () -> {
+          try {
+            round.await(30, TimeUnit.SECONDS);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        };
 
     Future<?> reanalysis =
         pool.submit(
             () -> {
-              await(bothStarted);
-              dao.replaceOccurrences(List.of(GAME_URL), Map.of(GAME_URL, occurrences()));
+              for (int i = 0; i < CONTENTION_ROUNDS; i++) {
+                sync.run();
+                dao.replaceOccurrences(List.of(GAME_URL), Map.of(GAME_URL, occurrences()));
+              }
             });
     Future<?> flush =
         pool.submit(
             () -> {
-              await(bothStarted);
-              dao.flushOwned(
-                  requestId, OWNER_A, NOW, List.of(gameFeature()), Map.of(GAME_URL, occurrences()));
+              for (int i = 0; i < CONTENTION_ROUNDS; i++) {
+                sync.run();
+                dao.flushOwned(
+                    requestId,
+                    OWNER_A,
+                    NOW,
+                    List.of(gameFeature()),
+                    Map.of(GAME_URL, occurrences()));
+              }
             });
 
-    reanalysis.get(30, TimeUnit.SECONDS);
-    flush.get(30, TimeUnit.SECONDS);
+    reanalysis.get(90, TimeUnit.SECONDS);
+    flush.get(90, TimeUnit.SECONDS);
 
     assertThat(countOccurrences())
-        .as("reanalysis and an indexing flush left two copies of every motif for this game")
+        .as("reanalysis and an indexing flush left duplicated motif rows for this game")
         .isEqualTo(2);
   }
 
   // --- helpers ---------------------------------------------------------------------------------
-
-  private static void await(CountDownLatch latch) {
-    latch.countDown();
-    try {
-      latch.await(20, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-  }
 
   private static LocalDateTime utcWallClock(Instant instant) {
     return instant.atOffset(ZoneOffset.UTC).toLocalDateTime();

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
@@ -301,8 +301,12 @@ public class IndexE2ETest {
    */
   @Test
   public void theLeaseIsRenewedSeveralTimesBeforeItCouldExpire() {
-    assertThat(IndexWorker.DEFAULT_HEARTBEAT_INTERVAL).isEqualTo(RetentionPolicy.LEASE_RENEWAL);
-    assertThat(RetentionPolicy.LEASE_RENEWAL.multipliedBy(3))
+    // Asserted on DEFAULT_HEARTBEAT_INTERVAL, which is what a change would actually touch.
+    // LEASE_RENEWAL is defined as LEASE.dividedBy(4), so any claim relating those two — including
+    // "three renewals fit inside a lease" — is arithmetic, true for every positive LEASE, and
+    // fails for nothing. The heartbeat interval is an independent constant that has already been
+    // pointed at the wrong policy once.
+    assertThat(IndexWorker.DEFAULT_HEARTBEAT_INTERVAL.multipliedBy(3))
         .as("at least three renewals may be lost before anyone else may take the request")
         .isLessThan(RetentionPolicy.LEASE);
   }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/e2e/IndexE2ETest.java
@@ -285,6 +285,39 @@ public class IndexE2ETest {
     assertThat(RetentionPolicy.REQUEST).isGreaterThan(RetentionPolicy.PERIOD);
   }
 
+  @Test
+  public void leaseIsFiveMinutes() {
+    assertThat(RetentionPolicy.LEASE).isEqualTo(Duration.ofMinutes(5));
+  }
+
+  /**
+   * The relationship that makes a lease work at all, and the one most easily broken by accident. A
+   * renewal interval at or above the lease means every lease lapses between beats — which does not
+   * fail loudly, it fails as healthy workers having their ranges reclaimed underneath them.
+   *
+   * <p>This exact mistake was live in an earlier draft of #1278: the heartbeat kept its old pacing
+   * off {@link RetentionPolicy#STALE_REQUEST} (a quarter of an hour) while the new lease was five
+   * minutes, so a worker would have lost its claim three times over between one beat and the next.
+   */
+  @Test
+  public void theLeaseIsRenewedSeveralTimesBeforeItCouldExpire() {
+    assertThat(IndexWorker.DEFAULT_HEARTBEAT_INTERVAL).isEqualTo(RetentionPolicy.LEASE_RENEWAL);
+    assertThat(RetentionPolicy.LEASE_RENEWAL.multipliedBy(3))
+        .as("at least three renewals may be lost before anyone else may take the request")
+        .isLessThan(RetentionPolicy.LEASE);
+  }
+
+  /**
+   * The two clocks are answers to different questions and must not converge. The hour is for work
+   * nobody has claimed, where the only evidence is the row's age; the lease is for work someone
+   * has, where the owner itself reports in. If the lease ever grew to the staleness cutoff the
+   * distinction would be decorative.
+   */
+  @Test
+  public void aDeadOwnerIsReclaimedFarSoonerThanAnUnclaimedRow() {
+    assertThat(RetentionPolicy.LEASE).isLessThan(RetentionPolicy.STALE_REQUEST);
+  }
+
   /**
    * A clock parked {@code offset} into the future. RetentionWorker subtracts RetentionPolicy.PERIOD
    * from it, so the resulting threshold sits {@code offset - PERIOD} either side of "now" — which

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
@@ -416,6 +416,8 @@ public class IndexRequestServiceTest {
    */
   private static final class InMemoryRequestStore implements IndexingRequestStore {
     private final Map<UUID, IndexingRequest> rows = new HashMap<>();
+    private final Map<UUID, String> owners = new HashMap<>();
+    private final Map<UUID, Instant> leases = new HashMap<>();
     private Instant clock = Instant.parse("2026-07-01T12:00:00Z");
 
     private static boolean live(IndexingRequest r) {
@@ -496,6 +498,10 @@ public class IndexRequestServiceTest {
     @Override
     public void updateStatus(UUID id, String status, String errorMessage, int gamesIndexed) {
       IndexingRequest row = rows.get(id);
+      if (!"PENDING".equals(status) && !"PROCESSING".equals(status)) {
+        owners.remove(id);
+        leases.remove(id);
+      }
       rows.put(
           id,
           new IndexingRequest(
@@ -513,21 +519,80 @@ public class IndexRequestServiceTest {
     }
 
     @Override
-    public boolean heartbeat(UUID id, Instant now) {
+    public boolean claim(UUID id, String ownerId, Duration lease, Instant now) {
       IndexingRequest r = rows.get(id);
       if (r == null || !live(r)) {
         return false;
       }
+      String held = owners.get(id);
+      Instant expires = leases.get(id);
+      boolean heldByAnother =
+          held != null && !held.equals(ownerId) && expires != null && expires.isAfter(now);
+      if (heldByAnother) {
+        return false;
+      }
+      owners.put(id, ownerId);
+      leases.put(id, now.plus(lease));
       strand(id, now);
+      return true;
+    }
+
+    @Override
+    public boolean renewLease(UUID id, String ownerId, Duration lease, Instant now) {
+      IndexingRequest r = rows.get(id);
+      // Deliberately lenient about expiry, matching the DAO: renewing a lapsed-but-unstolen lease
+      // is the recovery path. Only a change of owner_id ends a worker's claim.
+      if (r == null || !live(r) || !ownerId.equals(owners.get(id))) {
+        return false;
+      }
+      leases.put(id, now.plus(lease));
+      strand(id, now);
+      return true;
+    }
+
+    @Override
+    public boolean holdsLease(UUID id, String ownerId, Instant now) {
+      IndexingRequest r = rows.get(id);
+      Instant expires = leases.get(id);
+      return r != null
+          && live(r)
+          && ownerId.equals(owners.get(id))
+          && expires != null
+          && expires.isAfter(now);
+    }
+
+    @Override
+    public boolean updateStatusOwned(
+        UUID id,
+        String ownerId,
+        String status,
+        String errorMessage,
+        int gamesIndexed,
+        Instant now) {
+      if (!holdsLease(id, ownerId, now)) {
+        return false;
+      }
+      updateStatus(id, status, errorMessage, gamesIndexed);
       return true;
     }
 
     @Override
     public int reclaimStale(Duration staleAfter, Instant now) {
       Instant cutoff = now.minus(staleAfter);
+      // Two arms, as in the DAO: a claimed row is judged by its lease, an unclaimed one by its
+      // age. Collapsing them here would let a test pass that retires a row a worker still owns.
       List<IndexingRequest> stranded =
-          rows.values().stream().filter(r -> live(r) && r.updatedAt().isBefore(cutoff)).toList();
+          rows.values().stream()
+              .filter(
+                  r ->
+                      live(r)
+                          && (owners.containsKey(r.id())
+                              ? leases.get(r.id()) != null && leases.get(r.id()).isBefore(now)
+                              : r.updatedAt().isBefore(cutoff)))
+              .toList();
       for (IndexingRequest r : stranded) {
+        owners.remove(r.id());
+        leases.remove(r.id());
         rows.put(
             r.id(),
             new IndexingRequest(

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
@@ -486,8 +486,14 @@ public class IndexRequestServiceTest {
         Duration staleAfter,
         Instant now) {
       Instant cutoff = now.minus(staleAfter);
+      // Mirrors the DAO's two arms. A fake that answers this more loosely than production lets a
+      // divergence between dedupe and reclamation pass unnoticed here and fail against Postgres.
       return liveHolder(player, platform, startMonth, endMonth, excludeBullet)
-          .filter(r -> !r.updatedAt().isBefore(cutoff));
+          .filter(
+              r ->
+                  owners.containsKey(r.id())
+                      ? leases.get(r.id()) != null && leases.get(r.id()).isAfter(now)
+                      : !r.updatedAt().isBefore(cutoff));
     }
 
     @Override

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -724,7 +724,29 @@ public class IndexWorkerTest {
     }
 
     @Override
-    public boolean heartbeat(UUID id, Instant now) {
+    public boolean claim(UUID id, String ownerId, java.time.Duration lease, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean renewLease(UUID id, String ownerId, java.time.Duration lease, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean holdsLease(UUID id, String ownerId, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean updateStatusOwned(
+        UUID id,
+        String ownerId,
+        String status,
+        String errorMessage,
+        int gamesIndexed,
+        Instant now) {
+      updateStatus(id, status, errorMessage, gamesIndexed);
       return true;
     }
 
@@ -761,6 +783,25 @@ public class IndexWorkerTest {
   private static class NoOpGameFeatureStore implements GameFeatureStore {
     @Override
     public void insertBatch(List<GameFeature> features) {}
+
+    /**
+     * Composed from the primitives rather than stubbed out, so a subclass that records only {@code
+     * insertBatch} still sees what a flush wrote. The production DAO does the same three things;
+     * the difference is that it does them in one transaction, which a fake cannot model and which
+     * the H2-backed ConcurrentFlushTest covers instead.
+     */
+    @Override
+    public boolean flushOwned(
+        UUID requestId,
+        String ownerId,
+        Instant now,
+        List<GameFeature> features,
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+      insertBatch(features);
+      deleteOccurrencesByGameUrls(new ArrayList<>(occurrencesByGame.keySet()));
+      insertOccurrencesBatch(occurrencesByGame);
+      return true;
+    }
 
     @Override
     public int deleteOlderThan(Instant threshold) {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -294,6 +294,56 @@ public class RequestLivenessTest {
         .isEqualTo("COMPLETED");
   }
 
+  /**
+   * A run that genuinely fails, under a lease that lapsed with nobody taking it, must still record
+   * the failure.
+   *
+   * <p>The recovery path is not a nicety for the happy cases. Progress, the flush and COMPLETED all
+   * renew-and-retry when their own lease has merely lapsed; the FAILED write went straight at the
+   * store, so the one write that exists to explain a failure was the one most likely to be refused
+   * — and refused for a reason that has nothing to do with the failure. What follows is worse than
+   * a missing log line: the row stays PROCESSING holding its dedupe slot, so the range is blocked
+   * until the hourly sweep retires it under a message about an owner that stopped responding, which
+   * is not what happened. The user is told to wait, then told the wrong thing.
+   *
+   * <p>Reachable exactly when it hurts most: a database problem that throws out of the run is the
+   * same database problem that stalls the heartbeat.
+   */
+  @Test
+  @Timeout(30)
+  public void aRunThatFailsUnderALapsedLeaseStillRecordsTheFailure() throws Exception {
+    TestDb testDb = TestDb.create("liveness_failed_lapsed");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    IndexWorker worker =
+        newWorker(new ThrowingChessClient(insideFetch, releaseFetch), dao, Duration.ofHours(1));
+
+    Future<?> run = workerExecutor.submit(() -> worker.process(message(requestId)));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS)).isTrue();
+
+    clock.advance(RetentionPolicy.LEASE.plusMinutes(1));
+    assertThat(dao.holdsLease(requestId, worker.ownerId(), clock.instant()))
+        .as("precondition: the lease really has lapsed, and nobody has taken it")
+        .isFalse();
+
+    releaseFetch.countDown();
+    run.get(20, TimeUnit.SECONDS);
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(requestId).orElseThrow();
+    assertThat(row.status())
+        .as("the failure has to be recorded, not left for the sweep to mislabel")
+        .isEqualTo("FAILED");
+    assertThat(row.errorMessage()).contains("Indexing failed");
+    assertThat(
+            dao.createOrAdopt(PLAYER, PLATFORM, MONTH, MONTH, false, STALE_AFTER, clock.instant())
+                .created())
+        .as("and the dedupe slot is released, so the range is requestable again immediately")
+        .isTrue();
+  }
+
   /** Two workers, one request: the second must decline rather than double up on the games. */
   @Test
   @Timeout(30)
@@ -506,6 +556,34 @@ public class RequestLivenessTest {
       // The archive is empty: the month still counts as indexed, and the worker takes its
       // no-games path. What is under test is the silence before this returns, not the payload.
       return Optional.empty();
+    }
+
+    @Override
+    public Optional<Player> fetchPlayer(String player) {
+      return Optional.empty();
+    }
+  }
+
+  /** Parks in the archive fetch until released, then fails the run for real. */
+  private static final class ThrowingChessClient extends ChessClient {
+    private final CountDownLatch entered;
+    private final CountDownLatch release;
+
+    ThrowingChessClient(CountDownLatch entered, CountDownLatch release) {
+      super(null, new ObjectMapper());
+      this.entered = entered;
+      this.release = release;
+    }
+
+    @Override
+    public Optional<GamesResponse> fetchGames(String player, YearMonth yearMonth) {
+      entered.countDown();
+      try {
+        release.await(20, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      throw new IllegalStateException("chess.com exploded");
     }
 
     @Override

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -155,9 +155,15 @@ public class RequestLivenessTest {
    * retires work that is owned and about to run, and tells the user to re-submit while the message
    * is still queued.
    *
-   * <p>This asserts the current, wrong-ish behaviour on purpose. When someone beats on enqueue —
-   * the actual fix, rather than a larger cutoff — this test should fail and be rewritten to assert
-   * the opposite. That failure is the notification.
+   * <p>Ownership made the consequence worse rather than better, which is worth being explicit
+   * about: the worker that eventually dequeues the message now fails to claim the retired row and
+   * declines it, so nothing is indexed. Before, it carried on and its unfenced terminal write
+   * landed — the user got their games, at the cost of the concurrent-writer corruption that could
+   * follow from the freed dedupe slot.
+   *
+   * <p>This asserts the current, wrong behaviour on purpose. When dispatch claims from this table
+   * (#1279) the row will be claimed rather than queued, this test should fail, and it should be
+   * rewritten to assert the opposite. That failure is the notification.
    */
   @Test
   public void queuedButUnstartedWorkIsStillRetired_knownGap() {
@@ -172,7 +178,9 @@ public class RequestLivenessTest {
     assertThat(dao.findById(queued).orElseThrow().status())
         .as(
             "known gap: queued-but-unstarted work is indistinguishable from abandoned work,"
-                + " because only a running worker heartbeats. Fix is to beat on enqueue.")
+                + " because only a claimed request has an owner to renew for it. Beating on"
+                + " enqueue would not fix it either — the process holding the queue is the one"
+                + " that may have died. The fix is dispatch claiming from this table (#1279).")
         .isEqualTo("FAILED");
   }
 
@@ -237,6 +245,53 @@ public class RequestLivenessTest {
     assertThat(claim(dao).created())
         .as("and the dedupe slot must still be held, not freed by a COMPLETED it had no right to")
         .isFalse();
+  }
+
+  /**
+   * A lease that lapses with nobody taking it must not abandon the run.
+   *
+   * <p>The three reasons a fenced write is refused are not the same event. Someone else took the
+   * request; the row went terminal; or this worker's own lease expired and no one claimed it. Only
+   * the first two mean the range has moved. Collapsing all three into "lost" throws away a run
+   * nobody else wants, mid-way, and leaves the row PROCESSING and still holding its dedupe slot
+   * until the sweep retires it with a message about an owner that never existed.
+   *
+   * <p>Reachable without anything being broken: the heartbeat shares one scheduler thread across
+   * every in-flight request on the instance, against a five-connection pool with a ten-second
+   * timeout, so a stall can outlast a five-minute lease. Here the renewal interval is set past the
+   * length of the test to stand in for that, and the clock is pushed past expiry while the worker
+   * is parked in the fetch.
+   */
+  @Test
+  @Timeout(30)
+  public void aLeaseThatLapsesWithNoTakerIsRenewedRatherThanAbandoned() throws Exception {
+    TestDb testDb = TestDb.create("liveness_lapsed");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    IndexWorker worker =
+        newWorker(
+            new ClockJumpingChessClient(clock, null, insideFetch, releaseFetch),
+            dao,
+            Duration.ofHours(1));
+
+    Future<?> run = workerExecutor.submit(() -> worker.process(message(requestId)));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS)).isTrue();
+
+    // The lease runs out. Nobody claims it.
+    clock.advance(RetentionPolicy.LEASE.plusMinutes(1));
+    assertThat(dao.holdsLease(requestId, worker.ownerId(), clock.instant()))
+        .as("precondition: the lease really has lapsed")
+        .isFalse();
+
+    releaseFetch.countDown();
+    run.get(20, TimeUnit.SECONDS);
+
+    assertThat(dao.findById(requestId).orElseThrow().status())
+        .as("the run finished under a lease it recovered, rather than being abandoned mid-way")
+        .isEqualTo("COMPLETED");
   }
 
   /** Two workers, one request: the second must decline rather than double up on the games. */

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
@@ -47,11 +48,11 @@ import org.junit.jupiter.api.Timeout;
  * Liveness of an in-flight indexing request: can a request that is being worked on right now be
  * mistaken for an abandoned one?
  *
- * <p>{@link RetentionPolicy#STALE_REQUEST} retires a PENDING/PROCESSING request whose {@code
- * updated_at} has not moved in an hour, on the theory that its owner is dead. That theory is only
- * as good as the worker's heartbeat, and status writes alone are not one: {@link IndexWorker} wrote
- * PROCESSING at the start of a run and again at each month boundary, cache hit, empty archive and
- * 100-game batch flush, leaving everything between two of those points unobserved.
+ * <p>The question used to be answered by inference. A PENDING/PROCESSING row whose {@code
+ * updated_at} had not moved in {@link RetentionPolicy#STALE_REQUEST} was presumed dead, which
+ * cannot tell a worker that is slow from one that is gone — and status writes are a poor proxy for
+ * either, since {@link IndexWorker} wrote PROCESSING only at month boundaries, cache hits, empty
+ * archives and 100-game batch flushes, leaving everything between two of those points unobserved.
  *
  * <p>The gap that mattered most was the ordinary one. A single-month request holding fewer than
  * {@code BATCH_SIZE} games flushes exactly once, at the end, so the whole month — the archive
@@ -60,19 +61,22 @@ import org.junit.jupiter.api.Timeout;
  * bound at all, and single-month requests are the common case since {@code submitHybrid} runs them
  * inline.
  *
+ * <p>#1278 replaced the inference with a claim. A worker takes an explicit lease naming itself and
+ * renews it on a timer, so "is the owner still there?" is answered by the owner rather than guessed
+ * from its output — a request can run for hours without progress and still be alive, and a crashed
+ * one is reclaimable in minutes rather than an hour.
+ *
  * <p>Crossing the cutoff is not just a wrong label. Retirement clears {@code dedupe_key}, which is
  * the whole mechanism keeping one live request per range, so a resubmit creates a replacement and
  * two workers index the same games concurrently — interleaving the {@code motif_occurrences}
  * delete/insert pair and doubling every motif count. That is precisely the failure #1249 exists to
- * prevent, reached by a different road.
+ * prevent, reached by a different road. {@code ConcurrentFlushTest} covers the write path itself;
+ * what is tested here is that the situation does not arise from a healthy worker being declared
+ * dead, and that a worker which really has lost its lease stops.
  *
- * <p>These tests were written against the defect and observed failing before the timer-based
- * heartbeat that now satisfies them. What they pin is the invariant, not the fix: any future change
- * that lets a running request go unobserved for longer than the cutoff breaks them.
- *
- * <p>One case is deliberately <em>not</em> covered here, because it is out of the heartbeat's
- * reach: a message still waiting in the queue has no worker to beat for it, so a backlog deeper
- * than the cutoff still retires work that is owned but not yet started. See {@link
+ * <p>One case is deliberately <em>not</em> covered here, because it is out of a lease's reach: a
+ * message still waiting in the queue has no worker to renew for it, so a backlog deeper than the
+ * cutoff still retires work that is owned but not yet started. See {@link
  * RetentionPolicy#STALE_REQUEST}.
  */
 public class RequestLivenessTest {
@@ -115,12 +119,12 @@ public class RequestLivenessTest {
    */
   @Test
   @Timeout(30)
-  public void theRequestIsTouchedWhileTheWorkerIsInsideASlowArchiveFetch() throws Exception {
+  public void theLeaseIsRenewedWhileTheWorkerIsInsideASlowArchiveFetch() throws Exception {
     CountDownLatch insideFetch = new CountDownLatch(1);
     CountDownLatch releaseFetch = new CountDownLatch(1);
     CountDownLatch beatDuringFetch = new CountDownLatch(1);
 
-    HeartbeatRecorder recorder = new HeartbeatRecorder(beatDuringFetch);
+    RenewalRecorder recorder = new RenewalRecorder(beatDuringFetch);
     IndexWorker worker =
         newWorker(
             new ClockJumpingChessClient(clock, null, insideFetch, releaseFetch),
@@ -137,9 +141,9 @@ public class RequestLivenessTest {
 
     assertThat(touched)
         .as(
-            "nothing refreshed the request while the worker sat in the archive fetch — that span"
-                + " is unbounded, so a healthy worker crosses the %s cutoff and is retired mid-run",
-            STALE_AFTER)
+            "nothing renewed the lease while the worker sat in the archive fetch — that span is"
+                + " unbounded, so a healthy worker outlives its %s lease and is reclaimed mid-run",
+            RetentionPolicy.LEASE)
         .isTrue();
   }
 
@@ -172,20 +176,99 @@ public class RequestLivenessTest {
         .isEqualTo("FAILED");
   }
 
-  /** A beat must not resurrect a request someone else already took. */
+  /** A renewal must not resurrect a request someone else already took. */
   @Test
-  public void aHeartbeatDoesNotReviveARequestThatWasAlreadyRetired() {
+  public void aRenewalDoesNotReviveARequestThatWasAlreadyRetired() {
     TestDb testDb = TestDb.create("liveness_fenced");
     IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
     UUID requestId = claim(dao).request().id();
+    dao.claim(requestId, "worker-a", RetentionPolicy.LEASE, clock.instant());
 
     clock.advance(SLOW_FETCH);
     dao.reclaimStale(STALE_AFTER, clock.instant());
 
-    assertThat(dao.heartbeat(requestId, clock.instant()))
+    assertThat(dao.renewLease(requestId, "worker-a", RetentionPolicy.LEASE, clock.instant()))
         .as("a retired request is not this worker's to keep alive")
         .isFalse();
     assertThat(dao.findById(requestId).orElseThrow().status()).isEqualTo("FAILED");
+  }
+
+  /**
+   * The fence, end to end: a worker whose lease lapses while it is parked in a fetch must not carry
+   * on writing to a row a replacement now owns.
+   *
+   * <p>Its renewal interval is set past the length of the test, which is what a process that has
+   * stopped renewing — paused, partitioned, or dying — looks like from the table's side. When it
+   * wakes up it has no way to know it was replaced, so the refusal has to come from the write.
+   */
+  @Test
+  @Timeout(30)
+  public void aWorkerWhoseLeaseWasTakenStopsWritingToTheRequestRow() throws Exception {
+    TestDb testDb = TestDb.create("liveness_taken");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    IndexWorker stalled =
+        newWorker(
+            new ClockJumpingChessClient(clock, null, insideFetch, releaseFetch),
+            dao,
+            Duration.ofHours(1));
+
+    Future<?> run = workerExecutor.submit(() -> stalled.process(message(requestId)));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS)).isTrue();
+
+    // Its lease runs out and a replacement takes the row.
+    clock.advance(RetentionPolicy.LEASE.plusMinutes(1));
+    assertThat(dao.claim(requestId, "replacement", RetentionPolicy.LEASE, clock.instant()))
+        .as("an expired lease is available to take")
+        .isTrue();
+
+    releaseFetch.countDown();
+    run.get(20, TimeUnit.SECONDS);
+
+    assertThat(dao.holdsLease(requestId, "replacement", clock.instant()))
+        .as("the replacement still owns the request the stalled worker was writing to")
+        .isTrue();
+    assertThat(dao.findById(requestId).orElseThrow().status())
+        .as("the stalled worker must not stamp its own outcome over the replacement's run")
+        .isEqualTo("PROCESSING");
+    assertThat(claim(dao).created())
+        .as("and the dedupe slot must still be held, not freed by a COMPLETED it had no right to")
+        .isFalse();
+  }
+
+  /** Two workers, one request: the second must decline rather than double up on the games. */
+  @Test
+  @Timeout(30)
+  public void aSecondWorkerDeclinesARequestThatIsAlreadyHeld() throws Exception {
+    TestDb testDb = TestDb.create("liveness_held");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    IndexWorker holder = blockingWorker(dao, insideFetch, releaseFetch);
+    workerExecutor.submit(() -> holder.process(message(requestId)));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS)).isTrue();
+
+    // Runs on this thread: it is expected to return at the claim gate without reaching the fetch.
+    CountDownLatch secondReachedFetch = new CountDownLatch(1);
+    IndexWorker second = blockingWorker(dao, secondReachedFetch, new CountDownLatch(0));
+    second.process(message(requestId));
+
+    // Asserted before the holder is released, because finishing its run would release the lease
+    // legitimately and the question here is whether the second worker could take it mid-run.
+    assertThat(secondReachedFetch.getCount())
+        .as("the second worker started indexing a range it does not own")
+        .isEqualTo(1);
+    assertThat(dao.holdsLease(requestId, second.ownerId(), clock.instant()))
+        .as("a second worker must not take a request while its holder's lease is live")
+        .isFalse();
+    assertThat(dao.holdsLease(requestId, holder.ownerId(), clock.instant())).isTrue();
+
+    releaseFetch.countDown();
   }
 
   /**
@@ -208,17 +291,17 @@ public class RequestLivenessTest {
         .as("worker should have reached the archive fetch")
         .isTrue();
 
-    // The fetch is hanging and an hour and a half of it goes by. In production the heartbeat has
-    // beaten dozens of times by now; here we wait for one so the assertion is about the sweep's
-    // decision rather than about scheduler timing.
+    // The fetch is hanging and an hour and a half of it goes by. In production the lease has been
+    // renewed dozens of times by now; here we wait for one renewal so the assertion is about the
+    // sweep's decision rather than about scheduler timing.
     clock.advance(SLOW_FETCH);
-    boolean beat = awaitHeartbeatAtOrAfter(dao, requestId, clock.instant());
+    boolean beat = awaitRenewalAtOrAfter(dao, requestId, clock.instant());
 
     dao.reclaimStale(STALE_AFTER, clock.instant());
     IndexingRequestStore.IndexingRequest row = dao.findById(requestId).orElseThrow();
     releaseFetch.countDown();
 
-    assertThat(beat).as("no heartbeat landed during the hanging fetch").isTrue();
+    assertThat(beat).as("no renewal landed during the hanging fetch").isTrue();
     assertThat(row.status())
         .as("a request whose worker is still running must not be retired as abandoned")
         .isIn("PENDING", "PROCESSING");
@@ -245,7 +328,7 @@ public class RequestLivenessTest {
     assertThat(insideFetch.await(15, TimeUnit.SECONDS)).isTrue();
 
     clock.advance(SLOW_FETCH);
-    awaitHeartbeatAtOrAfter(dao, requestId, clock.instant());
+    awaitRenewalAtOrAfter(dao, requestId, clock.instant());
     dao.reclaimStale(STALE_AFTER, clock.instant());
 
     IndexingRequestStore.Claim resubmit = claim(dao);
@@ -291,8 +374,8 @@ public class RequestLivenessTest {
         heartbeatInterval);
   }
 
-  /** Polls until the stored row has been refreshed to at least {@code at}, or gives up. */
-  private boolean awaitHeartbeatAtOrAfter(IndexingRequestDao dao, UUID id, Instant at)
+  /** Polls until the stored row has been renewed to at least {@code at}, or gives up. */
+  private boolean awaitRenewalAtOrAfter(IndexingRequestDao dao, UUID id, Instant at)
       throws InterruptedException {
     for (int i = 0; i < 200; i++) {
       Optional<IndexingRequestStore.IndexingRequest> row = dao.findById(id);
@@ -376,17 +459,38 @@ public class RequestLivenessTest {
     }
   }
 
-  /** Trips a latch the first time anything refreshes the request. */
-  private static final class HeartbeatRecorder implements IndexingRequestStore {
-    private final CountDownLatch touched;
+  /** Trips a latch the first time the worker renews its lease. */
+  private static final class RenewalRecorder implements IndexingRequestStore {
+    private final CountDownLatch renewed;
 
-    HeartbeatRecorder(CountDownLatch touched) {
-      this.touched = touched;
+    RenewalRecorder(CountDownLatch renewed) {
+      this.renewed = renewed;
     }
 
     @Override
-    public boolean heartbeat(UUID id, Instant now) {
-      touched.countDown();
+    public boolean claim(UUID id, String ownerId, Duration lease, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean renewLease(UUID id, String ownerId, Duration lease, Instant now) {
+      renewed.countDown();
+      return true;
+    }
+
+    @Override
+    public boolean holdsLease(UUID id, String ownerId, Instant now) {
+      return true;
+    }
+
+    @Override
+    public boolean updateStatusOwned(
+        UUID id,
+        String ownerId,
+        String status,
+        String errorMessage,
+        int gamesIndexed,
+        Instant now) {
       return true;
     }
 
@@ -469,6 +573,16 @@ public class RequestLivenessTest {
   private static final class NoOpGameFeatureStore implements GameFeatureStore {
     @Override
     public void insertBatch(List<GameFeature> features) {}
+
+    @Override
+    public boolean flushOwned(
+        UUID requestId,
+        String ownerId,
+        Instant now,
+        List<GameFeature> features,
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+      return true;
+    }
 
     @Override
     public int deleteOlderThan(Instant threshold) {


### PR DESCRIPTION
Closes #1278.

Liveness used to be inferred. A PENDING/PROCESSING row whose `updated_at` had not moved in an hour was presumed dead — which cannot tell a worker that is slow from one that is gone, and gives a later write nothing to check itself against. Both halves matter at scale-out, where more than one process is in a position to test the guess.

`indexing_requests` grows `owner_id` and `lease_expires_at`. A worker claims a request before it writes anything, renews every 75 seconds, and conditions every subsequent write — progress, the terminal status, and the batched game and occurrence writes — on the row still naming it.

## The bug this actually fixes

The control plane was fine. The data plane was not.

`flushBatch` inserted features, deleted the games' occurrences, and re-inserted them as **three separate transactions**, and `motif_occurrences` has no uniqueness beyond a random UUID. Two writers over one game interleave as delete, delete, insert, insert and both copies survive, so every motif for that game reads double. Two live requests reaching one game is ordinary rather than exotic — a game has two players, so indexing each of them covers it — which means dedupe could never have prevented it. Every previous PR in this cluster defended the control plane; none made the write path misbehave.

`ConcurrentFlushTest` drives that interleaving with a latch and asserts the doubled count, so it is a fact rather than an argument. The flush is now one transaction, conditional on ownership.

## Two reclamation clocks instead of one

| Situation | Eligible for retirement after | Why that clock |
|---|---|---|
| Claimed, owner stopped renewing | 5 minutes (`LEASE`) | The owner reports in every 75s. Three missed renewals survivable; expiry on the fourth. |
| Never claimed by anyone | 1 hour (`STALE_REQUEST`) | No owner whose silence could be measured — only the age of the row. |

Conflating those is what retired healthy workers for having nothing to say about a slow month. *Eligible*, not retired: reclamation is only as prompt as its hourly caller, and retiring frees the range rather than handing it over — nothing scans for expired leases and nothing re-dispatches. The docs say so now rather than describing the destination as if it had arrived.

## What the review panel changed

Three reviewers on correctness, data access, and tests/docs. The two that mattered most:

**The ownership probe took no row lock.** It was a bare `SELECT` inside the flush transaction, and I had written that this meant "no window between checking and writing". Nothing sets an isolation level, so both engines run READ COMMITTED and a plain read is a snapshot, not a claim: a concurrent `claim` commits in the gap and the flush writes rows for a request it no longer owns — for the duration of the whole flush, not an instant. The reviewer demonstrated it end to end on a PostgreSQL 16 cluster. Now `SELECT id … FOR UPDATE` (`id` rather than `COUNT(*)`, which PG rejects alongside `FOR UPDATE`).

**Transactional was not sufficient to make two writers safe against each other.** A `DELETE` blocked on another transaction's uncommitted delete re-checks the rows it blocked on but not the rows that transaction *inserted*, so the doubling survives one isolation level up. Reanalysis was the second writer, and this PR's own test file had blessed it as "still correct, single-threaded" — single-threaded within its own loop, racing an indexing worker on another thread. Both paths now take the game's `game_features` row first, the only thing they share, and reanalysis goes through a transactional `replaceOccurrences`.

Also fixed: a lapsed lease with no taker was abandoning runs it should have recovered; `findExistingRequest` still judged liveness by `updated_at` and short-circuits before reclamation, so the promised five minutes was reachable from nowhere; both terminal writes discarded their fencing result while logging success unconditionally; `upsertPeriod` was the one unfenced write in a run; the reclamation message told every retired request that nobody had picked it up, including the ones whose worker crashed mid-run, and that text renders in the web app; `IndexerModule` gave every lease participant the injected `Clock` except the worker that stamps `lease_expires_at`.

## Verification

Two of the guarantees are statements about PostgreSQL's READ COMMITTED behaviour that H2's MVStore does not reproduce, so asserting them on H2 would pass whether or not the code were right. They live in a new PG-gated suite: **it skips without `PG_TEST_DB_URL` and has not run locally — it first runs in CI.**

On H2: a takeover during an in-flight flush, reanalysis against a concurrent flush, a lapsed-but-unstolen lease surviving a run, dedupe declining a lapsed request, and the two reclamation messages. The expiry boundary is pinned on all five predicates that share it — relaxing either write-authorizing predicate to `>=` puts the replacement and the old owner on the same games for one instant, and tests a second either side noticed nothing. Every new predicate is mutation-checked.

Two tests written during this work were caught being vacuous and replaced: a barrier-driven concurrency loop that passed against the deliberately broken three-call sequence (a concurrent *reader* asserting it never sees the game mid-flush discriminates; the loop did not), and `LEASE_RENEWAL.multipliedBy(3) < LEASE` where `LEASE_RENEWAL` is defined as `LEASE.dividedBy(4)` — arithmetic that cannot fail.

## Known regression, stated rather than hidden

Retiring queued work is now **worse** than before this change. A message that waits longer than the unclaimed cutoff has its row retired underneath it, and the worker that eventually dequeues it fails to claim the retired row and declines — nothing is indexed. Previously it carried on and its unfenced terminal write landed, so the user got their games, at the cost of exactly the concurrent-writer corruption this PR prevents. Neither answer is right and a bigger cutoff only makes the wrong one slower. The fix is for queued work not to be invisible: dispatch claiming from the table rather than from a process-local queue, which is #1279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA

---
_Generated by [Claude Code](https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA)_