### PR TITLE
Let any worker run any queued indexing request (#1279)

### DIFF
--- a/domains/games/apis/mcpserver/BUILD.bazel
+++ b/domains/games/apis/mcpserver/BUILD.bazel
@@ -174,6 +174,7 @@ java_test_suite(
         ":dtos",
         ":module",
         ":tools",
+        "//domains/games/apis/one_d4:worker",
         artifact("io.micronaut:micronaut-context"),
         artifact("io.micronaut:micronaut-inject"),
         artifact("org.junit.jupiter:junit-jupiter-api"),

--- a/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/McpModule.java
+++ b/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/McpModule.java
@@ -179,7 +179,11 @@ public class McpModule {
         indexExtractionExecutor);
   }
 
+  // preDestroy is load-bearing, not hygiene: the poller is a daemon thread, so without it a deploy
+  // is indistinguishable from a crash — the row stays owned by a dead process for a full lease, and
+  // the attempt it spent is gone. See IndexWorkerLifecycle#stop.
   @Context
+  @Bean(preDestroy = "stop")
   public IndexWorkerLifecycle indexWorkerLifecycle(
       IndexQueue queue, IndexWorker worker, IndexingRequestStore requestStore, Clock clock) {
     return new IndexWorkerLifecycle(queue, worker, requestStore, clock);

--- a/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/McpModule.java
+++ b/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/McpModule.java
@@ -180,8 +180,9 @@ public class McpModule {
   }
 
   @Context
-  public IndexWorkerLifecycle indexWorkerLifecycle(IndexQueue queue, IndexWorker worker) {
-    return new IndexWorkerLifecycle(queue, worker);
+  public IndexWorkerLifecycle indexWorkerLifecycle(
+      IndexQueue queue, IndexWorker worker, IndexingRequestStore requestStore, Clock clock) {
+    return new IndexWorkerLifecycle(queue, worker, requestStore, clock);
   }
 
   @Context

--- a/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/McpModuleTest.java
+++ b/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/McpModuleTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.muchq.games.mcpserver.dtos.Tool;
 import com.muchq.games.mcpserver.tools.ToolRegistry;
+import com.muchq.games.one_d4.worker.IndexWorkerLifecycle;
 import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +14,29 @@ import org.junit.jupiter.api.Test;
  * only by manual smoke tests.
  */
 public class McpModuleTest {
+
+  /**
+   * The container's half of the shutdown contract, exercised for real: boot, then close, and the
+   * poller must have been told to stop.
+   *
+   * <p>Worth a real context rather than reading the annotation back off the factory method. The
+   * poller is a daemon thread, so if Micronaut does not invoke preDestroy — wrong bean scope, a
+   * misspelled method name, a refactor that renames stop() — nothing anywhere fails, and every
+   * deploy silently strands its in-flight request for a full lease and spends one of its three
+   * attempts. This is the one place that catches that.
+   */
+  @Test
+  public void closingTheContextStopsTheIndexWorker() {
+    IndexWorkerLifecycle lifecycle;
+    try (ApplicationContext context = ApplicationContext.run()) {
+      lifecycle = context.getBean(IndexWorkerLifecycle.class);
+      assertThat(lifecycle.isRunning()).as("the poller should be live while the app is").isTrue();
+    }
+
+    assertThat(lifecycle.isRunning())
+        .as("shutdown must reach the poller, or every deploy looks like a crash")
+        .isFalse();
+  }
 
   @Test
   public void contextStartsAndRegistersAllTools() {

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -378,6 +378,7 @@ java_test_suite(
     name = "worker_tests",
     size = "small",
     srcs = [
+        "src/test/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycleTest.java",
         "src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java",
         "src/test/java/com/muchq/games/one_d4/worker/OpeningsTest.java",
         "src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java",
@@ -474,6 +475,7 @@ java_test_suite(
         "src/test/java/com/muchq/games/one_d4/db/IndexedPeriodDaoTest.java",
         "src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java",
         "src/test/java/com/muchq/games/one_d4/db/MigrationTest.java",
+        "src/test/java/com/muchq/games/one_d4/db/TableDispatchTest.java",
     ],
     deps = [
         ":db",

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -460,7 +460,11 @@ java_test_suite(
         "src/test/java/com/muchq/games/one_d4/IndexerModuleTest.java",
     ],
     deps = [
+        ":db",
         ":module",
+        ":queue",
+        ":worker",
+        artifact("io.micronaut:micronaut-inject"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.assertj:assertj-core"),
     ],

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -37,7 +37,7 @@ flowchart TB
 
   subgraph IndexPath["Index Path"]
     Queue["IndexQueue\n(InMemory)"]
-    Lifecycle["IndexWorkerLifecycle\n(poll every 5s)"]
+    Lifecycle["IndexWorkerLifecycle\n(claims from indexing_requests)"]
     Worker["IndexWorker"]
     ChessClient["ChessClient"]
     Extractor["FeatureExtractor"]
@@ -81,7 +81,8 @@ flowchart TB
   RequestStore --> DB
   PeriodStore --> DB
 
-  Queue --> Lifecycle
+  RequestStore --> Lifecycle
+  Queue -.nudge.-> Lifecycle
   Lifecycle --> Worker
   Worker --> ChessClient
   Worker --> RequestStore
@@ -100,11 +101,11 @@ flowchart TB
   RetentionWorker --> RequestStore
 ```
 
-**Index flow:** Client posts to `POST /v1/index` → request is stored and a message is enqueued. A background thread (IndexWorkerLifecycle) polls the queue; IndexWorker fetches games from Chess.com per month (skipping months already in IndexedPeriodStore), runs FeatureExtractor (PgnParser → GameReplayer → MotifDetectors) on each game, and writes to GameFeatureStore (game_features + motif_occurrences) and IndexedPeriodStore. Fork occurrences are derived inside FeatureExtractor from ATTACK occurrences (same ply + attacker targeting 2+ pieces).
+**Index flow:** Client posts to `POST /v1/index` → a row is stored in `indexing_requests`, which is the work queue. A background thread (IndexWorkerLifecycle) on **any** instance claims the oldest unheld row and takes a lease on it; a local in-memory nudge just wakes the poller sooner. IndexWorker fetches games from Chess.com per month (skipping months already in IndexedPeriodStore), runs FeatureExtractor (PgnParser → GameReplayer → MotifDetectors) on each game, and writes to GameFeatureStore (game_features + motif_occurrences) and IndexedPeriodStore. Fork occurrences are derived inside FeatureExtractor from ATTACK occurrences (same ply + attacker targeting 2+ pieces).
 
 **Query flow:** Client posts a ChessQL string to `POST /v1/query` → Parser and SqlCompiler produce SQL → GameFeatureStore runs the query and loads motif_occurrences for the result set → response returns GameFeatureRow list with per-game occurrences.
 
-**Retention:** RetentionWorker runs hourly. It deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days, and indexing_requests older than 30 days — games first, so a request and its games clear in one pass. It also retires live requests nobody is working on — a claimed one whose owner has stopped renewing its five-minute lease, an unclaimed one over an hour old — freeing the dedupe slot each one holds. Since the sweep is hourly, those windows say when a request becomes eligible, not when it is retired.
+**Retention:** RetentionWorker runs hourly. It deletes game_features, motif_occurrences (via FK cascade), and indexed_periods older than 7 days, and indexing_requests older than 30 days — games first, so a request and its games clear in one pass. It also settles live requests nobody is working on: a lapsed lease returns the work to the queue for another worker, and only an exhausted attempt count or a fleet that is demonstrably not running anything retires a request to FAILED. Since the sweep is hourly, those windows say when a request becomes eligible, not when it is settled.
 
 ## Running Locally (in-memory)
 
@@ -249,34 +250,35 @@ between the two windows the surviving row is what lets `GET /v1/index/{id}` repo
 ("pruned — re-run it") rather than 404. The sweep deletes games before requests so both clear in
 one pass, and skips any request still referenced by a game.
 
-Separately, a live request that nobody is working on is retired to FAILED, which frees the dedupe
-slot it holds for its (player, platform, month range). Two different questions, on two clocks:
+Separately, a live request that nobody is working on is settled by the retention worker. Three
+outcomes, because "nobody is working on it" means three different things:
 
-| Situation | Eligible for retirement after | Why that clock |
+| Situation | Outcome | Why |
 |---|---|---|
-| Claimed, but the owner stopped renewing | **5 minutes** (`LEASE`) | The owner reports in every 75 seconds. Three missed renewals are survivable; expiry lands on the fourth. |
-| Never claimed by anyone | **1 hour** (`STALE_REQUEST`) | There is no owner whose silence could be measured, so the only evidence is the age of the row. |
+| Claimed, owner stopped renewing, attempts remain | **Requeued** | The owner is gone; the work is not. Another worker picks it up. Silent — the user is not told about work that is about to run. |
+| Claimed 3 times, each worker stopped before finishing | **FAILED** (poisoned) | Requeuing is unbounded by construction, so a request that kills its worker would tour the fleet forever. |
+| Untouched for **1 hour**, and no worker anywhere holds a lease | **FAILED** (stalled) | Every instance is down or partitioned. Nothing will run this, and silence is a worse answer than failure. |
 
-*Eligible*, not retired — the distinction matters. Reclamation is only as prompt as its caller, and
-the caller is the hourly `RetentionWorker`; the one faster path is a resubmit for the same range,
-which retires the key it is about to claim. And retiring frees the range rather than handing it
-over: nothing scans for expired leases and nothing re-dispatches, so the user resubmits. Making
-another worker pick the range up is [#1279](https://github.com/muchq/MoonBase/issues/1279).
+That last row's second condition is load-bearing. Age alone cannot tell "nothing is serving this"
+from "my turn hasn't come" — one worker draining a deep backlog leaves rows at the back untouched
+for as long as the backlog takes — so the sweep stays quiet while any worker holds a live lease.
 
-A worker takes an explicit lease on a request before it writes anything: `owner_id` names the
-process, and every subsequent write — progress, the terminal status, and the batched game and
-occurrence writes — is conditioned on the row still naming it. A worker whose row has changed
-hands stops rather than reasserting itself; a lease that merely lapsed with nobody taking it is
-renewed and the run continues, because abandoning work no one else wants helps nobody.
+The situations overlap, so the sweep applies them **poisoned, stalled, requeued** and the first
+match wins. A row at the attempt limit is usually also old and unheld, and both arms would fail it,
+but only one gives the user the real reason; and requeuing stamps `updated_at`, so doing it first
+would make a row look freshly touched and hide it from the staleness check for another whole hour.
 
-Renewal says "the owner is still here", not "progress was made", so a request can run for hours
-against a slow archive without looking abandoned. The hour above still misses one case, and
-ownership made its cost worse: a message waiting in the in-memory queue has no worker to renew for
-it, so a backlog deeper than an hour retires it — and the worker that eventually dequeues it finds
-a retired row, declines it, and indexes nothing. Previously it carried on and recorded a result,
-which is how the range could end up with two writers. Closing this properly means dispatch claiming
-from the table rather than from a process-local queue
-([#1279](https://github.com/muchq/MoonBase/issues/1279)).
+### Dispatch
+
+`indexing_requests` is the work queue. Any worker claims the oldest request nobody holds, runs it,
+and renews a lease while it does; every write is fenced on that ownership, so two instances polling
+one table cannot end up on the same range. The in-memory queue still exists but only as a wake-up
+nudge for the instance that accepted the submit — losing it costs latency, not work.
+
+This is what makes horizontal scale-out work. Previously a request could only ever be processed by
+the process that accepted it: adding an instance added no throughput for queued work, a restart lost
+the messages while the rows survived, and with REST and MCP as separate JVMs against one Postgres,
+load landed wherever the submit happened to arrive.
 
 ### Available Fields
 

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -268,6 +268,15 @@ match wins. A row at the attempt limit is usually also old and unheld, and both 
 but only one gives the user the real reason; and requeuing stamps `updated_at`, so doing it first
 would make a row look freshly touched and hide it from the staleness check for another whole hour.
 
+None of that covers a worker that is *leaving on purpose*, and it can't: every arm above needs the
+owner to have stopped answering, which a deploy only looks like after the lease expires. So a
+shutting-down worker hands its request back itself — unclaimed immediately, and with the attempt
+returned. The attempt matters more than the five minutes: `attempts` is spent on claim so that a
+request which kills its worker outright still moves the counter, which means a process exit is
+otherwise indistinguishable from a crash, and a long-running request outliving three rolling
+restarts would be retired as poisoned. A hand-back is the evidence that resolves it — the worker
+survived long enough to say it was going, which is exactly what a killer request prevents.
+
 ### Dispatch
 
 `indexing_requests` is the work queue. Any worker claims the oldest request nobody holds, runs it,

--- a/domains/games/apis/one_d4/docs/PARALLELIZING_INDEXING.md
+++ b/domains/games/apis/one_d4/docs/PARALLELIZING_INDEXING.md
@@ -4,7 +4,7 @@ Currently indexing is **strictly sequential**: one worker thread, one index requ
 
 ### Current bottleneck
 
-- **IndexWorkerLifecycle:** Single thread polls the queue and calls `worker.process(message)`; no overlap between index requests.
+- **IndexWorkerLifecycle:** Single thread per instance claims the oldest unheld row from `indexing_requests` and runs it; the in-memory queue is now only a wake-up nudge (#1279); no overlap between index requests.
 - **IndexWorker.process():** For each month, `chessClient.fetchGames(player, month)` (one HTTP call, ~10–100 games), then a **sequential** loop over games: `featureExtractor.extract(game.pgn())` then `gameFeatureStore.insert(row)` + `insertOccurrences()`. So per month, games are processed one-by-one.
 - **Costs:** Chess.com API latency (~200 ms/request) dominates when many months are requested; for a single month, PGN replay + motif detection (~2–5K games/sec in the Lichess bulk-ingest estimate) and DB writes are the limit. So both I/O and CPU matter.
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
@@ -256,7 +256,8 @@ public class IndexerModule {
   }
 
   @Context
-  public IndexWorkerLifecycle indexWorkerLifecycle(IndexQueue queue, IndexWorker worker) {
-    return new IndexWorkerLifecycle(queue, worker);
+  public IndexWorkerLifecycle indexWorkerLifecycle(
+      IndexQueue queue, IndexWorker worker, IndexingRequestStore requestStore, Clock clock) {
+    return new IndexWorkerLifecycle(queue, worker, requestStore, clock);
   }
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
@@ -255,7 +255,11 @@ public class IndexerModule {
         clock);
   }
 
+  // preDestroy is load-bearing, not hygiene: the poller is a daemon thread, so without it a deploy
+  // is indistinguishable from a crash — the row stays owned by a dead process for a full lease, and
+  // the attempt it spent is gone. See IndexWorkerLifecycle#stop.
   @Context
+  @Bean(preDestroy = "stop")
   public IndexWorkerLifecycle indexWorkerLifecycle(
       IndexQueue queue, IndexWorker worker, IndexingRequestStore requestStore, Clock clock) {
     return new IndexWorkerLifecycle(queue, worker, requestStore, clock);

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -25,21 +25,6 @@ public class IndexingRequestDao implements IndexingRequestStore {
    */
   private static final int MAX_CLAIM_ATTEMPTS = 5;
 
-  /** For the unclaimed arm: nobody ever picked this up. */
-  private static final String NEVER_CLAIMED_MESSAGE =
-      "Abandoned: no worker took ownership before the staleness cutoff (orphaned by restart or a"
-          + " failed inline dispatch). Re-submit to try again.";
-
-  /**
-   * For the lease arm. A different sentence because it describes a different event, and this text
-   * is not internal — it reaches the user as {@code IndexResponse.errorMessage} and is rendered in
-   * the web app. Telling someone whose worker crashed mid-run that nobody ever picked their request
-   * up sends them looking for a dispatch problem that is not there.
-   */
-  private static final String OWNER_GONE_MESSAGE =
-      "Abandoned: the worker indexing this request stopped responding and its lease expired."
-          + " Re-submit to try again.";
-
   private static final RowMapper<IndexingRequest> ROW_MAPPER =
       (rs, ctx) ->
           new IndexingRequest(
@@ -53,7 +38,9 @@ public class IndexingRequestDao implements IndexingRequestStore {
               rs.getTimestamp("updated_at").toInstant(),
               rs.getString("error_message"),
               rs.getInt("games_indexed"),
-              rs.getBoolean("exclude_bullet"));
+              rs.getBoolean("exclude_bullet"),
+              rs.getBoolean("skip_cache"),
+              rs.getInt("attempts"));
 
   private final Jdbi jdbi;
   private final Clock clock;
@@ -114,14 +101,15 @@ public class IndexingRequestDao implements IndexingRequestStore {
       String startMonth,
       String endMonth,
       boolean excludeBullet,
+      boolean skipCache,
       Duration staleAfter,
       Instant now) {
     String key = dedupeKey(player, platform, startMonth, endMonth, excludeBullet);
 
-    // Retire an abandoned holder first, so a dead request cannot keep its replacement out. Without
-    // this the unique constraint would turn #1250's stranded row from "dedupe keeps answering with
-    // it" into "the database refuses the replacement" — the same lockout, enforced harder.
-    retire(key, staleAfter, now);
+    // Settle any abandoned holder first. Usually that means releasing it — the work is still
+    // queued and this caller should adopt it rather than start a rival — and retiring it only once
+    // its attempts are spent, which frees the key so an insert can succeed.
+    reclaim(key, staleAfter, now);
 
     RuntimeException lastConflict = null;
     for (int attempt = 0; attempt < MAX_CLAIM_ATTEMPTS; attempt++) {
@@ -135,7 +123,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
       // engines. The constraint, not the transaction boundary, is what makes this safe: exactly
       // one racer's insert can succeed.
       try {
-        UUID id = insert(key, player, platform, startMonth, endMonth, excludeBullet);
+        UUID id = insert(key, player, platform, startMonth, endMonth, excludeBullet, skipCache);
         return new Claim(
             findById(id)
                 .orElseThrow(
@@ -172,7 +160,8 @@ public class IndexingRequestDao implements IndexingRequestStore {
       String platform,
       String startMonth,
       String endMonth,
-      boolean excludeBullet) {
+      boolean excludeBullet,
+      boolean skipCache) {
     UUID id = UUID.randomUUID();
     // created_at/updated_at are stamped here rather than left to the column DEFAULT, so they come
     // from the same clock the staleness predicates compare against.
@@ -183,8 +172,8 @@ public class IndexingRequestDao implements IndexingRequestStore {
                     """
                     INSERT INTO indexing_requests
                       (id, player, platform, start_month, end_month, exclude_bullet, dedupe_key,
-                       created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                       created_at, updated_at, skip_cache, attempts)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
                     """)
                 .bind(0, id)
                 .bind(1, player)
@@ -195,6 +184,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
                 .bind(6, dedupeKey)
                 .bindByType(7, stamp, LocalDateTime.class)
                 .bindByType(8, stamp, LocalDateTime.class)
+                .bind(9, skipCache)
                 .execute());
     return id;
   }
@@ -230,57 +220,172 @@ public class IndexingRequestDao implements IndexingRequestStore {
 
   @Override
   public int reclaimStale(Duration staleAfter, Instant now) {
-    int reclaimed = retire(null, staleAfter, now);
-    if (reclaimed > 0) {
-      // Deliberately vague about which arm fired: one statement covers both, and saying "not
-      // updated since <cutoff>" for a row retired on a five-minute lease — whose updated_at is
-      // minutes old — was simply false.
-      LOG.warn(
-          "Retired {} indexing request(s) nobody is working on: leases expired as of {}, or never"
-              + " claimed and untouched since {}",
-          reclaimed,
-          now,
-          now.minus(staleAfter));
-    }
-    return reclaimed;
+    return reclaim(null, staleAfter, now);
   }
 
   /**
-   * Marks abandoned live requests FAILED and releases the dedupe slot each one holds. Named
-   * parameters rather than positional ones, and two call sites rather than one with a conditional
-   * predicate: the sweep and the single-key reclaim differ only by one clause, and building that
-   * clause by concatenation meant the caller had to keep a {@code bind(3, ...)} in step with it.
+   * Returns abandoned work to the queue. An expired lease means the owner is gone, not that the
+   * work is unwanted, so the row is unclaimed and left live for the next worker to take.
+   *
+   * <p>This is the half of #1279 that is easiest to get backwards. Before dispatch read from this
+   * table an expired lease had to be retired: nothing was ever going to run that request again, so
+   * freeing the dedupe slot and telling the user to resubmit was the only way out. Now the row
+   * <em>is</em> the queue, and retiring it throws away work any worker could pick up. Clearing the
+   * owner is enough — {@code dedupe_key} stays, because the range is still spoken for.
    */
-  private static final String RETIRE_SQL =
+  private static final String RELEASE_SQL =
       """
       UPDATE indexing_requests
-      SET status = 'FAILED',
-          error_message = CASE WHEN owner_id IS NULL
-                            THEN CAST(:neverClaimed AS VARCHAR)
-                            ELSE CAST(:ownerGone AS VARCHAR) END,
-          dedupe_key = NULL, updated_at = :now,
-          owner_id = NULL, lease_expires_at = NULL
+      SET owner_id = NULL, updated_at = :now
       WHERE status IN ('PENDING', 'PROCESSING')
-        AND ((owner_id IS NOT NULL
-              AND lease_expires_at IS NOT NULL
-              AND lease_expires_at <= :now)
-             OR (owner_id IS NULL AND updated_at < :cutoff))
+        AND owner_id IS NOT NULL
+        AND lease_expires_at IS NOT NULL
+        AND lease_expires_at <= :now
+        AND attempts < :maxAttempts
       """;
 
-  private int retire(String keyOrNull, Duration staleAfter, Instant now) {
-    String sql = keyOrNull == null ? RETIRE_SQL : RETIRE_SQL + "  AND dedupe_key = :key\n";
-    return jdbi.withHandle(
+  /**
+   * The one case where abandoned work is still retired: it has been claimed {@link #MAX_ATTEMPTS}
+   * times and every worker stopped before finishing.
+   *
+   * <p>Releasing is unbounded by construction, and that is the new hazard. A request that kills the
+   * process handling it used to take that process's queue with it and stop there; once any worker
+   * can claim it, the same request tours the fleet indefinitely and each lap costs another worker.
+   * The counter is the only thing that separates "the last worker was unlucky" from "this request
+   * is the problem".
+   */
+  private static final String RETIRE_POISONED_SQL =
+      """
+      UPDATE indexing_requests
+      SET status = 'FAILED', error_message = :poisoned, dedupe_key = NULL, updated_at = :now,
+          owner_id = NULL, lease_expires_at = NULL
+      WHERE status IN ('PENDING', 'PROCESSING')
+        AND attempts >= :maxAttempts
+        AND (owner_id IS NULL
+             OR lease_expires_at IS NULL
+             OR lease_expires_at <= :now)
+      """;
+
+  /**
+   * The backstop: a request nobody is running, that nothing has touched in {@code staleAfter},
+   * while no worker anywhere holds a live lease.
+   *
+   * <p>Releasing work back to the queue is the right answer to a dead owner, but it cannot be the
+   * only answer. If every worker dies, or the fleet is partitioned from this database, released
+   * rows sit PENDING forever and the user is told nothing at all — which is worse than being told
+   * the request failed. Eventually the answer has to be an answer.
+   *
+   * <p>The {@code NOT EXISTS} is what stops this from re-becoming the bug two changes were spent
+   * removing. Plain age cannot distinguish "nothing is serving this" from "my turn has not come
+   * yet": a single worker draining a deep backlog leaves rows at the back untouched for as long as
+   * the backlog takes, and retiring those tells a user to resubmit work that was about to run.
+   *
+   * <p>Two probes, and it takes both, because either alone gets it wrong in a way that matters.
+   *
+   * <p>A live lease <em>right now</em> is the obvious signal and it is not enough on its own:
+   * leases are held in bursts, and between one job's terminal write and the next claim there is a
+   * real moment with none held anywhere. Sampling there declares a healthy fleet dead — reproduced
+   * on both engines, forty-nine queued rows FAILED in one statement by a millisecond-wide gap.
+   * Worse than the bug the guard exists to prevent.
+   *
+   * <p>A recent {@code lease_expires_at} covers that gap, and the column choice is the point. A
+   * plain "anything touched lately" would count submits, so a user submitting into a fleet of dead
+   * workers would suppress their own answer indefinitely — only a worker sets a lease. And it has
+   * to be the lease rather than {@code owner_id}, because a successful run clears the owner on its
+   * way out: the evidence that a worker was here would be erased by that worker finishing. So
+   * terminal writes and releases now leave {@code lease_expires_at} where it is. Nothing reads it
+   * as ownership — every such predicate also requires {@code owner_id} and a live status — and it
+   * becomes an honest record of when a worker last held this row.
+   *
+   * <p>The probe excludes the row being judged. Its own lease mark is not evidence that anyone is
+   * working <em>now</em> — it is the record of the worker that abandoned it, which is the whole
+   * reason it is a candidate.
+   *
+   * <p>Requiring both means this errs toward silence rather than toward false failure, which is the
+   * right way round — a wrong FAILED destroys queued work, a late FAILED only delays an answer. The
+   * residual case is a worker wedged mid-run: its heartbeat renews from a separate thread, so both
+   * probes stay positive, and that one live lease suppresses this arm for every queued row in the
+   * table rather than only its own. No liveness probe can close it — the worker is alive, and what
+   * is unknown is whether the run is progressing — so bounding it needs a ceiling on run duration.
+   * Tracked in #1282.
+   */
+  private static final String RETIRE_ABANDONED_SQL =
+      """
+      UPDATE indexing_requests
+      SET status = 'FAILED', error_message = :stalled, dedupe_key = NULL, updated_at = :now,
+          owner_id = NULL, lease_expires_at = NULL
+      WHERE status IN ('PENDING', 'PROCESSING')
+        AND (owner_id IS NULL
+             OR lease_expires_at IS NULL
+             OR lease_expires_at <= :now)
+        AND updated_at < :cutoff
+        AND NOT EXISTS (
+          SELECT 1 FROM indexing_requests live
+          WHERE live.owner_id IS NOT NULL AND live.lease_expires_at > :now)
+        AND NOT EXISTS (
+          SELECT 1 FROM indexing_requests recent
+          WHERE recent.id <> indexing_requests.id AND recent.lease_expires_at >= :cutoff)
+      """;
+
+  static final String STALLED_MESSAGE =
+      "Abandoned: no indexing worker has picked this up, and none is running anywhere. Re-submit"
+          + " once indexing is available again.";
+
+  private int reclaim(String keyOrNull, Duration staleAfter, Instant now) {
+    String keyClause = keyOrNull == null ? "" : "  AND dedupe_key = :key\n";
+    return jdbi.inTransaction(
         h -> {
-          var update =
-              h.createUpdate(sql)
-                  .bind("neverClaimed", NEVER_CLAIMED_MESSAGE)
-                  .bind("ownerGone", OWNER_GONE_MESSAGE)
+          // Order matters twice, for two different reasons, and neither is the one that looks
+          // obvious. A row at the attempt limit cannot match RELEASE_SQL at all — that statement
+          // carries its own attempts guard — so this is not about stopping an extra lap.
+          //
+          // Poisoned before stalled: a row whose attempts are spent is also unheld and may well be
+          // old, so it matches the stalled arm too. Both retire it; only one of them tells the
+          // user the truth about why.
+          //
+          // Stalled before released: releasing stamps updated_at, which would make the row look
+          // freshly touched and hide it from the staleness the stalled arm looks for — costing the
+          // user another full window of silence.
+          var retire =
+              h.createUpdate(RETIRE_POISONED_SQL + keyClause)
+                  .bind("poisoned", POISONED_MESSAGE)
+                  .bind("maxAttempts", MAX_ATTEMPTS)
+                  .bindByType("now", toUtcWallClock(now), LocalDateTime.class);
+          var release =
+              h.createUpdate(RELEASE_SQL + keyClause)
+                  .bind("maxAttempts", MAX_ATTEMPTS)
+                  .bindByType("now", toUtcWallClock(now), LocalDateTime.class);
+          if (keyOrNull != null) {
+            retire.bind("key", keyOrNull);
+            release.bind("key", keyOrNull);
+          }
+          var abandoned =
+              h.createUpdate(RETIRE_ABANDONED_SQL + keyClause)
+                  .bind("stalled", STALLED_MESSAGE)
                   .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
                   .bindByType("cutoff", toUtcWallClock(now.minus(staleAfter)), LocalDateTime.class);
           if (keyOrNull != null) {
-            update.bind("key", keyOrNull);
+            abandoned.bind("key", keyOrNull);
           }
-          return update.execute();
+          int retired = retire.execute();
+          // Before the release, deliberately: releasing sets updated_at = now, which would make
+          // every row look freshly touched and hide the very staleness this arm looks for.
+          int stalled = abandoned.execute();
+          int released = release.execute();
+          if (stalled > 0) {
+            LOG.warn(
+                "Retired {} indexing request(s) that no worker has taken, with no live worker"
+                    + " anywhere",
+                stalled);
+          }
+          if (released > 0) {
+            LOG.info("Returned {} abandoned indexing request(s) to the queue", released);
+          }
+          if (retired > 0) {
+            LOG.warn(
+                "Retired {} indexing request(s) after {} failed attempts", retired, MAX_ATTEMPTS);
+          }
+          return retired + stalled + released;
         });
   }
 
@@ -296,13 +401,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
 
   @Override
   public Optional<IndexingRequest> findExistingRequest(
-      String player,
-      String platform,
-      String startMonth,
-      String endMonth,
-      boolean excludeBullet,
-      Duration staleAfter,
-      Instant now) {
+      String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
     return jdbi.withHandle(
         h ->
             h.createQuery(
@@ -312,10 +411,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
                       AND start_month = :startMonth AND end_month = :endMonth
                       AND exclude_bullet = :excludeBullet
                       AND status IN ('PENDING', 'PROCESSING')
-                      AND ((owner_id IS NOT NULL
-                            AND lease_expires_at IS NOT NULL
-                            AND lease_expires_at > :now)
-                           OR (owner_id IS NULL AND updated_at >= :cutoff))
+                      AND attempts < :maxAttempts
                     ORDER BY created_at ASC, id ASC
                     LIMIT 1
                     """)
@@ -324,8 +420,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
                 .bind("startMonth", startMonth)
                 .bind("endMonth", endMonth)
                 .bind("excludeBullet", excludeBullet)
-                .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
-                .bindByType("cutoff", toUtcWallClock(now.minus(staleAfter)), LocalDateTime.class)
+                .bind("maxAttempts", MAX_ATTEMPTS)
                 .map(ROW_MAPPER)
                 .findFirst());
   }
@@ -365,9 +460,8 @@ public class IndexingRequestDao implements IndexingRequestStore {
             // that owner, and IndexWorker writes PROCESSING once per month rather than once per
             // run. The next such write would flip the row back to PROCESSING while leaving
             // dedupe_key NULL — a live request holding no slot. Its replacement already holds the
-            // key, so the constraint cannot see the violation, and a skipCache submit (which
-            // bypasses the dedupe read) would then start exactly the rival run this change exists
-            // to prevent.
+            // key, so the constraint cannot see the violation, and the next submit for that
+            // range would then start exactly the rival run this change exists to prevent.
             //
             // Restoring the key here instead would be wrong: the replacement holds it, so the
             // UPDATE would fail on the constraint. Refusing the resurrection is the only shape
@@ -414,7 +508,7 @@ public class IndexingRequestDao implements IndexingRequestStore {
             ? """
             UPDATE indexing_requests
             SET status = :status, error_message = :message, games_indexed = :games,
-                updated_at = :now, dedupe_key = NULL, owner_id = NULL, lease_expires_at = NULL
+                updated_at = :now, dedupe_key = NULL, owner_id = NULL
             WHERE id = :id AND owner_id = :owner
               AND status IN ('PENDING', 'PROCESSING')
               AND lease_expires_at > :now
@@ -445,6 +539,55 @@ public class IndexingRequestDao implements IndexingRequestStore {
     return updated > 0;
   }
 
+  static final int MAX_ATTEMPTS = IndexingRequestStore.MAX_ATTEMPTS;
+
+  static final String POISONED_MESSAGE =
+      "Abandoned: this request was attempted "
+          + MAX_ATTEMPTS
+          + " times and each worker stopped before finishing it. Something about this range fails"
+          + " repeatedly rather than transiently.";
+
+  /**
+   * How deep {@link #claimNext} looks. One candidate would make every instance race for the same
+   * row and all but one fail each pass; a handful lets them spread out without reordering the queue
+   * in any way a user could notice.
+   */
+  private static final int CLAIM_CANDIDATES = 8;
+
+  @Override
+  public Optional<IndexingRequest> claimNext(String ownerId, Duration lease, Instant now) {
+    // Read candidates, then try to claim each. One statement would want FOR UPDATE SKIP LOCKED and
+    // H2 has none; the conditional UPDATE claim already performs is what makes this safe without
+    // it, since at most one racer's WHERE can match a given row. Losing costs a retry against the
+    // next candidate, not correctness.
+    List<UUID> candidates =
+        jdbi.withHandle(
+            h ->
+                h.createQuery(
+                        """
+                        SELECT id FROM indexing_requests
+                        WHERE status IN ('PENDING', 'PROCESSING')
+                          AND attempts < :maxAttempts
+                          AND (owner_id IS NULL
+                               OR lease_expires_at IS NULL
+                               OR lease_expires_at <= :now)
+                        ORDER BY created_at ASC, id ASC
+                        LIMIT :limit
+                        """)
+                    .bind("maxAttempts", MAX_ATTEMPTS)
+                    .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
+                    .bind("limit", CLAIM_CANDIDATES)
+                    .mapTo(UUID.class)
+                    .list());
+
+    for (UUID id : candidates) {
+      if (claim(id, ownerId, lease, now)) {
+        return findById(id);
+      }
+    }
+    return Optional.empty();
+  }
+
   @Override
   public boolean claim(UUID id, String ownerId, Duration lease, Instant now) {
     // Unclaimed, or claimed by a lease that has run out. Expressed as one conditional UPDATE so
@@ -456,7 +599,9 @@ public class IndexingRequestDao implements IndexingRequestStore {
                 h.createUpdate(
                         """
                         UPDATE indexing_requests
-                        SET owner_id = :owner, lease_expires_at = :expires, updated_at = :now
+                        SET owner_id = :owner, lease_expires_at = :expires, updated_at = :now,
+                            attempts = CASE WHEN owner_id = :owner THEN attempts
+                                            ELSE attempts + 1 END
                         WHERE id = :id
                           AND status IN ('PENDING', 'PROCESSING')
                           AND (owner_id IS NULL

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -442,16 +442,24 @@ public class IndexingRequestDao implements IndexingRequestStore {
     // request block that range permanently.
     //
     // Nothing here is fenced on ownership, so this is the unowned path: it is for callers writing
-    // about a request no worker ever claimed — the inline-dispatch failure in IndexRequestService,
+    // about a request they hold no token for — the inline-dispatch failure in IndexRequestService,
     // and tests. A worker presents its token and goes through updateStatusOwned instead, which is
     // what stops a lapsed owner from stamping COMPLETED over a range someone else now holds.
+    //
+    // lease_expires_at is left alone here for the same reason updateStatusOwned leaves it alone:
+    // it is the fleet-liveness probe's only memory. Clearing owner_id is what ends the claim, and
+    // every predicate that reads ownership requires owner_id and a live status, so the mark is
+    // inert once a row is terminal. What it is not is unowned — "no worker ever claimed this" does
+    // not follow from "this caller holds no token". The inline handler's request was claimed and
+    // leased by the worker that then threw, and erasing its mark makes the fleet look dead and
+    // retires the whole queued backlog behind it.
     boolean terminal = isTerminal(status);
     String sql =
         terminal
             ? """
             UPDATE indexing_requests
             SET status = ?, error_message = ?, games_indexed = ?, updated_at = ?,
-                dedupe_key = NULL, owner_id = NULL, lease_expires_at = NULL
+                dedupe_key = NULL, owner_id = NULL
             WHERE id = ?
             """
             // A non-terminal write may only move a row that is still live. Without the status
@@ -636,6 +644,30 @@ public class IndexingRequestDao implements IndexingRequestStore {
                     .bind("owner", ownerId)
                     .execute());
     return renewed > 0;
+  }
+
+  @Override
+  public boolean handBack(UUID id, String ownerId, Instant now) {
+    int handed =
+        jdbi.withHandle(
+            h ->
+                h.createUpdate(
+                        """
+                        UPDATE indexing_requests
+                        SET owner_id = NULL, updated_at = :now,
+                            attempts = CASE WHEN attempts > 0 THEN attempts - 1 ELSE 0 END
+                        WHERE id = :id
+                          AND owner_id = :owner
+                          AND status IN ('PENDING', 'PROCESSING')
+                        """)
+                    .bindByType("now", toUtcWallClock(now), LocalDateTime.class)
+                    .bind("id", id)
+                    .bind("owner", ownerId)
+                    .execute());
+    if (handed > 0) {
+      LOG.info("Handed request {} back to the queue on shutdown", id);
+    }
+    return handed > 0;
   }
 
   @Override

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
@@ -9,6 +9,21 @@ import java.util.UUID;
 public interface IndexingRequestStore {
 
   /**
+   * How many times a request may be claimed before it is presumed to be killing its workers.
+   *
+   * <p>Counted on claim rather than on failure, which is the conservative direction: a worker the
+   * request kills before it can report anything still moves the counter. Three tolerates a
+   * transient fault — a restart, a rolling deploy, one bad node — and is few enough that a genuine
+   * poison pill does not tour the fleet.
+   *
+   * <p>On the interface rather than the DAO because it is part of the contract, not an
+   * implementation detail: {@link #findExistingRequest} and {@link #reclaimStale} are both defined
+   * in terms of it, so a fake that picks its own number models a different system than the one it
+   * stands in for.
+   */
+  int MAX_ATTEMPTS = 3;
+
+  /**
    * Atomically claims the live slot for this (player, platform, startMonth, endMonth,
    * excludeBullet), returning either a freshly created request or the one that already holds it.
    *
@@ -23,8 +38,10 @@ public interface IndexingRequestStore {
    * <p>The caller must dispatch work only when {@link Claim#created()} is true. Adopting means
    * another caller already owns the work.
    *
-   * <p>Implementations also retire rows stranded past {@code staleAfter} as part of the same atomic
-   * step, so an abandoned request cannot hold the slot against its replacement.
+   * <p>Implementations settle any abandoned holder first, as part of the same atomic step. Usually
+   * that means releasing it back to the queue and letting this caller adopt it rather than start a
+   * rival; only a request whose attempts are spent is retired, which frees the key so an insert can
+   * succeed. See {@link #reclaimStale}.
    */
   Claim createOrAdopt(
       String player,
@@ -32,8 +49,30 @@ public interface IndexingRequestStore {
       String startMonth,
       String endMonth,
       boolean excludeBullet,
+      boolean skipCache,
       Duration staleAfter,
       Instant now);
+
+  /**
+   * Takes the oldest live request nobody currently holds, and returns it — the table used as the
+   * work queue.
+   *
+   * <p>This is what lets any worker run any request. Before it, a request could only ever be
+   * processed by the process that accepted the submit, because the message went into that JVM's
+   * {@code InMemoryIndexQueue}: adding an instance added no throughput for work already queued, a
+   * restart lost the messages while the rows survived, and the two-JVM deployment sent load
+   * wherever the submit happened to arrive.
+   *
+   * <p>Selection then {@link #claim}, rather than one statement, and deliberately so. {@code SELECT
+   * ... FOR UPDATE SKIP LOCKED} would be the obvious shape and H2 does not have it; the conditional
+   * UPDATE {@code claim} already performs is what makes this safe without it, since at most one
+   * racer's WHERE can match. Losing the race costs a retry against the next candidate, not
+   * correctness.
+   *
+   * <p>Ordered oldest-first because the queue it replaces was FIFO. Rows whose attempts are
+   * exhausted are skipped — see {@link #reclaimStale}.
+   */
+  Optional<IndexingRequest> claimNext(String ownerId, Duration lease, Instant now);
 
   Optional<IndexingRequest> findById(UUID id);
 
@@ -41,54 +80,64 @@ public interface IndexingRequestStore {
    * Returns the live request with the same (player, platform, startMonth, endMonth, excludeBullet),
    * if there is one. Used to avoid creating duplicate indexing work.
    *
-   * <p>"Live" here must mean exactly what it means to {@link #reclaimStale} — the same two arms,
-   * negated. A claimed request is live while its lease holds; an unclaimed one is live until {@code
-   * staleAfter}. Answering that question two different ways on one submit is a bug with a long
-   * tail: this read runs first and short-circuits, so a laxer predicate here silently overrides the
-   * stricter reclamation behind it, and a request whose worker was killed keeps being handed back
-   * to callers for the full hour instead of the lease's few minutes.
+   * <p>Live means "still holds this range", which since #1279 is a narrower question than it looks.
+   * A request whose worker died is still live: the work goes back in the queue, so a second submit
+   * should adopt it rather than start a rival for the same games. A request sitting unclaimed is
+   * live for the same reason. What ends a claim on a range is exhausting the attempts — after that
+   * no worker may take it again, so it cannot go on holding the range against a resubmit.
+   *
+   * <p>Takes no clock, because it no longer ages rows out itself. That duplicated {@link
+   * #reclaimStale}'s judgement, and once the stalled arm grew a fleet-liveness probe the two
+   * answers diverged — this one would disown a queued row that reclamation would rightly leave
+   * alone. The question is now purely "does a row still hold this range", and the clock belongs to
+   * the one operation that settles rows.
+   *
+   * <p>Which leaves this with no production caller, and it should not acquire one — the same rule
+   * {@link #holdsLease} is under, for the same reason. Reading this and then acting on the answer
+   * is a check-then-act: two submits can both see nothing and both insert, which is the race {@link
+   * #createOrAdopt} exists to close by folding the read into the claim. And since the read cannot
+   * judge staleness any more, a caller that short-circuits on it skips the settle that {@code
+   * createOrAdopt} does first, so a row nobody will ever run goes on answering resubmits forever.
+   * Kept for tests and diagnostics, where "does anything hold this range" is a question worth
+   * asking on its own.
    */
   Optional<IndexingRequest> findExistingRequest(
-      String player,
-      String platform,
-      String startMonth,
-      String endMonth,
-      boolean excludeBullet,
-      Duration staleAfter,
-      Instant now);
+      String player, String platform, String startMonth, String endMonth, boolean excludeBullet);
 
   List<IndexingRequest> listRecent(int limit);
 
   void updateStatus(UUID id, String status, String errorMessage, int gamesIndexed);
 
   /**
-   * Retires live requests nobody is working on, freeing the dedupe slot and the lease each one
-   * holds. Returns the number retired.
-   *
-   * <p>Two different questions, deliberately kept apart:
+   * Settles every request nobody is working on, and returns how many it touched. Three outcomes,
+   * because "nobody is working on it" has three different meanings once the table is the queue.
    *
    * <ul>
-   *   <li><b>Claimed, lease expired.</b> Someone took this and stopped renewing, so the owner is
-   *       gone. Decided by {@link RetentionPolicy#LEASE}, in minutes.
-   *   <li><b>Never claimed, and old.</b> Nobody ever picked it up. Decided by {@code staleAfter},
-   *       in hours, because there is no owner whose silence could be measured — only the age of the
-   *       row itself.
+   *   <li><b>Released.</b> A lease expired with attempts to spare. The owner is gone; the work is
+   *       not. The row is unclaimed and left live for the next worker, keeping its {@code
+   *       dedupe_key} because the range is still spoken for. This is the common case and it is
+   *       silent — telling the user anything here would be a lie about work that is about to run.
+   *   <li><b>Poisoned.</b> Claimed {@code MAX_ATTEMPTS} times, each worker stopping before it
+   *       finished. Releasing is unbounded by construction, so without this a request that kills
+   *       the process handling it tours the fleet forever, costing a worker each lap — a
+   *       possibility that did not exist while a crashed process took its queue down with it.
+   *   <li><b>Stalled.</b> Nobody holds it, nothing has touched it in {@code staleAfter}, and no
+   *       worker <em>anywhere</em> holds a live lease. Every instance is down or partitioned, so
+   *       nothing is going to run this and the user is owed an answer. Silence is the worse one.
    * </ul>
    *
-   * <p>Conflating those two is what made a slow request indistinguishable from a dead one: a
-   * running worker that simply had nothing to report for an hour was retired underneath itself. A
-   * request being worked on now renews, and renewal is a claim about the owner rather than about
-   * progress, so it stays alive however long a month takes.
+   * <p>That last clause is doing real work, and leaving it out would recreate the bug two previous
+   * changes were spent removing. Age alone cannot distinguish "nothing is serving this" from "my
+   * turn has not come": one worker draining a deep backlog leaves rows at the back untouched for as
+   * long as the backlog takes, and retiring those tells users to resubmit work that was about to
+   * start. A live lease held by anyone is proof the fleet is working.
    *
-   * <p>Retiring makes a request reclaimable; it does not hand it to anyone. There is no scanner for
-   * expired leases and no re-dispatch — the row goes FAILED, the range becomes requestable, and the
-   * user resubmits. Actual takeover is #1279.
-   *
-   * <p>The unclaimed arm still has the gap it always had, and ownership made its consequence worse:
-   * a message waiting in a process-local queue has no owner to renew for it, so a backlog deeper
-   * than {@code staleAfter} retires work that is owned and about to run — and the worker that
-   * eventually reaches it now declines the retired row instead of indexing it anyway. Closing that
-   * means dispatch pulling from this table instead of an in-memory queue (#1279).
+   * <p>Implementations must apply the arms <b>poisoned, stalled, released</b> — which is not the
+   * order they are listed in above, because that list is ordered by how often each happens rather
+   * than by precedence. Two overlaps force it. A row whose attempts are spent is usually also
+   * unheld and old, so it matches the stalled arm as well; both retire it, but only one gives the
+   * user the real reason. And releasing stamps {@code updated_at}, which makes a row look freshly
+   * touched and hides it from the stalled arm for another whole window.
    */
   int reclaimStale(Duration staleAfter, Instant now);
 
@@ -184,5 +233,7 @@ public interface IndexingRequestStore {
       Instant updatedAt,
       String errorMessage,
       int gamesIndexed,
-      boolean excludeBullet) {}
+      boolean excludeBullet,
+      boolean skipCache,
+      int attempts) {}
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java
@@ -173,6 +173,29 @@ public interface IndexingRequestStore {
   boolean renewLease(UUID id, String ownerId, Duration lease, Instant now);
 
   /**
+   * Gives a claimed request back to the queue, unspent. Returns false if {@code owner_id} no longer
+   * names this caller — someone else has it, and unclaiming it would strand them mid-run.
+   *
+   * <p>For a worker that is going away on purpose. {@link #reclaimStale}'s release arm covers the
+   * owner that stopped answering, but it can only act once the lease has lapsed, because a lapsed
+   * lease is the only evidence it has. A process being shut down knows sooner and can say so, which
+   * turns five minutes of a stranded range into none.
+   *
+   * <p>It also returns the attempt, and that is the part that matters. {@code attempts} is spent on
+   * claim so that a request which kills its worker outright still moves the counter — necessary,
+   * and the reason the counter cannot tell a crash from a deploy on its own. Every process exit
+   * would otherwise look like the request killed it, and a long-running request outliving three
+   * rolling restarts would be retired as poisoned, telling the user its range fails repeatedly
+   * about a fleet that is working perfectly. A hand-back is the missing evidence: the worker
+   * survived long enough to say it was leaving, which is exactly what a killer request prevents.
+   *
+   * <p>Lenient about expiry, like {@link #renewLease} and for the same reason — a lease that lapsed
+   * without anyone taking it is still this caller's to give back. Keeps {@code lease_expires_at},
+   * because a fleet mid-deploy is the worst possible moment to look dead to {@link #reclaimStale}.
+   */
+  boolean handBack(UUID id, String ownerId, Instant now);
+
+  /**
    * True if {@code ownerId} still holds a live, unexpired lease on this request.
    *
    * <p>Has no production caller, and should not acquire one: asking this before a write would be a

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -339,10 +339,14 @@ public class Migration {
    * <p>Both default for existing rows, and both defaults are the pre-#1279 behaviour: requests in
    * flight during a deploy did not skip the cache and have not been attempted by a table-claiming
    * worker.
+   *
+   * <p>The DEFAULT is the whole backfill. Both engines fill existing rows from it as the column is
+   * added, so there is no second statement to write — and an earlier version of this that added one
+   * anyway was dead code that no test could distinguish from the DEFAULT doing its job. Both
+   * columns are read as primitives ({@code getBoolean}, {@code getInt}), so a NULL would silently
+   * arrive as false or zero rather than failing; the DEFAULT is what keeps that from being
+   * load-bearing.
    */
-  // Belt and braces: both engines fill existing rows from the DEFAULT when the column is added, so
-  // this should be a no-op — but the reader treats these as primitives, and a NULL would arrive as
-
   private static final String[] ADD_DISPATCH_COLUMNS = {
     // The DEFAULTs are what backfills existing rows — both engines apply them when the column is
     // added, so a request in flight during a deploy comes out as "do not skip the cache, never

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -321,6 +321,63 @@ public class Migration {
       "CREATE INDEX IF NOT EXISTS idx_indexing_requests_lease"
           + " ON indexing_requests(status, lease_expires_at)";
 
+  /**
+   * Columns that make the table dispatchable (#1279).
+   *
+   * <p>{@code skip_cache} has to be persisted because it stops being the submitter's business the
+   * moment any worker can pick the row up. Every other field a run needs is already a column; this
+   * one lived only in the queue message, so a worker claiming from the table would silently honour
+   * the period cache for a request that asked to bypass it.
+   *
+   * <p>{@code attempts} is the bound that replaces "nobody ever picked this up". Once an expired
+   * lease returns work to the queue instead of retiring it, a request that reliably kills its
+   * worker is retried forever, across every instance — a possibility that did not exist while a
+   * crashed process took its queue with it. Incremented on each claim, so it counts attempts and
+   * not failures, which is the conservative direction: a worker killed before it could report
+   * anything still moves the counter.
+   *
+   * <p>Both default for existing rows, and both defaults are the pre-#1279 behaviour: requests in
+   * flight during a deploy did not skip the cache and have not been attempted by a table-claiming
+   * worker.
+   */
+  // Belt and braces: both engines fill existing rows from the DEFAULT when the column is added, so
+  // this should be a no-op — but the reader treats these as primitives, and a NULL would arrive as
+
+  private static final String[] ADD_DISPATCH_COLUMNS = {
+    // The DEFAULTs are what backfills existing rows — both engines apply them when the column is
+    // added, so a request in flight during a deploy comes out as "do not skip the cache, never
+    // attempted", which is exactly its pre-#1279 behaviour. Both are read as primitives, so a NULL
+    // here would arrive silently as the same values without anyone having decided that.
+    "ALTER TABLE indexing_requests ADD COLUMN IF NOT EXISTS skip_cache BOOLEAN DEFAULT FALSE",
+    "ALTER TABLE indexing_requests ADD COLUMN IF NOT EXISTS attempts INT DEFAULT 0",
+  };
+
+  /**
+   * What {@code claimNext} scans: the oldest live row nobody currently holds, on a query every
+   * instance runs every few seconds. Ordered by {@code created_at} because the queue it replaces
+   * was FIFO, and a poller that skipped ahead would starve the front under sustained load.
+   *
+   * <p>Partial on Postgres, and that is not a preference. Postgres before 17 cannot emit btree
+   * output already ordered on a trailing column when the leading one sits under a {@code
+   * ScalarArrayOp}, which {@code status IN (...)} is — so a composite {@code (status, created_at)}
+   * is never chosen, and forcing it still produces a full top-N sort of every live row. Measured at
+   * 200k rows with 10k live, the partial index planned three orders of magnitude cheaper. Worth
+   * pinning explicitly because CI runs {@code postgres:18}, where ordered SAOP scans do exist and
+   * the composite would have looked perfectly healthy.
+   */
+  private static final String CREATE_IDX_REQUESTS_CLAIMABLE_PG =
+      "CREATE INDEX IF NOT EXISTS idx_indexing_requests_claimable"
+          + " ON indexing_requests(created_at) WHERE status IN ('PENDING', 'PROCESSING')";
+
+  /**
+   * The same index for H2, which has no partial indexes. The composite is what a partial index
+   * approximates there, and H2 is the test engine rather than the deployment target, so the cost of
+   * it being the weaker plan is a slower test rather than a slower production poll.
+   */
+  private static final String CREATE_IDX_REQUESTS_CLAIMABLE_H2 =
+      "CREATE INDEX IF NOT EXISTS idx_indexing_requests_claimable"
+          + " ON indexing_requests(status, created_at)";
+
   // The retention sweep's anti-join (deleteOlderThan) filters indexing_requests on an hourly
   // schedule by "does any game still point at me". Without this, EXPLAIN shows a hash anti-join
   // over a sequential scan of game_features — the largest table in the schema. Neither engine
@@ -415,6 +472,12 @@ public class Migration {
         stmt.execute(add);
       }
       stmt.execute(CREATE_IDX_REQUESTS_LEASE);
+
+      // Table-backed dispatch.
+      for (String add : ADD_DISPATCH_COLUMNS) {
+        stmt.execute(add);
+      }
+      stmt.execute(useH2 ? CREATE_IDX_REQUESTS_CLAIMABLE_H2 : CREATE_IDX_REQUESTS_CLAIMABLE_PG);
 
       LOG.info("Database migration completed successfully (H2={})", useH2);
     } catch (SQLException e) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java
@@ -33,39 +33,26 @@ public final class RetentionPolicy {
   public static final Duration REQUEST = Duration.ofDays(30);
 
   /**
-   * How long a live request that <em>nobody has claimed</em> may sit before it is presumed orphaned
-   * and retired to FAILED.
+   * How long a request may sit untouched, with no worker running anywhere, before it is retired and
+   * the user is told.
    *
-   * <p>Without a bound, a single stranded row blocks its (player, platform, month range) forever:
-   * dedupe keeps returning it, and the unique constraint on {@code dedupe_key} keeps a replacement
-   * from being created. Rows get stranded by ordinary events — a restart with work still in the
-   * process-local queue, or an inline MCP dispatch that throws before the worker takes ownership —
-   * so "rare" is not the same as "never".
+   * <p>This used to mean "nobody ever picked this up, so it is orphaned" — a reasonable reading
+   * while dispatch came from a process-local queue, where a row nobody had claimed usually meant a
+   * message that died with its process. Once workers claim from the table (#1279), an unclaimed row
+   * is simply queued, and retiring it on age alone throws away work that was about to run and tells
+   * the user to resubmit into the same queue.
    *
-   * <p>This is measured in hours because it is the wrong question asked of an unanswerable
-   * situation. There is no owner whose silence could be measured, so the only evidence is the age
-   * of the row, and the row's age says nothing about whether the work is about to start. For a
-   * request that <em>has</em> been claimed there is a better question and a much shorter clock: see
-   * {@link #LEASE}.
+   * <p>So the window survives, but qualified: it fires only when no worker anywhere holds a live
+   * lease. That is the difference between a backlog and an outage. A backlog is the system working;
+   * an outage — every instance down, or partitioned from this database — is the one case where
+   * nothing will ever pick the work up, and the user needs an answer rather than an indefinite
+   * PENDING. See {@link IndexingRequestStore#reclaimStale}.
    *
-   * <p>What the hour still does not cover is time spent waiting in the queue, and the cost of that
-   * went <em>up</em> when ownership arrived. {@code InMemoryIndexQueue} is drained by a single
-   * thread, and a queued message has no worker holding a lease for it, so its {@code updated_at}
-   * stays frozen at insert and a backlog deeper than an hour retires work that is owned and about
-   * to run. The worker then reaches the message, fails to claim a retired row, and declines: the
-   * indexing does not happen at all. Before ownership it carried on and its unfenced terminal write
-   * landed, so the user got their games — at the cost of exactly the concurrent-writer corruption
-   * this design prevents, since the freed dedupe slot may already have started a replacement.
-   *
-   * <p>Neither answer is right, and a bigger number only makes the wrong one slower. The fix is for
-   * queued work not to be invisible: dispatch claiming from this table instead of from memory,
-   * tracked as #1279.
-   *
-   * <p>The invariant that {@link #REQUEST} must exceed {@link #PERIOD} is asserted in {@code
-   * IndexE2ETest} alongside the existing check on PERIOD, not in a static initializer here. These
-   * are compile-time constants a few lines apart, so a violation can only be introduced by editing
-   * this file — and a static block would report it as an {@code ExceptionInInitializerError} during
-   * Micronaut startup rather than as a failing test.
+   * <p>An hour is generous for detecting an outage and harmless for a healthy fleet, where a queued
+   * request is claimed within seconds and its {@code updated_at} moves. The invariant that {@link
+   * #REQUEST} must exceed {@link #PERIOD} is asserted in {@code IndexE2ETest} rather than in a
+   * static initializer here, where a violation would surface as an {@code
+   * ExceptionInInitializerError} during Micronaut startup instead of as a failing test.
    */
   public static final Duration STALE_REQUEST = Duration.ofHours(1);
 
@@ -77,15 +64,11 @@ public final class RetentionPolicy {
    * nobody owns. This asks "is the owner still there?", which the owner itself answers by renewing
    * every {@link #LEASE_RENEWAL}, so it can be decided in minutes rather than an hour.
    *
-   * <p>What "decided" means today is narrower than it sounds, and worth stating rather than
-   * implying. A lapsed lease makes the request <em>reclaimable</em>; nothing picks it up. {@code
-   * IndexWorker.process} is the only caller of {@code claim}, and it runs on a dispatched message,
-   * so there is no scanner looking for expired leases and no re-dispatch. The row is retired to
-   * FAILED and the range becomes requestable again — the user resubmits. Reclamation itself is only
-   * as prompt as its caller: {@code RetentionWorker} is on an hourly schedule, and the only faster
-   * path is {@code createOrAdopt}, which retires the key it is about to claim. So the five minutes
-   * bounds when a lapse <em>may</em> be acted on, not when it is. Actually handing the range to
-   * another worker is #1279.
+   * <p>A lapsed lease returns the work to the queue rather than ending it: the sweep clears the
+   * owner and any worker may claim it next (#1279). The five minutes still bounds when that
+   * <em>may</em> happen rather than when it does, because reclamation is only as prompt as its
+   * caller — {@code RetentionWorker} runs hourly, and the one faster path is {@code createOrAdopt}
+   * settling the key it is about to claim.
    *
    * <p>Five minutes is four renewal intervals: three consecutive misses are survivable and expiry
    * lands on the fourth. Short enough that a crashed instance does not strand a range for longer

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
@@ -118,8 +118,8 @@ com.muchq.indexer/
 ### Indexing
 
 1. Client sends `POST /v1/index` with player, platform, month range
-2. `IndexController` creates a row in `indexing_requests` (status=PENDING), enqueues an `IndexMessage`
-3. `IndexWorkerLifecycle` daemon thread polls the queue
+2. `IndexController` creates a row in `indexing_requests` (status=PENDING). That row *is* the work queue; an `IndexMessage` is also enqueued locally, but only as a wake-up nudge whose payload is ignored
+3. `IndexWorkerLifecycle` on any instance claims the oldest unheld row (`claimNext`), taking a lease it renews for the duration
 4. `IndexWorker.process()`:
    - Sets status to PROCESSING
    - Iterates months, fetches games from chess.com API via `ChessClient`
@@ -154,7 +154,9 @@ com.muchq.indexer/
 | exclude_bullet | BOOLEAN     | Part of the dedupe tuple       |
 | dedupe_key    | VARCHAR      | UNIQUE. Held while live, NULLed on a terminal status — one live request per (player, platform, range, exclude_bullet) |
 | owner_id      | VARCHAR(128) | The worker process holding the lease; the fencing token every write is conditioned on |
-| lease_expires_at | TIMESTAMP | Renewed every 75s while the owner is alive. Past this the request is reclaimable |
+| lease_expires_at | TIMESTAMP | Renewed every 75s while the owner is alive. Past this the request is reclaimable. Deliberately survives a terminal write, as the record of when a worker last held the row |
+| skip_cache    | BOOLEAN      | Persisted so a worker on any instance honours what the submitter asked for |
+| attempts      | INT          | Claims so far. Bounds the requeue loop for a request that keeps killing its worker |
 
 ### game_features
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/DESIGN.md
@@ -13,35 +13,48 @@ A Micronaut service that indexes chess games from chess.com (lichess planned), e
                          │   Client     │
                          └──────┬───────┘
                                 │
-                    ┌───────────▼────────────┐
-                    │    Micronaut HTTP       │
-                    │  (Netty + JAX-RS)      │
-                    ├────────────┬───────────┤
-                    │ IndexCtrl  │ QueryCtrl │
-                    └─────┬──────┴─────┬─────┘
-                          │            │
-                 ┌────────▼──┐   ┌─────▼──────────┐
-                 │IndexQueue │   │  ChessQL        │
-                 │(in-memory)│   │  Lexer→Parser→  │
-                 └────┬──────┘   │  Compiler→SQL   │
-                      │          └─────┬───────────┘
-                ┌─────▼──────┐         │
-                │IndexWorker │         │
-                │  (daemon)  │         │
-                └─────┬──────┘         │
-                      │                │
-           ┌──────────▼─────┐          │
-           │ FeatureExtract │          │
-           │  PgnParser     │          │
-           │  GameReplayer  │          │
-           │  MotifDetect[] │          │
-           └──────┬─────────┘          │
-                  │                    │
-            ┌─────▼────────────────────▼──┐
-            │         PostgreSQL          │
-            │  indexing_requests          │
-            │  game_features             │
-            └─────────────────────────────┘
+                    ┌───────────▼───────────┐
+                    │    Micronaut HTTP     │
+                    │   (Netty + JAX-RS)    │
+                    ├───────────┬───────────┤
+                    │ IndexCtrl │ QueryCtrl │
+                    └─────┬─────┴─────┬─────┘
+                          │           │
+                   INSERT PENDING      │
+                          │     ┌─────▼───────────┐
+                          │     │  ChessQL        │
+                          │     │  Lexer→Parser→  │
+                          │     │  Compiler→SQL   │
+                          │     └─────┬───────────┘
+                          │           │
+     ┌────────────────────▼────────┐  │
+     │  indexing_requests          │  │   IndexQueue (in-memory)
+     │  — the work queue —         │  │   wake-up nudge only,
+     └────┬───────────────▲────────┘  │   payload ignored
+      claimNext     fenced writes     │            ╎
+          │               │           │            ╎
+          │      ┌────────┴──────┐    │            ╎
+          └─────►│  IndexWorker  │◄╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╯
+                 │   (daemon,    │    │
+                 │    any host)  │    │
+                 └───────┬───────┘    │
+                         │            │
+              ┌──────────▼─────┐      │
+              │ FeatureExtract │      │
+              │  PgnParser     │      │
+              │  GameReplayer  │      │
+              │  MotifDetect[] │      │
+              └──────┬─────────┘      │
+                     │                │
+               ┌─────▼────────────────▼──────┐
+               │      PostgreSQL / H2        │
+               │  indexing_requests          │
+               │  game_features              │
+               │  motif_occurrences          │
+               └─────────────────────────────┘
+
+Any instance's worker may claim any queued row, so the arrow into IndexWorker
+is not the nudge — the nudge only saves it waiting out the poll interval.
 ```
 
 ## Package Structure

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/IN_PROCESS_MODE.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/IN_PROCESS_MODE.md
@@ -27,7 +27,8 @@ curl -X POST http://localhost:8080/v1/query \
 
 ## Overview
 
-**In-process mode is the default.** The indexer runs with no external dependencies — no PostgreSQL, no SQS, no S3. Everything lives in-process using an in-memory queue and an H2 in-memory database.
+**In-process mode is the default.** The indexer runs with no external dependencies — no PostgreSQL, no SQS, no S3. Everything lives in-process against an H2 in-memory database, which is also the work queue —
+the in-memory `IndexQueue` survives only as a wake-up nudge.
 
 This mode is useful for:
 - Local development without Docker or PostgreSQL installed
@@ -226,7 +227,7 @@ The system auto-detects H2 vs PostgreSQL from the JDBC URL and uses the appropri
 - Full ChessQL query support
 - Full motif detection pipeline
 - chess.com API fetching (still makes real HTTP calls)
-- Concurrent indexing requests via the queue
+- Concurrent indexing requests, claimed from `indexing_requests` by the in-process worker
 
 ### What Doesn't Persist
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/IN_PROCESS_MODE.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/IN_PROCESS_MODE.md
@@ -46,12 +46,13 @@ To use PostgreSQL instead, set the `INDEXER_DB_URL` environment variable to a Po
 │                                               │
 │  ┌───────────┐   ┌──────────────────────┐    │
 │  │ HTTP API  │   │  InMemoryIndexQueue   │    │
-│  │ /v1/index ├──►│  (LinkedBlockingQueue) │    │
+│  │ /v1/index ├──►│  (wake-up nudge only)  │    │
 │  │ /v1/query │   └──────────┬───────────┘    │
-│  └─────┬─────┘              │                │
+│  └─────┬─────┘              ╎ (nudge)        │
 │        │              ┌─────▼──────┐         │
-│        │              │IndexWorker │         │
-│        │              └─────┬──────┘         │
+│        │              │IndexWorker │◄────────┼─ claims from
+│        │              └─────┬──────┘         │  indexing_requests
+│        │                    │                │
 │        │                    │                │
 │        │    ┌───────────────▼──────────────┐ │
 │        └───►│       H2 (in-memory)         │ │

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/IndexRequestService.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/service/IndexRequestService.java
@@ -63,8 +63,7 @@ public class IndexRequestService {
 
   /**
    * @param skipCache refetch every month in the range instead of serving any of them from the
-   *     indexed-period cache, and skip the dedupe read — the backfill path for rows indexed before
-   *     newer columns existed.
+   *     indexed-period cache — the backfill path for rows indexed before newer columns existed.
    *     <p>It does not permit a second concurrent run of the same range. If a live request already
    *     holds that (player, platform, month range, excludeBullet), this returns that request rather
    *     than starting a rival one: two indexers over the same games interleave {@code
@@ -122,26 +121,16 @@ public class IndexRequestService {
           "Maximum range is " + MAX_MONTH_SPAN + " months, got " + monthSpan);
     }
 
-    if (!submission.skipCache()) {
-      Optional<IndexingRequestStore.IndexingRequest> existing =
-          requestStore.findExistingRequest(
-              player,
-              platform,
-              submission.startMonth(),
-              submission.endMonth(),
-              submission.excludeBullet(),
-              RetentionPolicy.STALE_REQUEST,
-              clock.instant());
-      if (existing.isPresent()) {
-        return toResponse(existing.get());
-      }
-    }
-
-    // Even on the skipCache path this goes through createOrAdopt rather than a bare insert. The
-    // read above is an optimization — it answers a duplicate submit without touching the write
-    // path — but it cannot be the thing that prevents double-dispatch, because two callers can
-    // both read nothing. The claim is what decides, and only a caller that actually created the
-    // row is allowed to dispatch work for it.
+    // One question, one call. createOrAdopt settles the key first and then either adopts the row
+    // that holds it or inserts, so it answers a duplicate submit as well as a fresh one, and only
+    // a caller that actually created the row is allowed to dispatch work for it.
+    //
+    // A findExistingRequest read used to short-circuit ahead of this as an optimization, skipped
+    // on skipCache. Both paths converged here anyway, so it saved a settle on duplicate submits
+    // and nothing else — and once #1279 took the clock out of that read, what it saved was the
+    // settle. A row nobody will ever run still reads as live, so the short-circuit answered every
+    // resubmit with it and never reached the reclaim that would have retired it and freed the
+    // range. The submit path is the one prompt reclaimer there is; RetentionWorker is hourly.
     IndexingRequestStore.Claim claim =
         requestStore.createOrAdopt(
             player,
@@ -149,6 +138,7 @@ public class IndexRequestService {
             submission.startMonth(),
             submission.endMonth(),
             submission.excludeBullet(),
+            submission.skipCache(),
             RetentionPolicy.STALE_REQUEST,
             clock.instant());
     if (!claim.created()) {
@@ -166,11 +156,10 @@ public class IndexRequestService {
             submission.skipCache());
 
     if (inlineSingleMonth && monthSpan <= 1) {
-      // The inline path has no queue entry and no other owner: if this throws, nothing else will
-      // ever move the row off PENDING, and it holds its dedupe slot until the staleness sweep
-      // notices an hour later. IndexWorker.process already catches Exception and marks FAILED, so
-      // reaching here means its own status write failed or an Error escaped — rare, but the row
-      // is stranded either way. Retire it on the way out so the range frees immediately.
+      // The row is the queue now, so a throw here no longer strands it — a poller will claim it,
+      // on this instance or another. This handler is still worth having: it turns an Error that
+      // escaped IndexWorker.process into a recorded outcome rather than a silent requeue, and
+      // submitHybrid's caller is waiting for an answer rather than polling for one.
       try {
         inlineProcessor.accept(message);
       } catch (Throwable t) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -117,6 +117,18 @@ public class IndexWorker {
   private final Set<UUID> inFlight = ConcurrentHashMap.newKeySet();
 
   /**
+   * A snapshot of what this process is running, for the shutdown path to hand back.
+   *
+   * <p>A live view rather than a copy would be worse than useless here: the caller iterates it
+   * while runs are still finishing and removing themselves, so it would be racing the very set it
+   * is reading. Both entry points register here, so a request picked up inline is handed back on
+   * shutdown just like a claimed one — the JVM is going away either way.
+   */
+  public Set<UUID> inFlight() {
+    return Set.copyOf(inFlight);
+  }
+
+  /**
    * How often the lease is renewed. Paced against {@link RetentionPolicy#LEASE}, not against {@link
    * RetentionPolicy#STALE_REQUEST}: the hour is how long an <em>unclaimed</em> row may sit before
    * it is presumed orphaned, and beating on that schedule against a five-minute lease would let
@@ -361,6 +373,10 @@ public class IndexWorker {
               message.player(),
               monthStr);
         }
+        // Unfenced, like the 404 path above and for the same reason — indexed_periods is keyed by
+        // (player, platform, month), so there is no request to condition the write on. What keeps
+        // it safe is order: the flushBatch immediately above checks ownership and throws if this
+        // worker has lost it, so this line is unreachable without a live lease.
         upsertPeriod(message, monthStr, month, fetchedAt, monthCount, titleResolution.degraded());
         progress(message.requestId(), totalIndexed);
       }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -95,6 +96,25 @@ public class IndexWorker {
   public String ownerId() {
     return ownerId;
   }
+
+  /**
+   * Requests this process is running right now.
+   *
+   * <p>The lease cannot do this job, and that is not a gap in the lease — it is what the lease is.
+   * {@code ownerId} names the <em>process</em> so that a run can renew across its own retries, and
+   * {@link IndexingRequestStore#claim} therefore admits its own holder. Correct for the question it
+   * answers ("may this process write?"), and useless for a different one ("is this process already
+   * running this?").
+   *
+   * <p>Since #1279 there are two ways into a run and both live here: the poller, which claims from
+   * the table, and {@code submitHybrid}'s inline dispatch, which hands the message straight over.
+   * They can pick up the same row — the poller can claim it in the gap between {@code
+   * createOrAdopt} committing and the inline call starting — and both claims succeed, because they
+   * present the same token. Every fence downstream then passes for both, so the range is fetched
+   * and extracted twice, one run's terminal write is refused, and nothing says so. Across two
+   * processes the lease handles it; within one, only this does.
+   */
+  private final Set<UUID> inFlight = ConcurrentHashMap.newKeySet();
 
   /**
    * How often the lease is renewed. Paced against {@link RetentionPolicy#LEASE}, not against {@link
@@ -184,19 +204,29 @@ public class IndexWorker {
         message.player(),
         message.platform());
 
+    if (!inFlight.add(message.requestId())) {
+      LOG.info(
+          "Skipping request {}: this process is already running it. The poller and an inline"
+              + " dispatch both reached it; one run is enough.",
+          message.requestId());
+      return;
+    }
+    try {
+      claimAndRun(message);
+    } finally {
+      inFlight.remove(message.requestId());
+    }
+  }
+
+  private void claimAndRun(IndexMessage message) {
     if (!requestStore.claim(message.requestId(), ownerId, RetentionPolicy.LEASE, clock.instant())) {
       // Three causes, and the message must not pick one: a live rival holds the lease, the row
       // reached a terminal status, or it is gone. Only the first is benign — it means the work is
       // already owned and doing it again would put two writers on the same games.
       //
-      // The second is not benign and is the known cost of dispatching from a process-local queue.
-      // A message that waits longer than the unclaimed cutoff has its row retired underneath it,
-      // and this worker then declines the work rather than doing it: the dedupe slot is free, so a
-      // replacement may already be running the range. Before ownership existed the worker carried
-      // on and its unfenced terminal write landed, so the user got their games — at the cost of
-      // exactly the concurrent-writer corruption this change prevents. Neither answer is right;
-      // the fix is for queued work not to be retired at all, which needs dispatch to claim from
-      // the table rather than from memory (#1279).
+      // The second means the sweep has already given up on this request — its attempts are spent,
+      // or nothing was running anywhere for long enough that the user was told it failed. Either
+      // way it is not this worker's to resume.
       LOG.warn(
           "Declining request {}: it is not available to claim (already held, or retired while"
               + " queued). No games will be indexed for it.",

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycle.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycle.java
@@ -9,6 +9,7 @@ import io.micronaut.runtime.server.event.ServerStartupEvent;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Optional;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,7 +137,45 @@ public class IndexWorkerLifecycle implements ApplicationEventListener<ServerStar
     }
   }
 
+  /**
+   * Stops taking work, and gives back whatever this process is holding.
+   *
+   * <p>Wired as the bean's {@code preDestroy} in both modules, which is the whole point — the
+   * poller is a daemon thread, so without this a deploy is indistinguishable from a crash. The row
+   * stays owned by a process that no longer exists, nothing may take it until the lease lapses five
+   * minutes later, and the attempt spent claiming it is gone. A long-running request that outlives
+   * three rolling restarts is then retired as poisoned, telling the user its range fails repeatedly
+   * about a fleet that is working perfectly.
+   *
+   * <p>It hands back rather than draining, and that is deliberate. An indexing run has no bound — a
+   * twelve-month range against a slow chess.com is legitimately long — so a shutdown that waits for
+   * one is a shutdown that hangs, and the container kills it anyway. Handing back is what a drain
+   * was for: the work moves to a surviving instance immediately, unspent.
+   *
+   * <p>The departing run is not interrupted. It may still be mid-fetch when its row changes hands,
+   * and it needs no stopping — every write it makes is fenced on ownership it no longer has, so the
+   * first one fails and the run unwinds itself. That is the same mechanism that protects against a
+   * lapsed lease, reached a few minutes earlier.
+   */
+  /**
+   * Whether this poller is still taking work. Exists so a test can boot a real context, close it,
+   * and check the container actually invoked {@link #stop} — an annotation the tests only read back
+   * off the factory method would prove nothing about whether Micronaut honours it.
+   */
+  public boolean isRunning() {
+    return running;
+  }
+
   public void stop() {
     running = false;
+    for (UUID id : worker.inFlight()) {
+      try {
+        requestStore.handBack(id, worker.ownerId(), clock.instant());
+      } catch (Exception e) {
+        // Shutdown must not throw. Failing here costs the lease's five minutes and one attempt —
+        // exactly the pre-#1279 behaviour — which is a worse outcome, not a broken one.
+        LOG.warn("Could not hand request {} back on shutdown", id, e);
+      }
+    }
   }
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycle.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycle.java
@@ -1,24 +1,62 @@
 package com.muchq.games.one_d4.worker;
 
+import com.muchq.games.one_d4.db.IndexingRequestStore;
+import com.muchq.games.one_d4.db.RetentionPolicy;
 import com.muchq.games.one_d4.queue.IndexMessage;
 import com.muchq.games.one_d4.queue.IndexQueue;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.runtime.server.event.ServerStartupEvent;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Pulls indexing work from {@code indexing_requests} and runs it.
+ *
+ * <p>The table is the queue. Before #1279 this loop drained an {@link IndexQueue} — a {@code
+ * LinkedBlockingQueue} inside one JVM — so a request could only ever be processed by the process
+ * that accepted the submit. Adding an instance added no throughput for work already queued; a
+ * restart lost the messages while the rows survived; and the documented two-JVM deployment (REST
+ * and MCP against one Postgres) sent load wherever the submit happened to land. Any worker can now
+ * take any request.
+ *
+ * <p>The queue is still here, demoted to a wake-up nudge. Polling alone would add up to {@link
+ * #IDLE_POLL} of latency to a freshly submitted request; the nudge removes that when the submit
+ * arrived at this instance, and losing it costs latency rather than work, because the row is in the
+ * table either way. Its payload is deliberately ignored — reading it would reintroduce the
+ * assumption that the message and the worker share a process.
+ *
+ * <p>Claiming is what makes concurrent pollers safe. {@link IndexingRequestStore#claimNext} hands
+ * back a request this worker now owns, and every write the run makes is fenced on that ownership
+ * (#1278), so two instances polling one table cannot end up on the same range.
+ */
 public class IndexWorkerLifecycle implements ApplicationEventListener<ServerStartupEvent> {
   private static final Logger LOG = LoggerFactory.getLogger(IndexWorkerLifecycle.class);
 
+  /**
+   * How long an idle poller waits for a nudge before asking the table again. The fallback matters
+   * on its own: work submitted to another instance produces no local nudge, so this bounds how long
+   * a request sits unclaimed when the instance that accepted it cannot run it.
+   */
+  private static final Duration IDLE_POLL = Duration.ofSeconds(5);
+
+  /** Backoff after a failed poll, so a database outage does not become a hot loop. */
+  private static final Duration ERROR_BACKOFF = Duration.ofSeconds(5);
+
   private final IndexQueue queue;
   private final IndexWorker worker;
+  private final IndexingRequestStore requestStore;
+  private final Clock clock;
   private volatile boolean running = true;
 
-  public IndexWorkerLifecycle(IndexQueue queue, IndexWorker worker) {
+  public IndexWorkerLifecycle(
+      IndexQueue queue, IndexWorker worker, IndexingRequestStore requestStore, Clock clock) {
     this.queue = queue;
     this.worker = worker;
+    this.requestStore = requestStore;
+    this.clock = clock;
   }
 
   @Override
@@ -26,17 +64,75 @@ public class IndexWorkerLifecycle implements ApplicationEventListener<ServerStar
     Thread pollerThread = Thread.ofVirtual().name("index-worker").unstarted(this::pollLoop);
     pollerThread.setDaemon(true);
     pollerThread.start();
-    LOG.info("Index worker started");
+    LOG.info("Index worker started, claiming as {}", worker.ownerId());
   }
 
   private void pollLoop() {
     while (running) {
       try {
-        Optional<IndexMessage> message = queue.poll(Duration.ofSeconds(5));
-        message.ifPresent(worker::process);
+        if (claimAndRunOne()) {
+          // Straight round rather than waiting: a backlog should drain at the speed of the work,
+          // not at the speed of the poll interval.
+          continue;
+        }
+        // Idle. Block for a nudge from a local submit, or time out and ask the table again — the
+        // timeout is what picks up work submitted to another instance.
+        queue.poll(IDLE_POLL);
       } catch (Exception e) {
         LOG.error("Error in index worker poll loop", e);
+        sleepQuietly(ERROR_BACKOFF);
       }
+    }
+  }
+
+  /** Discards pending wake-ups. Their payloads are irrelevant; only the wake-up ever mattered. */
+  private void drainNudges() {
+    while (queue.poll(Duration.ZERO).isPresent()) {
+      // Nothing to do with it. The table said what to run.
+    }
+  }
+
+  /** Returns true if a request was claimed and run, false if there was nothing to take. */
+  boolean claimAndRunOne() {
+    Optional<IndexingRequestStore.IndexingRequest> claimed =
+        requestStore.claimNext(worker.ownerId(), RetentionPolicy.LEASE, clock.instant());
+    if (claimed.isEmpty()) {
+      return false;
+    }
+    // process() re-claims, which is a no-op extension for the owner we already are — claim's
+    // predicate admits its own holder. Going through the same entry point as the inline path keeps
+    // one place where a run starts.
+    worker.process(toMessage(claimed.get()));
+    // Nudges are consumed on the working path too, not only when idle. This loop is the queue's
+    // only consumer and it never reaches the blocking poll while the table has work, so on a busy
+    // instance every accepted submit would leave a message behind forever — and the accumulated
+    // stale nudges would then fire back-to-back the moment things went quiet, defeating IDLE_POLL
+    // for that whole burst.
+    drainNudges();
+    return true;
+  }
+
+  /**
+   * Rebuilds the message from the row. Every field a run needs is a column, which is the property
+   * that makes this table dispatchable — {@code skip_cache} was the last one that was not, and a
+   * worker claiming this row would otherwise honour a cache the submitter asked to bypass.
+   */
+  private static IndexMessage toMessage(IndexingRequestStore.IndexingRequest r) {
+    return new IndexMessage(
+        r.id(),
+        r.player(),
+        r.platform(),
+        r.startMonth(),
+        r.endMonth(),
+        r.excludeBullet(),
+        r.skipCache());
+  }
+
+  private static void sleepQuietly(Duration duration) {
+    try {
+      Thread.sleep(duration.toMillis());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/RetentionWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/RetentionWorker.java
@@ -66,10 +66,10 @@ public class RetentionWorker {
     Instant now = clock.instant();
     Instant threshold = now.minus(RETENTION_PERIOD);
     try {
-      // Retire abandoned requests before deleting anything. A stranded PENDING row holds its
-      // dedupe slot until something retires it, and the submit path only reclaims the one tuple
-      // being submitted — a strand nobody re-submits would otherwise sit there until it aged out
-      // of the request window entirely.
+      // Settle abandoned requests before deleting anything. This is the only unconditional caller:
+      // the submit path reclaims too, but only the one tuple being submitted, so a row nobody
+      // re-submits would otherwise sit unsettled until it aged out of the request window entirely
+      // — never returned to the queue if its owner died, and never answered if the fleet did.
       int reclaimed = indexingRequestStore.reclaimStale(STALE_REQUEST_PERIOD, now);
 
       // Games before requests, because game_features.request_id is a foreign key onto
@@ -82,9 +82,11 @@ public class RetentionWorker {
       int periods = indexedPeriodStore.deleteOlderThan(threshold);
       int requests = indexingRequestStore.deleteOlderThan(now.minus(REQUEST_RETENTION_PERIOD));
 
+      // "Settled", not "retired": since #1279 most of this count is requests returned to the
+      // queue for another worker, not requests given up on. The DAO logs the split.
       LOG.info(
-          "Retention cleanup complete: deleted {} games, {} periods, {} requests; retired {}"
-              + " stranded requests",
+          "Retention cleanup complete: deleted {} games, {} periods, {} requests; settled {}"
+              + " abandoned requests",
           games,
           periods,
           requests,

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/IndexerModuleTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/IndexerModuleTest.java
@@ -3,16 +3,47 @@ package com.muchq.games.one_d4;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.muchq.games.one_d4.db.IndexingRequestStore;
+import com.muchq.games.one_d4.queue.IndexQueue;
+import com.muchq.games.one_d4.worker.IndexWorker;
+import io.micronaut.context.annotation.Bean;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class IndexerModuleTest {
 
   @TempDir Path tmp;
+
+  /**
+   * The poller is a daemon thread, so nothing stops it at shutdown unless the container is told to.
+   * Without this annotation a deploy is indistinguishable from a crash: the in-flight row stays
+   * owned by a process that no longer exists for a full lease, and the attempt it spent is gone.
+   *
+   * <p>Asserted on the factory method rather than by booting a context, because that is where the
+   * mistake would be made — the method is easy to edit without noticing the annotation, and
+   * IndexWorkerLifecycleTest already covers what stop() does once it is called. McpModuleTest boots
+   * a real context and closes it, which is where the container's half of this is exercised.
+   */
+  @Test
+  public void indexWorkerLifecycleIsToldToStopOnShutdown() throws Exception {
+    Bean bean =
+        IndexerModule.class
+            .getMethod(
+                "indexWorkerLifecycle",
+                IndexQueue.class,
+                IndexWorker.class,
+                IndexingRequestStore.class,
+                Clock.class)
+            .getAnnotation(Bean.class);
+
+    assertThat(bean).as("the lifecycle bean declares no preDestroy").isNotNull();
+    assertThat(bean.preDestroy()).isEqualTo("stop");
+  }
 
   @Test
   public void readJdbcUrl_returnsEnvVar_whenSet() {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
@@ -468,6 +468,12 @@ public class IndexControllerTest {
     }
 
     @Override
+    public boolean handBack(UUID id, String ownerId, Instant now) {
+
+      return false;
+    }
+
+    @Override
     public boolean holdsLease(UUID id, String ownerId, Instant now) {
       return true;
     }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/IndexControllerTest.java
@@ -87,7 +87,9 @@ public class IndexControllerTest {
             Instant.now(),
             null,
             50,
-            false));
+            false,
+            false,
+            0));
 
     IndexRequest request = new IndexRequest("hikaru", "CHESS_COM", "2024-01", "2024-03", null);
     IndexResponse response = controller.createIndex(request);
@@ -118,7 +120,9 @@ public class IndexControllerTest {
             Instant.now(),
             null,
             0,
-            false));
+            false,
+            false,
+            0));
 
     IndexResponse response =
         controller.createIndex(new IndexRequest("player", "CHESS_COM", "2024-06", "2024-06", null));
@@ -176,7 +180,9 @@ public class IndexControllerTest {
             Instant.now(),
             null,
             0,
-            false));
+            false,
+            false,
+            0));
 
     IndexResponse response =
         controller.createIndex(
@@ -211,7 +217,9 @@ public class IndexControllerTest {
                         Instant.now(),
                         null,
                         10,
-                        false)));
+                        false,
+                        false,
+                        0)));
 
     List<IndexResponse> responses = controller.listRequests();
 
@@ -232,7 +240,9 @@ public class IndexControllerTest {
             Instant.now(),
             null,
             42,
-            false);
+            false,
+            false,
+            0);
     requestStore.setExistingRequest(stored);
     requestStore.setFindByIdResponse(stored);
 
@@ -313,7 +323,9 @@ public class IndexControllerTest {
         Instant.now(),
         null,
         42,
-        false);
+        false,
+        false,
+        0);
   }
 
   private static IndexResponse byPlayer(List<IndexResponse> responses, String player) {
@@ -393,6 +405,7 @@ public class IndexControllerTest {
         String startMonth,
         String endMonth,
         boolean excludeBullet,
+        boolean skipCache,
         Duration staleAfter,
         Instant now) {
       // Mirrors the schema's exclusivity: if a live request is already registered for this tuple,
@@ -421,8 +434,17 @@ public class IndexControllerTest {
               now,
               null,
               0,
-              excludeBullet),
+              excludeBullet,
+              false,
+              0),
           true);
+    }
+
+    /** Not exercised by IndexController tests: nothing here dispatches from the table. */
+    @Override
+    public Optional<IndexingRequestStore.IndexingRequest> claimNext(
+        String ownerId, java.time.Duration lease, Instant now) {
+      return Optional.empty();
     }
 
     @Override
@@ -476,13 +498,7 @@ public class IndexControllerTest {
 
     @Override
     public Optional<IndexingRequestStore.IndexingRequest> findExistingRequest(
-        String player,
-        String platform,
-        String startMonth,
-        String endMonth,
-        boolean excludeBullet,
-        Duration staleAfter,
-        Instant now) {
+        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
       return existingRequest.filter(
           r ->
               r.player().equals(player)

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
@@ -902,6 +902,156 @@ public class IndexingRequestDaoTest {
   }
 
   /**
+   * A worker shutting down cleanly gives the request back, and gives the attempt back with it.
+   *
+   * <p>{@code attempts} is spent on claim, deliberately — a request that kills its worker before it
+   * can report anything still has to move the counter, or the poison bound means nothing. The cost
+   * of counting that early is that it cannot tell a crash from a deploy, and every process exit
+   * looks like the request killed it. Three rolling restarts across a long-running request would
+   * retire it as poisoned and tell the user its range fails repeatedly, which is a lie about a
+   * healthy system.
+   *
+   * <p>A graceful hand-back is the evidence that resolves it: the worker survived long enough to
+   * say so, which is precisely what a killer request does not allow. So the lap does not count.
+   */
+  @Test
+  public void handBack_returnsTheRequestWithoutSpendingAnAttempt() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt(
+            "deploying", "CHESS_COM", "2027-06", "2027-06", false, false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+    assertThat(dao.findById(id).orElseThrow().attempts()).isEqualTo(1);
+
+    assertThat(dao.handBack(id, WORKER_A, now)).isTrue();
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(id).orElseThrow();
+    assertThat(row.attempts()).as("a deploy is not one of the three strikes").isZero();
+    assertThat(row.status()).as("the work is still wanted").isIn("PENDING", "PROCESSING");
+    assertThat(dao.claim(id, WORKER_B, LEASE, now))
+        .as("the next worker takes it now, not once the lease lapses")
+        .isTrue();
+  }
+
+  /** Fenced like every other write: a worker cannot give away a request someone else now holds. */
+  @Test
+  public void handBack_refusesOnceAnotherWorkerHasTakenTheRequest() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt(
+            "stolen", "CHESS_COM", "2027-07", "2027-07", false, false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+
+    Instant afterLapse = now.plus(LEASE).plusSeconds(1);
+    assertThat(dao.claim(id, WORKER_B, LEASE, afterLapse)).isTrue();
+
+    assertThat(dao.handBack(id, WORKER_A, afterLapse))
+        .as("A no longer holds this; unclaiming it would strand B mid-run")
+        .isFalse();
+    assertThat(dao.holdsLease(id, WORKER_B, afterLapse)).isTrue();
+  }
+
+  /**
+   * Hand-back keeps the lease mark, like every other path that ends a claim. It is the record of
+   * when a worker last held the row, and a fleet mid-deploy is the worst possible moment to look
+   * dead to the sweep — every instance is handing work back at once.
+   */
+  @Test
+  public void handBack_leavesTheFleetLookingAliveDuringADeploy() {
+    IndexingRequestStore.Claim queued =
+        dao.createOrAdopt(
+            "backlog", "CHESS_COM", "2027-08", "2027-08", false, false, STALE_AFTER, now);
+    backdateUpdatedAt(queued.request().id(), now.minus(Duration.ofHours(3)));
+
+    IndexingRequestStore.Claim running =
+        dao.createOrAdopt(
+            "handed", "CHESS_COM", "2027-09", "2027-09", false, false, STALE_AFTER, now);
+    dao.claim(running.request().id(), WORKER_A, LEASE, now);
+    dao.handBack(running.request().id(), WORKER_A, now);
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now))
+        .as("a worker was here moments ago — it just told us it was leaving")
+        .isZero();
+    assertThat(dao.findById(queued.request().id()).orElseThrow().status())
+        .isIn("PENDING", "PROCESSING");
+  }
+
+  /**
+   * The other half of the ordering, and the one that was left unpinned: poisoned before stalled.
+   *
+   * <p>A row whose attempts are spent is usually also unheld and old, so it matches the stalled arm
+   * too. Both arms retire it and both leave it FAILED, so the status proves nothing — the whole
+   * difference is the sentence the user reads. Run stalled first and someone whose range fails
+   * repeatedly is told the indexing fleet is down, which sends them to resubmit into a system that
+   * is working fine and will fail them again the same way.
+   *
+   * <p>Constructing the overlap takes both steps. Spending the attempts alone leaves {@code
+   * updated_at} at the last claim, which is recent by definition, so a poisoned row is not normally
+   * stalled as well — which is exactly why the suite stayed green with the arms swapped until this
+   * existed.
+   */
+  @Test
+  public void reclaimStale_prefersThePoisonedReasonWhenARowIsAlsoStalled() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt(
+            "both", "CHESS_COM", "2027-03", "2027-03", false, false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    exhaustAttempts(id);
+    backdateUpdatedAt(id, now.minus(Duration.ofHours(3)));
+
+    // Past the last lease exhaustAttempts took out, so the row is unheld, and with nothing else in
+    // the table no worker is running anywhere either. Poisoned and stalled are both true.
+    dao.reclaimStale(STALE_AFTER, now.plus(LEASE.multipliedBy(MAX_ATTEMPTS + 1)));
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(id).orElseThrow();
+    assertThat(row.status()).isEqualTo("FAILED");
+    assertThat(row.errorMessage())
+        .as("both arms retire this row; the one that names the real cause has to win")
+        .contains("each worker stopped before finishing");
+  }
+
+  /**
+   * An unowned terminal write must not erase the evidence that a worker was here.
+   *
+   * <p>{@code lease_expires_at} is the fleet-liveness probe's memory. A successful run clears its
+   * owner on the way out, so {@code owner_id} cannot answer "was anyone working recently?" — only
+   * the lease mark can, which is why {@link IndexingRequestStore#updateStatusOwned} leaves it in
+   * place. The unowned path has to keep the same promise: its one production caller is the inline
+   * dispatch failure handler, and by the time that runs the worker has already claimed and leased
+   * the row.
+   *
+   * <p>Erasing it there is not a cosmetic inconsistency. The mark this row carries is what tells
+   * the sweep the fleet is alive, so losing it retires the entire backlog behind it in one
+   * statement — the exact failure the probe was added to prevent, reached through a different door.
+   */
+  @Test
+  public void reclaimStale_stillSeesAWorkerAfterAnUnownedTerminalWrite() {
+    List<UUID> backlog = new java.util.ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      IndexingRequestStore.Claim queued =
+          dao.createOrAdopt(
+              "waiting" + i, "CHESS_COM", "2027-04", "2027-04", false, false, STALE_AFTER, now);
+      backdateUpdatedAt(queued.request().id(), now.minus(Duration.ofHours(3)));
+      backlog.add(queued.request().id());
+    }
+
+    // A worker claimed this one and ran it inline; it threw, and the inline handler recorded the
+    // outcome through updateStatus because it holds no token of its own.
+    IndexingRequestStore.Claim inline =
+        dao.createOrAdopt(
+            "inline", "CHESS_COM", "2027-05", "2027-05", false, false, STALE_AFTER, now);
+    dao.claim(inline.request().id(), WORKER_A, LEASE, now);
+    dao.updateStatus(inline.request().id(), "FAILED", "boom", 0);
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now))
+        .as("a worker held this row moments ago, so the fleet is not dead")
+        .isZero();
+    for (UUID id : backlog) {
+      assertThat(dao.findById(id).orElseThrow().status()).isIn("PENDING", "PROCESSING");
+    }
+  }
+
+  /**
    * And the guard on that arm, which is what stops it from re-becoming the bug #1278 and #1250 were
    * spent on. A single worker draining a deep backlog leaves rows at the back untouched for as long
    * as the backlog takes; age alone cannot tell that from a dead fleet. A live lease held by anyone

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java
@@ -38,14 +38,14 @@ public class IndexingRequestDaoTest {
 
   private IndexingRequestStore.IndexingRequest create(
       String player, String start, String end, boolean excludeBullet) {
-    return dao.createOrAdopt(player, "CHESS_COM", start, end, excludeBullet, STALE_AFTER, now)
+    return dao.createOrAdopt(
+            player, "CHESS_COM", start, end, excludeBullet, false, STALE_AFTER, now)
         .request();
   }
 
   private Optional<IndexingRequestStore.IndexingRequest> find(
       String player, String start, String end, boolean excludeBullet) {
-    return dao.findExistingRequest(
-        player, "CHESS_COM", start, end, excludeBullet, STALE_AFTER, now);
+    return dao.findExistingRequest(player, "CHESS_COM", start, end, excludeBullet);
   }
 
   @Test
@@ -117,9 +117,11 @@ public class IndexingRequestDaoTest {
   @Test
   public void createOrAdopt_secondIdenticalSubmitAdoptsTheFirstInsteadOfCreating() {
     IndexingRequestStore.Claim first =
-        dao.createOrAdopt("same", "CHESS_COM", "2024-01", "2024-01", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "same", "CHESS_COM", "2024-01", "2024-01", false, false, STALE_AFTER, now);
     IndexingRequestStore.Claim second =
-        dao.createOrAdopt("same", "CHESS_COM", "2024-01", "2024-01", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "same", "CHESS_COM", "2024-01", "2024-01", false, false, STALE_AFTER, now);
 
     assertThat(first.created()).isTrue();
     assertThat(second.created()).isFalse();
@@ -149,7 +151,7 @@ public class IndexingRequestDaoTest {
               startLine.await();
               IndexingRequestStore.Claim claim =
                   dao.createOrAdopt(
-                      "racer", "CHESS_COM", "2024-06", "2024-06", false, STALE_AFTER, now);
+                      "racer", "CHESS_COM", "2024-06", "2024-06", false, false, STALE_AFTER, now);
               claimedIds.add(claim.request().id());
               if (claim.created()) {
                 createdCount.incrementAndGet();
@@ -175,11 +177,13 @@ public class IndexingRequestDaoTest {
   @Test
   public void createOrAdopt_terminalStatusFreesTheSlotForANewRequest() {
     IndexingRequestStore.Claim first =
-        dao.createOrAdopt("done", "CHESS_COM", "2024-07", "2024-07", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "done", "CHESS_COM", "2024-07", "2024-07", false, false, STALE_AFTER, now);
     dao.updateStatus(first.request().id(), "COMPLETED", null, 12);
 
     IndexingRequestStore.Claim second =
-        dao.createOrAdopt("done", "CHESS_COM", "2024-07", "2024-07", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "done", "CHESS_COM", "2024-07", "2024-07", false, false, STALE_AFTER, now);
 
     assertThat(second.created()).isTrue();
     assertThat(second.request().id()).isNotEqualTo(first.request().id());
@@ -189,11 +193,13 @@ public class IndexingRequestDaoTest {
   @Test
   public void createOrAdopt_failedStatusAlsoFreesTheSlot() {
     IndexingRequestStore.Claim first =
-        dao.createOrAdopt("retry", "CHESS_COM", "2024-08", "2024-08", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "retry", "CHESS_COM", "2024-08", "2024-08", false, false, STALE_AFTER, now);
     dao.updateStatus(first.request().id(), "FAILED", "boom", 0);
 
     IndexingRequestStore.Claim second =
-        dao.createOrAdopt("retry", "CHESS_COM", "2024-08", "2024-08", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "retry", "CHESS_COM", "2024-08", "2024-08", false, false, STALE_AFTER, now);
 
     assertThat(second.created()).isTrue();
     assertThat(second.request().id()).isNotEqualTo(first.request().id());
@@ -203,11 +209,13 @@ public class IndexingRequestDaoTest {
   @Test
   public void createOrAdopt_processingStatusKeepsHoldingTheSlot() {
     IndexingRequestStore.Claim first =
-        dao.createOrAdopt("busy", "CHESS_COM", "2024-09", "2024-09", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "busy", "CHESS_COM", "2024-09", "2024-09", false, false, STALE_AFTER, now);
     dao.updateStatus(first.request().id(), "PROCESSING", null, 3);
 
     IndexingRequestStore.Claim second =
-        dao.createOrAdopt("busy", "CHESS_COM", "2024-09", "2024-09", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "busy", "CHESS_COM", "2024-09", "2024-09", false, false, STALE_AFTER, now);
 
     assertThat(second.created()).isFalse();
     assertThat(second.request().id()).isEqualTo(first.request().id());
@@ -227,11 +235,13 @@ public class IndexingRequestDaoTest {
   @Test
   public void createOrAdopt_reclaimsAStrandedHolderAndCreatesAReplacement() {
     IndexingRequestStore.Claim stranded =
-        dao.createOrAdopt("ghost", "CHESS_COM", "2024-10", "2024-10", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "ghost", "CHESS_COM", "2024-10", "2024-10", false, false, STALE_AFTER, now);
     backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(3)));
 
     IndexingRequestStore.Claim replacement =
-        dao.createOrAdopt("ghost", "CHESS_COM", "2024-10", "2024-10", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "ghost", "CHESS_COM", "2024-10", "2024-10", false, false, STALE_AFTER, now);
 
     assertThat(replacement.created()).isTrue();
     assertThat(replacement.request().id()).isNotEqualTo(stranded.request().id());
@@ -245,32 +255,41 @@ public class IndexingRequestDaoTest {
   @Test
   public void createOrAdopt_doesNotReclaimAHolderThatIsStillFresh() {
     IndexingRequestStore.Claim live =
-        dao.createOrAdopt("alive", "CHESS_COM", "2024-11", "2024-11", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "alive", "CHESS_COM", "2024-11", "2024-11", false, false, STALE_AFTER, now);
     backdateUpdatedAt(live.request().id(), now.minus(Duration.ofMinutes(30)));
 
     IndexingRequestStore.Claim second =
-        dao.createOrAdopt("alive", "CHESS_COM", "2024-11", "2024-11", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "alive", "CHESS_COM", "2024-11", "2024-11", false, false, STALE_AFTER, now);
 
     assertThat(second.created()).isFalse();
     assertThat(second.request().id()).isEqualTo(live.request().id());
     assertThat(dao.findById(live.request().id()).orElseThrow().status()).isEqualTo("PENDING");
   }
 
+  /**
+   * A row nobody has claimed is queued work, not a strand, so dedupe keeps answering with it. What
+   * used to make this row invisible was its age; age is now the business of the sweep's third arm,
+   * which retires it only when no worker is running anywhere.
+   */
   @Test
-  public void findExistingRequest_ignoresAStrandedRow() {
-    IndexingRequestStore.Claim stranded =
-        dao.createOrAdopt("ghost2", "CHESS_COM", "2024-12", "2024-12", false, STALE_AFTER, now);
-    backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(5)));
+  public void findExistingRequest_answersWithAQueuedRowHoweverLongItHasWaited() {
+    dao.createOrAdopt("ghost2", "CHESS_COM", "2024-12", "2024-12", false, false, STALE_AFTER, now);
+    UUID id = find("ghost2", "2024-12", "2024-12", false).orElseThrow().id();
+    backdateUpdatedAt(id, now.minus(Duration.ofHours(5)));
 
-    assertThat(find("ghost2", "2024-12", "2024-12", false)).isEmpty();
+    assertThat(find("ghost2", "2024-12", "2024-12", false))
+        .as("resubmitting a queued range should adopt it, not start a second one")
+        .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(id));
   }
 
   @Test
   public void reclaimStale_retiresStrandedRowsAndLeavesFreshOnes() {
     IndexingRequestStore.Claim old =
-        dao.createOrAdopt("p1", "CHESS_COM", "2025-01", "2025-01", false, STALE_AFTER, now);
+        dao.createOrAdopt("p1", "CHESS_COM", "2025-01", "2025-01", false, false, STALE_AFTER, now);
     IndexingRequestStore.Claim fresh =
-        dao.createOrAdopt("p2", "CHESS_COM", "2025-01", "2025-01", false, STALE_AFTER, now);
+        dao.createOrAdopt("p2", "CHESS_COM", "2025-01", "2025-01", false, false, STALE_AFTER, now);
     backdateUpdatedAt(old.request().id(), now.minus(Duration.ofHours(2)));
 
     assertThat(dao.reclaimStale(STALE_AFTER, now)).isEqualTo(1);
@@ -288,7 +307,8 @@ public class IndexingRequestDaoTest {
   @Test
   public void reclaimStale_retiresAStrandedProcessingRow() {
     IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("halfdone", "CHESS_COM", "2025-07", "2025-07", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "halfdone", "CHESS_COM", "2025-07", "2025-07", false, false, STALE_AFTER, now);
     dao.updateStatus(claim.request().id(), "PROCESSING", null, 4);
     backdateUpdatedAt(claim.request().id(), now.minus(Duration.ofHours(3)));
 
@@ -299,19 +319,22 @@ public class IndexingRequestDaoTest {
     assertThat(retired.gamesIndexed()).as("progress so far is preserved").isEqualTo(4);
 
     IndexingRequestStore.Claim replacement =
-        dao.createOrAdopt("halfdone", "CHESS_COM", "2025-07", "2025-07", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "halfdone", "CHESS_COM", "2025-07", "2025-07", false, false, STALE_AFTER, now);
     assertThat(replacement.created()).isTrue();
   }
 
   @Test
   public void createOrAdopt_reclaimsAStrandedProcessingHolder() {
     IndexingRequestStore.Claim stranded =
-        dao.createOrAdopt("halfdone2", "CHESS_COM", "2025-08", "2025-08", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "halfdone2", "CHESS_COM", "2025-08", "2025-08", false, false, STALE_AFTER, now);
     dao.updateStatus(stranded.request().id(), "PROCESSING", null, 2);
     backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(3)));
 
     IndexingRequestStore.Claim replacement =
-        dao.createOrAdopt("halfdone2", "CHESS_COM", "2025-08", "2025-08", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "halfdone2", "CHESS_COM", "2025-08", "2025-08", false, false, STALE_AFTER, now);
 
     assertThat(replacement.created()).isTrue();
     assertThat(replacement.request().id()).isNotEqualTo(stranded.request().id());
@@ -330,13 +353,15 @@ public class IndexingRequestDaoTest {
   @Test
   public void updateStatus_cannotResurrectARetiredRequest() {
     IndexingRequestStore.Claim stranded =
-        dao.createOrAdopt("zombie", "CHESS_COM", "2025-09", "2025-09", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "zombie", "CHESS_COM", "2025-09", "2025-09", false, false, STALE_AFTER, now);
     UUID strandedId = stranded.request().id();
     backdateUpdatedAt(strandedId, now.minus(Duration.ofHours(3)));
     dao.reclaimStale(STALE_AFTER, now);
 
     IndexingRequestStore.Claim replacement =
-        dao.createOrAdopt("zombie", "CHESS_COM", "2025-09", "2025-09", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "zombie", "CHESS_COM", "2025-09", "2025-09", false, false, STALE_AFTER, now);
     assertThat(replacement.created()).isTrue();
 
     // An unfenced status write landing after the fact.
@@ -354,7 +379,8 @@ public class IndexingRequestDaoTest {
   @Test
   public void updateStatus_terminalWriteOnARetiredRequestStillRecordsTheOutcome() {
     IndexingRequestStore.Claim stranded =
-        dao.createOrAdopt("late", "CHESS_COM", "2025-10", "2025-10", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "late", "CHESS_COM", "2025-10", "2025-10", false, false, STALE_AFTER, now);
     UUID strandedId = stranded.request().id();
     backdateUpdatedAt(strandedId, now.minus(Duration.ofHours(3)));
     dao.reclaimStale(STALE_AFTER, now);
@@ -386,7 +412,8 @@ public class IndexingRequestDaoTest {
   public void schema_allowsManyTerminalRowsForOneTuple() {
     for (int i = 0; i < 3; i++) {
       IndexingRequestStore.Claim claim =
-          dao.createOrAdopt("recycled", "CHESS_COM", "2025-12", "2025-12", false, STALE_AFTER, now);
+          dao.createOrAdopt(
+              "recycled", "CHESS_COM", "2025-12", "2025-12", false, false, STALE_AFTER, now);
       dao.updateStatus(claim.request().id(), "COMPLETED", null, i);
     }
     assertThat(countRequests()).isEqualTo(3);
@@ -395,7 +422,7 @@ public class IndexingRequestDaoTest {
   @Test
   public void reclaimStale_leavesTerminalRowsAlone() {
     IndexingRequestStore.Claim completed =
-        dao.createOrAdopt("p3", "CHESS_COM", "2025-02", "2025-02", false, STALE_AFTER, now);
+        dao.createOrAdopt("p3", "CHESS_COM", "2025-02", "2025-02", false, false, STALE_AFTER, now);
     dao.updateStatus(completed.request().id(), "COMPLETED", null, 7);
     backdateUpdatedAt(completed.request().id(), now.minus(Duration.ofDays(2)));
 
@@ -410,13 +437,13 @@ public class IndexingRequestDaoTest {
   @Test
   public void reclaimStale_freesTheSlotSoTheRangeCanBeRequestedAgain() {
     IndexingRequestStore.Claim stranded =
-        dao.createOrAdopt("p4", "CHESS_COM", "2025-03", "2025-03", false, STALE_AFTER, now);
+        dao.createOrAdopt("p4", "CHESS_COM", "2025-03", "2025-03", false, false, STALE_AFTER, now);
     backdateUpdatedAt(stranded.request().id(), now.minus(Duration.ofHours(4)));
 
     dao.reclaimStale(STALE_AFTER, now);
 
     IndexingRequestStore.Claim replacement =
-        dao.createOrAdopt("p4", "CHESS_COM", "2025-03", "2025-03", false, STALE_AFTER, now);
+        dao.createOrAdopt("p4", "CHESS_COM", "2025-03", "2025-03", false, false, STALE_AFTER, now);
     assertThat(replacement.created()).isTrue();
   }
 
@@ -425,9 +452,10 @@ public class IndexingRequestDaoTest {
   @Test
   public void deleteOlderThan_removesRequestsPastTheThreshold() {
     IndexingRequestStore.Claim old =
-        dao.createOrAdopt("old", "CHESS_COM", "2025-04", "2025-04", false, STALE_AFTER, now);
+        dao.createOrAdopt("old", "CHESS_COM", "2025-04", "2025-04", false, false, STALE_AFTER, now);
     IndexingRequestStore.Claim recent =
-        dao.createOrAdopt("recent", "CHESS_COM", "2025-05", "2025-05", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "recent", "CHESS_COM", "2025-05", "2025-05", false, false, STALE_AFTER, now);
     dao.updateStatus(old.request().id(), "COMPLETED", null, 5);
     dao.updateStatus(recent.request().id(), "COMPLETED", null, 5);
     backdateCreatedAt(old.request().id(), now.minus(Duration.ofDays(40)));
@@ -448,7 +476,8 @@ public class IndexingRequestDaoTest {
   @Test
   public void deleteOlderThan_refusesToSweepALiveRequestHoweverOldItIs() {
     IndexingRequestStore.Claim pending =
-        dao.createOrAdopt("ancient", "CHESS_COM", "2025-04", "2025-04", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "ancient", "CHESS_COM", "2025-04", "2025-04", false, false, STALE_AFTER, now);
     backdateCreatedAt(pending.request().id(), now.minus(Duration.ofDays(400)));
 
     assertThat(dao.deleteOlderThan(now.minus(Duration.ofDays(30)))).isEqualTo(0);
@@ -458,7 +487,8 @@ public class IndexingRequestDaoTest {
   @Test
   public void deleteOlderThan_leavesRequestsThatStillOwnGames() {
     IndexingRequestStore.Claim owner =
-        dao.createOrAdopt("owner", "CHESS_COM", "2025-06", "2025-06", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "owner", "CHESS_COM", "2025-06", "2025-06", false, false, STALE_AFTER, now);
     backdateCreatedAt(owner.request().id(), now.minus(Duration.ofDays(40)));
     insertGame(owner.request().id(), "https://chess.com/still-here");
 
@@ -489,6 +519,7 @@ public class IndexingRequestDaoTest {
   // --- ownership leases (#1278) -----------------------------------------------------------------
 
   private static final Duration LEASE = Duration.ofMinutes(5);
+  private static final int MAX_ATTEMPTS = IndexingRequestDao.MAX_ATTEMPTS;
   private static final String WORKER_A = "host-a/1/aaaa";
   private static final String WORKER_B = "host-b/2/bbbb";
 
@@ -546,14 +577,18 @@ public class IndexingRequestDaoTest {
 
   /** The same boundary on the sweep's side, so the two predicates cannot drift apart. */
   @Test
-  public void reclaimStale_retiresALeaseAtTheExactInstantItExpires() {
+  public void reclaimStale_releasesALeaseAtTheExactInstantItExpires() {
     IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("boundary2", "CHESS_COM", "2025-14", "2025-14", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "boundary2", "CHESS_COM", "2025-14", "2025-14", false, false, STALE_AFTER, now);
     UUID id = claim.request().id();
     dao.claim(id, WORKER_A, LEASE, now);
 
     assertThat(dao.reclaimStale(STALE_AFTER, now.plus(LEASE))).isEqualTo(1);
-    assertThat(dao.findById(id).orElseThrow().status()).isEqualTo("FAILED");
+    assertThat(dao.findById(id).orElseThrow().status()).isIn("PENDING", "PROCESSING");
+    assertThat(dao.holdsLease(id, WORKER_A, now.plus(LEASE)))
+        .as("released means the owner is cleared, not that the request is over")
+        .isFalse();
   }
 
   /**
@@ -613,14 +648,15 @@ public class IndexingRequestDaoTest {
   }
 
   /**
-   * The lease arm of reclamation: a crashed owner is reclaimable in minutes, without waiting out
-   * the hour that governs work nobody ever picked up. That is the whole point of asking "is the
-   * owner there?" instead of "has anything happened lately?".
+   * The lease arm: a crashed owner is dealt with in minutes, without waiting out the hour that
+   * governs a fleet nobody is running. Dealt with now means <em>requeued</em> — the work is still
+   * wanted, and any worker can take it.
    */
   @Test
-  public void reclaimStale_takesAnExpiredLeaseWithoutWaitingForTheStalenessCutoff() {
+  public void reclaimStale_requeuesAnExpiredLeaseWithoutWaitingForTheStalenessCutoff() {
     IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("crashed", "CHESS_COM", "2025-11", "2025-11", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "crashed", "CHESS_COM", "2025-11", "2025-11", false, false, STALE_AFTER, now);
     UUID id = claim.request().id();
     dao.claim(id, WORKER_A, LEASE, now);
 
@@ -628,12 +664,11 @@ public class IndexingRequestDaoTest {
     assertThat(dao.reclaimStale(STALE_AFTER, sixMinutesLater))
         .as("six minutes is nowhere near the one-hour cutoff, but the lease is gone")
         .isEqualTo(1);
-    assertThat(dao.findById(id).orElseThrow().status()).isEqualTo("FAILED");
 
-    IndexingRequestStore.Claim replacement =
-        dao.createOrAdopt(
-            "crashed", "CHESS_COM", "2025-11", "2025-11", false, STALE_AFTER, sixMinutesLater);
-    assertThat(replacement.created()).as("and the range is free again").isTrue();
+    assertThat(dao.findById(id).orElseThrow().status()).isIn("PENDING", "PROCESSING");
+    assertThat(dao.claimNext(WORKER_B, LEASE, sixMinutesLater))
+        .as("and another worker can pick it straight up")
+        .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(id));
   }
 
   /**
@@ -647,7 +682,8 @@ public class IndexingRequestDaoTest {
   @Test
   public void reclaimStale_leavesAClaimedRequestAloneEvenWhenItHasBeenQuietForHours() {
     IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("patient", "CHESS_COM", "2025-12", "2025-12", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "patient", "CHESS_COM", "2025-12", "2025-12", false, false, STALE_AFTER, now);
     UUID id = claim.request().id();
     dao.claim(id, WORKER_A, LEASE, now);
     backdateUpdatedAt(id, now.minus(Duration.ofHours(3)));
@@ -696,80 +732,206 @@ public class IndexingRequestDaoTest {
   }
 
   /**
-   * Dedupe must answer "is this alive?" the same way reclamation does. This read runs first on
-   * every submit and short-circuits, so a laxer predicate here silently overrides the stricter
-   * reclamation behind it.
+   * A lapsed lease no longer means the range is free. The row goes back in the queue, so it is
+   * still the holder and dedupe must keep answering with it — a second submit should adopt the work
+   * already waiting rather than create a rival for the same range.
    *
-   * <p>The case that exposed it: a worker claims, then is killed. Its lease lapses in minutes and
-   * the row is reclaimable — but {@code updated_at} was bumped by its last renewal, so a predicate
-   * that asks only about age keeps handing the dead request back to callers for the full hour. The
-   * README's "five minutes" was delivered nowhere a user could reach.
+   * <p>This is the inverse of what it asserted before #1279, and deliberately so: back then a
+   * lapsed lease was retired, because nothing was ever going to run that request again.
    */
   @Test
-  public void findExistingRequest_doesNotAnswerWithARequestWhoseLeaseHasLapsed() {
-    dao.createOrAdopt("killed", "CHESS_COM", "2026-05", "2026-05", false, STALE_AFTER, now);
+  public void findExistingRequest_stillAnswersWithARequestWhoseLeaseHasLapsed() {
+    dao.createOrAdopt("killed", "CHESS_COM", "2026-05", "2026-05", false, false, STALE_AFTER, now);
     UUID id = find("killed", "2026-05", "2026-05", false).orElseThrow().id();
     dao.claim(id, WORKER_A, LEASE, now);
 
     Instant afterLapse = now.plus(LEASE).plusSeconds(1);
-    assertThat(
-            dao.findExistingRequest(
-                "killed", "CHESS_COM", "2026-05", "2026-05", false, STALE_AFTER, afterLapse))
-        .as("a request whose owner is gone must not keep answering for the range")
-        .isEmpty();
-    // The boundary itself. reclaimStale takes the row at exactly this instant, so dedupe must
-    // already have stopped offering it — otherwise there is a moment where the row is both
-    // reclaimable and reported as the live holder.
-    assertThat(
-            dao.findExistingRequest(
-                "killed", "CHESS_COM", "2026-05", "2026-05", false, STALE_AFTER, now.plus(LEASE)))
+    assertThat(dao.findExistingRequest("killed", "CHESS_COM", "2026-05", "2026-05", false))
+        .as("the work is queued for another worker, so the range is still spoken for")
+        .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(id));
+  }
+
+  /** What does end it: burning through the attempts. Then the range really is free. */
+  @Test
+  public void findExistingRequest_stopsAnsweringOnceARequestIsPoisoned() {
+    dao.createOrAdopt("doomed", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, now);
+    UUID id = find("doomed", "2026-06", "2026-06", false).orElseThrow().id();
+    exhaustAttempts(id);
+
+    assertThat(find("doomed", "2026-06", "2026-06", false))
+        .as("a request no worker may take again cannot go on holding its range")
         .isEmpty();
   }
 
   /** The converse: a claimed request with a live lease is still the answer, however quiet it is. */
   @Test
   public void findExistingRequest_stillAnswersWithAClaimedRequestThatIsRenewing() {
-    dao.createOrAdopt("busy", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, now);
+    dao.createOrAdopt("busy", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, now);
     UUID id = find("busy", "2026-06", "2026-06", false).orElseThrow().id();
     dao.claim(id, WORKER_A, LEASE, now);
     backdateUpdatedAt(id, now.minus(Duration.ofHours(3)));
     dao.renewLease(id, WORKER_A, LEASE, now);
 
-    assertThat(
-            dao.findExistingRequest(
-                "busy", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, now))
+    assertThat(dao.findExistingRequest("busy", "CHESS_COM", "2026-06", "2026-06", false))
         .as("an owner that is renewing owns the range no matter how long the work takes")
         .isPresent();
   }
 
   /**
-   * The two arms report different things to the user. {@code error_message} is surfaced by the API
-   * and rendered in the web app, so telling someone whose worker crashed mid-run that nobody ever
-   * picked their request up sends them looking for a dispatch problem that is not there.
+   * The three outcomes report three different things, and two of them reach the user as {@code
+   * error_message} rendered in the web app. A crashed owner whose attempts remain is not a failure
+   * at all — the work goes back in the queue silently — so saying anything to the user there would
+   * be a lie about work that is about to run.
    */
   @Test
-  public void reclaimStale_saysWhichArmRetiredTheRequest() {
-    IndexingRequestStore.Claim claimed =
-        dao.createOrAdopt("crashed2", "CHESS_COM", "2026-07", "2026-07", false, STALE_AFTER, now);
-    dao.claim(claimed.request().id(), WORKER_A, LEASE, now);
+  public void reclaimStale_distinguishesReleasedFromPoisonedFromStalled() {
+    // A crashed owner with attempts to spare: released, still live, no message.
+    IndexingRequestStore.Claim crashed =
+        dao.createOrAdopt(
+            "crashed2", "CHESS_COM", "2026-07", "2026-07", false, false, STALE_AFTER, now);
+    dao.claim(crashed.request().id(), WORKER_A, LEASE, now);
 
-    IndexingRequestStore.Claim neverClaimed =
-        dao.createOrAdopt("orphan", "CHESS_COM", "2026-08", "2026-08", false, STALE_AFTER, now);
-    backdateUpdatedAt(neverClaimed.request().id(), now.minus(Duration.ofHours(3)));
+    // A request that has burned through its attempts: retired as poisoned.
+    IndexingRequestStore.Claim poisoned =
+        dao.createOrAdopt(
+            "poison", "CHESS_COM", "2026-09", "2026-09", false, false, STALE_AFTER, now);
+    exhaustAttempts(poisoned.request().id());
 
-    dao.reclaimStale(STALE_AFTER, now.plus(Duration.ofMinutes(6)));
+    // Past the last lease exhaustAttempts took out, or the poisoned row still looks held.
+    Instant afterEveryLease = now.plus(LEASE.multipliedBy(MAX_ATTEMPTS + 1));
+    dao.reclaimStale(STALE_AFTER, afterEveryLease);
 
-    assertThat(dao.findById(claimed.request().id()).orElseThrow().errorMessage())
-        .contains("stopped responding")
-        .doesNotContain("no worker took ownership");
-    assertThat(dao.findById(neverClaimed.request().id()).orElseThrow().errorMessage())
-        .contains("no worker took ownership");
+    IndexingRequestStore.IndexingRequest released =
+        dao.findById(crashed.request().id()).orElseThrow();
+    assertThat(released.status())
+        .as("a crashed owner with attempts left means requeue, not failure")
+        .isIn("PENDING", "PROCESSING");
+    assertThat(released.errorMessage()).isNull();
+
+    assertThat(dao.findById(poisoned.request().id()).orElseThrow().errorMessage())
+        .contains("each worker stopped before finishing");
+  }
+
+  /**
+   * The third arm, and the reason it exists: eventually the user needs an answer. A request nobody
+   * has taken, while no worker anywhere holds a lease, means the fleet is not serving it — every
+   * instance is down, or partitioned from this database — and silence is a worse answer than
+   * failure.
+   */
+  @Test
+  public void reclaimStale_retiresQueuedWorkOnceNoWorkerIsRunningAnywhere() {
+    IndexingRequestStore.Claim queued =
+        dao.createOrAdopt(
+            "orphan", "CHESS_COM", "2026-08", "2026-08", false, false, STALE_AFTER, now);
+    backdateUpdatedAt(queued.request().id(), now.minus(Duration.ofHours(3)));
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now)).isEqualTo(1);
+    IndexingRequestStore.IndexingRequest row = dao.findById(queued.request().id()).orElseThrow();
+    assertThat(row.status()).isEqualTo("FAILED");
+    assertThat(row.errorMessage()).contains("none is running anywhere");
+  }
+
+  /**
+   * The gap between two jobs is not an outage, and the sweep must not mistake it for one.
+   *
+   * <p>A worker finishes a request: its terminal write clears {@code owner_id}, and for the moment
+   * before its next claim lands there is no live lease anywhere in the table. Sampling for one at
+   * that instant declares a healthy fleet dead. With a backlog behind it, that is not one wrong
+   * answer — it is every queued request FAILED in a single statement, which is worse than the bug
+   * the guard exists to prevent.
+   *
+   * <p>So liveness is a window: has anything been touched recently, not is a lease held right now.
+   * Claims, renewals, progress writes and completions all leave a trail; leases are held in bursts.
+   */
+  @Test
+  public void reclaimStale_doesNotMistakeTheGapBetweenTwoJobsForADeadFleet() {
+    // A backlog, old enough to be eligible.
+    List<UUID> backlog = new java.util.ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      IndexingRequestStore.Claim queued =
+          dao.createOrAdopt(
+              "queued" + i, "CHESS_COM", "2027-01", "2027-01", false, false, STALE_AFTER, now);
+      backdateUpdatedAt(queued.request().id(), now.minus(Duration.ofHours(3)));
+      backlog.add(queued.request().id());
+    }
+
+    // A worker just finished something. It holds no lease at this instant, but it was working
+    // moments ago — which is what "the fleet is alive" actually looks like between two jobs.
+    IndexingRequestStore.Claim justFinished =
+        dao.createOrAdopt(
+            "done", "CHESS_COM", "2027-02", "2027-02", false, false, STALE_AFTER, now);
+    dao.claim(justFinished.request().id(), WORKER_A, LEASE, now);
+    dao.updateStatusOwned(justFinished.request().id(), WORKER_A, "COMPLETED", null, 5, now);
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now))
+        .as("a momentary gap with no lease held is not an outage")
+        .isZero();
+    for (UUID id : backlog) {
+      assertThat(dao.findById(id).orElseThrow().status()).isIn("PENDING", "PROCESSING");
+    }
+  }
+
+  /**
+   * The arms have to run poisoned, stalled, released — and this is the row that proves it.
+   *
+   * <p>A worker claimed this request and then the whole fleet went away: its lease is long expired,
+   * nothing has touched it since the claim, and no worker holds a lease anywhere. All three facts
+   * are true at once, so it matches both the stalled arm and the release arm.
+   *
+   * <p>Releasing first would set {@code updated_at} to now, which makes the row look freshly
+   * touched and hides it from the stalled arm for another full window. The user waits another hour
+   * to be told something the sweep already knew.
+   */
+  @Test
+  public void reclaimStale_retiresAStalledRowRatherThanRequeueingItFirst() {
+    IndexingRequestStore.Claim claim =
+        dao.createOrAdopt(
+            "fleet-gone", "CHESS_COM", "2026-12", "2026-12", false, false, STALE_AFTER, now);
+    UUID id = claim.request().id();
+    dao.claim(id, WORKER_A, LEASE, now);
+    backdateUpdatedAt(id, now.minus(Duration.ofHours(3)));
+
+    // Long past the lease, and nothing else is running.
+    dao.reclaimStale(STALE_AFTER, now.plus(Duration.ofHours(1)));
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(id).orElseThrow();
+    assertThat(row.status())
+        .as("both arms match this row; the one that tells the user has to win")
+        .isEqualTo("FAILED");
+    assertThat(row.errorMessage()).contains("none is running anywhere");
+  }
+
+  /**
+   * And the guard on that arm, which is what stops it from re-becoming the bug #1278 and #1250 were
+   * spent on. A single worker draining a deep backlog leaves rows at the back untouched for as long
+   * as the backlog takes; age alone cannot tell that from a dead fleet. A live lease held by anyone
+   * is proof the fleet is working, so queued work is left alone while anything is being indexed.
+   */
+  @Test
+  public void reclaimStale_leavesQueuedWorkAloneWhileAnyWorkerIsStillIndexing() {
+    IndexingRequestStore.Claim backlogged =
+        dao.createOrAdopt(
+            "waiting", "CHESS_COM", "2026-10", "2026-10", false, false, STALE_AFTER, now);
+    backdateUpdatedAt(backlogged.request().id(), now.minus(Duration.ofHours(3)));
+
+    // Another request is being indexed right now, by a worker whose lease is live.
+    IndexingRequestStore.Claim running =
+        dao.createOrAdopt(
+            "busy-elsewhere", "CHESS_COM", "2026-11", "2026-11", false, false, STALE_AFTER, now);
+    dao.claim(running.request().id(), WORKER_A, LEASE, now);
+
+    assertThat(dao.reclaimStale(STALE_AFTER, now))
+        .as("nothing to reclaim: the fleet is alive and this row is simply waiting its turn")
+        .isZero();
+    assertThat(dao.findById(backlogged.request().id()).orElseThrow().status())
+        .isIn("PENDING", "PROCESSING");
   }
 
   @Test
   public void updateStatusOwned_terminalWriteReleasesTheLeaseAndTheDedupeSlot() {
     IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("released", "CHESS_COM", "2026-03", "2026-03", false, STALE_AFTER, now);
+        dao.createOrAdopt(
+            "released", "CHESS_COM", "2026-03", "2026-03", false, false, STALE_AFTER, now);
     UUID id = claim.request().id();
     dao.claim(id, WORKER_A, LEASE, now);
 
@@ -781,11 +943,17 @@ public class IndexingRequestDaoTest {
     // Read straight off the row. holdsLease would answer false for a COMPLETED request whatever
     // the columns say, so it cannot tell a released lease from a stale one left behind.
     assertThat(columnOf(id, "owner_id")).as("the lease is released, not just unusable").isNull();
-    assertThat(columnOf(id, "lease_expires_at")).isNull();
+    // lease_expires_at deliberately survives. Nothing reads it as ownership — every such predicate
+    // also requires owner_id and a live status — and it is the only durable record that a worker
+    // held this row, which the stalled arm's liveness probe needs precisely because a successful
+    // run clears the owner on its way out.
+    assertThat(columnOf(id, "lease_expires_at"))
+        .as("the mark of when a worker last held this row outlives the run")
+        .isNotNull();
     assertThat(dao.holdsLease(id, WORKER_A, now)).isFalse();
     assertThat(
             dao.createOrAdopt(
-                    "released", "CHESS_COM", "2026-03", "2026-03", false, STALE_AFTER, now)
+                    "released", "CHESS_COM", "2026-03", "2026-03", false, false, STALE_AFTER, now)
                 .created())
         .as("the range is requestable again the moment the work stops being in flight")
         .isTrue();
@@ -818,6 +986,22 @@ public class IndexingRequestDaoTest {
       }
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Claims a request until its attempts are spent, letting each lease lapse in between.
+   *
+   * <p>Claiming repeatedly at one instant does not work and the reason is the point: a live lease
+   * refuses every other owner, so attempts can only accumulate through the release-and-retake cycle
+   * that a crashing fleet actually produces.
+   */
+  private void exhaustAttempts(UUID id) {
+    for (int i = 0; i < IndexingRequestDao.MAX_ATTEMPTS; i++) {
+      Instant at = now.plus(LEASE.multipliedBy(i));
+      assertThat(dao.claim(id, "worker-" + i, LEASE, at))
+          .as("attempt %s should have been claimable", i)
+          .isTrue();
     }
   }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -41,6 +41,67 @@ public class MigrationTest {
     }
   }
 
+  /**
+   * The columns that make the table dispatchable, and the upgrade path onto them.
+   *
+   * <p>Asserted against a table that already has a row, because the interesting case is not a fresh
+   * schema — it is a request in flight during a deploy. Both columns are read as primitives, so a
+   * row the migration left NULL would arrive silently as "do not skip the cache, never attempted".
+   */
+  @Test
+  public void run_addsDispatchColumnsAndBackfillsExistingRows() throws Exception {
+    new Migration(dataSource, true).run();
+
+    UUID legacy = UUID.randomUUID();
+    try (Connection conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " status) VALUES (?, 'legacy', 'CHESS_COM', '2024-01', '2024-01',"
+                    + " 'PENDING')")) {
+      ps.setObject(1, legacy);
+      ps.executeUpdate();
+    }
+
+    // Idempotent: running again must not disturb the row or the columns.
+    new Migration(dataSource, true).run();
+
+    try (Connection conn = dataSource.getConnection();
+        var ps =
+            conn.prepareStatement(
+                "SELECT skip_cache, attempts FROM indexing_requests WHERE id = ?")) {
+      ps.setObject(1, legacy);
+      try (ResultSet rs = ps.executeQuery()) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getObject("skip_cache")).as("skip_cache must not be NULL").isNotNull();
+        assertThat(rs.getBoolean("skip_cache")).isFalse();
+        assertThat(rs.getObject("attempts")).as("attempts must not be NULL").isNotNull();
+        assertThat(rs.getInt("attempts")).isZero();
+      }
+    }
+  }
+
+  /**
+   * The index the poller's candidate scan depends on, on a query every instance runs constantly.
+   */
+  @Test
+  public void run_addsTheClaimableIndex() throws Exception {
+    new Migration(dataSource, true).run();
+
+    try (Connection conn = dataSource.getConnection();
+        ResultSet indexes =
+            conn.getMetaData().getIndexInfo(null, null, "INDEXING_REQUESTS", false, false)) {
+      boolean found = false;
+      while (indexes.next()) {
+        String name = indexes.getString("INDEX_NAME");
+        if (name != null && name.equalsIgnoreCase("idx_indexing_requests_claimable")) {
+          found = true;
+        }
+      }
+      assertThat(found).as("idx_indexing_requests_claimable should exist").isTrue();
+    }
+  }
+
   @Test
   public void run_addsTitleAndOpeningColumns() throws Exception {
     Migration migration = new Migration(dataSource, true);
@@ -135,6 +196,7 @@ public class MigrationTest {
             "2024-01",
             "2024-03",
             true,
+            false,
             java.time.Duration.ofHours(1),
             java.time.Instant.now());
     assertThat(claim.created()).isFalse();
@@ -194,14 +256,7 @@ public class MigrationTest {
 
     IndexingRequestDao dao = new IndexingRequestDao(org.jdbi.v3.core.Jdbi.create(dataSource));
     UUID found =
-        dao.findExistingRequest(
-                "tied",
-                "CHESS_COM",
-                "2024-05",
-                "2024-05",
-                false,
-                java.time.Duration.ofDays(3650),
-                Instant.parse("2026-06-01T01:00:00Z"))
+        dao.findExistingRequest("tied", "CHESS_COM", "2024-05", "2024-05", false)
             .orElseThrow()
             .id();
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -241,6 +242,75 @@ public class PostgresConcurrentWriteTest {
     assertThat(countOccurrences())
         .as("reanalysis and an indexing flush left duplicated motif rows for this game")
         .isEqualTo(2);
+  }
+
+  /**
+   * Many pollers, one table, on the engine that actually runs this in production.
+   *
+   * <p>{@code claimNext} reads candidates without a lock — every poller is entitled to see the same
+   * ones — and relies entirely on {@code claim} being a conditional UPDATE to decide who gets each
+   * row. H2 covers the shape; this covers it where the row locks are Postgres's, with enough
+   * pollers and rounds that a broken predicate has somewhere to show itself.
+   *
+   * <p>Two workers holding one request is the failure this whole cluster of changes exists to
+   * prevent, so it is asserted directly rather than inferred from a count.
+   */
+  @Test
+  @Timeout(120)
+  public void concurrentPollersNeverHandOneRequestToTwoWorkers() throws Exception {
+    IndexingRequestDao requests = new IndexingRequestDao(Jdbi.create(dataSource));
+    // The suite's fixture request is claimable too: setUp leaves it PROCESSING with a lease that
+    // has expired long before the instant these pollers claim at. Counting only the rows this test
+    // inserts would make the totals wrong by exactly one — which is how this was caught.
+    int fixtureRows = 1;
+    int pollers = 4;
+    int requestCount = 40;
+    for (int i = 0; i < requestCount; i++) {
+      requests.createOrAdopt(
+          "racer" + i,
+          "CHESS_COM",
+          "2026-01",
+          "2026-01",
+          false,
+          false,
+          Duration.ofHours(1),
+          NOW.plusSeconds(i));
+    }
+
+    ExecutorService racers = Executors.newFixedThreadPool(pollers);
+    try {
+      java.util.concurrent.CyclicBarrier start = new java.util.concurrent.CyclicBarrier(pollers);
+      List<java.util.concurrent.Callable<List<UUID>>> tasks = new java.util.ArrayList<>();
+      for (int i = 0; i < pollers; i++) {
+        String owner = "pg-worker-" + i;
+        tasks.add(
+            () -> {
+              start.await(30, TimeUnit.SECONDS);
+              List<UUID> mine = new java.util.ArrayList<>();
+              for (Optional<IndexingRequestStore.IndexingRequest> got =
+                      requests.claimNext(owner, Duration.ofMinutes(5), NOW.plusSeconds(1000));
+                  got.isPresent();
+                  got = requests.claimNext(owner, Duration.ofMinutes(5), NOW.plusSeconds(1000))) {
+                mine.add(got.get().id());
+              }
+              return mine;
+            });
+      }
+
+      List<UUID> all = new java.util.ArrayList<>();
+      for (Future<List<UUID>> f : racers.invokeAll(tasks, 90, TimeUnit.SECONDS)) {
+        all.addAll(f.get());
+      }
+
+      assertThat(all)
+          .as("every request should have been claimed by someone")
+          .hasSize(requestCount + fixtureRows);
+      assertThat(java.util.Set.copyOf(all))
+          .as("a request was handed to more than one worker")
+          .hasSize(all.size());
+    } finally {
+      racers.shutdownNow();
+    }
   }
 
   // --- helpers ---------------------------------------------------------------------------------

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/RequestStalenessTimeZoneTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/RequestStalenessTimeZoneTest.java
@@ -67,7 +67,7 @@ public class RequestStalenessTimeZoneTest {
   @Test
   public void storedTimestampsAreUtcWallClocksNotJvmLocal() {
     IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("tz", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+        dao.createOrAdopt("tz", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, NOW);
 
     LocalDateTime expected = LocalDateTime.of(2026, 7, 1, 12, 0, 0);
     assertThat(rawTimestamp(claim.request().id(), "created_at")).isEqualTo(expected);
@@ -77,7 +77,7 @@ public class RequestStalenessTimeZoneTest {
   @Test
   public void updateStatusAlsoStampsAUtcWallClock() {
     IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("tz2", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+        dao.createOrAdopt("tz2", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, NOW);
     dao.updateStatus(claim.request().id(), "PROCESSING", null, 1);
 
     assertThat(rawTimestamp(claim.request().id(), "updated_at"))
@@ -92,9 +92,9 @@ public class RequestStalenessTimeZoneTest {
   @Test
   public void stalenessIsMeasuredInUtcRegardlessOfTheJvmZone() {
     IndexingRequestStore.Claim fresh =
-        dao.createOrAdopt("tz3", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+        dao.createOrAdopt("tz3", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, NOW);
     IndexingRequestStore.Claim stale =
-        dao.createOrAdopt("tz4", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
+        dao.createOrAdopt("tz4", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, NOW);
 
     // 30 minutes old and 3 hours old, written as UTC wall clocks by hand.
     writeUtcWallClock(fresh.request().id(), LocalDateTime.of(2026, 7, 1, 11, 30));
@@ -107,19 +107,26 @@ public class RequestStalenessTimeZoneTest {
   }
 
   /**
-   * The same boundary through the dedupe read. Under a UTC+14 leak the 30-minute-old row would look
-   * 14 hours stale and dedupe would stop seeing it, which is what silently disables #1249's guard.
+   * The same boundary through the submit path. Under a UTC+14 leak the 30-minute-old row would look
+   * 14 hours stale, so the reclaim {@code createOrAdopt} runs first would retire it and this caller
+   * would insert a rival for the same games — which is exactly what silently disables #1249's
+   * guard.
+   *
+   * <p>Asserted through {@code createOrAdopt} rather than through {@code findExistingRequest},
+   * which since #1279 reads no timestamps at all: dedupe asks only whether a row still holds the
+   * range, and the clock belongs to reclamation. Pointing this at the read would make it vacuous.
    */
   @Test
-  public void findExistingRequestStillSeesAFreshRowUnderANonUtcZone() {
-    IndexingRequestStore.Claim claim =
-        dao.createOrAdopt("tz5", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW);
-    writeUtcWallClock(claim.request().id(), LocalDateTime.of(2026, 7, 1, 11, 30));
+  public void submittingAgainAdoptsAFreshRowUnderANonUtcZone() {
+    IndexingRequestStore.Claim first =
+        dao.createOrAdopt("tz5", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, NOW);
+    writeUtcWallClock(first.request().id(), LocalDateTime.of(2026, 7, 1, 11, 30));
 
-    assertThat(
-            dao.findExistingRequest(
-                "tz5", "CHESS_COM", "2026-06", "2026-06", false, STALE_AFTER, NOW))
-        .isPresent();
+    IndexingRequestStore.Claim second =
+        dao.createOrAdopt("tz5", "CHESS_COM", "2026-06", "2026-06", false, false, STALE_AFTER, NOW);
+
+    assertThat(second.created()).as("a 30-minute-old row must not be retired as stale").isFalse();
+    assertThat(second.request().id()).isEqualTo(first.request().id());
   }
 
   private LocalDateTime rawTimestamp(UUID id, String column) {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/TableDispatchTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/TableDispatchTest.java
@@ -1,0 +1,204 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The property #1279 exists for: any available worker can process any queued request.
+ *
+ * <p>Before this, a request could only ever run in the process that accepted the submit, because
+ * the message went into that JVM's {@code InMemoryIndexQueue}. Adding an instance added no
+ * throughput for work already queued, a restart lost the messages while the rows survived, and the
+ * documented two-JVM deployment sent load wherever the submit happened to land. The table is the
+ * queue now, and these tests are what says so.
+ */
+public class TableDispatchTest {
+
+  private static final Duration LEASE = RetentionPolicy.LEASE;
+  private static final Duration STALE_AFTER = RetentionPolicy.STALE_REQUEST;
+  private static final Instant NOW = Instant.parse("2026-07-01T12:00:00Z");
+
+  private TestDb testDb;
+  private IndexingRequestDao dao;
+  private ExecutorService pool;
+
+  @BeforeEach
+  public void setUp() {
+    testDb = TestDb.create("table_dispatch");
+    dao = new IndexingRequestDao(testDb.jdbi());
+    pool = Executors.newFixedThreadPool(4);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    pool.shutdownNow();
+  }
+
+  /** The headline, stated plainly. Submitted by one instance, run by another. */
+  @Test
+  public void aRequestSubmittedByOneInstanceIsClaimableByAnother() {
+    UUID id = submit("handoff", "2026-01").request().id();
+
+    Optional<IndexingRequestStore.IndexingRequest> taken =
+        dao.claimNext("instance-b/1/bbbb", LEASE, NOW);
+
+    assertThat(taken)
+        .as("a second instance must be able to take work the first accepted")
+        .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(id));
+    assertThat(dao.holdsLease(id, "instance-b/1/bbbb", NOW)).isTrue();
+  }
+
+  /**
+   * {@code skipCache} has to survive the table, because it stops being the submitter's business the
+   * moment another process runs the request.
+   *
+   * <p>Every other field a run needs was already a column. This one lived only in the queue
+   * message, so a worker claiming the row would have honoured the period cache for a request that
+   * asked to bypass it — silently, and only for requests that crossed an instance boundary.
+   */
+  @Test
+  public void skipCacheSurvivesTheHandoff() {
+    dao.createOrAdopt("bypass", "CHESS_COM", "2026-02", "2026-02", false, true, STALE_AFTER, NOW);
+
+    assertThat(dao.claimNext("instance-b/1/bbbb", LEASE, NOW))
+        .hasValueSatisfying(r -> assertThat(r.skipCache()).isTrue());
+  }
+
+  /** And the default is not silently sticky the other way. */
+  @Test
+  public void aCacheRespectingRequestStaysCacheRespecting() {
+    submit("normal", "2026-03");
+
+    assertThat(dao.claimNext("instance-b/1/bbbb", LEASE, NOW))
+        .hasValueSatisfying(r -> assertThat(r.skipCache()).isFalse());
+  }
+
+  /**
+   * Oldest first: the queue it replaces was FIFO, and a poller that skips ahead starves the head.
+   */
+  @Test
+  public void workIsHandedOutOldestFirst() {
+    // Inserted newest-first on purpose. With the older row also inserted first, physical scan
+    // order already matches the asserted order and deleting the ORDER BY changes nothing.
+    UUID second = submitAt("fifo-b", "2026-05", NOW.plusSeconds(60)).request().id();
+    UUID first = submitAt("fifo-a", "2026-04", NOW).request().id();
+
+    assertThat(dao.claimNext("w1", LEASE, NOW.plusSeconds(120)))
+        .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(first));
+    assertThat(dao.claimNext("w2", LEASE, NOW.plusSeconds(120)))
+        .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(second));
+  }
+
+  /** A request already held is not offered again while its lease is live. */
+  @Test
+  public void heldWorkIsNotHandedToASecondWorker() {
+    submit("exclusive", "2026-06");
+    assertThat(dao.claimNext("w1", LEASE, NOW)).isPresent();
+
+    assertThat(dao.claimNext("w2", LEASE, NOW.plusSeconds(1)))
+        .as("the only request in the table is already owned")
+        .isEmpty();
+  }
+
+  /**
+   * Four pollers, four requests, all racing. Every request goes to exactly one worker.
+   *
+   * <p>This is the property the whole design rests on, and it does not come from the selection
+   * query — that is an unlocked read, and all four are entitled to return the same candidates. It
+   * comes from {@code claim} being a conditional UPDATE, so at most one racer's WHERE can match a
+   * given row and the losers move on to the next candidate.
+   */
+  @Test
+  @Timeout(30)
+  public void concurrentPollersNeverHandTheSameRequestToTwoWorkers() throws Exception {
+    int workers = 4;
+    for (int i = 0; i < workers; i++) {
+      submitAt("racer" + i, "2026-07", NOW.plusSeconds(i));
+    }
+
+    CyclicBarrier start = new CyclicBarrier(workers);
+    List<Callable<Optional<UUID>>> tasks =
+        java.util.stream.IntStream.range(0, workers)
+            .<Callable<Optional<UUID>>>mapToObj(
+                i ->
+                    () -> {
+                      start.await(20, TimeUnit.SECONDS);
+                      return dao.claimNext("racer-worker-" + i, LEASE, NOW.plusSeconds(100))
+                          .map(IndexingRequestStore.IndexingRequest::id);
+                    })
+            .toList();
+
+    List<UUID> claimed =
+        pool.invokeAll(tasks, 25, TimeUnit.SECONDS).stream()
+            .map(TableDispatchTest::get)
+            .flatMap(Optional::stream)
+            .toList();
+
+    assertThat(claimed).as("every worker should have found work").hasSize(workers);
+    assertThat(Set.copyOf(claimed))
+        .as("two workers were handed the same request")
+        .hasSize(claimed.size());
+  }
+
+  /**
+   * A request that keeps killing its worker is eventually stopped rather than toured around the
+   * fleet. Releasing is unbounded by construction, so without the counter this loop never ends.
+   */
+  @Test
+  public void aRequestThatOutlivesItsAttemptsStopsBeingOffered() {
+    UUID id = submit("poison", "2026-08").request().id();
+
+    for (int i = 0; i < IndexingRequestDao.MAX_ATTEMPTS; i++) {
+      Instant at = NOW.plus(LEASE.multipliedBy(i));
+      assertThat(dao.claimNext("worker-" + i, LEASE, at))
+          .as("attempt %s should still be offered", i)
+          .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(id));
+    }
+
+    Instant afterEveryLease = NOW.plus(LEASE.multipliedBy(IndexingRequestDao.MAX_ATTEMPTS + 1));
+    assertThat(dao.claimNext("worker-last", LEASE, afterEveryLease))
+        .as("a request that has burned its attempts must stop being handed out")
+        .isEmpty();
+
+    dao.reclaimStale(STALE_AFTER, afterEveryLease);
+    assertThat(dao.findById(id).orElseThrow().status())
+        .as("and the user is told, rather than left waiting on work nobody will run")
+        .isEqualTo("FAILED");
+  }
+
+  // --- helpers ---------------------------------------------------------------------------------
+
+  private static <T> T get(Future<T> f) {
+    try {
+      return f.get();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private IndexingRequestStore.Claim submit(String player, String month) {
+    return submitAt(player, month, NOW);
+  }
+
+  private IndexingRequestStore.Claim submitAt(String player, String month, Instant at) {
+    IndexingRequestDao stamped =
+        new IndexingRequestDao(testDb.jdbi(), java.time.Clock.fixed(at, java.time.ZoneOffset.UTC));
+    return stamped.createOrAdopt(player, "CHESS_COM", month, month, false, false, STALE_AFTER, at);
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/DataAvailabilityResolverTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/DataAvailabilityResolverTest.java
@@ -107,7 +107,9 @@ public class DataAvailabilityResolverTest {
             FETCHED,
             null,
             42,
-            true);
+            true,
+            false,
+            0);
 
     // The period a CHESS_COM bullet-including request would have written cannot vouch for it.
     periods.add("hikaru", "CHESS_COM", false, "2026-07", FETCHED);
@@ -212,7 +214,9 @@ public class DataAvailabilityResolverTest {
         FETCHED,
         null,
         42,
-        false);
+        false,
+        false,
+        0);
   }
 
   private static final class FakePeriodStore implements IndexedPeriodStore {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
@@ -160,9 +160,9 @@ public class IndexRequestServiceTest {
   }
 
   /**
-   * #1249: two callers that both see nothing must still produce one unit of work. The service's
-   * dedupe read cannot prevent this — only the claim can — so this drives the path where the read
-   * is bypassed entirely.
+   * #1249: two callers that both see nothing must still produce one unit of work. Only the claim
+   * can decide that — a read followed by a write has a window in it, which is why the submit path
+   * asks createOrAdopt and nothing else.
    */
   @Test
   public void submit_secondCallerAdoptsRatherThanDispatchingASecondTime() {
@@ -174,8 +174,17 @@ public class IndexRequestServiceTest {
   }
 
   /**
-   * #1250: a request whose owner died must not hold its range hostage. Before the age bound, the
-   * stranded row answered every later submit forever and the only escape was skipCache.
+   * #1250: a request nothing is going to run must not hold its range hostage. Before the age bound,
+   * that row answered every later submit forever and the only escape was skipCache.
+   *
+   * <p>No worker has ever held a lease in this fixture, which since #1279 is the whole reason it
+   * retires: an old row is only stalled when nothing is running anywhere. An old row on a working
+   * fleet is a backlog, and the test below it covers the case where the age has not yet elapsed.
+   *
+   * <p>This is also what pins the submit path to a single call. #1279 took the clock out of {@code
+   * findExistingRequest}, and the dedupe read that used to run ahead of {@code createOrAdopt}
+   * immediately started answering with this row instead of reaching the reclaim that retires it —
+   * reintroducing a short-circuit here fails on exactly this assertion.
    */
   @Test
   public void submit_strandedRequestIsRetiredAndReplacedOnTheNextSubmit() {
@@ -294,9 +303,7 @@ public class IndexRequestServiceTest {
         .isInstanceOf(RuntimeException.class)
         .hasMessage("boom");
 
-    assertThat(
-            requestStore.findExistingRequest(
-                "hikaru", "CHESS_COM", "2024-01", "2024-01", false, Duration.ofHours(1), NOW))
+    assertThat(requestStore.findExistingRequest("hikaru", "CHESS_COM", "2024-01", "2024-01", false))
         .as("the range must not stay locked by a row nothing will ever finish")
         .isEmpty();
 
@@ -445,6 +452,7 @@ public class IndexRequestServiceTest {
         String startMonth,
         String endMonth,
         boolean excludeBullet,
+        boolean skipCache,
         Duration staleAfter,
         Instant now) {
       reclaimStale(staleAfter, now);
@@ -466,9 +474,23 @@ public class IndexRequestServiceTest {
               now,
               null,
               0,
-              excludeBullet);
+              excludeBullet,
+              skipCache,
+              0);
       rows.put(id, created);
       return new Claim(created, true);
+    }
+
+    /**
+     * Unimplemented on purpose. The submit path never claims — it creates a row and hands the work
+     * to a worker, and {@code IndexWorkerLifecycle} is the only thing that takes rows off the
+     * table. Returning empty here would be the quieter choice and the worse one: if a later change
+     * makes the service claim, an empty answer looks like "no work" and the test still passes.
+     */
+    @Override
+    public Optional<IndexingRequest> claimNext(String ownerId, Duration lease, Instant now) {
+      throw new UnsupportedOperationException(
+          "the submit path does not claim; see IndexWorkerLifecycleTest");
     }
 
     @Override
@@ -478,22 +500,11 @@ public class IndexRequestServiceTest {
 
     @Override
     public Optional<IndexingRequest> findExistingRequest(
-        String player,
-        String platform,
-        String startMonth,
-        String endMonth,
-        boolean excludeBullet,
-        Duration staleAfter,
-        Instant now) {
-      Instant cutoff = now.minus(staleAfter);
-      // Mirrors the DAO's two arms. A fake that answers this more loosely than production lets a
-      // divergence between dedupe and reclamation pass unnoticed here and fail against Postgres.
+        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
+      // Mirrors the DAO: live, and not yet out of attempts. Age and ownership deliberately do not
+      // appear — a row whose worker died is still queued, so it still holds the range.
       return liveHolder(player, platform, startMonth, endMonth, excludeBullet)
-          .filter(
-              r ->
-                  owners.containsKey(r.id())
-                      ? leases.get(r.id()) != null && leases.get(r.id()).isAfter(now)
-                      : !r.updatedAt().isBefore(cutoff));
+          .filter(r -> r.attempts() < MAX_ATTEMPTS);
     }
 
     @Override
@@ -521,7 +532,9 @@ public class IndexRequestServiceTest {
               clock,
               errorMessage,
               gamesIndexed,
-              row.excludeBullet()));
+              row.excludeBullet(),
+              row.skipCache(),
+              row.attempts()));
     }
 
     @Override
@@ -537,10 +550,29 @@ public class IndexRequestServiceTest {
       if (heldByAnother) {
         return false;
       }
+      boolean reclaiming = !ownerId.equals(held);
       owners.put(id, ownerId);
       leases.put(id, now.plus(lease));
-      strand(id, now);
+      // Counted per new owner, as in the DAO — re-claiming your own row is a renewal, not a lap.
+      rows.put(id, withAttempts(touched(r, now), reclaiming ? r.attempts() + 1 : r.attempts()));
       return true;
+    }
+
+    private static IndexingRequest withAttempts(IndexingRequest r, int attempts) {
+      return new IndexingRequest(
+          r.id(),
+          r.player(),
+          r.platform(),
+          r.startMonth(),
+          r.endMonth(),
+          r.status(),
+          r.createdAt(),
+          r.updatedAt(),
+          r.errorMessage(),
+          r.gamesIndexed(),
+          r.excludeBullet(),
+          r.skipCache(),
+          attempts);
     }
 
     @Override
@@ -552,7 +584,7 @@ public class IndexRequestServiceTest {
         return false;
       }
       leases.put(id, now.plus(lease));
-      strand(id, now);
+      rows.put(id, touched(r, now));
       return true;
     }
 
@@ -582,39 +614,97 @@ public class IndexRequestServiceTest {
       return true;
     }
 
+    /**
+     * Three arms, as in the DAO, applied poisoned then stalled then released.
+     *
+     * <p>Worth modelling rather than stubbing, and worth getting the arms right, because this is
+     * the fake the submit path runs against and the two outcomes differ in exactly the way that
+     * matters here: a retired row frees its range for the next submit, a released one does not. An
+     * earlier version of this fake retired on lease expiry — the behaviour #1279 deleted — which
+     * would have let a service that resurrects released work look correct.
+     */
     @Override
     public int reclaimStale(Duration staleAfter, Instant now) {
       Instant cutoff = now.minus(staleAfter);
-      // Two arms, as in the DAO: a claimed row is judged by its lease, an unclaimed one by its
-      // age. Collapsing them here would let a test pass that retires a row a worker still owns.
-      List<IndexingRequest> stranded =
+      List<IndexingRequest> candidates =
+          rows.values().stream().filter(InMemoryRequestStore::live).toList();
+      boolean anyoneWorking =
           rows.values().stream()
-              .filter(
-                  r ->
-                      live(r)
-                          && (owners.containsKey(r.id())
-                              ? leases.get(r.id()) != null && leases.get(r.id()).isBefore(now)
-                              : r.updatedAt().isBefore(cutoff)))
-              .toList();
-      for (IndexingRequest r : stranded) {
-        owners.remove(r.id());
-        leases.remove(r.id());
-        rows.put(
-            r.id(),
-            new IndexingRequest(
-                r.id(),
-                r.player(),
-                r.platform(),
-                r.startMonth(),
-                r.endMonth(),
-                "FAILED",
-                r.createdAt(),
-                now,
-                "Abandoned",
-                r.gamesIndexed(),
-                r.excludeBullet()));
+              .anyMatch(r -> owners.containsKey(r.id()) && expiresAfter(r.id(), now));
+
+      int settled = 0;
+      for (IndexingRequest r : candidates) {
+        boolean unheld = !owners.containsKey(r.id()) || !expiresAfter(r.id(), now);
+        if (r.attempts() >= MAX_ATTEMPTS && unheld) {
+          retire(r, "Abandoned: attempts exhausted", now);
+        } else if (unheld
+            && r.updatedAt().isBefore(cutoff)
+            && !anyoneWorking
+            && !leasedSince(r, cutoff)) {
+          retire(r, "Abandoned: no worker running anywhere", now);
+        } else if (owners.containsKey(r.id()) && !expiresAfter(r.id(), now)) {
+          // Released: the owner is gone, the work is not. The row stays live and keeps its range.
+          owners.remove(r.id());
+          rows.put(r.id(), touched(r, now));
+        } else {
+          continue;
+        }
+        settled++;
       }
-      return stranded.size();
+      return settled;
+    }
+
+    private boolean expiresAfter(UUID id, Instant now) {
+      Instant expires = leases.get(id);
+      return expires != null && expires.isAfter(now);
+    }
+
+    /** Any other row a worker held recently — the DAO's second liveness probe. */
+    private boolean leasedSince(IndexingRequest judged, Instant cutoff) {
+      return rows.values().stream()
+          .anyMatch(
+              other ->
+                  !other.id().equals(judged.id())
+                      && leases.get(other.id()) != null
+                      && !leases.get(other.id()).isBefore(cutoff));
+    }
+
+    private void retire(IndexingRequest r, String reason, Instant now) {
+      owners.remove(r.id());
+      leases.remove(r.id());
+      rows.put(
+          r.id(),
+          new IndexingRequest(
+              r.id(),
+              r.player(),
+              r.platform(),
+              r.startMonth(),
+              r.endMonth(),
+              "FAILED",
+              r.createdAt(),
+              now,
+              reason,
+              r.gamesIndexed(),
+              r.excludeBullet(),
+              r.skipCache(),
+              r.attempts()));
+    }
+
+    private static IndexingRequest touched(IndexingRequest r, Instant now) {
+      return new IndexingRequest(
+          r.id(),
+          r.player(),
+          r.platform(),
+          r.startMonth(),
+          r.endMonth(),
+          r.status(),
+          r.createdAt(),
+          now,
+          r.errorMessage(),
+          r.gamesIndexed(),
+          r.excludeBullet(),
+          r.skipCache(),
+          r.attempts());
     }
 
     @Override
@@ -629,22 +719,9 @@ public class IndexRequestServiceTest {
     }
 
     /** Backdates a row's updatedAt so a test can strand it without waiting an hour. */
+    /** Backdates {@code updated_at}, so a test can age a row past the staleness window. */
     void strand(UUID id, Instant updatedAt) {
-      IndexingRequest r = rows.get(id);
-      rows.put(
-          id,
-          new IndexingRequest(
-              r.id(),
-              r.player(),
-              r.platform(),
-              r.startMonth(),
-              r.endMonth(),
-              r.status(),
-              r.createdAt(),
-              updatedAt,
-              r.errorMessage(),
-              r.gamesIndexed(),
-              r.excludeBullet()));
+      rows.put(id, touched(rows.get(id), updatedAt));
     }
   }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/service/IndexRequestServiceTest.java
@@ -589,6 +589,17 @@ public class IndexRequestServiceTest {
     }
 
     @Override
+    public boolean handBack(UUID id, String ownerId, Instant now) {
+      IndexingRequest r = rows.get(id);
+      if (r == null || !live(r) || !ownerId.equals(owners.get(id))) {
+        return false;
+      }
+      owners.remove(id);
+      rows.put(id, withAttempts(touched(r, now), Math.max(0, r.attempts() - 1)));
+      return true;
+    }
+
+    @Override
     public boolean holdsLease(UUID id, String ownerId, Instant now) {
       IndexingRequest r = rows.get(id);
       Instant expires = leases.get(id);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycleTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycleTest.java
@@ -35,8 +35,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -160,6 +162,61 @@ public class IndexWorkerLifecycleTest {
         .isZero();
   }
 
+  /**
+   * Shutting down hands the work back, rather than letting the JVM drop it on the floor.
+   *
+   * <p>The poller is a daemon thread, so process exit kills whatever it is running. Without this,
+   * every deploy looks exactly like a crash: the row stays owned by a process that no longer
+   * exists, nothing may take it until the lease lapses five minutes later, and the attempt spent on
+   * claiming it is gone. Three rolling restarts across one long request retire it as poisoned and
+   * tell the user its range fails repeatedly — about a fleet that is working perfectly.
+   *
+   * <p>Handing back rather than waiting for the run to finish is the deliberate choice. An indexing
+   * run has no bound — a twelve-month range against a slow chess.com is legitimately long — so a
+   * shutdown that drains is a shutdown that hangs. The departing run is not interrupted here; it
+   * simply loses the right to write, which the fencing already enforces.
+   */
+  @Test
+  @Timeout(30)
+  public void stopHandsBackTheRequestThisProcessWasRunning() throws Exception {
+    UUID id = submit("mid-run", false).request().id();
+    CountDownLatch reachedFetch = new CountDownLatch(1);
+    CountDownLatch letItFinish = new CountDownLatch(1);
+    IndexWorkerLifecycle lifecycle =
+        lifecycleFor(new BlockingClient(reachedFetch, letItFinish), new InMemoryIndexQueue());
+
+    Thread run = Thread.ofVirtual().start(lifecycle::claimAndRunOne);
+    try {
+      assertThat(reachedFetch.await(20, TimeUnit.SECONDS)).as("the run got going").isTrue();
+      assertThat(dao.findById(id).orElseThrow().attempts()).isEqualTo(1);
+
+      lifecycle.stop();
+
+      assertThat(dao.findById(id).orElseThrow().attempts())
+          .as("a deploy must not spend one of the three attempts")
+          .isZero();
+      assertThat(dao.claim(id, "another-instance", RetentionPolicy.LEASE, NOW))
+          .as("the work moves to a surviving instance now, not five minutes from now")
+          .isTrue();
+    } finally {
+      letItFinish.countDown();
+      run.join();
+    }
+  }
+
+  /** Nothing in flight, nothing to give back — shutting down idle must not touch the table. */
+  @Test
+  @Timeout(30)
+  public void stopIsHarmlessWhenNothingIsRunning() {
+    UUID id = submit("untouched", false).request().id();
+
+    lifecycleFor(new RecordingClient(), new InMemoryIndexQueue()).stop();
+
+    IndexingRequestStore.IndexingRequest row = dao.findById(id).orElseThrow();
+    assertThat(row.status()).isEqualTo("PENDING");
+    assertThat(row.attempts()).isZero();
+  }
+
   // --- wiring ---------------------------------------------------------------------------------
 
   private IndexingRequestStore.Claim submit(String player, boolean skipCache) {
@@ -193,6 +250,34 @@ public class IndexWorkerLifecycleTest {
             CLOCK,
             Duration.ofHours(1));
     return new IndexWorkerLifecycle(queue, worker, dao, CLOCK);
+  }
+
+  /** Parks inside the fetch so a test can act while a run is genuinely in flight. */
+  private static final class BlockingClient extends ChessClient {
+    private final CountDownLatch reachedFetch;
+    private final CountDownLatch letItFinish;
+
+    BlockingClient(CountDownLatch reachedFetch, CountDownLatch letItFinish) {
+      super(null, new ObjectMapper());
+      this.reachedFetch = reachedFetch;
+      this.letItFinish = letItFinish;
+    }
+
+    @Override
+    public Optional<GamesResponse> fetchGames(String player, YearMonth yearMonth) {
+      reachedFetch.countDown();
+      try {
+        letItFinish.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Player> fetchPlayer(String player) {
+      return Optional.empty();
+    }
   }
 
   /** Records which players were actually fetched, and returns nothing for each. */

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycleTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycleTest.java
@@ -1,0 +1,327 @@
+package com.muchq.games.one_d4.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.muchq.games.chess_com_client.ChessClient;
+import com.muchq.games.chess_com_client.GamesResponse;
+import com.muchq.games.chess_com_client.Player;
+import com.muchq.games.one_d4.api.dto.AggregateRow;
+import com.muchq.games.one_d4.api.dto.GameFeature;
+import com.muchq.games.one_d4.api.dto.OccurrenceRow;
+import com.muchq.games.one_d4.db.GameFeatureStore;
+import com.muchq.games.one_d4.db.IndexedPeriodStore;
+import com.muchq.games.one_d4.db.IndexingRequestDao;
+import com.muchq.games.one_d4.db.IndexingRequestStore;
+import com.muchq.games.one_d4.db.RetentionPolicy;
+import com.muchq.games.one_d4.db.TestDb;
+import com.muchq.games.one_d4.engine.FeatureExtractor;
+import com.muchq.games.one_d4.engine.GameReplayer;
+import com.muchq.games.one_d4.engine.PgnParser;
+import com.muchq.games.one_d4.engine.model.GameFeatures;
+import com.muchq.games.one_d4.engine.model.Motif;
+import com.muchq.games.one_d4.motifs.CheckDetector;
+import com.muchq.games.one_d4.queue.InMemoryIndexQueue;
+import com.muchq.games.one_d4.queue.IndexMessage;
+import com.muchq.games.one_d4.queue.IndexQueue;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * The dispatcher itself — the piece #1279 is actually about, and the one that had no test.
+ *
+ * <p>{@code TableDispatchTest} proves the store can hand a request to any worker. {@code
+ * IndexWorkerLifecycle} is what decides to ask, and it owns three behaviours nothing else covers:
+ * that a claimed row is turned back into a runnable message with every field intact, that the
+ * wake-up nudges it does not read are still consumed, and that it does not care which instance
+ * accepted the submit.
+ *
+ * <p>Driven by calling {@code claimAndRunOne} directly rather than by starting the loop. The loop's
+ * own job is the blocking poll and the backoff, both of which are time, and a test that waits on
+ * them buys flakiness rather than coverage.
+ */
+public class IndexWorkerLifecycleTest {
+
+  private static final Instant NOW = Instant.parse("2026-07-01T12:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+  private TestDb testDb;
+  private IndexingRequestDao dao;
+  private ExecutorService extraction;
+
+  @BeforeEach
+  public void setUp() {
+    testDb = TestDb.create("lifecycle");
+    dao = new IndexingRequestDao(testDb.jdbi(), CLOCK);
+    extraction = Executors.newFixedThreadPool(2);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    extraction.shutdownNow();
+  }
+
+  /**
+   * The headline at the level that implements it: a row this instance never saw submitted still
+   * gets claimed and run.
+   */
+  @Test
+  @Timeout(30)
+  public void claimsAndRunsARequestItNeverReceivedAMessageFor() {
+    UUID id = submit("elsewhere", false).request().id();
+
+    RecordingClient client = new RecordingClient();
+    IndexWorkerLifecycle lifecycle = lifecycleFor(client, new InMemoryIndexQueue());
+
+    assertThat(lifecycle.claimAndRunOne()).as("there was work to take").isTrue();
+    assertThat(client.players).containsExactly("elsewhere");
+    assertThat(dao.findById(id).orElseThrow().status()).isEqualTo("COMPLETED");
+  }
+
+  /** And says so when there is nothing, rather than spinning. */
+  @Test
+  @Timeout(30)
+  public void reportsAnEmptyQueueWhenThereIsNoWork() {
+    IndexWorkerLifecycle lifecycle = lifecycleFor(new RecordingClient(), new InMemoryIndexQueue());
+    assertThat(lifecycle.claimAndRunOne()).isFalse();
+  }
+
+  /**
+   * {@code skipCache} has to reach the worker, not merely survive the column.
+   *
+   * <p>The DAO round-trip is tested next door; this is the other half, and it is the half the
+   * column exists for. Nothing else pins it — changing {@code toMessage} to pass {@code false}
+   * leaves every other suite green, and the symptom in production would be a request that quietly
+   * honours a cache the submitter asked it to bypass, only when it crossed an instance boundary.
+   */
+  @Test
+  @Timeout(30)
+  public void carriesSkipCacheFromTheRowIntoTheRun() {
+    submit("bypasser", true);
+
+    RecordingClient client = new RecordingClient();
+    CachedPeriodStore periods = new CachedPeriodStore();
+    lifecycleFor(client, new InMemoryIndexQueue(), periods).claimAndRunOne();
+
+    assertThat(client.players)
+        .as("a cached period was honoured for a request that asked to skip the cache")
+        .containsExactly("bypasser");
+  }
+
+  /** The converse, so the test above is not passing because the cache is simply never consulted. */
+  @Test
+  @Timeout(30)
+  public void honoursACachedPeriodWhenTheRequestDidNotAskToSkipIt() {
+    submit("cached", false);
+
+    RecordingClient client = new RecordingClient();
+    lifecycleFor(client, new InMemoryIndexQueue(), new CachedPeriodStore()).claimAndRunOne();
+
+    assertThat(client.players).as("the cached month should not have been refetched").isEmpty();
+  }
+
+  /**
+   * Nudges are consumed after work, not only when idle.
+   *
+   * <p>This loop is the queue's only consumer and it never reaches the blocking poll while the
+   * table has work, so without an explicit drain every accepted submit on a busy instance leaves a
+   * message behind forever — and the accumulated backlog of stale nudges then fires back-to-back
+   * the moment things go quiet, defeating the idle interval entirely.
+   */
+  @Test
+  @Timeout(30)
+  public void drainsPendingNudgesAfterClaimingWork() {
+    submit("nudged", false);
+    IndexQueue queue = new InMemoryIndexQueue();
+    for (int i = 0; i < 5; i++) {
+      queue.enqueue(
+          new IndexMessage(UUID.randomUUID(), "stale", "CHESS_COM", "2024-01", "2024-01", false));
+    }
+
+    assertThat(lifecycleFor(new RecordingClient(), queue).claimAndRunOne()).isTrue();
+
+    assertThat(queue.size())
+        .as("stale nudges accumulate forever on an instance that always has work")
+        .isZero();
+  }
+
+  // --- wiring ---------------------------------------------------------------------------------
+
+  private IndexingRequestStore.Claim submit(String player, boolean skipCache) {
+    return dao.createOrAdopt(
+        player,
+        "CHESS_COM",
+        "2024-01",
+        "2024-01",
+        false,
+        skipCache,
+        RetentionPolicy.STALE_REQUEST,
+        NOW);
+  }
+
+  private IndexWorkerLifecycle lifecycleFor(ChessClient client, IndexQueue queue) {
+    return lifecycleFor(client, queue, new NoOpPeriodStore());
+  }
+
+  private IndexWorkerLifecycle lifecycleFor(
+      ChessClient client, IndexQueue queue, IndexedPeriodStore periods) {
+    FeatureExtractor extractor =
+        new FeatureExtractor(new PgnParser(), new GameReplayer(), List.of(new CheckDetector()));
+    IndexWorker worker =
+        new IndexWorker(
+            client,
+            extractor,
+            dao,
+            new NoOpGameFeatureStore(),
+            periods,
+            extraction,
+            CLOCK,
+            Duration.ofHours(1));
+    return new IndexWorkerLifecycle(queue, worker, dao, CLOCK);
+  }
+
+  /** Records which players were actually fetched, and returns nothing for each. */
+  private static final class RecordingClient extends ChessClient {
+    final Collection<String> players = new ConcurrentLinkedQueue<>();
+
+    RecordingClient() {
+      super(null, new ObjectMapper());
+    }
+
+    @Override
+    public Optional<GamesResponse> fetchGames(String player, YearMonth yearMonth) {
+      players.add(player);
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Player> fetchPlayer(String player) {
+      return Optional.empty();
+    }
+  }
+
+  /** Reports every month as already indexed, so only a skipCache run reaches chess.com. */
+  private static final class CachedPeriodStore implements IndexedPeriodStore {
+    @Override
+    public Optional<IndexedPeriod> findCompletePeriod(
+        String player, String platform, String month, boolean excludeBullet) {
+      return Optional.of(new IndexedPeriod(player, platform, month, NOW, true, 7, excludeBullet));
+    }
+
+    @Override
+    public void upsertPeriod(
+        String player,
+        String platform,
+        String month,
+        Instant fetchedAt,
+        boolean isComplete,
+        int gamesCount,
+        boolean excludeBullet) {}
+
+    @Override
+    public List<IndexedPeriod> findPeriodsForPlayers(Collection<String> players) {
+      return List.of();
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
+    }
+  }
+
+  private static final class NoOpPeriodStore implements IndexedPeriodStore {
+    @Override
+    public Optional<IndexedPeriod> findCompletePeriod(
+        String player, String platform, String month, boolean excludeBullet) {
+      return Optional.empty();
+    }
+
+    @Override
+    public void upsertPeriod(
+        String player,
+        String platform,
+        String month,
+        Instant fetchedAt,
+        boolean isComplete,
+        int gamesCount,
+        boolean excludeBullet) {}
+
+    @Override
+    public List<IndexedPeriod> findPeriodsForPlayers(Collection<String> players) {
+      return List.of();
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
+    }
+  }
+
+  private static final class NoOpGameFeatureStore implements GameFeatureStore {
+    @Override
+    public void insertBatch(List<GameFeature> features) {}
+
+    @Override
+    public boolean flushOwned(
+        UUID requestId,
+        String ownerId,
+        Instant now,
+        List<GameFeature> features,
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {
+      return true;
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return 0;
+    }
+
+    @Override
+    public void insertOccurrencesBatch(
+        Map<String, Map<Motif, List<GameFeatures.MotifOccurrence>>> occurrencesByGame) {}
+
+    @Override
+    public void deleteOccurrencesByGameUrls(List<String> gameUrls) {}
+
+    @Override
+    public List<GameFeature> query(Object compiledQuery, int limit, int offset) {
+      return List.of();
+    }
+
+    @Override
+    public List<AggregateRow> aggregate(
+        Object compiledQuery, List<String> groupColumns, int limit) {
+      return List.of();
+    }
+
+    @Override
+    public AggregateTotals aggregateTotals(Object compiledQuery) {
+      return new AggregateTotals(0, 0);
+    }
+
+    @Override
+    public Map<String, Map<String, List<OccurrenceRow>>> queryOccurrences(List<String> gameUrls) {
+      return Map.of();
+    }
+
+    @Override
+    public List<GameForReanalysis> fetchForReanalysis(int limit, int offset) {
+      return List.of();
+    }
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -744,6 +744,12 @@ public class IndexWorkerTest {
     }
 
     @Override
+    public boolean handBack(UUID id, String ownerId, Instant now) {
+
+      return false;
+    }
+
+    @Override
     public boolean holdsLease(UUID id, String ownerId, Instant now) {
       return true;
     }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -695,6 +695,7 @@ public class IndexWorkerTest {
         String startMonth,
         String endMonth,
         boolean excludeBullet,
+        boolean skipCache,
         java.time.Duration staleAfter,
         Instant now) {
       return new Claim(
@@ -709,8 +710,17 @@ public class IndexWorkerTest {
               now,
               null,
               0,
-              excludeBullet),
+              excludeBullet,
+              false,
+              0),
           true);
+    }
+
+    /** Not exercised by IndexWorker tests: nothing here dispatches from the table. */
+    @Override
+    public Optional<IndexingRequestStore.IndexingRequest> claimNext(
+        String ownerId, java.time.Duration lease, Instant now) {
+      return Optional.empty();
     }
 
     @Override
@@ -769,13 +779,7 @@ public class IndexWorkerTest {
 
     @Override
     public Optional<IndexingRequestStore.IndexingRequest> findExistingRequest(
-        String player,
-        String platform,
-        String startMonth,
-        String endMonth,
-        boolean excludeBullet,
-        java.time.Duration staleAfter,
-        Instant now) {
+        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
       return Optional.empty();
     }
   }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -148,40 +148,39 @@ public class RequestLivenessTest {
   }
 
   /**
-   * Characterizes the hole the heartbeat does <em>not</em> close, so it cannot drift silently.
+   * The tripwire from #1278, now tripped, and honoured rather than renamed.
    *
-   * <p>A message waiting in the queue has no worker running for it, so nothing beats on its behalf
-   * and {@code updated_at} stays frozen at insert. A backlog deeper than the cutoff therefore
-   * retires work that is owned and about to run, and tells the user to re-submit while the message
-   * is still queued.
+   * <p>It used to assert that queued-but-unstarted work was retired, and said so as a known gap:
+   * "when dispatch claims from this table (#1279) the row will be claimed rather than queued, this
+   * test should fail, and it should be rewritten to assert the opposite."
    *
-   * <p>Ownership made the consequence worse rather than better, which is worth being explicit
-   * about: the worker that eventually dequeues the message now fails to claim the retired row and
-   * declines it, so nothing is indexed. Before, it carried on and its unfenced terminal write
-   * landed — the user got their games, at the cost of the concurrent-writer corruption that could
-   * follow from the freed dedupe slot.
-   *
-   * <p>This asserts the current, wrong behaviour on purpose. When dispatch claims from this table
-   * (#1279) the row will be claimed rather than queued, this test should fail, and it should be
-   * rewritten to assert the opposite. That failure is the notification.
+   * <p>So: a request nobody has started is not abandoned, it is queued, and any worker may take it.
+   * What still ends it is not age but a fleet that is demonstrably not running anything — the
+   * distinction between "my turn has not come" and "nothing is serving this", which age alone could
+   * never make.
    */
   @Test
-  public void queuedButUnstartedWorkIsStillRetired_knownGap() {
+  public void queuedButUnstartedWorkIsWaitingForAWorker() {
     TestDb testDb = TestDb.create("liveness_backlog");
     IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
     UUID queued = claim(dao).request().id();
 
-    // No worker has picked the message up yet; the backlog outlasts the cutoff.
+    // A worker is busy elsewhere: the fleet is alive, this row's turn has not come.
+    IndexingRequestStore.Claim elsewhere =
+        dao.createOrAdopt(
+            "other", PLATFORM, MONTH, MONTH, false, false, STALE_AFTER, clock.instant());
+    dao.claim(elsewhere.request().id(), "busy-worker", RetentionPolicy.LEASE, clock.instant());
+
     clock.advance(SLOW_FETCH);
+    dao.renewLease(elsewhere.request().id(), "busy-worker", RetentionPolicy.LEASE, clock.instant());
     dao.reclaimStale(STALE_AFTER, clock.instant());
 
     assertThat(dao.findById(queued).orElseThrow().status())
-        .as(
-            "known gap: queued-but-unstarted work is indistinguishable from abandoned work,"
-                + " because only a claimed request has an owner to renew for it. Beating on"
-                + " enqueue would not fix it either — the process holding the queue is the one"
-                + " that may have died. The fix is dispatch claiming from this table (#1279).")
-        .isEqualTo("FAILED");
+        .as("waiting behind a working fleet is not abandonment")
+        .isIn("PENDING", "PROCESSING");
+    assertThat(dao.claimNext("free-worker", RetentionPolicy.LEASE, clock.instant()))
+        .as("and any worker can take it")
+        .hasValueSatisfying(r -> assertThat(r.id()).isEqualTo(queued));
   }
 
   /** A renewal must not resurrect a request someone else already took. */
@@ -338,10 +337,51 @@ public class RequestLivenessTest {
         .isEqualTo("FAILED");
     assertThat(row.errorMessage()).contains("Indexing failed");
     assertThat(
-            dao.createOrAdopt(PLAYER, PLATFORM, MONTH, MONTH, false, STALE_AFTER, clock.instant())
+            dao.createOrAdopt(
+                    PLAYER, PLATFORM, MONTH, MONTH, false, false, STALE_AFTER, clock.instant())
                 .created())
         .as("and the dedupe slot is released, so the range is requestable again immediately")
         .isTrue();
+  }
+
+  /**
+   * One process, two ways in, one run.
+   *
+   * <p>#1279 gave this process a second entry point. The poller claims from the table; {@code
+   * submitHybrid} hands a message straight to {@code process}. Both can reach the same row — the
+   * poller can claim it in the gap between {@code createOrAdopt} committing and the inline call
+   * starting — and the lease cannot separate them, because {@code ownerId} names the process and
+   * {@code claim} therefore admits its own holder. That is correct for the question the lease
+   * answers and useless for this one.
+   *
+   * <p>Without an in-process guard both runs pass every fence, so the whole range is fetched and
+   * extracted twice, one terminal write is refused, and nothing anywhere says so.
+   */
+  @Test
+  @Timeout(30)
+  public void oneProcessRunsARequestOnceEvenWhenBothEntryPointsReachIt() throws Exception {
+    TestDb testDb = TestDb.create("liveness_two_entries");
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
+    UUID requestId = claim(dao).request().id();
+
+    CountDownLatch insideFetch = new CountDownLatch(1);
+    CountDownLatch releaseFetch = new CountDownLatch(1);
+    CountingChessClient client = new CountingChessClient(insideFetch, releaseFetch);
+    IndexWorker worker = newWorker(client, dao, Duration.ofMillis(20));
+
+    // The poller's run gets there first and parks in the fetch.
+    Future<?> viaPoller = workerExecutor.submit(() -> worker.process(message(requestId)));
+    assertThat(insideFetch.await(15, TimeUnit.SECONDS)).isTrue();
+
+    // The inline dispatch arrives for the same row, in the same process, on this thread.
+    worker.process(message(requestId));
+
+    releaseFetch.countDown();
+    viaPoller.get(20, TimeUnit.SECONDS);
+
+    assertThat(client.fetches.get())
+        .as("the range was indexed twice — the same games fetched and extracted by both runs")
+        .isEqualTo(1);
   }
 
   /** Two workers, one request: the second must decline rather than double up on the games. */
@@ -450,7 +490,8 @@ public class RequestLivenessTest {
   // --- wiring ---------------------------------------------------------------------------------
 
   private IndexingRequestStore.Claim claim(IndexingRequestDao dao) {
-    return dao.createOrAdopt(PLAYER, PLATFORM, MONTH, MONTH, false, STALE_AFTER, clock.instant());
+    return dao.createOrAdopt(
+        PLAYER, PLATFORM, MONTH, MONTH, false, false, STALE_AFTER, clock.instant());
   }
 
   private IndexMessage message(UUID requestId) {
@@ -564,6 +605,37 @@ public class RequestLivenessTest {
     }
   }
 
+  /** Parks in the archive fetch until released, and counts how many runs got that far. */
+  private static final class CountingChessClient extends ChessClient {
+    final java.util.concurrent.atomic.AtomicInteger fetches =
+        new java.util.concurrent.atomic.AtomicInteger();
+    private final CountDownLatch entered;
+    private final CountDownLatch release;
+
+    CountingChessClient(CountDownLatch entered, CountDownLatch release) {
+      super(null, new ObjectMapper());
+      this.entered = entered;
+      this.release = release;
+    }
+
+    @Override
+    public Optional<GamesResponse> fetchGames(String player, YearMonth yearMonth) {
+      fetches.incrementAndGet();
+      entered.countDown();
+      try {
+        release.await(20, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Player> fetchPlayer(String player) {
+      return Optional.empty();
+    }
+  }
+
   /** Parks in the archive fetch until released, then fails the run for real. */
   private static final class ThrowingChessClient extends ChessClient {
     private final CountDownLatch entered;
@@ -637,9 +709,16 @@ public class RequestLivenessTest {
         String startMonth,
         String endMonth,
         boolean excludeBullet,
+        boolean skipCache,
         Duration staleAfter,
         Instant now) {
       throw new UnsupportedOperationException();
+    }
+
+    /** Not exercised by RequestLiveness tests: nothing here dispatches from the table. */
+    @Override
+    public Optional<IndexingRequest> claimNext(String ownerId, Duration lease, Instant now) {
+      return Optional.empty();
     }
 
     @Override
@@ -649,13 +728,7 @@ public class RequestLivenessTest {
 
     @Override
     public Optional<IndexingRequest> findExistingRequest(
-        String player,
-        String platform,
-        String startMonth,
-        String endMonth,
-        boolean excludeBullet,
-        Duration staleAfter,
-        Instant now) {
+        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
       return Optional.empty();
     }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -684,6 +684,12 @@ public class RequestLivenessTest {
     }
 
     @Override
+    public boolean handBack(UUID id, String ownerId, Instant now) {
+
+      return false;
+    }
+
+    @Override
     public boolean holdsLease(UUID id, String ownerId, Instant now) {
       return true;
     }


### PR DESCRIPTION
Closes #1279.

`indexing_requests` becomes the work queue. `IndexWorkerLifecycle` claims the oldest row nobody holds, takes a lease, and runs it — whichever instance accepted the submit.

Before this, a request could only be processed by the JVM that accepted it, because the message went into that process's `InMemoryIndexQueue`. Adding an instance added no throughput for work already queued; a restart lost the messages while the rows survived; and the documented two-JVM deployment (one_d4 REST plus mcpserver against one Postgres) sent load wherever the submit happened to land. The queue survives, demoted to a wake-up nudge for the instance that took the submit — losing one costs latency, not work.

Claiming is what makes concurrent pollers safe, and #1280 already built it: every worker has an owner id and every write is fenced on it. Selection then conditional UPDATE rather than one statement, because H2 has no `SELECT ... FOR UPDATE SKIP LOCKED` and the conditional UPDATE is what makes it safe without one — at most one racer's WHERE can match, and losing costs a retry against the next candidate. Raced on real Postgres 16, not only H2.

## Reclamation had to be rethought, not extended

An expired lease used to mean "retire it": nothing was ever going to run that request again. Now the row *is* the queue, and retiring throws away work any worker could pick up. Three arms, applied **poisoned → stalled → released**:

| Situation | Outcome | Why |
|---|---|---|
| Lease lapsed, attempts remain | **Released** | The owner is gone; the work is not. Clear `owner_id`, keep the row and its `dedupe_key`. Silent — the user is not told about work that is about to run. |
| Claimed `MAX_ATTEMPTS` times, each worker stopping short | **FAILED** (poisoned) | Releasing is unbounded by construction, so without a counter a request that kills its worker tours the fleet forever, costing one per lap — impossible while a crashed process took its queue down with it. |
| Unheld, untouched for `STALE_REQUEST`, and no worker anywhere holds a live lease | **FAILED** (stalled) | Every instance is down or partitioned. The user is owed an answer and silence is the worse one. |

Both bounds are needed and neither substitutes for the other. Attempts alone never answers a user whose whole fleet is dead. The age window alone cannot tell "nothing is serving this" from "my turn hasn't come" — one worker draining a deep backlog leaves rows at the back untouched for as long as the backlog takes.

**The fleet-liveness probe took three tries.** Sampling "any live lease right now" is not enough: leases are held in bursts, and the real gap between one job's terminal write and the next claim FAILED forty-nine queued rows in one statement — worse than the bug the guard exists to prevent. "Anything touched lately" is worse still, because it counts submits, so a user submitting into a dead fleet suppresses their own answer indefinitely. The shipped form requires **both** probes, reads `lease_expires_at` because only a worker sets it, and excludes the row being judged. Terminal writes and releases now leave that column alone so it survives as an honest record of when a worker last held the row.

Arm order is pinned by a test, and for the two reasons that are actually load-bearing — not the one that looks obvious. A spent row cannot match the release arm at all (that statement carries its own attempts guard), so this is not about stopping an extra lap. Poisoned before stalled because both retire a spent row but only one tells the user why. Stalled before released because releasing stamps `updated_at`, which would make the row look freshly touched and hide it from the staleness check for another whole window.

## The submit path now asks one question

`createOrAdopt` and nothing else. A `findExistingRequest` read used to short-circuit ahead of it as an optimization; once that read stopped judging staleness, a row nobody would ever run still read as live, so the short-circuit answered every resubmit with it and never reached the reclaim that retires it. Both paths converged on `createOrAdopt` anyway — the read only ever saved the settle, which is precisely what it must not save. An existing #1250 regression test is what caught this.

That leaves `findExistingRequest` with no production caller, documented under the same rule `holdsLease` is: reading it and acting on the answer is the check-then-act `createOrAdopt` exists to close.

## Also here

- A worker no longer runs the same request twice in one process — the nudge and the poll could both reach it.
- Nudges are drained on the working path. A busy instance never reaches the blocking poll, so it would otherwise bank stale messages and fire them back-to-back the moment things went quiet.
- Schema: `skip_cache` and `attempts` on `indexing_requests`, both backfilled by their column DEFAULTs, plus a claimable-rows index — partial on Postgres, composite on H2, which has no partial indexes.
- `RetentionWorker` logged "retired N stranded requests" for a count that is mostly requeues now.
- `IndexRequestServiceTest`'s fake retired on lease expiry — the exact behaviour this change deletes — so a service that resurrected released work would have looked correct. It now models all three arms including the liveness probes, and its `claimNext` throws rather than returning empty, so a later change that makes the submit path claim fails loudly instead of reading as "no work".

## Verification

- `bazel test //domains/games/apis/one_d4/...` — 52/52.
- Same suite against a **real Postgres 16** with `PG_TEST_DB_URL` set — 52/52. The PG-gated suites skip silently without it, so a green local run proves nothing about the SQL; several defects here were Postgres-only.
- `scripts/diff-build origin/main` — 40 impacted targets, all passing, including the downstream `mcpserver`.
- Arm ordering, attempt exhaustion, and the `flushOwned` row lock are each pinned by a test that fails when the behaviour is reverted; found via `scripts/mutation-check` after two earlier versions of the concurrency tests turned out to be vacuous.
- Review panel ran on the implementation and produced two of the fixes above (the same-process double-run and the liveness probe). It did **not** run on this final cleanup pass; the one behavioural change in it — removing the dedupe pre-read — was caught and is pinned by an existing regression test.

## Known gap

Filed as #1282: a worker wedged mid-run keeps renewing from its heartbeat thread, so both probes stay positive and that one lease suppresses the stalled arm for the whole table, not just its own row. No liveness probe can close it — the worker is alive; what is unknown is whether the run is progressing — so it needs a ceiling on run duration. Referenced from `RETIRE_ABANDONED_SQL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA

---
_Generated by [Claude Code](https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA)_