### PR TITLE
Java services get custom metrics; 1d4 reports indexing and motifs; Host page gets its Disk panels back (#1212)

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -28,6 +28,40 @@ jobs:
       - name: Test deploy.sh
         run: ./scripts/test-deploy
 
+  # deploy_config_test pins the text of the collector config, which can only
+  # catch mistakes someone already knew to look for: `match_type: glob` passed
+  # review and passed the line-presence test that existed at the time, and would
+  # have taken the whole metrics pipeline down on deploy. This starts the pinned
+  # collector against the real config instead.
+  #
+  # Its own job, not a step in test-deploy: that one runs inside the ci-base
+  # container and this needs the runner's own docker. Path-gated because it
+  # pulls the collector image, and nothing outside these three files can change
+  # the answer.
+  validate-otel-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for collector config changes
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD -- \
+            deploy/consolidated/o11y/otel-collector.yml \
+            deploy/consolidated/docker-compose.observability.yml \
+            scripts/validate-otel-config)
+          if [ -n "$CHANGED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dry-run the collector config
+        if: steps.filter.outputs.changed == 'true'
+        run: ./scripts/validate-otel-config
+
   # deploy.sh runs from a developer machine, and macOS ships bash 3.2 as
   # /bin/bash — no associative arrays or case-conversion expansions. The Linux
   # job above runs bash 5 and cannot reproduce that, so run the same suite on a

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -53,3 +53,11 @@ config_setting(
         "@platforms//os:linux",
     ],
 )
+
+# Neither .github/ nor scripts/ has a BUILD file, so these belong to the root
+# package. deploy/consolidated's dry-run wiring test reads both, and a go_test
+# only sees what it declares — so the root package has to export them first.
+exports_files([
+    ".github/workflows/branch.yml",
+    "scripts/validate-otel-config",
+])

--- a/deploy/consolidated/BUILD.bazel
+++ b/deploy/consolidated/BUILD.bazel
@@ -10,5 +10,7 @@ go_test(
     data = [
         "Caddyfile",
         "compose.yaml",
+        "docker-compose.observability.yml",
+        "o11y/otel-collector.yml",
     ],
 )

--- a/deploy/consolidated/BUILD.bazel
+++ b/deploy/consolidated/BUILD.bazel
@@ -12,5 +12,9 @@ go_test(
         "compose.yaml",
         "docker-compose.observability.yml",
         "o11y/otel-collector.yml",
+        # Read by TestCIStillRunsTheCollectorDryRun, which checks that CI has not
+        # quietly stopped invoking the collector dry-run.
+        "//:.github/workflows/branch.yml",
+        "//:scripts/validate-otel-config",
     ],
 )

--- a/deploy/consolidated/deploy_config_test.go
+++ b/deploy/consolidated/deploy_config_test.go
@@ -164,24 +164,61 @@ func readConfig(t *testing.T, name string) string {
 const hostfsMountPath = "/hostfs"
 
 func TestHostMetricsReadsTheHostAndNotTheCollectorContainer(t *testing.T) {
-	receiver := readConfig(t, "o11y/otel-collector.yml")
-	compose := readConfig(t, "docker-compose.observability.yml")
+	receiver := activeLines(t, "o11y/otel-collector.yml")
+	compose := activeLines(t, "docker-compose.observability.yml")
 
-	if !strings.Contains(receiver, "root_path: "+hostfsMountPath) {
-		t.Errorf("hostmetrics has no root_path: %s — every scraper measures the collector container,"+
-			" and the disk panels silently report nothing", hostfsMountPath)
+	// Exact lines, not substrings. `strings.Contains` would accept a commented-out
+	// directive and — worse — `root_path: /hostfs-typo`, which is the very state the
+	// error message below describes: a root_path naming a path the container has no
+	// mount for. Both were true of the first version of this test.
+	if !hasLine(receiver, "root_path: "+hostfsMountPath) {
+		t.Errorf("hostmetrics has no active `root_path: %s` — every scraper measures the collector"+
+			" container, and the disk panels silently report nothing", hostfsMountPath)
 	}
-	if !strings.Contains(compose, "- /:"+hostfsMountPath+":ro") {
-		t.Errorf("otelcol does not bind the host root at %s — root_path points at a path that does not"+
-			" exist in the container", hostfsMountPath)
+	if !hasLine(compose, "- /:"+hostfsMountPath+":ro") {
+		t.Errorf("otelcol does not bind the host root at %s — root_path points at a path that does"+
+			" not exist in the container", hostfsMountPath)
 	}
 
-	// Both scrapers are the ones that need the mount; the panels are named
-	// after them. Enabled-but-unmounted was the bug, so enabled is worth
-	// asserting alongside the mount rather than assumed.
+	// Enabled-but-unmounted was the bug, so the scrapers are asserted alongside the
+	// mount rather than assumed. These two are the ones whose panels were empty.
 	for _, scraper := range []string{"disk:", "filesystem:"} {
-		if !strings.Contains(receiver, scraper) {
+		if !hasLinePrefix(receiver, scraper) {
 			t.Errorf("hostmetrics scraper %q is not enabled; the Host page charts it", scraper)
 		}
 	}
+}
+
+// Config lines with comments and blanks removed, so an assertion cannot be
+// satisfied by a directive somebody commented out.
+func activeLines(t *testing.T, name string) []string {
+	t.Helper()
+	var out []string
+	for _, line := range strings.Split(readConfig(t, name), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func hasLine(lines []string, want string) bool {
+	for _, line := range lines {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}
+
+// For a mapping key whose value may be inline (`disk: {}`) or nested.
+func hasLinePrefix(lines []string, want string) bool {
+	for _, line := range lines {
+		if strings.HasPrefix(line, want) {
+			return true
+		}
+	}
+	return false
 }

--- a/deploy/consolidated/deploy_config_test.go
+++ b/deploy/consolidated/deploy_config_test.go
@@ -265,3 +265,49 @@ func TestMountPointExcludesAreWrittenFromTheHostsPerspective(t *testing.T) {
 		}
 	}
 }
+
+// The two tests above read the config as text, which bounds what they can find
+// to mistakes someone already thought of. `match_type: glob` was not one of
+// those: it passed review and passed the line-presence test of the day, and it
+// would have failed the hostmetrics receiver on deploy.
+//
+// scripts/validate-otel-config is the check that does not need to know the
+// mistake in advance — it starts the pinned collector against the real config.
+// But it only runs if CI invokes it, and a workflow that stopped invoking it
+// would leave every test in this file green. So the wiring is pinned too.
+//
+// This asserts the call exists, not that it passed; the job's own exit code is
+// the real signal. What it rules out is the silent version, where the dry-run
+// is dropped and nothing anywhere goes red.
+func TestCIStillRunsTheCollectorDryRun(t *testing.T) {
+	const script = "scripts/validate-otel-config"
+	workflow := readConfig(t, "../../.github/workflows/branch.yml")
+
+	// An exact line, not a substring. `strings.Contains` would be satisfied by a
+	// commented-out step, by a path that merely starts with this one, and by the
+	// script's name appearing in a comment — which is how the golden-instrument
+	// test in this same PR managed to pin nothing at all.
+	invocation := "run: ./" + script
+	found := false
+	for _, line := range strings.Split(workflow, "\n") {
+		if strings.TrimSpace(line) == invocation {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no active `%s` step in branch.yml — the collector config is back to being"+
+			" checked only as text, and the next match_type: glob ships", invocation)
+	}
+
+	// Worthless if it is not executable: CI invokes it directly rather than
+	// through `bash`, so a lost +x is a job that fails for a reason nobody will
+	// connect back to this file.
+	info, err := os.Stat("../../" + script)
+	if err != nil {
+		t.Fatalf("branch.yml runs %s but it does not exist: %v", script, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("%s is not executable (%v); CI runs it directly", script, info.Mode())
+	}
+}

--- a/deploy/consolidated/deploy_config_test.go
+++ b/deploy/consolidated/deploy_config_test.go
@@ -146,3 +146,42 @@ func readConfig(t *testing.T, name string) string {
 	}
 	return string(contents)
 }
+
+// The host-metrics pair.
+//
+// The collector runs in a container, so the hostmetrics receiver reads the
+// machine only through a bind mount plus a matching root_path. Those two live
+// in different files, and losing either produces no error anywhere: the
+// receiver happily scrapes its own namespace, cpu/memory/network keep
+// reporting plausible numbers from /proc inside the container, and only the
+// disk and filesystem panels go quiet — because /proc/diskstats is not the
+// host's and the container's mounts are all overlay and tmpfs, which the
+// scraper filters. An empty chart reads as an idle machine, so this was live
+// for a while before anyone asked.
+//
+// Pinned as a pair rather than as two separate facts: either one alone is the
+// broken state.
+const hostfsMountPath = "/hostfs"
+
+func TestHostMetricsReadsTheHostAndNotTheCollectorContainer(t *testing.T) {
+	receiver := readConfig(t, "o11y/otel-collector.yml")
+	compose := readConfig(t, "docker-compose.observability.yml")
+
+	if !strings.Contains(receiver, "root_path: "+hostfsMountPath) {
+		t.Errorf("hostmetrics has no root_path: %s — every scraper measures the collector container,"+
+			" and the disk panels silently report nothing", hostfsMountPath)
+	}
+	if !strings.Contains(compose, "- /:"+hostfsMountPath+":ro") {
+		t.Errorf("otelcol does not bind the host root at %s — root_path points at a path that does not"+
+			" exist in the container", hostfsMountPath)
+	}
+
+	// Both scrapers are the ones that need the mount; the panels are named
+	// after them. Enabled-but-unmounted was the bug, so enabled is worth
+	// asserting alongside the mount rather than assumed.
+	for _, scraper := range []string{"disk:", "filesystem:"} {
+		if !strings.Contains(receiver, scraper) {
+			t.Errorf("hostmetrics scraper %q is not enabled; the Host page charts it", scraper)
+		}
+	}
+}

--- a/deploy/consolidated/deploy_config_test.go
+++ b/deploy/consolidated/deploy_config_test.go
@@ -222,3 +222,46 @@ func hasLinePrefix(lines []string, want string) bool {
 	}
 	return false
 }
+
+// The collector rejects a match_type it does not know, and the rejection is not
+// local: CreateFilterSet errors out of the filesystem scraper, that fails the
+// hostmetrics receiver, and hostmetrics shares a pipeline with otlp — so an
+// invalid value here takes every application metric down with the host ones.
+// `glob` reads like it should work and does not; filterset accepts only these
+// two (internal/filter/filterset/config.go at the pinned v0.155.0).
+var validFilterMatchTypes = map[string]bool{"strict": true, "regexp": true}
+
+func TestHostMetricsFilterConfigIsOneTheCollectorAccepts(t *testing.T) {
+	for _, line := range activeLines(t, "o11y/otel-collector.yml") {
+		if !strings.HasPrefix(line, "match_type:") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, "match_type:"))
+		if !validFilterMatchTypes[value] {
+			t.Errorf("match_type %q is not one the collector accepts (strict or regexp);"+
+				" hostmetrics fails to build and takes the otlp pipeline with it", value)
+		}
+	}
+}
+
+// Mount-point filters run before root_path is applied, so they are written from
+// the host's perspective. A /hostfs-prefixed pattern matches nothing and the
+// exclusion silently does not happen — which looks like the filter working,
+// because the panel still renders.
+func TestMountPointExcludesAreWrittenFromTheHostsPerspective(t *testing.T) {
+	inExcludeBlock := false
+	for _, line := range activeLines(t, "o11y/otel-collector.yml") {
+		switch {
+		case strings.HasPrefix(line, "exclude_mount_points:"):
+			inExcludeBlock = true
+		case strings.HasPrefix(line, "exclude_fs_types:"), strings.HasPrefix(line, "network:"):
+			inExcludeBlock = false
+		case inExcludeBlock && strings.HasPrefix(line, "- "):
+			pattern := strings.TrimPrefix(line, "- ")
+			if strings.HasPrefix(pattern, hostfsMountPath+"/") {
+				t.Errorf("mount-point exclude %q is prefixed with %s; filtering happens before"+
+					" root_path is applied, so this can never match", pattern, hostfsMountPath)
+			}
+		}
+	}
+}

--- a/deploy/consolidated/docker-compose.observability.yml
+++ b/deploy/consolidated/docker-compose.observability.yml
@@ -29,6 +29,10 @@ services:
     command: ["--config=/etc/otel-collector-config.yml"]
     volumes:
       - ./o11y/otel-collector.yml:/etc/otel-collector-config.yml
+      # What the hostmetrics receiver reads through `root_path: /hostfs`.
+      # Read-only, and the reason the Host page can report the machine rather
+      # than this container — cadvisor below has had the equivalent all along.
+      - /:/hostfs:ro
     ports:
       - "4318:4318"   # OTLP HTTP receiver
       - "8889:8889"   # Prometheus metrics endpoint

--- a/deploy/consolidated/o11y/otel-collector.yml
+++ b/deploy/consolidated/o11y/otel-collector.yml
@@ -7,14 +7,73 @@ receivers:
         endpoint: 0.0.0.0:4318
   
   hostmetrics:
+    # The collector runs in a container, so without this every scraper below
+    # measures the container instead of the machine. cpu, memory and network
+    # still produced plausible-looking numbers that way — /proc/stat,
+    # /proc/meminfo and /proc/net/dev exist in any namespace — which is what
+    # made the gap easy to miss. disk and filesystem produced nothing at all:
+    # /proc/diskstats was not the host's, and the container's only mounts are
+    # overlay and tmpfs, which the filesystem scraper filters out. That is the
+    # empty "Disk I/O" and "Disk Usage" panels on the Host page.
+    #
+    # Paired with the `/:/hostfs:ro` bind in docker-compose.observability.yml.
+    # Change one without the other and the panels go quiet again, so
+    # deploy_config_test pins the pair.
+    root_path: /hostfs
     collection_interval: 10s
     scrapers:
       cpu: {}
       memory: {}
       disk: {}
-      filesystem: {}
+      filesystem:
+        # Host root brings the container runtime's own bookkeeping with it.
+        # Without these the usage panel is mostly per-container overlay mounts,
+        # which is cadvisor's job and drowns out the real volumes.
+        exclude_mount_points:
+          mount_points:
+            - /hostfs/var/lib/docker/*
+            - /hostfs/snap/*
+            - /hostfs/run/*
+            - /hostfs/dev/*
+            - /hostfs/sys/*
+            - /hostfs/proc/*
+          match_type: glob
+        exclude_fs_types:
+          fs_types:
+            [
+              autofs,
+              binfmt_misc,
+              bpf,
+              cgroup2,
+              configfs,
+              debugfs,
+              devpts,
+              devtmpfs,
+              fusectl,
+              hugetlbfs,
+              iso9660,
+              mqueue,
+              nsfs,
+              overlay,
+              proc,
+              procfs,
+              pstore,
+              securityfs,
+              selinuxfs,
+              squashfs,
+              sysfs,
+              tracefs,
+            ]
+          match_type: strict
       network: {}
-      process: {}
+      process:
+        # Reading the host's /proc as a non-root container user means most
+        # processes belong to somebody else. These are the fields that denies
+        # on, and each one otherwise logs per process per interval — enough
+        # noise to bury a real error.
+        mute_process_exe_error: true
+        mute_process_io_error: true
+        mute_process_user_error: true
 
 processors:
   batch:

--- a/deploy/consolidated/o11y/otel-collector.yml
+++ b/deploy/consolidated/o11y/otel-collector.yml
@@ -26,18 +26,29 @@ receivers:
       memory: {}
       disk: {}
       filesystem:
-        # Host root brings the container runtime's own bookkeeping with it.
-        # Without these the usage panel is mostly per-container overlay mounts,
-        # which is cadvisor's job and drowns out the real volumes.
+        # Host root brings the container runtime's own bookkeeping with it. Without
+        # these the usage panel is mostly per-container overlay mounts, which is
+        # cadvisor's job and drowns out the real volumes.
+        #
+        # regexp, not glob: filterset accepts only strict and regexp
+        # (internal/filter/filterset/config.go), and an unrecognised match_type is an
+        # error out of CreateFilterSet — which fails the whole hostmetrics receiver,
+        # and with it the otlp pipeline it shares. Empty disk panels would have been
+        # the least of it.
+        #
+        # Paths are the host's, unprefixed: root_path is applied when the scraper
+        # reads usage, not when it filters, so a /hostfs-prefixed pattern matches
+        # nothing.
         exclude_mount_points:
           mount_points:
-            - /hostfs/var/lib/docker/*
-            - /hostfs/snap/*
-            - /hostfs/run/*
-            - /hostfs/dev/*
-            - /hostfs/sys/*
-            - /hostfs/proc/*
-          match_type: glob
+            - /var/lib/docker/.*
+            - /var/lib/kubelet/.*
+            - /snap/.*
+            - /run/.*
+            - /dev/.*
+            - /sys/.*
+            - /proc/.*
+          match_type: regexp
         exclude_fs_types:
           fs_types:
             [
@@ -66,14 +77,6 @@ receivers:
             ]
           match_type: strict
       network: {}
-      process:
-        # Reading the host's /proc as a non-root container user means most
-        # processes belong to somebody else. These are the fields that denies
-        # on, and each one otherwise logs per process per interval — enough
-        # noise to bury a real error.
-        mute_process_exe_error: true
-        mute_process_io_error: true
-        mute_process_user_error: true
 
 processors:
   batch:

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -109,6 +109,7 @@ java_library(
         ":model",
         ":queue",
         "//domains/games/libs/chess_com_client",
+        "//domains/platform/libs/yodel",
         artifact("com.fasterxml.jackson.core:jackson-core"),
         artifact("com.fasterxml.jackson.core:jackson-databind"),
         artifact("dev.failsafe:failsafe"),
@@ -214,6 +215,7 @@ java_library(
         "//domains/platform/libs/http_client:core",
         "//domains/platform/libs/http_client:jdk11",
         "//domains/platform/libs/json",
+        "//domains/platform/libs/yodel",
         artifact("com.fasterxml.jackson.core:jackson-databind"),
         artifact("com.zaxxer:HikariCP"),
         artifact("org.jdbi:jdbi3-core"),
@@ -262,6 +264,7 @@ java_binary(
         "//domains/platform/libs/http_client:jdk11",
         "//domains/platform/libs/json",
         "//domains/platform/libs/logging",
+        "//domains/platform/libs/yodel",
         artifact("com.fasterxml.jackson.core:jackson-databind"),
         artifact("com.zaxxer:HikariCP"),
         artifact("org.jdbi:jdbi3-core"),
@@ -397,6 +400,7 @@ java_test_suite(
         "//domains/games/libs/chess_com_client",
         "//domains/games/libs/chessql:compiler",
         "//domains/games/libs/chessql:parser",
+        "//domains/platform/libs/yodel",
         artifact("com.fasterxml.jackson.core:jackson-databind"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.assertj:assertj-core"),
@@ -611,6 +615,11 @@ java_test_suite(
     ],
     runtime_deps = [
         "//domains/platform/libs/logging",
+        # The same integration the binary carries. IndexerModule injects yodel's
+        # CustomMetrics into the worker, and the bean that supplies it lives here —
+        # without it a context boot fails on a missing bean rather than on anything
+        # these tests are about.
+        "//domains/platform/libs/yodel:micronaut",
         artifact("org.postgresql:postgresql"),
     ],
     deps = [
@@ -668,6 +677,11 @@ java_test_suite(
     ],
     runtime_deps = [
         "//domains/platform/libs/logging",
+        # The same integration the binary carries. IndexerModule injects yodel's
+        # CustomMetrics into the worker, and the bean that supplies it lives here —
+        # without it a context boot fails on a missing bean rather than on anything
+        # these tests are about.
+        "//domains/platform/libs/yodel:micronaut",
         artifact("org.postgresql:postgresql"),
     ],
     deps = [

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/IndexerModule.java
@@ -25,6 +25,7 @@ import com.muchq.games.one_d4.worker.IndexWorkerLifecycle;
 import com.muchq.platform.http_client.core.HttpClient;
 import com.muchq.platform.http_client.jdk.Jdk11HttpClient;
 import com.muchq.platform.json.JsonUtils;
+import com.muchq.platform.yodel.CustomMetrics;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
@@ -244,7 +245,8 @@ public class IndexerModule {
       GameFeatureStore gameFeatureStore,
       IndexedPeriodStore periodStore,
       @jakarta.inject.Named("indexExtraction") ExecutorService indexExtractionExecutor,
-      Clock clock) {
+      Clock clock,
+      CustomMetrics metrics) {
     return new IndexWorker(
         chessClient,
         featureExtractor,
@@ -252,7 +254,9 @@ public class IndexerModule {
         gameFeatureStore,
         periodStore,
         indexExtractionExecutor,
-        clock);
+        clock,
+        IndexWorker.DEFAULT_HEARTBEAT_INTERVAL,
+        metrics);
   }
 
   // preDestroy is load-bearing, not hygiene: the poller is a daemon thread, so without it a deploy

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -94,7 +94,13 @@ public class IndexWorker {
    * <p>The default set yodel shares with the HTTP latency histogram tops out at 10ms, which no
    * index run has ever finished inside — a run does at least four database round trips before it
    * fetches anything. Every observation would land in the overflow bucket: fifteen series pinned at
-   * zero, a sixteenth equal to the count, and a p95 of +Inf for whoever charts one later.
+   * zero and a sixteenth equal to the count.
+   *
+   * <p>The quantile that reads them does not announce this. When the rank falls in the {@code +Inf}
+   * bucket, {@code histogram_quantile} returns the upper bound of the highest <em>finite</em>
+   * bucket, so a p95 over runs that all take minutes answers a flat 10000 — a plausible-looking
+   * 10ms, not an obvious {@code +Inf}. That is the failure worth avoiding: a broken histogram that
+   * reads like a fast one.
    */
   static final double[] RUN_DURATION_BOUNDS = {
     1_000,

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -14,6 +14,7 @@ import com.muchq.games.one_d4.engine.FeatureExtractor;
 import com.muchq.games.one_d4.engine.model.GameFeatures;
 import com.muchq.games.one_d4.engine.model.Motif;
 import com.muchq.games.one_d4.queue.IndexMessage;
+import com.muchq.platform.yodel.CustomMetrics;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import java.sql.SQLException;
@@ -73,6 +74,18 @@ public class IndexWorker {
   private final Clock clock;
   private final Duration heartbeatInterval;
   private final ScheduledExecutorService heartbeatScheduler;
+  private final CustomMetrics metrics;
+
+  // Instrument names. The collector's Prometheus exporter appends _total to counters, so
+  // index_runs is queried as index_runs_total. Labels are outcomes and motif names only — bounded
+  // sets. A player name or a request id here would mint a new stored series per user.
+  static final String RUNS = "index_runs";
+  static final String GAMES_INDEXED = "games_indexed";
+  static final String MONTHS = "index_months";
+  static final String ARCHIVE_FETCHES = "chess_com_archive_fetches";
+  static final String MOTIF_OCCURRENCES = "motif_occurrences";
+  static final String RUN_DURATION = "index_run_duration_micros";
+  static final String GAMES_PER_MONTH = "index_games_per_month";
 
   /**
    * Identifies this worker as the holder of a lease. Stable for the life of the process and unique
@@ -261,6 +274,34 @@ public class IndexWorker {
       ExecutorService extractionExecutor,
       Clock clock,
       Duration heartbeatInterval) {
+    this(
+        chessClient,
+        featureExtractor,
+        requestStore,
+        gameFeatureStore,
+        periodStore,
+        extractionExecutor,
+        clock,
+        heartbeatInterval,
+        new CustomMetrics());
+  }
+
+  /**
+   * @param metrics where this worker reports what it did. Defaulted to a detached registry by the
+   *     constructors above rather than made nullable: recording into memory nobody exports is the
+   *     same no-op yodel already gives a service with no OTEL endpoint configured, and it keeps
+   *     every emit site free of a null check.
+   */
+  public IndexWorker(
+      ChessClient chessClient,
+      FeatureExtractor featureExtractor,
+      IndexingRequestStore requestStore,
+      GameFeatureStore gameFeatureStore,
+      IndexedPeriodStore periodStore,
+      ExecutorService extractionExecutor,
+      Clock clock,
+      Duration heartbeatInterval,
+      CustomMetrics metrics) {
     this.chessClient = chessClient;
     this.featureExtractor = featureExtractor;
     this.requestStore = requestStore;
@@ -269,6 +310,7 @@ public class IndexWorker {
     this.extractionExecutor = extractionExecutor;
     this.clock = clock;
     this.heartbeatInterval = heartbeatInterval;
+    this.metrics = metrics;
     this.heartbeatScheduler =
         Executors.newSingleThreadScheduledExecutor(
             r -> {
@@ -321,6 +363,10 @@ public class IndexWorker {
     runHandles.put(message.requestId(), handle);
     ScheduledFuture<?> heartbeat = startHeartbeat(message.requestId());
     boolean abandonedBecauseInterrupted = false;
+    // Wall-clock, not the injected clock: this measures how long the run really took, and a test
+    // that jumps its clock by six hours to trip the ceiling would otherwise report a six-hour run.
+    long runStartNanos = System.nanoTime();
+    String outcome = "failed";
     try {
       progress(message.requestId(), 0);
 
@@ -370,6 +416,8 @@ public class IndexWorker {
         // placed the same way — on the way out of a span that blocks, which is where an interrupt
         // can have been absorbed without a trace.
         ensureNotInterrupted(message.requestId());
+        metrics.increment(
+            ARCHIVE_FETCHES, Map.of("result", response.isEmpty() ? "no_archive" : "ok"));
         if (response.isEmpty()) {
           // chess.com 404s the archive for a month the player has no games in. The month *was*
           // indexed — the answer is "none" — so record an empty period rather than dropping
@@ -385,6 +433,8 @@ public class IndexWorker {
           // sweeps it.
           progress(message.requestId(), totalIndexed);
           upsertPeriod(message, monthStr, month, fetchedAt, 0, false);
+          metrics.increment(MONTHS, Map.of("result", "empty"));
+          metrics.record(GAMES_PER_MONTH, 0);
           continue;
         }
 
@@ -452,6 +502,17 @@ public class IndexWorker {
             if (!result.occurrences().isEmpty()) {
               occurrencesBatch.put(result.gameUrl(), result.occurrences());
             }
+            // Counted here rather than at flush time because the flush batches by request and
+            // loses the per-motif breakdown. The motif name is the label, and the detector set is
+            // fixed and small, so the cardinality is bounded by the code rather than by traffic.
+            result
+                .occurrences()
+                .forEach(
+                    (motif, occurrences) ->
+                        metrics.add(
+                            MOTIF_OCCURRENCES,
+                            occurrences.size(),
+                            Map.of("motif", motif.name().toLowerCase())));
             monthCount++;
             totalIndexed++;
             if (featureBatch.size() >= BATCH_SIZE) {
@@ -480,6 +541,10 @@ public class IndexWorker {
         // it safe is order: the flushBatch immediately above checks ownership and throws if this
         // worker has lost it, so this line is unreachable without a live lease.
         upsertPeriod(message, monthStr, month, fetchedAt, monthCount, titleResolution.degraded());
+        metrics.increment(
+            MONTHS, Map.of("result", titleResolution.degraded() ? "degraded" : "indexed"));
+        metrics.add(GAMES_INDEXED, monthCount, Map.of());
+        metrics.record(GAMES_PER_MONTH, monthCount);
         progress(message.requestId(), totalIndexed);
       }
 
@@ -491,6 +556,7 @@ public class IndexWorker {
                   message.requestId(), ownerId, "COMPLETED", null, finalCount, clock.instant()),
           "the run could be completed")) {
         LOG.info("Completed indexing request {} with {} games", message.requestId(), totalIndexed);
+        outcome = "completed";
       } else {
         // Logging the count unconditionally read as success whatever the row said. The games are
         // on disk either way; what is lost is the record that this run produced them.
@@ -498,6 +564,9 @@ public class IndexWorker {
             "Indexed {} games for request {} but could not record COMPLETED: the lease is gone.",
             totalIndexed,
             message.requestId());
+        // The games landed but the run cannot claim them. Distinct from "completed" on purpose:
+        // counting it as success would hide a range changing hands mid-run behind a green chart.
+        outcome = "lease_lost";
       }
     } catch (LeaseLostException e) {
       // No terminal write is attempted, and that is the whole difference from an ordinary failure.
@@ -505,6 +574,7 @@ public class IndexWorker {
       // too, and would simply be refused. It is that attempting it would log a spurious error for
       // a run that did not fail: it was stopped, correctly, because the range moved.
       LOG.warn("Abandoning request {}: {}", message.requestId(), e.getMessage());
+      outcome = "lease_lost";
     } catch (Exception e) {
       if (e instanceof RunInterruptedException || Thread.currentThread().isInterrupted()) {
         // Stopped, not failed, and the row's outcome turns on the difference. A FAILED here spends
@@ -522,6 +592,7 @@ public class IndexWorker {
             message.requestId(),
             e);
         abandonedBecauseInterrupted = true;
+        outcome = "interrupted";
       } else {
         recordFailure(message.requestId(), e);
       }
@@ -556,7 +627,13 @@ public class IndexWorker {
       // first is false.
       if (weInterruptedThisRun || abandonedBecauseInterrupted) {
         releaseAfterInterrupt(message.requestId());
+        // A run the ceiling cut loose reports as interrupted even when it unwound through the
+        // LeaseLostException branch above, which is the shape a past-ceiling fenced refusal takes.
+        // Reporting those as lease_lost would bury the wedge signal in ordinary range handovers.
+        outcome = "interrupted";
       }
+      metrics.increment(RUNS, Map.of("outcome", outcome));
+      metrics.record(RUN_DURATION, (System.nanoTime() - runStartNanos) / 1000.0);
     }
   }
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -85,6 +86,32 @@ public class IndexWorker {
   static final String ARCHIVE_FETCHES = "chess_com_archive_fetches";
   static final String MOTIF_OCCURRENCES = "motif_occurrences";
   static final String RUN_DURATION = "index_run_duration_micros";
+
+  /**
+   * Bounds for {@link #RUN_DURATION}, in microseconds, spanning a millisecond to the {@link
+   * RetentionPolicy#MAX_RUN} ceiling.
+   *
+   * <p>The default set yodel shares with the HTTP latency histogram tops out at 10ms, which no
+   * index run has ever finished inside — a run does at least four database round trips before it
+   * fetches anything. Every observation would land in the overflow bucket: fifteen series pinned at
+   * zero, a sixteenth equal to the count, and a p95 of +Inf for whoever charts one later.
+   */
+  static final double[] RUN_DURATION_BOUNDS = {
+    1_000,
+    10_000,
+    100_000,
+    1_000_000,
+    5_000_000,
+    30_000_000,
+    60_000_000,
+    300_000_000,
+    900_000_000,
+    1_800_000_000,
+    3_600_000_000L,
+    10_800_000_000L,
+    21_600_000_000L
+  };
+
   static final String GAMES_PER_MONTH = "index_games_per_month";
 
   /**
@@ -367,6 +394,7 @@ public class IndexWorker {
     // that jumps its clock by six hours to trip the ceiling would otherwise report a six-hour run.
     long runStartNanos = System.nanoTime();
     String outcome = "failed";
+    metrics.defineDistribution(RUN_DURATION, RUN_DURATION_BOUNDS);
     try {
       progress(message.requestId(), 0);
 
@@ -401,12 +429,22 @@ public class IndexWorker {
                 message.platform(),
                 monthStr,
                 count);
+            metrics.increment(MONTHS, Map.of("result", "cached"));
             progress(message.requestId(), totalIndexed);
             continue;
           }
         }
 
-        Optional<GamesResponse> response = chessClient.fetchGames(message.player(), month);
+        Optional<GamesResponse> response;
+        try {
+          response = chessClient.fetchGames(message.player(), month);
+        } catch (RuntimeException e) {
+          // Counted before rethrowing. ChessClient maps only a 404 to empty and throws on every
+          // other non-200, so without this the rate-limits and 5xx — the failures an operator most
+          // wants a rate on — were the one archive outcome the counter could not show.
+          metrics.increment(ARCHIVE_FETCHES, Map.of("result", "error"));
+          throw e;
+        }
         // Checked on the way out of the fetch, not only where an interrupt is thrown, because a
         // blocking call is entitled to swallow one — restore the status, return normally, and
         // leave the caller unable to tell an empty archive from a call that was cut short. Taking
@@ -433,8 +471,11 @@ public class IndexWorker {
           // sweeps it.
           progress(message.requestId(), totalIndexed);
           upsertPeriod(message, monthStr, month, fetchedAt, 0, false);
+          // Counted as an empty month, and deliberately not recorded into
+          // GAMES_PER_MONTH: a decade-long backfill of a three-year player is mostly
+          // 404s, and feeding those zeros in makes the average archive look a third
+          // its real size. empty_months_total already carries that population.
           metrics.increment(MONTHS, Map.of("result", "empty"));
-          metrics.record(GAMES_PER_MONTH, 0);
           continue;
         }
 
@@ -512,7 +553,7 @@ public class IndexWorker {
                         metrics.add(
                             MOTIF_OCCURRENCES,
                             occurrences.size(),
-                            Map.of("motif", motif.name().toLowerCase())));
+                            Map.of("motif", motif.name().toLowerCase(Locale.ROOT))));
             monthCount++;
             totalIndexed++;
             if (featureBatch.size() >= BATCH_SIZE) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -674,7 +674,12 @@ public class IndexWorker {
         outcome = "interrupted";
       }
       metrics.increment(RUNS, Map.of("outcome", outcome));
-      metrics.record(RUN_DURATION, (System.nanoTime() - runStartNanos) / 1000.0);
+      // Labelled by outcome, like the counter beside it. An interrupted run sat at the MAX_RUN
+      // ceiling by definition, so pooling it with the completed ones makes the average run time
+      // jump precisely when a wedge is being cut loose — the tile reads worst exactly when it is
+      // being used to judge how bad things are. Four outcomes over these bounds is 64 series.
+      metrics.record(
+          RUN_DURATION, (System.nanoTime() - runStartNanos) / 1000.0, Map.of("outcome", outcome));
     }
   }
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -115,6 +115,19 @@ public class IndexWorker {
   static final String GAMES_PER_MONTH = "index_games_per_month";
 
   /**
+   * Bounds for {@link #GAMES_PER_MONTH}, in games.
+   *
+   * <p>The HTTP default set happens to span a month's archive well enough — a heavy blitz player
+   * clears a few hundred games and the top bound is 10,000 — so the mean this is charted through
+   * reads correctly either way. Declared anyway, because "happens to" is the whole failure: the two
+   * distributions would be silently coupled to a latency histogram, and the first quantile anyone
+   * draws over a month count is the moment that stops being harmless.
+   */
+  static final double[] GAMES_PER_MONTH_BOUNDS = {
+    1, 2, 5, 10, 25, 50, 100, 200, 400, 800, 1_600, 3_200
+  };
+
+  /**
    * Identifies this worker as the holder of a lease. Stable for the life of the process and unique
    * across the instances competing for the same table, which is what makes it usable as a fencing
    * token: every write this worker makes is conditioned on the request still naming it. The host
@@ -395,6 +408,7 @@ public class IndexWorker {
     long runStartNanos = System.nanoTime();
     String outcome = "failed";
     metrics.defineDistribution(RUN_DURATION, RUN_DURATION_BOUNDS);
+    metrics.defineDistribution(GAMES_PER_MONTH, GAMES_PER_MONTH_BOUNDS);
     try {
       progress(message.requestId(), 0);
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -1095,6 +1095,9 @@ public class IndexWorkerTest {
     assertThat(distributionSum(IndexWorker.GAMES_PER_MONTH))
         .as("per-month shape, not just the run total")
         .isEqualTo(3.0);
+    assertThat(metrics.boundsFor(IndexWorker.GAMES_PER_MONTH))
+        .as("counts get count-shaped buckets, not the HTTP latency set they happen to fit")
+        .isEqualTo(IndexWorker.GAMES_PER_MONTH_BOUNDS);
   }
 
   /**

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -26,6 +26,7 @@ import com.muchq.games.one_d4.motifs.MotifDetector;
 import com.muchq.games.one_d4.motifs.PinDetector;
 import com.muchq.games.one_d4.motifs.SkewerDetector;
 import com.muchq.games.one_d4.queue.IndexMessage;
+import com.muchq.platform.yodel.CustomMetrics;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -589,6 +590,23 @@ public class IndexWorkerTest {
       1. e4 e5 2. Qh5 Nc6 3. Bc4 Nf6 4. Qxf7# 1-0
       """;
 
+  /**
+   * Two checks in one game: 3...Qe5+ down the open e-file, then 6.Nxc7+ forking from c7. A
+   * one-check fixture cannot tell "count the occurrences" from "count one per game", which is a
+   * real way for a motif chart to under-report by exactly the amount that matters.
+   */
+  private static final String TWO_CHECKS_PGN =
+      """
+      [Event "Live Chess"]
+      [Site "Chess.com"]
+      [White "White"]
+      [Black "Black"]
+      [Result "*"]
+      [ECO "B01"]
+
+      1. e4 d5 2. exd5 Qxd5 3. Nc3 Qe5+ 4. Be2 Qg5 5. Nb5 Na6 6. Nxc7+ Kd8 *
+      """;
+
   private static final class StubChessClient extends ChessClient {
     private final List<java.time.YearMonth> fetchCalls = new ArrayList<>();
     private final Map<java.time.YearMonth, List<PlayedGame>> responseByMonth = new HashMap<>();
@@ -943,5 +961,246 @@ public class IndexWorkerTest {
     public int deleteOlderThan(Instant threshold) {
       return 0;
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // What the indexer reports about its own work (#1212).
+  //
+  // The dashboard showed request counts and nothing about indexing, because a Java service had no
+  // way to record anything else. These assert the instruments the one_d4 registry entry queries,
+  // and they assert values rather than presence: a counter stuck at zero is exactly what a broken
+  // emit site produces, and it renders as a flat line rather than as an error.
+  // ---------------------------------------------------------------------------
+
+  private CustomMetrics metrics;
+
+  private IndexWorker meteredWorker() {
+    metrics = new CustomMetrics();
+    // Its own extractor: the shared one in setUp has no CheckDetector, so the motif assertions
+    // below would pass against a worker that never counted anything.
+    FeatureExtractor withCheck =
+        new FeatureExtractor(new PgnParser(), new GameReplayer(), List.of(new CheckDetector()));
+    return new IndexWorker(
+        stubChessClient,
+        withCheck,
+        requestStore,
+        new NoOpGameFeatureStore(),
+        periodStore,
+        extractionExecutor,
+        java.time.Clock.systemUTC(),
+        IndexWorker.DEFAULT_HEARTBEAT_INTERVAL,
+        metrics);
+  }
+
+  private long counter(String name, Map<String, String> labels) {
+    return metrics.counterSnapshot().stream()
+        .filter(s -> s.name().equals(name) && s.labels().equals(labels))
+        .mapToLong(CustomMetrics.CounterSnapshot::value)
+        .sum();
+  }
+
+  private long distributionCount(String name) {
+    return metrics.distributionSnapshot().stream()
+        .filter(s -> s.name().equals(name))
+        .mapToLong(CustomMetrics.DistributionSnapshot::count)
+        .sum();
+  }
+
+  private double distributionSum(String name) {
+    return metrics.distributionSnapshot().stream()
+        .filter(s -> s.name().equals(name))
+        .mapToDouble(CustomMetrics.DistributionSnapshot::sum)
+        .sum();
+  }
+
+  private static IndexMessage oneMonth() {
+    return new IndexMessage(UUID.randomUUID(), PLAYER, PLATFORM, "2024-01", "2024-01", false);
+  }
+
+  @Test
+  public void metrics_completedRunReportsOutcomeAndGamesIndexed() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(
+            playedGame("https://chess.com/game/m1", SCHOLARS_MATE_PGN, "blitz"),
+            playedGame("https://chess.com/game/m2", SCHOLARS_MATE_PGN, "blitz"),
+            playedGame("https://chess.com/game/m3", SCHOLARS_MATE_PGN, "blitz")));
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.GAMES_INDEXED, Map.of()))
+        .as("the headline number the dashboard exists to show")
+        .isEqualTo(3);
+    assertThat(counter(IndexWorker.MONTHS, Map.of("result", "indexed"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.ARCHIVE_FETCHES, Map.of("result", "ok"))).isEqualTo(1);
+    assertThat(distributionCount(IndexWorker.RUN_DURATION)).isEqualTo(1);
+    assertThat(distributionSum(IndexWorker.GAMES_PER_MONTH))
+        .as("per-month shape, not just the run total")
+        .isEqualTo(3.0);
+  }
+
+  /**
+   * A month with no archive is indexed — the answer is "none". Counting it as a failure would make
+   * a quiet player look like an outage.
+   */
+  @Test
+  public void metrics_monthWithNoArchiveCountsAsIndexedNotFailed() {
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.ARCHIVE_FETCHES, Map.of("result", "no_archive"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.MONTHS, Map.of("result", "empty"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.GAMES_INDEXED, Map.of())).isZero();
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed"))).isEqualTo(1);
+  }
+
+  @Test
+  public void metrics_motifOccurrencesAreCountedByMotif() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/mm1", SCHOLARS_MATE_PGN, "blitz")));
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.MOTIF_OCCURRENCES, Map.of("motif", "check")))
+        .as("scholar's mate ends in Qxf7#, so CheckDetector must have found one")
+        .isPositive();
+  }
+
+  /**
+   * Every occurrence counts, not one per game. With a single-check fixture "add occurrences.size()"
+   * and "add 1" are the same statement, and the difference is a motif chart that silently reports
+   * games-containing-a-motif while claiming to report occurrences.
+   */
+  @Test
+  public void metrics_countsEveryOccurrenceNotOnePerGame() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/two", TWO_CHECKS_PGN, "blitz")));
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.MOTIF_OCCURRENCES, Map.of("motif", "check")))
+        .as("one game, two checks")
+        .isGreaterThanOrEqualTo(2);
+  }
+
+  /** Two runs over the same motif accumulate rather than overwrite. */
+  @Test
+  public void metrics_motifCountsAccumulateAcrossGames() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/ma1", SCHOLARS_MATE_PGN, "blitz")));
+    IndexWorker w = meteredWorker();
+    w.process(oneMonth());
+    long afterOne = counter(IndexWorker.MOTIF_OCCURRENCES, Map.of("motif", "check"));
+    assertThat(afterOne).isPositive();
+
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(
+            playedGame("https://chess.com/game/ma2", SCHOLARS_MATE_PGN, "blitz"),
+            playedGame("https://chess.com/game/ma3", SCHOLARS_MATE_PGN, "blitz")));
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.MOTIF_OCCURRENCES, Map.of("motif", "check")))
+        .isEqualTo(afterOne * 3);
+  }
+
+  /**
+   * Title enrichment must never fail indexing, so a profile lookup that errors leaves the month
+   * indexed but incomplete. That is worth seeing on its own: a chart where every month is degraded
+   * is a chess.com problem, and one where none are is the healthy case — reporting both as
+   * "indexed" hides the difference entirely.
+   */
+  @Test
+  public void metrics_monthWithFailedTitleLookupIsReportedDegraded() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/deg", SCHOLARS_MATE_PGN, "blitz")));
+    stubChessClient.setThrowOnFetchPlayer(new RuntimeException("429 from chess.com"));
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.MONTHS, Map.of("result", "degraded"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.MONTHS, Map.of("result", "indexed"))).isZero();
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed")))
+        .as("degraded titles must not turn into a failed run")
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void metrics_runThatThrowsIsReportedFailedNotCompleted() {
+    stubChessClient.setThrowOnFetch(new RuntimeException("chess.com is down"));
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "failed"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed"))).isZero();
+    assertThat(distributionCount(IndexWorker.RUN_DURATION))
+        .as("a failed run still took time, and that time is the interesting part")
+        .isEqualTo(1);
+  }
+
+  /**
+   * The privacy sweep. Every distinct label set is a stored series, so one label carrying a player
+   * name turns the metrics backend into a directory of who uses the service, growing without bound.
+   * Asserted over every emitted series rather than at each call site, so an emit site added later
+   * cannot quietly opt out.
+   */
+  @Test
+  public void metrics_noLabelCarriesAPlayerOrGameIdentifier() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/priv", SCHOLARS_MATE_PGN, "blitz")));
+    IndexWorker w = meteredWorker();
+    w.process(oneMonth());
+
+    List<String> values = new ArrayList<>();
+    metrics.counterSnapshot().forEach(s -> values.addAll(s.labels().values()));
+    metrics.distributionSnapshot().forEach(s -> values.addAll(s.labels().values()));
+
+    assertThat(values).isNotEmpty();
+    assertThat(values).doesNotContain(PLAYER);
+    assertThat(values).noneSatisfy(v -> assertThat(v).contains("chess.com"));
+    assertThat(values)
+        .as("labels are bounded vocabularies — outcomes, results, motif names")
+        .allSatisfy(v -> assertThat(v).matches("[a-z_]+"));
+  }
+
+  /**
+   * The Java half of a cross-language contract. prom_proxy's one_d4 entry queries these names with
+   * {@code _total} appended by the collector's Prometheus exporter, and a rename here is invisible
+   * on that side: the query stays valid PromQL, matches no series, and the dashboard shows an empty
+   * chart that looks exactly like an idle indexer. Pinned as literals rather than read from the
+   * constants, so renaming a constant fails here instead of silently agreeing with itself. The Go
+   * half is TestOneD4Queries_GoldenInstrumentNames.
+   */
+  @Test
+  public void metrics_exportedInstrumentNames() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/names", SCHOLARS_MATE_PGN, "blitz")));
+    IndexWorker w = meteredWorker();
+    w.process(oneMonth());
+
+    assertThat(metrics.counterSnapshot())
+        .extracting(CustomMetrics.CounterSnapshot::name)
+        .containsOnly(
+            "index_runs",
+            "games_indexed",
+            "index_months",
+            "chess_com_archive_fetches",
+            "motif_occurrences");
+    assertThat(metrics.distributionSnapshot())
+        .extracting(CustomMetrics.DistributionSnapshot::name)
+        .containsOnly("index_run_duration_micros", "index_games_per_month");
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -1084,8 +1084,9 @@ public class IndexWorkerTest {
         .isEqualTo(1);
     // The bounds, not just the count. CustomMetricsTest pins that declared bounds are honoured;
     // nothing pinned that this worker declares any, and without the call every run lands in the
-    // overflow bucket of a histogram whose top bound is 10ms — fifteen dead series and a p95 of
-    // +Inf, with _sum and _count still perfectly correct.
+    // overflow bucket of a histogram whose top bound is 10ms — fifteen dead series, and a p95 that
+    // answers a flat 10000 rather than failing loudly, with _sum and _count still perfectly
+    // correct. A histogram that reads like a fast run is why this is pinned and not argued.
     assertThat(metrics.boundsFor(IndexWorker.RUN_DURATION))
         .as("run duration must not be bucketed on the HTTP latency bounds")
         .isEqualTo(IndexWorker.RUN_DURATION_BOUNDS);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -1032,10 +1032,24 @@ public class IndexWorkerTest {
         .sum();
   }
 
+  private long distributionCount(String name, Map<String, String> labels) {
+    return metrics.distributionSnapshot().stream()
+        .filter(s -> s.name().equals(name) && s.labels().equals(labels))
+        .mapToLong(CustomMetrics.DistributionSnapshot::count)
+        .sum();
+  }
+
   private double distributionSum(String name) {
     return metrics.distributionSnapshot().stream()
         .filter(s -> s.name().equals(name))
         .mapToDouble(CustomMetrics.DistributionSnapshot::sum)
+        .sum();
+  }
+
+  private long runDurationOverflowCount() {
+    return metrics.distributionSnapshot().stream()
+        .filter(d -> d.name().equals(IndexWorker.RUN_DURATION))
+        .mapToLong(d -> d.bucketCounts()[d.bucketCounts().length - 1])
         .sum();
   }
 
@@ -1062,6 +1076,22 @@ public class IndexWorkerTest {
     assertThat(counter(IndexWorker.MONTHS, Map.of("result", "indexed"))).isEqualTo(1);
     assertThat(counter(IndexWorker.ARCHIVE_FETCHES, Map.of("result", "ok"))).isEqualTo(1);
     assertThat(distributionCount(IndexWorker.RUN_DURATION)).isEqualTo(1);
+    // Under the outcome label, not bare. prom_proxy's avg_run_seconds_1h selects
+    // outcome="completed" so a ceiling-length interrupted run cannot drag the average; an
+    // unlabelled histogram makes that selector match nothing and the tile reads empty.
+    assertThat(distributionCount(IndexWorker.RUN_DURATION, Map.of("outcome", "completed")))
+        .as("the duration histogram is labelled the same way the run counter is")
+        .isEqualTo(1);
+    // The bounds, not just the count. CustomMetricsTest pins that declared bounds are honoured;
+    // nothing pinned that this worker declares any, and without the call every run lands in the
+    // overflow bucket of a histogram whose top bound is 10ms — fifteen dead series and a p95 of
+    // +Inf, with _sum and _count still perfectly correct.
+    assertThat(metrics.boundsFor(IndexWorker.RUN_DURATION))
+        .as("run duration must not be bucketed on the HTTP latency bounds")
+        .isEqualTo(IndexWorker.RUN_DURATION_BOUNDS);
+    assertThat(runDurationOverflowCount())
+        .as("a run of ordinary length belongs in a real bucket, not the overflow")
+        .isZero();
     assertThat(distributionSum(IndexWorker.GAMES_PER_MONTH))
         .as("per-month shape, not just the run total")
         .isEqualTo(3.0);
@@ -1081,6 +1111,12 @@ public class IndexWorkerTest {
     assertThat(counter(IndexWorker.MONTHS, Map.of("result", "empty"))).isEqualTo(1);
     assertThat(counter(IndexWorker.GAMES_INDEXED, Map.of())).isZero();
     assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed"))).isEqualTo(1);
+    // A decade-long backfill of a three-year player is mostly 404s. Feeding those zeros into the
+    // per-month distribution makes the average archive read a third its real size, and they are
+    // already counted as empty months.
+    assertThat(distributionCount(IndexWorker.GAMES_PER_MONTH))
+        .as("an empty month is counted, not averaged in")
+        .isZero();
   }
 
   @Test
@@ -1186,6 +1222,11 @@ public class IndexWorkerTest {
     assertThat(distributionCount(IndexWorker.RUN_DURATION))
         .as("a failed run still took time, and that time is the interesting part")
         .isEqualTo(1);
+    assertThat(distributionCount(IndexWorker.RUN_DURATION, Map.of("outcome", "failed")))
+        .as("and it is recorded under failed, so it stays out of the completed-run average")
+        .isEqualTo(1);
+    assertThat(distributionCount(IndexWorker.RUN_DURATION, Map.of("outcome", "completed")))
+        .isZero();
     // ChessClient maps only a 404 to empty and throws on everything else, so without an explicit
     // count here the rate-limits and 5xx — the archive failures worth alerting on — are the one
     // outcome the counter cannot show.
@@ -1250,7 +1291,7 @@ public class IndexWorkerTest {
    * on that side: the query stays valid PromQL, matches no series, and the dashboard shows an empty
    * chart that looks exactly like an idle indexer. Pinned as literals rather than read from the
    * constants, so renaming a constant fails here instead of silently agreeing with itself. The Go
-   * half is TestOneD4Queries_GoldenInstrumentNames.
+   * half is TestOneD4QueriesNameRealInstrumentsAndScopeThem.
    */
   @Test
   public void metrics_exportedInstrumentNames() {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -628,6 +628,13 @@ public class IndexWorkerTest {
       this.throwOnFetch = ex;
     }
 
+    private boolean interruptDuringFetch;
+
+    /** Interrupts the run from inside the call, the way the MAX_RUN ceiling does. */
+    void setInterruptDuringFetch() {
+      this.interruptDuringFetch = true;
+    }
+
     void setTitle(String player, String title) {
       titlesByPlayer.put(player.toLowerCase(), title);
     }
@@ -641,6 +648,9 @@ public class IndexWorkerTest {
       fetchCalls.add(yearMonth);
       if (throwOnFetch != null) {
         throw throwOnFetch;
+      }
+      if (interruptDuringFetch) {
+        Thread.currentThread().interrupt();
       }
       List<PlayedGame> games = responseByMonth.get(yearMonth);
       if (games != null) {
@@ -690,6 +700,14 @@ public class IndexWorkerTest {
   }
 
   private static final class RecordingRequestStore implements IndexingRequestStore {
+    // When set, the terminal write is refused the way a lost lease refuses it. Progress writes
+    // still succeed, so the run gets all the way to the end before discovering the range moved.
+    private boolean refuseTerminalWrite;
+
+    void refuseTerminalWrite() {
+      this.refuseTerminalWrite = true;
+    }
+
     private String lastStatus;
     private String lastErrorMessage;
     private int lastGamesIndexed;
@@ -786,6 +804,9 @@ public class IndexWorkerTest {
         String errorMessage,
         int gamesIndexed,
         Instant now) {
+      if (refuseTerminalWrite && !"PROCESSING".equals(status)) {
+        return false;
+      }
       updateStatus(id, status, errorMessage, gamesIndexed);
       return true;
     }
@@ -978,8 +999,13 @@ public class IndexWorkerTest {
     metrics = new CustomMetrics();
     // Its own extractor: the shared one in setUp has no CheckDetector, so the motif assertions
     // below would pass against a worker that never counted anything.
+    // Two detectors, so the motif label is a dimension rather than a constant: with only one,
+    // replacing motif.name() with the literal "check" would pass.
     FeatureExtractor withCheck =
-        new FeatureExtractor(new PgnParser(), new GameReplayer(), List.of(new CheckDetector()));
+        new FeatureExtractor(
+            new PgnParser(),
+            new GameReplayer(),
+            List.of(new CheckDetector(), new AttackDetector()));
     return new IndexWorker(
         stubChessClient,
         withCheck,
@@ -1069,6 +1095,19 @@ public class IndexWorkerTest {
     assertThat(counter(IndexWorker.MOTIF_OCCURRENCES, Map.of("motif", "check")))
         .as("scholar's mate ends in Qxf7#, so CheckDetector must have found one")
         .isPositive();
+
+    // The label has to be a dimension, not a constant. With one motif in play, hardcoding
+    // "check" at the emit site is indistinguishable from reading motif.name() — so assert that a
+    // second detector's findings arrive under their own label.
+    List<String> motifLabels =
+        metrics.counterSnapshot().stream()
+            .filter(c -> c.name().equals(IndexWorker.MOTIF_OCCURRENCES))
+            .map(c -> c.labels().get("motif"))
+            .toList();
+    assertThat(motifLabels)
+        .as("two detectors are registered, so more than one motif name must appear")
+        .hasSizeGreaterThan(1);
+    assertThat(motifLabels).doesNotHaveDuplicates();
   }
 
   /**
@@ -1147,6 +1186,36 @@ public class IndexWorkerTest {
     assertThat(distributionCount(IndexWorker.RUN_DURATION))
         .as("a failed run still took time, and that time is the interesting part")
         .isEqualTo(1);
+    // ChessClient maps only a 404 to empty and throws on everything else, so without an explicit
+    // count here the rate-limits and 5xx — the archive failures worth alerting on — are the one
+    // outcome the counter cannot show.
+    assertThat(counter(IndexWorker.ARCHIVE_FETCHES, Map.of("result", "error"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.ARCHIVE_FETCHES, Map.of("result", "ok"))).isZero();
+  }
+
+  /**
+   * A month served from the period cache is neither indexed nor empty, and without its own result
+   * it is counted under none of them — so sum(index_months_total) is not months processed, and
+   * cache effectiveness, the thing that decides how much chess.com traffic this service makes, is
+   * invisible.
+   */
+  @Test
+  public void metrics_cachedMonthIsCountedAsCached() {
+    periodStore.setCachedPeriod(
+        PLAYER,
+        PLATFORM,
+        "2024-01",
+        new IndexedPeriodStore.IndexedPeriod(
+            PLAYER, PLATFORM, "2024-01", Instant.EPOCH, true, 9, false));
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.MONTHS, Map.of("result", "cached"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.MONTHS, Map.of("result", "indexed"))).isZero();
+    assertThat(counter(IndexWorker.ARCHIVE_FETCHES, Map.of("result", "ok")))
+        .as("a cached month must not look like a chess.com fetch")
+        .isZero();
   }
 
   /**
@@ -1202,5 +1271,74 @@ public class IndexWorkerTest {
     assertThat(metrics.distributionSnapshot())
         .extracting(CustomMetrics.DistributionSnapshot::name)
         .containsOnly("index_run_duration_micros", "index_games_per_month");
+  }
+
+  /**
+   * Per-month, not per-run. Every other metrics test here indexes a single month, and across one
+   * month `monthCount` and `totalIndexed` are the same number — so the distribution could be
+   * recording the run total, or recording once outside the loop, and nothing would notice. Two
+   * months with different counts is what separates them.
+   */
+  @Test
+  public void metrics_gamesPerMonthIsRecordedPerMonth() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/jan1", SCHOLARS_MATE_PGN, "blitz")));
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 2),
+        List.of(
+            playedGame("https://chess.com/game/feb1", SCHOLARS_MATE_PGN, "blitz"),
+            playedGame("https://chess.com/game/feb2", SCHOLARS_MATE_PGN, "blitz"),
+            playedGame("https://chess.com/game/feb3", SCHOLARS_MATE_PGN, "blitz")));
+    IndexWorker w = meteredWorker();
+
+    w.process(new IndexMessage(UUID.randomUUID(), PLAYER, PLATFORM, "2024-01", "2024-02", false));
+
+    assertThat(distributionCount(IndexWorker.GAMES_PER_MONTH))
+        .as("one observation per month, not one per run")
+        .isEqualTo(2);
+    assertThat(distributionSum(IndexWorker.GAMES_PER_MONTH)).isEqualTo(4.0);
+    assertThat(counter(IndexWorker.GAMES_INDEXED, Map.of())).isEqualTo(4);
+    assertThat(counter(IndexWorker.MONTHS, Map.of("result", "indexed"))).isEqualTo(2);
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed"))).isEqualTo(1);
+  }
+
+  /**
+   * The wedge alarm. prom_proxy ships runs_interrupted_total as the #1282 signal that a worker was
+   * stuck long enough to be given up on, and it had no test on either side — collapsing interrupted
+   * into failed would have gone unnoticed while an operator was told to trust the number.
+   */
+  @Test
+  public void metrics_interruptedRunIsReportedInterruptedNotFailed() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/int", SCHOLARS_MATE_PGN, "blitz")));
+    stubChessClient.setInterruptDuringFetch();
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+    // The run consumes its own interrupt on the way out; clear anything that escaped so the next
+    // test in this class does not inherit it.
+    Thread.interrupted();
+
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "interrupted"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "failed"))).isZero();
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed"))).isZero();
+  }
+
+  /** A range that changes hands is not a failure, and the two must not share a bucket. */
+  @Test
+  public void metrics_runThatLosesItsLeaseIsReportedLeaseLostNotFailed() {
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/game/ll", SCHOLARS_MATE_PGN, "blitz")));
+    requestStore.refuseTerminalWrite();
+    IndexWorker w = meteredWorker();
+
+    w.process(oneMonth());
+
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "lease_lost"))).isEqualTo(1);
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "failed"))).isZero();
+    assertThat(counter(IndexWorker.RUNS, Map.of("outcome", "completed"))).isZero();
   }
 }

--- a/domains/games/apps/1d4_web/package-lock.json
+++ b/domains/games/apps/1d4_web/package-lock.json
@@ -16,18 +16,19 @@
         "react-router": "^8.3.0"
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "^1.0.0",
+        "@cloudflare/vite-plugin": "^1.49.0",
         "@tailwindcss/vite": "^4.0.0",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.0.0",
+        "@types/node": "^26.1.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.0",
         "jsdom": "^30.0.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^7.0.2",
-        "vite": "^8.0.0",
+        "vite": "^8.2.0",
         "vitest": "^4.0.18"
       }
     },
@@ -2337,6 +2338,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -4181,6 +4192,13 @@
       "engines": {
         "node": ">=22.19.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/domains/games/apps/1d4_web/package.json
+++ b/domains/games/apps/1d4_web/package.json
@@ -25,6 +25,7 @@
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.0.0",
+    "@types/node": "^26.1.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.0",

--- a/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
@@ -126,4 +126,16 @@ describe('GameTable', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText('Carol')).toBeInTheDocument();
   });
+
+  // jsdom has no layout, so this cannot assert the rendered result — only that
+  // the hook the stylesheet hangs the fix on is still here. Eleven columns do
+  // not fit a laptop, and without the modifier the browser keeps honouring
+  // width:100% by crushing the last ones instead of letting the wrapper scroll:
+  // ISO dates break after the month and motif badges split mid-word.
+  it('marks the games table as wide so its columns scroll instead of being crushed', () => {
+    const { container } = render(<GameTable games={mockGames} />);
+    const wrap = container.querySelector('.table-wrap');
+    expect(wrap).not.toBeNull();
+    expect(wrap).toHaveClass('table-wrap--wide');
+  });
 });

--- a/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
 import { describe, it, expect, vi } from 'vitest';
 import GameTable from '../components/GameTable';
 import type { GameRow } from '../types';
@@ -137,5 +138,28 @@ describe('GameTable', () => {
     const wrap = container.querySelector('.table-wrap');
     expect(wrap).not.toBeNull();
     expect(wrap).toHaveClass('table-wrap--wide');
+  });
+
+  // The other half. A class name with no rule behind it is a passing test and a
+  // clipped table, and the assertion above cannot tell the two apart — so this
+  // reads the stylesheet directly. Not a layout test: it says the three
+  // declarations the modifier exists for are still declared, which is the most
+  // jsdom's absent layout engine leaves available.
+  it('backs that class with the rules that make it mean something', () => {
+    // Read off disk, not imported: vitest stubs CSS imports, and `?raw` comes back
+    // empty here — which would make every assertion below pass against an empty
+    // string. process.cwd() is the vitest root, i.e. this package.
+    const css = readFileSync('src/index.css', 'utf8');
+    expect(css).not.toHaveLength(0);
+    const rule = (selector: string) =>
+      css.match(new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`))?.[1] ?? '';
+
+    expect(rule('.table-wrap--wide table')).toMatch(/min-width:\s*\d/);
+    expect(rule('.table-wrap--wide td')).toMatch(/white-space:\s*nowrap/);
+    // Badges wrap between themselves; only mid-badge breaking is the bug.
+    expect(rule('.table-wrap--wide td .motifs')).toMatch(/white-space:\s*normal/);
+    // The wrapper has to be the thing that scrolls, or the min-width just
+    // overflows the page and the columns are off-screen instead of squeezed.
+    expect(rule('.table-wrap')).toMatch(/overflow-x:\s*auto/);
   });
 });

--- a/domains/games/apps/1d4_web/src/components/GameTable.tsx
+++ b/domains/games/apps/1d4_web/src/components/GameTable.tsx
@@ -92,7 +92,7 @@ export default function GameTable({
   onClose,
 }: Props) {
   return (
-    <div className="table-wrap">
+    <div className="table-wrap table-wrap--wide">
       <table>
         <thead>
           <tr>

--- a/domains/games/apps/1d4_web/src/index.css
+++ b/domains/games/apps/1d4_web/src/index.css
@@ -159,12 +159,58 @@ body {
 .table-wrap {
   overflow-x: auto;
   margin-top: 1rem;
+  /* Overlay scrollbars stay invisible until something scrolls them, so a table
+     that overflows reads as truncated rather than scrollable — the content just
+     stops at the edge. Reserving the gutter and painting the bar puts the
+     affordance on screen before anyone tries. */
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.table-wrap::-webkit-scrollbar {
+  height: 10px;
+}
+
+.table-wrap::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.table-wrap::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 5px;
+}
+
+.table-wrap::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.875rem;
+}
+
+/* The games table carries eleven columns. Without a floor the browser keeps
+   honouring width:100% by crushing the last ones instead of letting the wrapper
+   scroll, and the motif badges — the narrowest column's content — get cut
+   mid-word. Scoped to this table so the shorter index-requests table still fits
+   a phone without a scrollbar. */
+.table-wrap--wide table {
+  min-width: 64rem;
+}
+
+/* Every value in this table is an atom — a username, an ELO, an ISO date. None
+   of them mean anything broken across two lines, and "2026-07-" over "25" is
+   what a squeezed column produces before the min-width above can catch it. The
+   motifs cell opts back in: it is a flex container whose badges are meant to
+   wrap, just never mid-badge. */
+.table-wrap--wide td {
+  white-space: nowrap;
+}
+
+.table-wrap--wide td .motifs {
+  white-space: normal;
 }
 
 th,
@@ -218,6 +264,9 @@ td a.external:hover {
   font-size: 0.75rem;
   font-weight: 500;
   color: var(--text-muted);
+  /* A badge is one token. Without this "discovered attack" breaks across two
+     lines inside its own pill and the second word hangs outside the cell. */
+  white-space: nowrap;
 }
 
 /* Status */

--- a/domains/games/apps/1d4_web/tsconfig.json
+++ b/domains/games/apps/1d4_web/tsconfig.json
@@ -11,6 +11,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "types": ["node"],
     "strict": true,
     "noFallthroughCasesInSwitch": true
   },

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -107,20 +107,35 @@ var serviceRegistry = map[string]serviceEntry{
 			// A wedge cut loose by the MAX_RUN ceiling lands here (#1282). Anything
 			// above zero means a worker was stuck long enough to be given up on.
 			{"Indexing", "runs_interrupted_total", "", `sum(index_runs_total{service_name="one_d4",outcome="interrupted"})`},
+			// Emitted since the ceiling landed, and listed so the four outcomes add up to
+			// index_runs_total. A range changing hands mid-run is ordinary; a rising count
+			// beside a flat interrupted count is contention, not a wedge.
+			{"Indexing", "runs_lease_lost_total", "", `sum(index_runs_total{service_name="one_d4",outcome="lease_lost"})`},
 			// Windowed averages over the histograms: rate(sum)/rate(count) is the
 			// mean per run in the window, the same shape portrait uses.
 			{"Indexing", "avg_run_seconds_1h", "s", `sum(rate(index_run_duration_micros_sum{service_name="one_d4"}[1h]))/sum(rate(index_run_duration_micros_count{service_name="one_d4"}[1h]))/1000000`},
 			{"Indexing", "avg_games_per_month_1h", "games", `sum(rate(index_games_per_month_sum{service_name="one_d4"}[1h]))/sum(rate(index_games_per_month_count{service_name="one_d4"}[1h]))`},
 			{"Indexing", "empty_months_total", "", `sum(index_months_total{service_name="one_d4",result="empty"})`},
+			{"Indexing", "cached_months_total", "", `sum(index_months_total{service_name="one_d4",result="cached"})`},
 			{"Indexing", "archive_fetches_per_sec", "/s", `sum(rate(chess_com_archive_fetches_total{service_name="one_d4"}[5m]))`},
 			{"Motifs", "occurrences_per_sec", "/s", `sum(rate(motif_occurrences_total{service_name="one_d4"}[5m]))`},
 			{"Motifs", "occurrences_total", "", `sum(motif_occurrences_total{service_name="one_d4"})`},
-			{"Motifs", "per_game_avg_1h", "motifs", `sum(rate(motif_occurrences_total{service_name="one_d4"}[1h]))/clamp_min(sum(rate(games_indexed_total{service_name="one_d4"}[1h])), 0.0001)`},
+			// No motifs-per-game tile. The two counters are recorded on opposite sides of
+			// the durability boundary — motifs per game inside the drain loop, games only
+			// after the month's flush and period write succeed — so an interrupted or
+			// lease-lost month contributes motifs and zero games. The ratio then divides
+			// by a rate of zero, and any clamp large enough to avoid a divide-by-zero is
+			// small enough to turn the result into a four-order-of-magnitude spike. A tile
+			// that is wrong exactly when the system is unhealthy is worse than no tile.
 		},
 		CustomTimeseries: map[string]string{
 			"games_indexed_rate":  `sum(rate(games_indexed_total{service_name="one_d4"}[5m]))`,
 			"run_completion_rate": `sum(rate(index_runs_total{service_name="one_d4",outcome="completed"}[5m]))`,
-			"run_failure_rate":    `sum(rate(index_runs_total{service_name="one_d4"}[5m])) - sum(rate(index_runs_total{service_name="one_d4",outcome="completed"}[5m]))`,
+			// Selected, not subtracted. In PromQL sum() over no matching series is an
+			// empty vector, and vector-minus-empty is empty rather than the left side —
+			// so a total-minus-completed form renders nothing on a fresh process whose
+			// runs are all failing, which is precisely when someone is looking at it.
+			"run_failure_rate":    `sum(rate(index_runs_total{service_name="one_d4",outcome!="completed"}[5m]))`,
 			"run_duration_avg_us": `sum(rate(index_run_duration_micros_sum{service_name="one_d4"}[5m]))/sum(rate(index_run_duration_micros_count{service_name="one_d4"}[5m]))`,
 			"motif_rate":          `sum(rate(motif_occurrences_total{service_name="one_d4"}[5m]))`,
 		},

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -113,7 +113,10 @@ var serviceRegistry = map[string]serviceEntry{
 			{"Indexing", "runs_lease_lost_total", "", `sum(index_runs_total{service_name="one_d4",outcome="lease_lost"})`},
 			// Windowed averages over the histograms: rate(sum)/rate(count) is the
 			// mean per run in the window, the same shape portrait uses.
-			{"Indexing", "avg_run_seconds_1h", "s", `sum(rate(index_run_duration_micros_sum{service_name="one_d4"}[1h]))/sum(rate(index_run_duration_micros_count{service_name="one_d4"}[1h]))/1000000`},
+			// Completed runs only. The histogram is labelled by outcome, and an interrupted
+			// run is one that sat at the MAX_RUN ceiling — pooling those in makes the average
+			// spike at exactly the moment someone is reading it to size a real run.
+			{"Indexing", "avg_run_seconds_1h", "s", `sum(rate(index_run_duration_micros_sum{service_name="one_d4",outcome="completed"}[1h]))/sum(rate(index_run_duration_micros_count{service_name="one_d4",outcome="completed"}[1h]))/1000000`},
 			{"Indexing", "avg_games_per_month_1h", "games", `sum(rate(index_games_per_month_sum{service_name="one_d4"}[1h]))/sum(rate(index_games_per_month_count{service_name="one_d4"}[1h]))`},
 			{"Indexing", "empty_months_total", "", `sum(index_months_total{service_name="one_d4",result="empty"})`},
 			{"Indexing", "cached_months_total", "", `sum(index_months_total{service_name="one_d4",result="cached"})`},
@@ -135,8 +138,13 @@ var serviceRegistry = map[string]serviceEntry{
 			// empty vector, and vector-minus-empty is empty rather than the left side —
 			// so a total-minus-completed form renders nothing on a fresh process whose
 			// runs are all failing, which is precisely when someone is looking at it.
-			"run_failure_rate":    `sum(rate(index_runs_total{service_name="one_d4",outcome!="completed"}[5m]))`,
-			"run_duration_avg_us": `sum(rate(index_run_duration_micros_sum{service_name="one_d4"}[5m]))/sum(rate(index_run_duration_micros_count{service_name="one_d4"}[5m]))`,
+			//
+			// Named outcomes rather than != "completed": lease_lost is the fourth, and it
+			// is ordinary. A range changing hands mid-run happens whenever two pollers
+			// overlap, so counting it here puts a permanent floor under the failure line
+			// and buries the two outcomes that do mean something went wrong.
+			"run_failure_rate":    `sum(rate(index_runs_total{service_name="one_d4",outcome=~"failed|interrupted"}[5m]))`,
+			"run_duration_avg_us": `sum(rate(index_run_duration_micros_sum{service_name="one_d4",outcome="completed"}[5m]))/sum(rate(index_run_duration_micros_count{service_name="one_d4",outcome="completed"}[5m]))`,
 			"motif_rate":          `sum(rate(motif_occurrences_total{service_name="one_d4"}[5m]))`,
 		},
 	},

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -95,7 +95,36 @@ var serviceRegistry = map[string]serviceEntry{
 	// The Java services (#1212): yodel's standard instruments only, no
 	// custom set yet.
 	"mcpserver": {},
-	"one_d4":    {},
+	// The first Java service with a custom set, now that yodel has counters and
+	// distributions to record into. Counts, outcomes and motif names only — the
+	// emitter never labels by player or by game, so no series here is per-user.
+	"one_d4": {
+		CustomScalars: []customScalarDef{
+			{"Indexing", "games_indexed_total", "games", `sum(games_indexed_total{service_name="one_d4"})`},
+			{"Indexing", "games_per_sec", "/s", `sum(rate(games_indexed_total{service_name="one_d4"}[5m]))`},
+			{"Indexing", "runs_completed_total", "", `sum(index_runs_total{service_name="one_d4",outcome="completed"})`},
+			{"Indexing", "runs_failed_total", "", `sum(index_runs_total{service_name="one_d4",outcome="failed"})`},
+			// A wedge cut loose by the MAX_RUN ceiling lands here (#1282). Anything
+			// above zero means a worker was stuck long enough to be given up on.
+			{"Indexing", "runs_interrupted_total", "", `sum(index_runs_total{service_name="one_d4",outcome="interrupted"})`},
+			// Windowed averages over the histograms: rate(sum)/rate(count) is the
+			// mean per run in the window, the same shape portrait uses.
+			{"Indexing", "avg_run_seconds_1h", "s", `sum(rate(index_run_duration_micros_sum{service_name="one_d4"}[1h]))/sum(rate(index_run_duration_micros_count{service_name="one_d4"}[1h]))/1000000`},
+			{"Indexing", "avg_games_per_month_1h", "games", `sum(rate(index_games_per_month_sum{service_name="one_d4"}[1h]))/sum(rate(index_games_per_month_count{service_name="one_d4"}[1h]))`},
+			{"Indexing", "empty_months_total", "", `sum(index_months_total{service_name="one_d4",result="empty"})`},
+			{"Indexing", "archive_fetches_per_sec", "/s", `sum(rate(chess_com_archive_fetches_total{service_name="one_d4"}[5m]))`},
+			{"Motifs", "occurrences_per_sec", "/s", `sum(rate(motif_occurrences_total{service_name="one_d4"}[5m]))`},
+			{"Motifs", "occurrences_total", "", `sum(motif_occurrences_total{service_name="one_d4"})`},
+			{"Motifs", "per_game_avg_1h", "motifs", `sum(rate(motif_occurrences_total{service_name="one_d4"}[1h]))/clamp_min(sum(rate(games_indexed_total{service_name="one_d4"}[1h])), 0.0001)`},
+		},
+		CustomTimeseries: map[string]string{
+			"games_indexed_rate":  `sum(rate(games_indexed_total{service_name="one_d4"}[5m]))`,
+			"run_completion_rate": `sum(rate(index_runs_total{service_name="one_d4",outcome="completed"}[5m]))`,
+			"run_failure_rate":    `sum(rate(index_runs_total{service_name="one_d4"}[5m])) - sum(rate(index_runs_total{service_name="one_d4",outcome="completed"}[5m]))`,
+			"run_duration_avg_us": `sum(rate(index_run_duration_micros_sum{service_name="one_d4"}[5m]))/sum(rate(index_run_duration_micros_count{service_name="one_d4"}[5m]))`,
+			"motif_rate":          `sum(rate(motif_occurrences_total{service_name="one_d4"}[5m]))`,
+		},
+	},
 	// Wordchains: server_pal's standard instruments only, no custom set.
 	"mithril": {},
 	// Image blur/edges: server_pal's standard instruments only.

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -584,4 +584,35 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 		`outcome="interrupted"`, `outcome="lease_lost"`, `result="empty"`, `result="cached"`} {
 		assert.Contains(t, joined, label, "no query selects %s", label)
 	}
+
+	// The duration histogram carries the same outcome label the run counter does, and both
+	// averages over it have to say which outcome they mean. Unscoped, a single run cut loose
+	// at the six-hour MAX_RUN ceiling swamps every ordinary run in the window — the average
+	// reads worst at the moment it is being used to judge how bad things are.
+	for what, queries := range labelled {
+		for _, query := range queries {
+			for _, match := range oneD4SelectorPattern.FindAllStringSubmatch(query, -1) {
+				if !strings.HasPrefix(match[1], "index_run_duration_micros") {
+					continue
+				}
+				assert.Contains(t, match[2], `outcome="completed"`,
+					"%s averages over every outcome, ceiling-length interrupts included: %s",
+					what, query)
+			}
+		}
+	}
+
+	// And selected positively. outcome!="completed" reads as "everything that went wrong",
+	// but IndexWorker's fourth outcome is lease_lost — a range changing hands because two
+	// pollers overlapped, which is ordinary — so a negation puts a permanent floor under the
+	// failure line. It also opts every future outcome in by default: whoever adds a fifth
+	// label gets it counted as a failure without deciding that it is one.
+	for _, def := range entry.CustomScalars {
+		assert.NotRegexp(t, `outcome\s*!=|outcome\s*!~`, def.Query,
+			"scalar %s selects outcomes by exclusion", def.Label)
+	}
+	for key, query := range entry.CustomTimeseries {
+		assert.NotRegexp(t, `outcome\s*!=|outcome\s*!~`, query,
+			"timeseries %s selects outcomes by exclusion", key)
+	}
 }

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -505,41 +505,83 @@ func TestMetricsHandler_GetHostMetricsTimeSeries(t *testing.T) {
 	assert.Equal(t, 7, containerSeries)
 }
 
-// The one_d4 custom set is a cross-language contract: IndexWorker names an
-// instrument, the collector's Prometheus exporter appends _total to counters,
-// and these queries have to name the result exactly. Nothing fails loudly when
-// they disagree — the query is valid PromQL that matches no series, so the
-// dashboard renders an empty chart, which looks exactly like an idle indexer.
-// The Java half is pinned by IndexWorkerTest#metrics_exportedInstrumentNames.
-func TestOneD4Queries_GoldenInstrumentNames(t *testing.T) {
+// Every selector in the one_d4 set, checked one at a time.
+//
+// The first version of this joined every query into one blob and ran
+// strings.Contains over it. That pins almost nothing: a prefix rename of every
+// instrument passes (the old name is still a substring of the new one), dropping
+// service_name from all seventeen selectors passes, deleting every timeseries
+// passes, and pointing games_per_sec at index_runs_total passes — because a union
+// of names never says which query uses which. The third of those is the exact
+// failure the comment claimed to prevent.
+//
+// So this borrows the shape TestRegistry_PortraitCacheQueriesUseTheStandardFamily
+// already uses: match each selector, assert on that selector, and close the set of
+// names so a new instrument has to be declared here too.
+var oneD4SelectorPattern = regexp.MustCompile(`\b((?:games_indexed|index_runs|index_months|chess_com_archive_fetches|motif_occurrences|index_run_duration_micros|index_games_per_month)[a-z_]*)(\{[^}]*\})?`)
+
+// What IndexWorker emits, plus the suffixes the collector's Prometheus exporter
+// appends: _total for a cumulative monotonic sum, _sum/_count for a histogram.
+// The Java end is IndexWorkerTest#metrics_exportedInstrumentNames.
+var oneD4ExportedNames = map[string]bool{
+	"games_indexed_total":             true,
+	"index_runs_total":                true,
+	"index_months_total":              true,
+	"chess_com_archive_fetches_total": true,
+	"motif_occurrences_total":         true,
+	"index_run_duration_micros_sum":   true,
+	"index_run_duration_micros_count": true,
+	"index_games_per_month_sum":       true,
+	"index_games_per_month_count":     true,
+}
+
+func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 	entry := serviceRegistry["one_d4"]
-	var all []string
-	for _, s := range entry.CustomScalars {
-		all = append(all, s.Query)
-	}
-	for _, q := range entry.CustomTimeseries {
-		all = append(all, q)
-	}
-	joined := strings.Join(all, "\n")
+	require.NotEmpty(t, entry.CustomScalars)
+	require.NotEmpty(t, entry.CustomTimeseries, "the timeseries panels are part of this entry")
 
-	for _, name := range []string{
-		"games_indexed_total",
-		"index_runs_total",
-		"index_months_total",
-		"chess_com_archive_fetches_total",
-		"motif_occurrences_total",
-		"index_run_duration_micros_sum",
-		"index_run_duration_micros_count",
-		"index_games_per_month_sum",
-		"index_games_per_month_count",
-	} {
-		assert.Contains(t, joined, name, "one_d4 query set must reference %s", name)
+	labelled := map[string][]string{}
+	for _, def := range entry.CustomScalars {
+		labelled["scalar "+def.Label] = []string{def.Query}
+	}
+	for key, query := range entry.CustomTimeseries {
+		labelled["timeseries "+key] = []string{query}
 	}
 
-	// Outcome labels are the vocabulary IndexWorker writes; a typo here silently
-	// selects nothing rather than erroring.
-	assert.Contains(t, joined, `outcome="completed"`)
-	assert.Contains(t, joined, `outcome="failed"`)
-	assert.Contains(t, joined, `outcome="interrupted"`)
-	assert.Contains(t, joined, `result="empty"`)
+	seen := map[string]int{}
+	for what, queries := range labelled {
+		for _, query := range queries {
+			matches := oneD4SelectorPattern.FindAllStringSubmatch(query, -1)
+			assert.NotEmpty(t, matches, "%s queries no one_d4 instrument: %s", what, query)
+			for _, match := range matches {
+				name := match[1]
+				seen[name]++
+				assert.True(t, oneD4ExportedNames[name],
+					"%s reads %q, which IndexWorker does not export", what, name)
+				assert.Contains(t, match[2], `service_name="one_d4"`,
+					"selector %q in %s is not scoped to one_d4, so it sums every service that ever"+
+						" emits that name: %s", match[0], what, query)
+			}
+		}
+	}
+
+	// Closed in the other direction too: an instrument nothing charts is one the
+	// service pays to export and nobody reads.
+	for name := range oneD4ExportedNames {
+		assert.NotZero(t, seen[name], "nothing in the one_d4 entry reads %s", name)
+	}
+
+	// Outcome labels are IndexWorker's vocabulary. A typo selects nothing rather
+	// than erroring, so the tiles would read zero forever.
+	joined := strings.Join([]string{}, "")
+	for _, def := range entry.CustomScalars {
+		joined += def.Query + "\n"
+	}
+	for _, query := range entry.CustomTimeseries {
+		joined += query + "\n"
+	}
+	for _, label := range []string{`outcome="completed"`, `outcome="failed"`,
+		`outcome="interrupted"`, `outcome="lease_lost"`, `result="empty"`, `result="cached"`} {
+		assert.Contains(t, joined, label, "no query selects %s", label)
+	}
 }

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -175,7 +175,10 @@ func TestMetricsHandler_GetServiceCatalog(t *testing.T) {
 		{"mcpserver", false},
 		{"microgpt-serve", true},
 		{"mithril", false},
-		{"one_d4", false},
+		// The first Java service with a custom set (#1212): yodel grew counters and
+		// distributions, so one_d4 can report indexing and motif work rather than
+		// only the requests that asked for it.
+		{"one_d4", true},
 		{"portrait", true},
 		{"posterize", false},
 	}
@@ -500,4 +503,43 @@ func TestMetricsHandler_GetHostMetricsTimeSeries(t *testing.T) {
 	assert.True(t, names["container_restarts"])
 	assert.Equal(t, 5, hostSeries)
 	assert.Equal(t, 7, containerSeries)
+}
+
+// The one_d4 custom set is a cross-language contract: IndexWorker names an
+// instrument, the collector's Prometheus exporter appends _total to counters,
+// and these queries have to name the result exactly. Nothing fails loudly when
+// they disagree — the query is valid PromQL that matches no series, so the
+// dashboard renders an empty chart, which looks exactly like an idle indexer.
+// The Java half is pinned by IndexWorkerTest#metrics_exportedInstrumentNames.
+func TestOneD4Queries_GoldenInstrumentNames(t *testing.T) {
+	entry := serviceRegistry["one_d4"]
+	var all []string
+	for _, s := range entry.CustomScalars {
+		all = append(all, s.Query)
+	}
+	for _, q := range entry.CustomTimeseries {
+		all = append(all, q)
+	}
+	joined := strings.Join(all, "\n")
+
+	for _, name := range []string{
+		"games_indexed_total",
+		"index_runs_total",
+		"index_months_total",
+		"chess_com_archive_fetches_total",
+		"motif_occurrences_total",
+		"index_run_duration_micros_sum",
+		"index_run_duration_micros_count",
+		"index_games_per_month_sum",
+		"index_games_per_month_count",
+	} {
+		assert.Contains(t, joined, name, "one_d4 query set must reference %s", name)
+	}
+
+	// Outcome labels are the vocabulary IndexWorker writes; a typo here silently
+	// selects nothing rather than erroring.
+	assert.Contains(t, joined, `outcome="completed"`)
+	assert.Contains(t, joined, `outcome="failed"`)
+	assert.Contains(t, joined, `outcome="interrupted"`)
+	assert.Contains(t, joined, `result="empty"`)
 }

--- a/domains/platform/libs/yodel/BUILD.bazel
+++ b/domains/platform/libs/yodel/BUILD.bazel
@@ -94,6 +94,7 @@ java_test_suite(
         artifact("io.micronaut:micronaut-http-server-netty"),
         artifact("io.micronaut:micronaut-inject"),
         artifact("io.micronaut:micronaut-runtime"),
+        artifact("jakarta.annotation:jakarta.annotation-api"),
         artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.assertj:assertj-core"),
     ],

--- a/domains/platform/libs/yodel/BUILD.bazel
+++ b/domains/platform/libs/yodel/BUILD.bazel
@@ -3,6 +3,7 @@ load("//bazel/rules:java.bzl", "artifact", "java_library", "java_test_suite")
 java_library(
     name = "yodel",
     srcs = [
+        "src/main/java/com/muchq/platform/yodel/CustomMetrics.java",
         "src/main/java/com/muchq/platform/yodel/HttpMetricsPipeline.java",
         "src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java",
         "src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java",
@@ -24,10 +25,12 @@ java_library(
     name = "micronaut",
     srcs = [
         "src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java",
+        "src/main/java/com/muchq/platform/yodel/micronaut/YodelMetricsFactory.java",
     ],
     visibility = ["//visibility:public"],
     deps = [
         ":yodel",
+        artifact("io.micronaut:micronaut-context"),
         artifact("io.micronaut:micronaut-core"),
         artifact("io.micronaut:micronaut-http"),
         artifact("io.micronaut:micronaut-inject"),
@@ -42,6 +45,8 @@ java_test_suite(
     name = "yodel_tests",
     size = "small",
     srcs = [
+        "src/test/java/com/muchq/platform/yodel/CustomMetricsEncodingTest.java",
+        "src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java",
         "src/test/java/com/muchq/platform/yodel/HttpMetricsPipelineTest.java",
         "src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java",
         "src/test/java/com/muchq/platform/yodel/OtlpHttpMetricsExporterTest.java",

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -1,0 +1,181 @@
+package com.muchq.platform.yodel;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.regex.Pattern;
+
+/**
+ * Instruments a service defines for itself, exported beside the {@code http_server_*} family.
+ *
+ * <p>Until this existed a Java service could say how many requests it served and nothing about what
+ * it did with them, which is why every Java entry in prom_proxy's registry was empty
+ * (https://github.com/muchq/MoonBase/issues/1212). The C++ and Rust rails already had the
+ * equivalent — futility/otel's counters and server_pal's {@code RecordDistribution} — so this is
+ * Java catching up to them rather than a new idea.
+ *
+ * <p>Two instrument kinds, matching what the dashboard can already render:
+ *
+ * <ul>
+ *   <li><b>Counters</b> — monotonic totals. The collector's Prometheus exporter appends {@code
+ *       _total}, so a counter named {@code games_indexed} is queried as {@code
+ *       games_indexed_total}.
+ *   <li><b>Distributions</b> — histograms over the same bucket bounds the HTTP duration histogram
+ *       uses, exported as {@code _sum}/{@code _count}/{@code _bucket}. A windowed mean is then
+ *       {@code rate(x_sum[5m])/rate(x_count[5m])}, which is how portrait reports scene complexity.
+ * </ul>
+ *
+ * <p>Labels are for bounded, low-cardinality dimensions — an outcome, a stage, a motif name. Never
+ * a user id, a player name, or a URL: every distinct label set is a separate stored series, and one
+ * unbounded label is what turns a metrics backend into an outage.
+ *
+ * <p>Safe to call from any thread; recording is lock-free.
+ */
+public final class CustomMetrics {
+
+  /**
+   * Prometheus' own name grammar. Enforced on the way in because the alternative is a metric that
+   * records perfectly, exports, and then quietly fails to match any dashboard query — a failure
+   * that shows up as an empty chart weeks later rather than as anything a test would catch.
+   */
+  private static final Pattern VALID_NAME = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+
+  private final ConcurrentHashMap<Series, LongAdder> counters = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Series, Distribution> distributions = new ConcurrentHashMap<>();
+
+  /** Adds one to {@code name} with no labels. */
+  public void increment(String name) {
+    add(name, 1, Map.of());
+  }
+
+  /** Adds one to {@code name} for this label set. */
+  public void increment(String name, Map<String, String> labels) {
+    add(name, 1, labels);
+  }
+
+  /** Adds {@code delta} to {@code name} for this label set. Counters only go up. */
+  public void add(String name, long delta, Map<String, String> labels) {
+    if (delta < 0) {
+      throw new IllegalArgumentException(
+          "counter " + name + " may not decrease (delta " + delta + ")");
+    }
+    counters.computeIfAbsent(series(name, labels), s -> new LongAdder()).add(delta);
+  }
+
+  /** Records one observation of {@code name} with no labels. */
+  public void record(String name, double value) {
+    record(name, value, Map.of());
+  }
+
+  /** Records one observation of {@code name} for this label set. */
+  public void record(String name, double value, Map<String, String> labels) {
+    distributions.computeIfAbsent(series(name, labels), s -> new Distribution()).record(value);
+  }
+
+  /** Cumulative counter totals, ordered by name then labels so payloads are stable. */
+  public List<CounterSnapshot> counterSnapshot() {
+    List<CounterSnapshot> out = new ArrayList<>(counters.size());
+    counters.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            e ->
+                out.add(
+                    new CounterSnapshot(
+                        e.getKey().name(), e.getKey().labels(), e.getValue().sum())));
+    return out;
+  }
+
+  /** Cumulative distribution state, ordered by name then labels so payloads are stable. */
+  public List<DistributionSnapshot> distributionSnapshot() {
+    List<DistributionSnapshot> out = new ArrayList<>(distributions.size());
+    distributions.entrySet().stream()
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(e -> out.add(e.getValue().snapshot(e.getKey().name(), e.getKey().labels())));
+    return out;
+  }
+
+  /** True when nothing has been recorded, so the encoder can leave the scope out entirely. */
+  public boolean isEmpty() {
+    return counters.isEmpty() && distributions.isEmpty();
+  }
+
+  private static Series series(String name, Map<String, String> labels) {
+    requireValid("metric name", name);
+    SortedMap<String, String> sorted = new TreeMap<>();
+    labels.forEach(
+        (key, value) -> {
+          requireValid("label name", key);
+          sorted.put(key, value);
+        });
+    return new Series(name, sorted);
+  }
+
+  private static void requireValid(String what, String value) {
+    if (value == null || !VALID_NAME.matcher(value).matches()) {
+      throw new IllegalArgumentException(
+          what + " must match " + VALID_NAME.pattern() + " to survive export, got: " + value);
+    }
+  }
+
+  /**
+   * A single exported series. Labels are held sorted so that two callers passing the same pairs in
+   * different orders land on one series rather than two that silently double-count.
+   */
+  record Series(String name, SortedMap<String, String> labels) implements Comparable<Series> {
+    private static final Comparator<Series> ORDER =
+        Comparator.comparing(Series::name).thenComparing(s -> s.labels().toString());
+
+    @Override
+    public int compareTo(Series other) {
+      return ORDER.compare(this, other);
+    }
+  }
+
+  public record CounterSnapshot(String name, Map<String, String> labels, long value) {}
+
+  public record DistributionSnapshot(
+      String name, Map<String, String> labels, double sum, long count, long[] bucketCounts) {}
+
+  private static final class Distribution {
+    final DoubleAdder sum = new DoubleAdder();
+    final LongAdder count = new LongAdder();
+    final LongAdder[] buckets;
+
+    Distribution() {
+      buckets = new LongAdder[HttpServerMetrics.BUCKET_BOUNDS.length + 1];
+      for (int i = 0; i < buckets.length; i++) {
+        buckets[i] = new LongAdder();
+      }
+    }
+
+    void record(double value) {
+      sum.add(value);
+      count.increment();
+      bucketFor(value).increment();
+    }
+
+    // Upper-inclusive, matching HttpServerMetrics and the OTLP bucket convention.
+    LongAdder bucketFor(double value) {
+      for (int i = 0; i < HttpServerMetrics.BUCKET_BOUNDS.length; i++) {
+        if (value <= HttpServerMetrics.BUCKET_BOUNDS[i]) {
+          return buckets[i];
+        }
+      }
+      return buckets[HttpServerMetrics.BUCKET_BOUNDS.length];
+    }
+
+    DistributionSnapshot snapshot(String name, Map<String, String> labels) {
+      long[] counts = new long[buckets.length];
+      for (int i = 0; i < buckets.length; i++) {
+        counts[i] = buckets[i].sum();
+      }
+      return new DistributionSnapshot(name, labels, sum.sum(), count.sum(), counts);
+    }
+  }
+}

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -48,6 +48,7 @@ public final class CustomMetrics {
 
   private final ConcurrentHashMap<Series, LongAdder> counters = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<Series, Distribution> distributions = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, double[]> boundsByName = new ConcurrentHashMap<>();
 
   /** Adds one to {@code name} with no labels. */
   public void increment(String name) {
@@ -68,14 +69,71 @@ public final class CustomMetrics {
     counters.computeIfAbsent(series(name, labels), s -> new LongAdder()).add(delta);
   }
 
+  /**
+   * Declares the bucket bounds for a distribution, ahead of the first observation.
+   *
+   * <p>The default is the set the HTTP latency histogram uses, which tops out at 10ms. That suits
+   * anything request-shaped and suits nothing else: a distribution over minutes, or over counts in
+   * the thousands, puts every observation in the overflow bucket. The mean still reads correctly
+   * off {@code _sum}/{@code _count}, so the damage is quiet — fifteen bucket series pinned at zero,
+   * and any quantile over them returning {@code +Inf}.
+   *
+   * <p>Call before recording. Bounds must be ascending, and a later call for the same name is
+   * ignored rather than allowed to reshape a histogram mid-flight — the collector treats bucket
+   * counts as cumulative, and swapping bounds underneath them corrupts the series rather than
+   * correcting it.
+   */
+  public void defineDistribution(String name, double[] bounds) {
+    requireValid("metric name", name);
+    if (bounds.length == 0) {
+      throw new IllegalArgumentException("distribution " + name + " needs at least one bound");
+    }
+    for (int i = 1; i < bounds.length; i++) {
+      if (bounds[i] <= bounds[i - 1]) {
+        throw new IllegalArgumentException(
+            "distribution "
+                + name
+                + " bounds must ascend, got "
+                + bounds[i - 1]
+                + " then "
+                + bounds[i]);
+      }
+    }
+    boundsByName.putIfAbsent(name, bounds.clone());
+  }
+
+  /** The bounds a distribution will use, whether declared or defaulted. */
+  public double[] boundsFor(String name) {
+    return boundsByName.getOrDefault(name, HttpServerMetrics.BUCKET_BOUNDS).clone();
+  }
+
   /** Records one observation of {@code name} with no labels. */
   public void record(String name, double value) {
     record(name, value, Map.of());
   }
 
-  /** Records one observation of {@code name} for this label set. */
+  /**
+   * Records one observation of {@code name} for this label set.
+   *
+   * <p>Rejects NaN and negatives for the same reason {@link #add} rejects a negative delta, and the
+   * failure is quieter here: the exported {@code _sum} is cumulative, so a negative observation
+   * makes it fall and Prometheus reads the drop as a counter reset and invents a {@code rate()}
+   * spike. NaN is worse — {@code DoubleAdder} keeps it forever, and protojson accepts the string
+   * {@code "NaN"} for a double, so the series parses cleanly and is silently NaN from then on.
+   */
   public void record(String name, double value, Map<String, String> labels) {
-    distributions.computeIfAbsent(series(name, labels), s -> new Distribution()).record(value);
+    if (Double.isNaN(value) || Double.isInfinite(value)) {
+      throw new IllegalArgumentException("distribution " + name + " cannot record " + value);
+    }
+    if (value < 0) {
+      throw new IllegalArgumentException(
+          "distribution " + name + " cannot record a negative observation (" + value + ")");
+    }
+    distributions
+        .computeIfAbsent(
+            series(name, labels),
+            s -> new Distribution(boundsByName.getOrDefault(name, HttpServerMetrics.BUCKET_BOUNDS)))
+        .record(value);
   }
 
   /** Cumulative counter totals, ordered by name then labels so payloads are stable. */
@@ -87,7 +145,13 @@ public final class CustomMetrics {
             e ->
                 out.add(
                     new CounterSnapshot(
-                        e.getKey().name(), e.getKey().labels(), e.getValue().sum())));
+                        e.getKey().name(),
+                        // Copy: the key's own map decides its hash. Handing it out lets a caller
+                        // mutate a live key, stranding the entry in the wrong bin so the next
+                        // record for those labels mints a second one — two data points with
+                        // identical attributes in one payload, which Prometheus rejects.
+                        Map.copyOf(e.getKey().labels()),
+                        e.getValue().sum())));
     return out;
   }
 
@@ -96,7 +160,9 @@ public final class CustomMetrics {
     List<DistributionSnapshot> out = new ArrayList<>(distributions.size());
     distributions.entrySet().stream()
         .sorted(Map.Entry.comparingByKey())
-        .forEach(e -> out.add(e.getValue().snapshot(e.getKey().name(), e.getKey().labels())));
+        .forEach(
+            e ->
+                out.add(e.getValue().snapshot(e.getKey().name(), Map.copyOf(e.getKey().labels()))));
     return out;
   }
 
@@ -111,6 +177,13 @@ public final class CustomMetrics {
     labels.forEach(
         (key, value) -> {
           requireValid("label name", key);
+          // The encoder stamps service_name on every point, and the OTel spec forbids a data point
+          // carrying the same attribute key twice. Refusing it here beats emitting a payload a
+          // strict collector drops.
+          if ("service_name".equals(key)) {
+            throw new IllegalArgumentException(
+                "service_name is added on export; a metric may not set it as a label");
+          }
           sorted.put(key, value);
         });
     return new Series(name, sorted);
@@ -128,8 +201,15 @@ public final class CustomMetrics {
    * different orders land on one series rather than two that silently double-count.
    */
   record Series(String name, SortedMap<String, String> labels) implements Comparable<Series> {
+    // Compared entry by entry rather than on the map's toString: "{a=1, b=2}" is also what a
+    // single entry {a="1, b=2"} stringifies to, and label values are not validated. Two distinct
+    // series comparing equal would leave their order to hash iteration, which is the opposite of
+    // the stable payload this ordering exists to produce.
     private static final Comparator<Series> ORDER =
-        Comparator.comparing(Series::name).thenComparing(s -> s.labels().toString());
+        Comparator.comparing(Series::name)
+            .thenComparing(s -> s.labels().size())
+            .thenComparing(s -> String.join("\u0000", s.labels().keySet()))
+            .thenComparing(s -> String.join("\u0000", s.labels().values()));
 
     @Override
     public int compareTo(Series other) {
@@ -140,15 +220,22 @@ public final class CustomMetrics {
   public record CounterSnapshot(String name, Map<String, String> labels, long value) {}
 
   public record DistributionSnapshot(
-      String name, Map<String, String> labels, double sum, long count, long[] bucketCounts) {}
+      String name,
+      Map<String, String> labels,
+      double sum,
+      long count,
+      long[] bucketCounts,
+      double[] bounds) {}
 
   private static final class Distribution {
     final DoubleAdder sum = new DoubleAdder();
     final LongAdder count = new LongAdder();
+    final double[] bounds;
     final LongAdder[] buckets;
 
-    Distribution() {
-      buckets = new LongAdder[HttpServerMetrics.BUCKET_BOUNDS.length + 1];
+    Distribution(double[] bounds) {
+      this.bounds = bounds;
+      buckets = new LongAdder[bounds.length + 1];
       for (int i = 0; i < buckets.length; i++) {
         buckets[i] = new LongAdder();
       }
@@ -162,12 +249,12 @@ public final class CustomMetrics {
 
     // Upper-inclusive, matching HttpServerMetrics and the OTLP bucket convention.
     LongAdder bucketFor(double value) {
-      for (int i = 0; i < HttpServerMetrics.BUCKET_BOUNDS.length; i++) {
-        if (value <= HttpServerMetrics.BUCKET_BOUNDS[i]) {
+      for (int i = 0; i < bounds.length; i++) {
+        if (value <= bounds[i]) {
           return buckets[i];
         }
       }
-      return buckets[HttpServerMetrics.BUCKET_BOUNDS.length];
+      return buckets[bounds.length];
     }
 
     DistributionSnapshot snapshot(String name, Map<String, String> labels) {
@@ -175,7 +262,7 @@ public final class CustomMetrics {
       for (int i = 0; i < buckets.length; i++) {
         counts[i] = buckets[i].sum();
       }
-      return new DistributionSnapshot(name, labels, sum.sum(), count.sum(), counts);
+      return new DistributionSnapshot(name, labels, sum.sum(), count.sum(), counts, bounds);
     }
   }
 }

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -234,6 +234,10 @@ public final class CustomMetrics {
     final LongAdder[] buckets;
 
     Distribution(double[] bounds) {
+      // Held by reference, deliberately: for an undeclared distribution this is the shared
+      // HttpServerMetrics.BUCKET_BOUNDS static, and for a declared one it is the array
+      // boundsByName already owns. Neither escapes — boundsFor and snapshot both copy — and a
+      // clone here would be a third copy no test can distinguish from its absence.
       this.bounds = bounds;
       buckets = new LongAdder[bounds.length + 1];
       for (int i = 0; i < buckets.length; i++) {
@@ -262,7 +266,12 @@ public final class CustomMetrics {
       for (int i = 0; i < buckets.length; i++) {
         counts[i] = buckets[i].sum();
       }
-      return new DistributionSnapshot(name, labels, sum.sum(), count.sum(), counts, bounds);
+      // bounds is cloned for the same reason the label map is copied above: handing out the live
+      // array lets a caller reshape a histogram that is already recording into it, so observations
+      // before and after the edit sit in buckets that mean different things while the exported
+      // explicitBounds claims one set. A thirteen-element copy per series per export is nothing
+      // beside the buckets we already allocate on the same line.
+      return new DistributionSnapshot(name, labels, sum.sum(), count.sum(), counts, bounds.clone());
     }
   }
 }

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -72,11 +72,15 @@ public final class CustomMetrics {
   /**
    * Declares the bucket bounds for a distribution, ahead of the first observation.
    *
-   * <p>The default is the set the HTTP latency histogram uses, which tops out at 10ms. That suits
-   * anything request-shaped and suits nothing else: a distribution over minutes, or over counts in
-   * the thousands, puts every observation in the overflow bucket. The mean still reads correctly
-   * off {@code _sum}/{@code _count}, so the damage is quiet — fifteen bucket series pinned at zero,
-   * and any quantile over them returning {@code +Inf}.
+   * <p>The default is the set the HTTP latency histogram uses, which tops out at 10ms — a ceiling
+   * that is too low even for the requests it was chosen for (#1286), and hopeless for anything
+   * else. A distribution over minutes, or over counts in the thousands, puts every observation in
+   * the overflow bucket. Declare bounds for any instrument that is not sub-10ms request latency;
+   * treat inheriting this default as a bug rather than a choice. The mean still reads correctly off
+   * {@code _sum}/{@code _count}, so the damage is quiet — fifteen bucket series pinned at zero, and
+   * any quantile over them answering the top bound rather than the truth. {@code
+   * histogram_quantile} falls back to the highest finite bucket when the rank lands in {@code
+   * +Inf}, so the chart shows 10ms forever instead of showing nothing.
    *
    * <p>Call before recording. Bounds must be ascending, and a later call for the same name is
    * ignored rather than allowed to reshape a histogram mid-flight — the collector treats bucket

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpMetricsPipeline.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpMetricsPipeline.java
@@ -15,11 +15,13 @@ public final class HttpMetricsPipeline implements AutoCloseable {
   private static final Duration EXPORT_INTERVAL = Duration.ofSeconds(15);
 
   private final HttpServerMetrics metrics;
+  private final CustomMetrics custom;
   private final @Nullable OtlpHttpMetricsExporter exporter;
 
   private HttpMetricsPipeline(
-      HttpServerMetrics metrics, @Nullable OtlpHttpMetricsExporter exporter) {
+      HttpServerMetrics metrics, CustomMetrics custom, @Nullable OtlpHttpMetricsExporter exporter) {
     this.metrics = metrics;
+    this.custom = custom;
     this.exporter = exporter;
   }
 
@@ -31,15 +33,16 @@ public final class HttpMetricsPipeline implements AutoCloseable {
     String serviceName = env.getOrDefault("OTEL_SERVICE_NAME", "");
     HttpServerMetrics metrics =
         new HttpServerMetrics(serviceName, System.currentTimeMillis() * 1_000_000L);
+    CustomMetrics custom = new CustomMetrics();
     String endpoint = env.get("OTEL_EXPORTER_OTLP_ENDPOINT");
     if (endpoint == null || endpoint.isBlank()) {
-      return new HttpMetricsPipeline(metrics, null);
+      return new HttpMetricsPipeline(metrics, custom, null);
     }
     OtlpHttpMetricsExporter exporter =
         new OtlpHttpMetricsExporter(
-            endpoint, resourceAttributes(env, serviceName), metrics, EXPORT_INTERVAL);
+            endpoint, resourceAttributes(env, serviceName), metrics, custom, EXPORT_INTERVAL);
     exporter.start();
-    return new HttpMetricsPipeline(metrics, exporter);
+    return new HttpMetricsPipeline(metrics, custom, exporter);
   }
 
   /**
@@ -62,6 +65,15 @@ public final class HttpMetricsPipeline implements AutoCloseable {
 
   public HttpServerMetrics metrics() {
     return metrics;
+  }
+
+  /**
+   * The service's own instruments. Always present, exported on the same interval as the HTTP family
+   * when an endpoint is configured and recording harmlessly into memory when it is not — so a
+   * caller never has to branch on whether observability is switched on.
+   */
+  public CustomMetrics custom() {
+    return custom;
   }
 
   @Override

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java
@@ -19,6 +19,12 @@ public final class HttpServerMetrics {
   // The OTel SDK default explicit bucket boundaries. The C++ and Rust emitters
   // record microseconds against these same defaults, and the dashboard's
   // histogram_quantile and avg queries are built on them.
+  //
+  // Known wrong, and left wrong deliberately: the defaults are shaped for
+  // milliseconds, so read as microseconds they top out at 10ms and every p95
+  // tile is capped there (#1286). Matching the other two emitters is what keeps
+  // the shared query comparable across languages, so this moves when they do,
+  // not before. Do not "fix" this array on its own.
   static final double[] BUCKET_BOUNDS = {
     0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000
   };

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java
@@ -7,6 +7,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +29,7 @@ public final class OtlpHttpMetricsExporter implements AutoCloseable {
   private final Thread thread;
   private volatile boolean started;
   private volatile boolean closed;
+  private final AtomicBoolean flushed = new AtomicBoolean();
 
   public OtlpHttpMetricsExporter(
       String endpoint,
@@ -100,8 +102,12 @@ public final class OtlpHttpMetricsExporter implements AutoCloseable {
   public void close() {
     closed = true;
     thread.interrupt();
-    if (started) {
-      // Final flush so the last interval's counts aren't lost on clean shutdown.
+    // Final flush so the last interval's counts aren't lost on clean shutdown — once, whoever
+    // calls. The flush is a synchronous POST that can block for REQUEST_TIMEOUT, and cumulative
+    // sums mean a repeat sends the same totals again rather than more data, so a second close
+    // buys nothing and costs five seconds of a shutdown path. compareAndSet rather than a check
+    // on `closed`: two threads racing here would both read false and both post.
+    if (started && flushed.compareAndSet(false, true)) {
       exportOnce();
     }
   }

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpHttpMetricsExporter.java
@@ -22,6 +22,7 @@ public final class OtlpHttpMetricsExporter implements AutoCloseable {
   private final URI metricsUri;
   private final Map<String, String> resourceAttributes;
   private final HttpServerMetrics metrics;
+  private final CustomMetrics custom;
   private final Duration interval;
   private final HttpClient client;
   private final Thread thread;
@@ -33,10 +34,20 @@ public final class OtlpHttpMetricsExporter implements AutoCloseable {
       Map<String, String> resourceAttributes,
       HttpServerMetrics metrics,
       Duration interval) {
+    this(endpoint, resourceAttributes, metrics, new CustomMetrics(), interval);
+  }
+
+  public OtlpHttpMetricsExporter(
+      String endpoint,
+      Map<String, String> resourceAttributes,
+      HttpServerMetrics metrics,
+      CustomMetrics custom,
+      Duration interval) {
     String base = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
     this.metricsUri = URI.create(base + "/v1/metrics");
     this.resourceAttributes = Map.copyOf(resourceAttributes);
     this.metrics = metrics;
+    this.custom = custom;
     this.interval = interval;
     this.client = HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build();
     this.thread = new Thread(this::runLoop, "yodel-otlp-exporter");
@@ -66,7 +77,7 @@ public final class OtlpHttpMetricsExporter implements AutoCloseable {
   void exportOnce() {
     byte[] body =
         OtlpJsonEncoder.encode(
-            resourceAttributes, metrics, System.currentTimeMillis() * 1_000_000L);
+            resourceAttributes, metrics, custom, System.currentTimeMillis() * 1_000_000L);
     HttpRequest request =
         HttpRequest.newBuilder(metricsUri)
             .timeout(REQUEST_TIMEOUT)

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
 
 /**
  * Renders the http_server_* family as an OTLP/HTTP JSON ExportMetricsServiceRequest. 64-bit values
@@ -23,6 +25,14 @@ final class OtlpJsonEncoder {
 
   static byte[] encode(
       Map<String, String> resourceAttributes, HttpServerMetrics metrics, long timeUnixNanos) {
+    return encode(resourceAttributes, metrics, new CustomMetrics(), timeUnixNanos);
+  }
+
+  static byte[] encode(
+      Map<String, String> resourceAttributes,
+      HttpServerMetrics metrics,
+      CustomMetrics custom,
+      long timeUnixNanos) {
     ObjectNode root = MAPPER.createObjectNode();
     ObjectNode resourceMetric = root.putArray("resourceMetrics").addObject();
     ArrayNode resourceAttrs = resourceMetric.putObject("resource").putArray("attributes");
@@ -77,6 +87,17 @@ final class OtlpJsonEncoder {
             startNanos,
             timeUnixNanos));
     metricNodes.add(histogram(snapshots, serviceName, startNanos, timeUnixNanos));
+
+    // Service-defined instruments ride in their own scope so a reader can tell at a glance which
+    // series are the shared rails and which the service invented. Omitted entirely when nothing
+    // has been recorded, rather than exporting an empty scope every interval.
+    if (!custom.isEmpty()) {
+      ObjectNode customScope = resourceMetric.withArray("scopeMetrics").addObject();
+      customScope.putObject("scope").put("name", "custom");
+      ArrayNode customNodes = customScope.putArray("metrics");
+      addCustomCounters(customNodes, custom, serviceName, startNanos, timeUnixNanos);
+      addCustomDistributions(customNodes, custom, serviceName, startNanos, timeUnixNanos);
+    }
 
     try {
       return MAPPER.writeValueAsBytes(root);
@@ -140,6 +161,90 @@ final class OtlpJsonEncoder {
       addPointAttributes(point, serviceName, snapshot.httpMethod());
     }
     return metric;
+  }
+
+  /**
+   * One OTLP metric per counter name, with a data point per label set. Grouping matters: emitting a
+   * separate metric node per label set is legal JSON but leaves the collector reconciling repeated
+   * names, and the labels stop behaving like dimensions of one series.
+   */
+  private static void addCustomCounters(
+      ArrayNode metricNodes,
+      CustomMetrics custom,
+      String serviceName,
+      long startNanos,
+      long timeNanos) {
+    Map<String, List<CustomMetrics.CounterSnapshot>> byName =
+        custom.counterSnapshot().stream()
+            .collect(
+                Collectors.groupingBy(
+                    CustomMetrics.CounterSnapshot::name, LinkedHashMap::new, Collectors.toList()));
+    byName.forEach(
+        (name, points) -> {
+          ObjectNode metric = metricNodes.addObject();
+          metric.put("name", name);
+          ObjectNode sum = metric.putObject("sum");
+          sum.put("aggregationTemporality", AGGREGATION_TEMPORALITY_CUMULATIVE);
+          sum.put("isMonotonic", true);
+          ArrayNode dataPoints = sum.putArray("dataPoints");
+          for (CustomMetrics.CounterSnapshot snapshot : points) {
+            ObjectNode point = dataPoints.addObject();
+            point.put("startTimeUnixNano", Long.toString(startNanos));
+            point.put("timeUnixNano", Long.toString(timeNanos));
+            point.put("asInt", Long.toString(snapshot.value()));
+            addLabelledAttributes(point, serviceName, snapshot.labels());
+          }
+        });
+  }
+
+  private static void addCustomDistributions(
+      ArrayNode metricNodes,
+      CustomMetrics custom,
+      String serviceName,
+      long startNanos,
+      long timeNanos) {
+    Map<String, List<CustomMetrics.DistributionSnapshot>> byName =
+        custom.distributionSnapshot().stream()
+            .collect(
+                Collectors.groupingBy(
+                    CustomMetrics.DistributionSnapshot::name,
+                    LinkedHashMap::new,
+                    Collectors.toList()));
+    byName.forEach(
+        (name, points) -> {
+          ObjectNode metric = metricNodes.addObject();
+          metric.put("name", name);
+          ObjectNode histogram = metric.putObject("histogram");
+          histogram.put("aggregationTemporality", AGGREGATION_TEMPORALITY_CUMULATIVE);
+          ArrayNode dataPoints = histogram.putArray("dataPoints");
+          for (CustomMetrics.DistributionSnapshot snapshot : points) {
+            ObjectNode point = dataPoints.addObject();
+            point.put("startTimeUnixNano", Long.toString(startNanos));
+            point.put("timeUnixNano", Long.toString(timeNanos));
+            point.put("count", Long.toString(snapshot.count()));
+            point.put("sum", snapshot.sum());
+            ArrayNode bucketCounts = point.putArray("bucketCounts");
+            for (long count : snapshot.bucketCounts()) {
+              bucketCounts.add(Long.toString(count));
+            }
+            ArrayNode bounds = point.putArray("explicitBounds");
+            for (double bound : HttpServerMetrics.BUCKET_BOUNDS) {
+              bounds.add(bound);
+            }
+            addLabelledAttributes(point, serviceName, snapshot.labels());
+          }
+        });
+  }
+
+  /**
+   * {@code service_name} on every point, exactly as the HTTP family does — prom_proxy scopes every
+   * query by it, so a custom series without it belongs to no service on the dashboard.
+   */
+  private static void addLabelledAttributes(
+      ObjectNode point, String serviceName, Map<String, String> labels) {
+    ArrayNode attributes = point.putArray("attributes");
+    labels.forEach((key, value) -> addAttribute(attributes, key, value));
+    addAttribute(attributes, "service_name", serviceName);
   }
 
   private static void addPointAttributes(ObjectNode point, String serviceName, String httpMethod) {

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java
@@ -228,7 +228,7 @@ final class OtlpJsonEncoder {
               bucketCounts.add(Long.toString(count));
             }
             ArrayNode bounds = point.putArray("explicitBounds");
-            for (double bound : HttpServerMetrics.BUCKET_BOUNDS) {
+            for (double bound : snapshot.bounds()) {
               bounds.add(bound);
             }
             addLabelledAttributes(point, serviceName, snapshot.labels());

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
@@ -82,9 +82,12 @@ public class HttpServerMetricsFilter implements HttpServerFilter {
   // No @PreDestroy closing the pipeline. It used to be right — the filter built the pipeline in
   // its own constructor and was the only thing holding it. Now YodelMetricsFactory owns it and
   // declares preDestroy = "close", so closing it here as well would shut the same exporter down
-  // twice. OtlpHttpMetricsExporter.close() is not idempotent about its side effect: it runs a
-  // final synchronous export, so a double close means two OTLP POSTs on the shutdown path, each
-  // able to block for the request timeout. Worse, Micronaut destroys dependents before their
-  // dependencies, so the filter would stop the exporter while the service's own beans are still
-  // recording into the CustomMetrics it drains.
+  // twice: Micronaut destroys dependents before their dependencies, so the filter's hook would
+  // run first and stop the exporter while the service's own beans are still recording into the
+  // CustomMetrics it drains.
+  //
+  // Pinned by theFilterDeclaresNoDestroyHookForAPipelineItDoesNotOwn, which also covers the
+  // AutoCloseable route — Micronaut closes those with no annotation at all. The redundant flush
+  // is separately defused in OtlpHttpMetricsExporter.close(); the ordering is not, which is why
+  // the hook stays gone rather than being made safe.
 }

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
@@ -8,7 +8,6 @@ import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.filter.ServerFilterPhase;
-import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.reactivestreams.Publisher;
@@ -80,8 +79,12 @@ public class HttpServerMetricsFilter implements HttpServerFilter {
             });
   }
 
-  @PreDestroy
-  void stop() {
-    pipeline.close();
-  }
+  // No @PreDestroy closing the pipeline. It used to be right — the filter built the pipeline in
+  // its own constructor and was the only thing holding it. Now YodelMetricsFactory owns it and
+  // declares preDestroy = "close", so closing it here as well would shut the same exporter down
+  // twice. OtlpHttpMetricsExporter.close() is not idempotent about its side effect: it runs a
+  // final synchronous export, so a double close means two OTLP POSTs on the shutdown path, each
+  // able to block for the request timeout. Worse, Micronaut destroys dependents before their
+  // dependencies, so the filter would stop the exporter while the service's own beans are still
+  // recording into the CustomMetrics it drains.
 }

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilter.java
@@ -24,13 +24,18 @@ import reactor.core.publisher.Mono;
 public class HttpServerMetricsFilter implements HttpServerFilter {
   private final HttpMetricsPipeline pipeline;
 
+  /**
+   * Takes the process-wide pipeline from {@link YodelMetricsFactory} rather than building its own,
+   * so the service's custom instruments and this filter's HTTP counts leave on the same exporter.
+   */
   @Inject
-  public HttpServerMetricsFilter() {
-    this(HttpMetricsPipeline.fromEnv());
+  public HttpServerMetricsFilter(HttpMetricsPipeline pipeline) {
+    this.pipeline = pipeline;
   }
 
-  HttpServerMetricsFilter(HttpMetricsPipeline pipeline) {
-    this.pipeline = pipeline;
+  /** For a filter constructed outside a bean context. */
+  public HttpServerMetricsFilter() {
+    this(HttpMetricsPipeline.fromEnv());
   }
 
   public HttpServerMetrics metrics() {

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/YodelMetricsFactory.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/micronaut/YodelMetricsFactory.java
@@ -1,0 +1,40 @@
+package com.muchq.platform.yodel.micronaut;
+
+import com.muchq.platform.yodel.CustomMetrics;
+import com.muchq.platform.yodel.HttpMetricsPipeline;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
+
+/**
+ * Makes the process's metrics pipeline injectable, so a service can record its own work into the
+ * same exporter that already carries the {@code http_server_*} family.
+ *
+ * <p>Before this the filter built a pipeline privately in its own constructor and nothing else
+ * could reach it. That was fine while HTTP counts were the only instruments — and it is exactly why
+ * every Java entry in prom_proxy's registry was empty: there was somewhere to record custom metrics
+ * to, but no way for application code to get hold of it
+ * (https://github.com/muchq/MoonBase/issues/1212).
+ *
+ * <p>One pipeline per process, not one per injection point. Two would mean two exporters posting
+ * two partial views of the same service on the same interval, and the dashboard summing across them
+ * would double-count every request.
+ */
+@Factory
+public class YodelMetricsFactory {
+
+  @Singleton
+  @Bean(preDestroy = "close")
+  HttpMetricsPipeline httpMetricsPipeline() {
+    return HttpMetricsPipeline.fromEnv();
+  }
+
+  /**
+   * The service's own instruments. Injectable on its own so application code never has to know the
+   * pipeline exists, and records harmlessly into memory when no OTEL endpoint is configured.
+   */
+  @Singleton
+  CustomMetrics customMetrics(HttpMetricsPipeline pipeline) {
+    return pipeline.custom();
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsEncodingTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsEncodingTest.java
@@ -1,0 +1,135 @@
+package com.muchq.platform.yodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the wire contract for service-defined instruments, which is the half prom_proxy actually
+ * queries. A counter that records correctly and encodes wrongly is invisible in exactly the way
+ * that takes weeks to notice: the chart is empty, and an empty chart looks like an idle service.
+ */
+public class CustomMetricsEncodingTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static JsonNode encode(CustomMetrics custom) throws Exception {
+    byte[] payload =
+        OtlpJsonEncoder.encode(
+            Map.of("service.name", "svc"),
+            new HttpServerMetrics("svc", 1_000_000_000L),
+            custom,
+            2_000_000_000L);
+    return MAPPER.readTree(payload);
+  }
+
+  private static JsonNode customScope(JsonNode root) {
+    for (JsonNode scope : root.at("/resourceMetrics/0/scopeMetrics")) {
+      if ("custom".equals(scope.at("/scope/name").asText())) {
+        return scope;
+      }
+    }
+    return MAPPER.missingNode();
+  }
+
+  /**
+   * Nothing recorded means no scope at all — not an empty one. Every 15 seconds forever is a long
+   * time to ship a payload that says nothing.
+   */
+  @Test
+  public void aServiceThatRecordsNothingEmitsNoCustomScope() throws Exception {
+    JsonNode root = encode(new CustomMetrics());
+    assertThat(root.at("/resourceMetrics/0/scopeMetrics")).hasSize(1);
+    assertThat(customScope(root).isMissingNode()).isTrue();
+  }
+
+  @Test
+  public void aCounterEncodesAsACumulativeMonotonicSum() throws Exception {
+    CustomMetrics custom = new CustomMetrics();
+    custom.add("games_indexed", 7, Map.of());
+
+    JsonNode metric = customScope(encode(custom)).at("/metrics/0");
+    assertThat(metric.get("name").asText()).isEqualTo("games_indexed");
+    assertThat(metric.at("/sum/isMonotonic").asBoolean()).isTrue();
+    assertThat(metric.at("/sum/aggregationTemporality").asInt()).isEqualTo(2);
+    // proto3 JSON maps 64-bit ints to strings; a raw number silently loses precision at the top
+    // of the range and some collectors reject it outright.
+    assertThat(metric.at("/sum/dataPoints/0/asInt").isTextual()).isTrue();
+    assertThat(metric.at("/sum/dataPoints/0/asInt").asText()).isEqualTo("7");
+  }
+
+  /**
+   * One metric, many points — not many metrics sharing a name. The labels are dimensions of a
+   * single series, and repeating the name instead is what makes a collector treat them as rivals.
+   */
+  @Test
+  public void labelSetsBecomeDataPointsOfOneMetricRatherThanRepeatedMetrics() throws Exception {
+    CustomMetrics custom = new CustomMetrics();
+    custom.increment("index_runs", Map.of("outcome", "completed"));
+    custom.increment("index_runs", Map.of("outcome", "failed"));
+    custom.increment("index_runs", Map.of("outcome", "interrupted"));
+
+    JsonNode metrics = customScope(encode(custom)).at("/metrics");
+    List<String> names = new ArrayList<>();
+    metrics.forEach(m -> names.add(m.get("name").asText()));
+    assertThat(names).containsExactly("index_runs");
+    assertThat(metrics.at("/0/sum/dataPoints")).hasSize(3);
+  }
+
+  /** prom_proxy scopes every query by service_name; a point without it belongs to no service. */
+  @Test
+  public void everyCustomPointCarriesServiceNameAlongsideItsOwnLabels() throws Exception {
+    CustomMetrics custom = new CustomMetrics();
+    custom.increment("index_runs", Map.of("outcome", "completed"));
+    custom.record("index_run_duration_micros", 12.0, Map.of("outcome", "completed"));
+
+    JsonNode scope = customScope(encode(custom));
+    for (JsonNode metric : scope.at("/metrics")) {
+      JsonNode points =
+          metric.has("sum") ? metric.at("/sum/dataPoints") : metric.at("/histogram/dataPoints");
+      for (JsonNode point : points) {
+        Map<String, String> attrs = new java.util.HashMap<>();
+        point
+            .get("attributes")
+            .forEach(a -> attrs.put(a.get("key").asText(), a.at("/value/stringValue").asText()));
+        assertThat(attrs)
+            .containsEntry("service_name", "svc")
+            .containsEntry("outcome", "completed");
+      }
+    }
+  }
+
+  @Test
+  public void aDistributionEncodesAsAHistogramWithTheSharedBounds() throws Exception {
+    CustomMetrics custom = new CustomMetrics();
+    custom.record("motif_occurrences_per_game", 3.0);
+    custom.record("motif_occurrences_per_game", 8.0);
+
+    JsonNode metric = customScope(encode(custom)).at("/metrics/0");
+    assertThat(metric.get("name").asText()).isEqualTo("motif_occurrences_per_game");
+    assertThat(metric.at("/histogram/aggregationTemporality").asInt()).isEqualTo(2);
+    JsonNode point = metric.at("/histogram/dataPoints/0");
+    assertThat(point.get("count").asText()).isEqualTo("2");
+    assertThat(point.get("sum").asDouble()).isEqualTo(11.0);
+    assertThat(point.get("explicitBounds")).hasSize(HttpServerMetrics.BUCKET_BOUNDS.length);
+    // Buckets are bounds+1: the trailing one catches everything past the last bound.
+    assertThat(point.get("bucketCounts")).hasSize(HttpServerMetrics.BUCKET_BOUNDS.length + 1);
+  }
+
+  /** The standard family must be untouched by any of this. */
+  @Test
+  public void theStandardHttpScopeStillShipsAlongsideTheCustomOne() throws Exception {
+    CustomMetrics custom = new CustomMetrics();
+    custom.increment("games_indexed");
+
+    JsonNode root = encode(custom);
+    assertThat(root.at("/resourceMetrics/0/scopeMetrics")).hasSize(2);
+    assertThat(root.at("/resourceMetrics/0/scopeMetrics/0/scope/name").asText())
+        .isEqualTo("http_server");
+    assertThat(customScope(root).isMissingNode()).isFalse();
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
@@ -178,6 +178,46 @@ public class CustomMetricsTest {
     assertThat(metrics.boundsFor("undeclared")).isEqualTo(HttpServerMetrics.BUCKET_BOUNDS);
   }
 
+  /**
+   * Every array that crosses this class's boundary is a copy, in both directions.
+   *
+   * <p>The interesting one is the last: an undeclared distribution buckets on {@link
+   * HttpServerMetrics#BUCKET_BOUNDS}, a shared static. If that reference reached a snapshot, one
+   * caller editing what looks like its own result would rebucket the HTTP latency histogram — and
+   * every other undeclared distribution in the process — for the rest of the run. Nothing would
+   * throw; the exported {@code explicitBounds} would simply stop describing the buckets beside it.
+   */
+  @Test
+  public void boundsArraysAreCopiedOnEveryCrossing() {
+    CustomMetrics metrics = new CustomMetrics();
+    double[] declared = {10, 20, 30};
+    metrics.defineDistribution("d", declared);
+
+    declared[0] = 999; // the caller still holds the array it passed in
+    assertThat(metrics.boundsFor("d")).containsExactly(10.0, 20.0, 30.0);
+
+    metrics.boundsFor("d")[1] = 999; // and the array it was handed back
+    assertThat(metrics.boundsFor("d")).containsExactly(10.0, 20.0, 30.0);
+
+    metrics.record("d", 15);
+    // And the one on its snapshot. Widening the *lowest* bound, not the highest: bucketing is
+    // upper-inclusive first-match, so raising bounds[0] past a later observation pulls it all the
+    // way down to bucket 0, while raising the top bound leaves everything where it was — which is
+    // why the obvious edit here is a pin that passes against the aliased version too.
+    metrics.distributionSnapshot().get(0).bounds()[0] = 100;
+    metrics.record("d", 25);
+    assertThat(metrics.distributionSnapshot().get(0).bucketCounts())
+        .as("15 and 25 belong in buckets 1 and 2; against a live array the 25 drops to bucket 0")
+        .containsExactly(0L, 1L, 1L, 0L);
+
+    CustomMetrics other = new CustomMetrics();
+    other.record("undeclared", 1);
+    other.distributionSnapshot().get(0).bounds()[0] = 999;
+    assertThat(HttpServerMetrics.BUCKET_BOUNDS[0])
+        .as("the shared default set is not reachable through a snapshot")
+        .isNotEqualTo(999.0);
+  }
+
   @Test
   public void distributionBoundsMustAscend() {
     CustomMetrics metrics = new CustomMetrics();

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
@@ -1,0 +1,135 @@
+package com.muchq.platform.yodel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+public class CustomMetricsTest {
+
+  @Test
+  public void aCounterAccumulatesPerLabelSet() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.increment("games_indexed", Map.of("platform", "chess_com"));
+    metrics.add("games_indexed", 4, Map.of("platform", "chess_com"));
+    metrics.increment("games_indexed", Map.of("platform", "lichess"));
+
+    assertThat(metrics.counterSnapshot())
+        .extracting(
+            CustomMetrics.CounterSnapshot::name,
+            s -> s.labels().get("platform"),
+            CustomMetrics.CounterSnapshot::value)
+        .containsExactly(
+            org.assertj.core.groups.Tuple.tuple("games_indexed", "chess_com", 5L),
+            org.assertj.core.groups.Tuple.tuple("games_indexed", "lichess", 1L));
+  }
+
+  /**
+   * The same pairs in a different order are the same series. Without normalisation they would be
+   * two, and a dashboard summing one of them would silently report half the traffic.
+   */
+  @Test
+  public void labelOrderDoesNotSplitASeries() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.increment("runs", Map.of("outcome", "completed", "stage", "flush"));
+    metrics.increment("runs", Map.of("stage", "flush", "outcome", "completed"));
+
+    assertThat(metrics.counterSnapshot()).hasSize(1);
+    assertThat(metrics.counterSnapshot().get(0).value()).isEqualTo(2L);
+  }
+
+  @Test
+  public void aDistributionRecordsSumCountAndBuckets() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.record("month_duration_micros", 30.0);
+    metrics.record("month_duration_micros", 70.0);
+
+    List<CustomMetrics.DistributionSnapshot> snapshots = metrics.distributionSnapshot();
+    assertThat(snapshots).hasSize(1);
+    CustomMetrics.DistributionSnapshot d = snapshots.get(0);
+    assertThat(d.count()).isEqualTo(2L);
+    assertThat(d.sum()).isEqualTo(100.0);
+    // Bounds are {0,5,10,25,50,75,...}: 30 lands in the "<=50" bucket, 70 in "<=75".
+    assertThat(d.bucketCounts()[HttpServerMetrics.BUCKET_BOUNDS.length]).isZero();
+    assertThat(java.util.Arrays.stream(d.bucketCounts()).sum()).isEqualTo(2L);
+  }
+
+  @Test
+  public void anObservationBeyondTheLastBoundLandsInTheOverflowBucket() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.record("month_duration_micros", 999_999.0);
+
+    long[] buckets = metrics.distributionSnapshot().get(0).bucketCounts();
+    assertThat(buckets[HttpServerMetrics.BUCKET_BOUNDS.length])
+        .as("a value past the largest bound must still be counted, not dropped")
+        .isEqualTo(1L);
+  }
+
+  /**
+   * A name the Prometheus exporter cannot represent is not a small problem: it records fine,
+   * exports fine, and then matches no dashboard query. Failing at the call site is the only place
+   * the mistake is still cheap.
+   */
+  @Test
+  public void aNameThatCouldNotSurviveExportIsRejectedAtTheCallSite() {
+    CustomMetrics metrics = new CustomMetrics();
+    assertThatThrownBy(() -> metrics.increment("games.indexed"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("games.indexed");
+    assertThatThrownBy(() -> metrics.increment("runs", Map.of("out come", "x")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void aCounterRefusesToGoBackwards() {
+    CustomMetrics metrics = new CustomMetrics();
+    assertThatThrownBy(() -> metrics.add("games_indexed", -1, Map.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("may not decrease");
+  }
+
+  @Test
+  public void anUntouchedRegistryIsEmptySoTheEncoderCanSkipIt() {
+    CustomMetrics metrics = new CustomMetrics();
+    assertThat(metrics.isEmpty()).isTrue();
+    metrics.increment("games_indexed");
+    assertThat(metrics.isEmpty()).isFalse();
+  }
+
+  /** Recording happens on request threads and worker threads at once; nothing may be lost. */
+  @Test
+  public void concurrentRecordingLosesNothing() throws Exception {
+    CustomMetrics metrics = new CustomMetrics();
+    int threads = 8;
+    int perThread = 1000;
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+    CountDownLatch go = new CountDownLatch(1);
+    try {
+      for (int t = 0; t < threads; t++) {
+        pool.submit(
+            () -> {
+              go.await();
+              for (int i = 0; i < perThread; i++) {
+                metrics.increment("games_indexed", Map.of("platform", "chess_com"));
+                metrics.record("month_duration_micros", 1.0);
+              }
+              return null;
+            });
+      }
+      go.countDown();
+      pool.shutdown();
+      assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertThat(metrics.counterSnapshot().get(0).value()).isEqualTo((long) threads * perThread);
+    assertThat(metrics.distributionSnapshot().get(0).count()).isEqualTo((long) threads * perThread);
+  }
+}

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
@@ -31,8 +31,12 @@ public class CustomMetricsTest {
   }
 
   /**
-   * The same pairs in a different order are the same series. Without normalisation they would be
-   * two, and a dashboard summing one of them would silently report half the traffic.
+   * Two callers passing the same pairs in different orders land on one series.
+   *
+   * <p>Weaker than it looks on its own — {@code Map.equals} is order-insensitive, so a
+   * ConcurrentHashMap keyed on any map would dedup these — which is why the ordering assertion
+   * below is the real subject. Sorting is what makes {@code Series.compareTo} total, and a
+   * comparator that ties leaves payload order to hash iteration.
    */
   @Test
   public void labelOrderDoesNotSplitASeries() {
@@ -42,6 +46,144 @@ public class CustomMetricsTest {
 
     assertThat(metrics.counterSnapshot()).hasSize(1);
     assertThat(metrics.counterSnapshot().get(0).value()).isEqualTo(2L);
+  }
+
+  /**
+   * Snapshot order is a function of name and labels, not of insertion or hash order. Asserted over
+   * series that differ only in a later label, since those are the ones a tie would reorder.
+   */
+  @Test
+  public void snapshotOrderIsStableAcrossLabelSets() {
+    CustomMetrics first = new CustomMetrics();
+    first.increment("runs", Map.of("outcome", "failed"));
+    first.increment("runs", Map.of("outcome", "completed"));
+    first.increment("games", Map.of("outcome", "completed"));
+
+    CustomMetrics second = new CustomMetrics();
+    second.increment("games", Map.of("outcome", "completed"));
+    second.increment("runs", Map.of("outcome", "completed"));
+    second.increment("runs", Map.of("outcome", "failed"));
+
+    assertThat(describe(first))
+        .containsExactly(
+            "games{outcome=completed}", "runs{outcome=completed}", "runs{outcome=failed}");
+    assertThat(describe(first)).isEqualTo(describe(second));
+  }
+
+  /**
+   * Two series whose label maps stringify identically stay two series, in a fixed order.
+   *
+   * <p>{@code {a=1, b=2}} and the single entry {@code {a="1, b=2"}} produce the same {@code
+   * toString}, and label values are not validated — so a comparator built on that string ties, and
+   * a tie hands ordering back to hash iteration. Compared on the label maps rather than on a
+   * rendering of them, because a rendering is exactly what collapses the two.
+   */
+  @Test
+  public void seriesThatStringifyAlikeStayDistinctAndOrderStably() {
+    Map<String, String> twoLabels = Map.of("a", "1", "b", "2");
+    Map<String, String> oneAmbiguousLabel = Map.of("a", "1, b=2");
+
+    CustomMetrics first = new CustomMetrics();
+    first.increment("runs", twoLabels);
+    first.increment("runs", oneAmbiguousLabel);
+
+    CustomMetrics second = new CustomMetrics();
+    second.increment("runs", oneAmbiguousLabel);
+    second.increment("runs", twoLabels);
+
+    assertThat(first.counterSnapshot()).hasSize(2);
+    assertThat(labelsOf(first))
+        .as("distinct label sets, not one merged series")
+        .containsExactlyInAnyOrder(twoLabels, oneAmbiguousLabel);
+    assertThat(labelsOf(first))
+        .as("and the same order regardless of which arrived first")
+        .isEqualTo(labelsOf(second));
+  }
+
+  private static List<Map<String, String>> labelsOf(CustomMetrics metrics) {
+    return metrics.counterSnapshot().stream().map(CustomMetrics.CounterSnapshot::labels).toList();
+  }
+
+  private static List<String> describe(CustomMetrics metrics) {
+    return metrics.counterSnapshot().stream().map(s -> s.name() + s.labels()).toList();
+  }
+
+  /**
+   * A snapshot hands out a copy of the labels, never the live hash key.
+   *
+   * <p>The key's own map decides its hash. Handing the caller the real one lets a mutation strand
+   * the entry in the wrong bin: the next record for those labels mints a second entry from zero
+   * while iteration still finds the old one, and the encoder emits two data points with identical
+   * attributes in a single payload — which Prometheus rejects as a duplicate sample.
+   */
+  @Test
+  public void aSnapshotDoesNotExposeTheLiveSeriesKey() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.increment("runs", Map.of("outcome", "completed"));
+    metrics.record("d", 1.0, Map.of("outcome", "completed"));
+
+    assertThatThrownBy(() -> metrics.counterSnapshot().get(0).labels().put("outcome", "failed"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(
+            () -> metrics.distributionSnapshot().get(0).labels().put("outcome", "failed"))
+        .isInstanceOf(UnsupportedOperationException.class);
+
+    // And the registry is untouched by the attempt.
+    metrics.increment("runs", Map.of("outcome", "completed"));
+    assertThat(metrics.counterSnapshot()).hasSize(1);
+    assertThat(metrics.counterSnapshot().get(0).value()).isEqualTo(2L);
+  }
+
+  /** A label the encoder always adds cannot also be supplied by the caller. */
+  @Test
+  public void serviceNameIsRejectedAsACallerLabel() {
+    CustomMetrics metrics = new CustomMetrics();
+    assertThatThrownBy(() -> metrics.increment("runs", Map.of("service_name", "one_d4")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("service_name");
+  }
+
+  /** A negative or NaN observation corrupts a cumulative _sum silently. */
+  @Test
+  public void aDistributionRefusesObservationsThatWouldCorruptTheSum() {
+    CustomMetrics metrics = new CustomMetrics();
+    assertThatThrownBy(() -> metrics.record("d", -1.0))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> metrics.record("d", Double.NaN))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> metrics.record("d", Double.POSITIVE_INFINITY))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * Declared bounds are used, and the default set is not. Without this the per-distribution bounds
+   * are unpinned: every observation of a minutes-scale value would silently land in the overflow
+   * bucket while _sum and _count stayed correct, which is exactly the failure the feature exists to
+   * prevent.
+   */
+  @Test
+  public void aDeclaredDistributionUsesItsOwnBounds() {
+    CustomMetrics metrics = new CustomMetrics();
+    double[] bounds = {1_000, 1_000_000, 60_000_000};
+    metrics.defineDistribution("run_micros", bounds);
+
+    metrics.record("run_micros", 500); // <= 1_000        -> bucket 0
+    metrics.record("run_micros", 30_000_000); // <= 60_000_000   -> bucket 2
+    metrics.record("run_micros", 90_000_000); // overflow        -> bucket 3
+
+    CustomMetrics.DistributionSnapshot d = metrics.distributionSnapshot().get(0);
+    assertThat(d.bounds()).containsExactly(1_000.0, 1_000_000.0, 60_000_000.0);
+    assertThat(d.bucketCounts()).containsExactly(1L, 0L, 1L, 1L);
+    assertThat(metrics.boundsFor("run_micros")).containsExactly(1_000.0, 1_000_000.0, 60_000_000.0);
+    assertThat(metrics.boundsFor("undeclared")).isEqualTo(HttpServerMetrics.BUCKET_BOUNDS);
+  }
+
+  @Test
+  public void distributionBoundsMustAscend() {
+    CustomMetrics metrics = new CustomMetrics();
+    assertThatThrownBy(() -> metrics.defineDistribution("d", new double[] {10, 5}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ascend");
   }
 
   @Test
@@ -55,9 +197,29 @@ public class CustomMetricsTest {
     CustomMetrics.DistributionSnapshot d = snapshots.get(0);
     assertThat(d.count()).isEqualTo(2L);
     assertThat(d.sum()).isEqualTo(100.0);
-    // Bounds are {0,5,10,25,50,75,...}: 30 lands in the "<=50" bucket, 70 in "<=75".
-    assertThat(d.bucketCounts()[HttpServerMetrics.BUCKET_BOUNDS.length]).isZero();
+    // The placement, not just the total. Asserting "nothing overflowed" and "nothing was lost"
+    // passes against a bucketFor that puts every value in bucket 0 — which leaves _sum and _count
+    // right and every _bucket series and quantile wrong.
+    // Bounds are {0,5,10,25,50,75,...}: 30 lands in the "<=50" slot, 70 in "<=75".
+    int fifty = indexOfBound(50);
+    int seventyFive = indexOfBound(75);
+    assertThat(d.bucketCounts()[fifty]).as("30 belongs in <=50").isEqualTo(1L);
+    assertThat(d.bucketCounts()[seventyFive]).as("70 belongs in <=75").isEqualTo(1L);
     assertThat(java.util.Arrays.stream(d.bucketCounts()).sum()).isEqualTo(2L);
+
+    // Upper-inclusive: a value exactly on a bound belongs to that bucket, not the next.
+    CustomMetrics onBoundary = new CustomMetrics();
+    onBoundary.record("d", 50.0);
+    assertThat(onBoundary.distributionSnapshot().get(0).bucketCounts()[fifty]).isEqualTo(1L);
+  }
+
+  private static int indexOfBound(double bound) {
+    for (int i = 0; i < HttpServerMetrics.BUCKET_BOUNDS.length; i++) {
+      if (HttpServerMetrics.BUCKET_BOUNDS[i] == bound) {
+        return i;
+      }
+    }
+    throw new IllegalArgumentException("no such bound: " + bound);
   }
 
   @Test

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java
@@ -74,6 +74,34 @@ public class HttpServerMetricsTest {
     assertThat(buckets[buckets.length - 1]).isEqualTo(1); // (10000, +Inf)
   }
 
+  /**
+   * The HTTP bounds are wrong and may not be fixed here alone (#1286).
+   *
+   * <p>They are the OTel SDK defaults, which are shaped for milliseconds; this emitter records
+   * microseconds, so the top bound is 10ms and every p95 tile is capped there. The Rust
+   * (server_pal) and C++ (futility/otel) emitters inherit the same defaults from their SDKs and
+   * record microseconds too, and prom_proxy charts all three through one shared PromQL expression.
+   * Widening Java's array on its own would leave those services answering the same query on a
+   * different bucket layout — a worse state than the one it fixes, and a silent one.
+   *
+   * <p>So this test does not assert the bounds are right. It asserts they still match the defaults
+   * the other two emitters get, and fails the moment Java drifts alone.
+   */
+  @Test
+  public void httpBoundsStayMatchedToTheOtherEmittersUntilAllThreeMove() {
+    double[] otelSdkDefaults = {
+      0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000
+    };
+
+    assertThat(HttpServerMetrics.BUCKET_BOUNDS)
+        .as(
+            "yodel's HTTP bounds no longer match the OTel SDK defaults that server_pal (Rust) and "
+                + "futility/otel (C++) inherit. If this is the #1286 fix, it has to land in all "
+                + "three emitters together — prom_proxy's p95 query spans them. If it is not, "
+                + "Java services have quietly become incomparable to every other service.")
+        .isEqualTo(otelSdkDefaults);
+  }
+
   @Test
   public void snapshotOrdersMethodsDeterministically() {
     HttpServerMetrics metrics = new HttpServerMetrics("svc", 0L);

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/OtlpHttpMetricsExporterTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/OtlpHttpMetricsExporterTest.java
@@ -64,4 +64,32 @@ public class OtlpHttpMetricsExporterTest {
     assertThat(payload.at("/resourceMetrics/0/scopeMetrics/0/metrics/0/name").asText())
         .isEqualTo("http_server_requests");
   }
+
+  /**
+   * close() flushes once, however many callers reach it.
+   *
+   * <p>Two owners closing the same exporter used to mean two synchronous POSTs on the shutdown
+   * path, each able to block for REQUEST_TIMEOUT. The second carries no new information either —
+   * the sums are cumulative, so it re-sends the totals the first one already delivered.
+   */
+  @Test
+  public void aSecondCloseSendsNothingFurther() throws Exception {
+    HttpServerMetrics metrics = new HttpServerMetrics("svc", 1_000_000_000L);
+    metrics.recordRequestStart("GET");
+
+    OtlpHttpMetricsExporter exporter =
+        new OtlpHttpMetricsExporter(
+            "http://127.0.0.1:" + server.getAddress().getPort(),
+            Map.of("service.name", "svc"),
+            metrics,
+            // Long enough that the periodic loop never fires; every POST here is a close flush.
+            Duration.ofHours(1));
+    exporter.start();
+
+    exporter.close();
+    assertThat(received.poll(5, TimeUnit.SECONDS)).as("the shutdown flush").isNotNull();
+
+    exporter.close();
+    assertThat(received.poll(1, TimeUnit.SECONDS)).as("and only the one").isNull();
+  }
 }

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilterTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilterTest.java
@@ -85,4 +85,33 @@ public class HttpServerMetricsFilterTest {
         server.getApplicationContext().getBean(HttpServerMetricsFilter.class);
     assertThat(filter.metrics()).isSameAs(first.metrics());
   }
+
+  /**
+   * Sharing the pipeline means the filter no longer owns it, and the destroy hook has to move with
+   * the ownership. {@link YodelMetricsFactory} declares {@code preDestroy = "close"}; a hook here
+   * as well would close the same exporter twice.
+   *
+   * <p>Micronaut destroys dependents before their dependencies, so the filter's hook runs first —
+   * stopping the exporter while the service's own beans are still recording into the {@code
+   * CustomMetrics} it drains. That the second close is now a no-op ({@code
+   * OtlpHttpMetricsExporterTest.aSecondCloseSendsNothingFurther}) limits the damage to a lost
+   * shutdown flush rather than a duplicate one; it does not make the hook correct.
+   *
+   * <p>Checked reflectively because the failure is an annotation that is absent — there is no call
+   * to assert on, and a behavioural test would need a stub OTLP endpoint injected through {@code
+   * fromEnv}, which the factory does not offer. Both {@code Closeable} routes are covered too:
+   * Micronaut gives any {@code AutoCloseable} bean an implicit destroy hook, so implementing the
+   * interface reintroduces exactly what removing the annotation fixed.
+   */
+  @Test
+  public void theFilterDeclaresNoDestroyHookForAPipelineItDoesNotOwn() {
+    assertThat(AutoCloseable.class.isAssignableFrom(HttpServerMetricsFilter.class))
+        .as("an AutoCloseable bean is closed by Micronaut without any annotation")
+        .isFalse();
+
+    assertThat(HttpServerMetricsFilter.class.getDeclaredMethods())
+        .filteredOn(m -> m.isAnnotationPresent(jakarta.annotation.PreDestroy.class))
+        .as("the factory owns the pipeline's lifecycle; the filter is a consumer")
+        .isEmpty();
+  }
 }

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilterTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/micronaut/HttpServerMetricsFilterTest.java
@@ -2,6 +2,8 @@ package com.muchq.platform.yodel.micronaut;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.muchq.platform.yodel.CustomMetrics;
+import com.muchq.platform.yodel.HttpMetricsPipeline;
 import com.muchq.platform.yodel.HttpServerMetrics;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.runtime.server.EmbeddedServer;
@@ -57,5 +59,30 @@ public class HttpServerMetricsFilterTest {
     assertThat(get.active()).isZero();
     assertThat(get.durationCount()).isEqualTo(3);
     assertThat(get.durationSumMicros()).isGreaterThan(0.0);
+  }
+
+  /**
+   * One pipeline per process, which the factory's javadoc asserts and nothing was checking.
+   *
+   * <p>Micronaut factory methods are prototype-scoped unless annotated, so dropping
+   * {@code @Singleton} gives the filter and the injected {@code CustomMetrics} different pipelines
+   * — two exporter threads posting two partial views of the same service on the same interval, and
+   * a dashboard summing across them double-counts every request. Nothing fails at boot; the numbers
+   * are just quietly wrong.
+   */
+  @Test
+  public void thePipelineIsOneInstanceSharedByTheFilterAndTheService() {
+    HttpMetricsPipeline first = server.getApplicationContext().getBean(HttpMetricsPipeline.class);
+    HttpMetricsPipeline second = server.getApplicationContext().getBean(HttpMetricsPipeline.class);
+    assertThat(first).isSameAs(second);
+
+    // And the injectable registry is that pipeline's own, not a detached one — otherwise a
+    // service's recordings never reach the exporter.
+    CustomMetrics custom = server.getApplicationContext().getBean(CustomMetrics.class);
+    assertThat(custom).isSameAs(first.custom());
+
+    HttpServerMetricsFilter filter =
+        server.getApplicationContext().getBean(HttpServerMetricsFilter.class);
+    assertThat(filter.metrics()).isSameAs(first.metrics());
   }
 }

--- a/scripts/validate-otel-config
+++ b/scripts/validate-otel-config
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Starts the pinned collector against the real config and asserts it comes up.
+#
+# deploy_config_test pins the *text* of o11y/otel-collector.yml: that no
+# forbidden match_type appears, that mount points are written unprefixed. Static
+# checks only catch the mistakes someone already knew to look for. `match_type:
+# glob` passed review and passed the line-presence test that existed at the
+# time, and it would have failed the whole hostmetrics receiver on deploy —
+# taking the otlp pipeline with it, since they share a metrics pipeline. The
+# only thing that catches the next one of those is the collector itself.
+#
+# Not `otelcol validate`: that unmarshals the config and calls Validate() on it,
+# which is a weaker check than building the components. The filterset error
+# comes out of CreateFilterSet at scraper construction, so the config has to
+# actually start.
+#
+# Self-validating. The run is done twice — once against the real config
+# expecting it to stay up, once against a copy with `match_type: glob` spliced
+# back in expecting it to die. A docker that is absent, stubbed, or otherwise
+# not discriminating fails one of the two, so this script cannot pass by doing
+# nothing. That property is the point; keep both halves.
+set -uo pipefail
+
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+COMPOSE=$REPO/deploy/consolidated/docker-compose.observability.yml
+CONFIG=$REPO/deploy/consolidated/o11y/otel-collector.yml
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+FAILURES=0
+pass() { echo "  ok    $1"; }
+fail() {
+  echo "  FAIL  $1"
+  FAILURES=$((FAILURES + 1))
+}
+
+# How long a healthy collector has to prove it is healthy. A broken one exits
+# in well under a second, so this only ever costs wall-clock on success.
+WINDOW=${OTEL_VALIDATE_WINDOW:-15}
+
+# The tag the deploy actually uses. Hardcoding a version here would let this
+# drift onto a collector nobody runs, which is the failure it exists to prevent.
+IMAGE=$(sed -n \
+  's|^[[:space:]]*image:[[:space:]]*\(otel/opentelemetry-collector-contrib:[^[:space:]]*\).*$|\1|p' \
+  "$COMPOSE")
+
+if [ -z "$IMAGE" ]; then
+  echo "could not read the collector image out of $COMPOSE" >&2
+  exit 1
+fi
+
+echo "otel-collector config dry-run against $IMAGE"
+
+# Echoes "up" if the collector was still running when the window closed, or
+# "down:<code>" if it exited on its own. A collector that builds its pipelines
+# runs until something stops it, so being killed by the timeout (124) is the
+# success signal.
+run_collector() {
+  local cfg=$1 log=$2
+  timeout "$WINDOW" docker run --rm \
+    -v "$cfg:/etc/otel-collector-config.yml:ro" \
+    -v /:/hostfs:ro \
+    "$IMAGE" --config=/etc/otel-collector-config.yml \
+    > "$log" 2>&1
+  local rc=$?
+  if [ "$rc" -eq 124 ]; then echo "up"; else echo "down:$rc"; fi
+}
+
+# ------------------------------------------------- the config as committed
+
+REAL=$(run_collector "$CONFIG" "$WORK/real.log")
+if [ "$REAL" = "up" ]; then
+  pass "the committed config builds its pipelines and stays up"
+else
+  fail "the committed config did not start ($REAL)"
+  echo "--- collector output ---" >&2
+  cat "$WORK/real.log" >&2
+  echo "------------------------" >&2
+fi
+
+# ------------------------------------------- the mistake this exists to catch
+
+# Puts back the exact blocker that shipped in this file once: filterset accepts
+# only strict and regexp, and anything else is an error out of CreateFilterSet.
+sed 's/match_type: regexp/match_type: glob/' "$CONFIG" > "$WORK/glob.yml"
+
+if ! grep -q "match_type: glob" "$WORK/glob.yml"; then
+  fail "could not splice match_type: glob into a copy — this check is not running"
+else
+  MUTANT=$(run_collector "$WORK/glob.yml" "$WORK/glob.log")
+  if [ "$MUTANT" = "up" ]; then
+    fail "a config with match_type: glob started anyway — this dry-run proves nothing"
+  else
+    pass "match_type: glob is rejected by the collector ($MUTANT)"
+  fi
+fi
+
+# ---------------------------------------------------------------- verdict
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "otel config dry-run passed"
+  exit 0
+fi
+echo "$FAILURES check(s) failed"
+exit 1


### PR DESCRIPTION
Eight commits. Separable if you'd rather split them.

> **Two review rounds, a correction, and a gap closed.** A three-lens panel (correctness / data+cost / tests+claims) ran against commits 1–3; commit 4 is its findings. cursor[bot] then reviewed the result and found a blocker in commit 3 that would have taken the collector down; commits 5–6 are that round. Commit 7 corrects a claim the earlier rounds got wrong. Commit 8 closes the one thing I had declined to do. All of it is described below rather than quietly fixed.

---

# 1 — the games table crushes its own columns

Eleven columns do not fit a laptop, and the table asked for `width: 100%` with no floor. The browser honours that by squeezing the trailing columns rather than letting `.table-wrap` scroll, and the squeeze is the bug: ISO dates break after the month, and motif badges split mid-pill with `discovered attack` hanging outside its cell.

A `64rem` floor so overflow becomes a scroll; `white-space: nowrap` on cells, since every value in this table is an atom (the motifs cell opts back in — its badges are *meant* to wrap, just never mid-badge); `nowrap` on the badge; and a styled scrollbar with a stable gutter, because overlay scrollbars stay invisible until something scrolls them and an overflowing table then reads as truncated. All scoped to this table so the shorter index-requests table still fits a phone.

Verified in Chromium at 600–1700px: with the rules disabled, badges split at every width at or below 1100; with them, no badge breaks and none escapes its cell.

**Two things I could not verify.** I never reproduced clipping at ~1700px, the width the original screenshot implies — at that width the table fits with room to spare. And headless reserves no scrollbar height, so the affordance rests on the CSS rather than a measurement. jsdom has no layout engine, so the tests assert the class *and* — since commit 5 — the rules behind it, read off the stylesheet. Neither is a layout assertion.

---

# 2 — Java services could not report anything but requests

**Not a missing registry entry.** `yodel` was HTTP-only end to end: `HttpServerMetrics` exposed only `recordRequestStart/Complete/Abandoned`, and `OtlpJsonEncoder` was hard-wired to `MethodSnapshot`. There was nowhere to record "games indexed" *to* — hence `"one_d4": {}` next to a comment reading *"the Java services (#1212): yodel's standard instruments only, no custom set yet"*. `mcpserver` is empty for the same reason.

**yodel** gains `CustomMetrics` (labelled counters and distributions), an OTLP scope beside the `http_server_*` family, and `YodelMetricsFactory` so the pipeline is a shared bean application code can inject. One pipeline per process — two would post two partial views of the same service and the dashboard would double-count.

**one_d4** emits run outcomes (`completed` / `failed` / `interrupted` / `lease_lost`), games indexed, months by result (`indexed` / `degraded` / `empty` / `cached`), archive fetches (`ok` / `no_archive` / `error`), motif occurrences by motif, and distributions for run duration (labelled by outcome) and games per month. `interrupted` is the #1282 ceiling made visible.

**prom_proxy** gets Indexing and Motifs groups, rendered generically. Queries are scoped by `service_name`.

Labels are bounded vocabularies; a test sweeps every emitted series for player names and URLs.

---

# 3 — the Host page's Disk panels

Empty because **the collector was reading the wrong machine.** `otelcol` mounted only its config file — no `/proc`, no `/sys`, no host root, no `root_path` — so `hostmetrics` scraped its own container. `cadvisor`, twelve lines below, has had `/:/rootfs:ro` since it was added.

**Three of the six scrapers kept working**, which is why this survived: `cpu`, `memory` and `network` read files that exist in any namespace, so they reported plausible numbers — the container's. Only `disk` and `filesystem` produced nothing, and an empty chart looks like an idle machine.

Fixed with the documented pairing: `/:/hostfs:ro` plus `root_path: /hostfs`. **CPU and memory will now describe the host**, which is what a page called Host Metrics should have shown. Host root brings the runtime's overlay mounts along, so those and the virtual filesystems are excluded.

The mount and the `root_path` are in different files and **either alone is the broken state**, so `deploy_config_test` pins them as a pair.

---

# 4 — the panel round

## Correctness

- **Double close, introduced by this PR.** Making the pipeline a shared bean inverted its ownership, but the filter kept its `@PreDestroy`. `OtlpHttpMetricsExporter.close()` runs a final synchronous export, so shutdown fired two OTLP POSTs, each able to block for the request timeout — and Micronaut destroys the filter *before* the pipeline it was stopping.
- **A snapshot handed out the live hash key.** Mutating it stranded the entry, so the next record for those labels minted a second one — two data points with identical attributes in a payload Prometheus rejects.
- `record()` now refuses NaN, infinity and negatives, matching `add()`. A negative makes a cumulative `_sum` fall, which reads as a counter reset; protojson accepts `"NaN"` for a double, so that one parses cleanly and poisons the series forever.
- `service_name` rejected as a caller label; the `Series` comparator no longer ties on `toString`.

## Data and cost

- **`run_failure_rate` was `total - completed`.** `sum()` over no series is an *empty vector*, and vector-minus-empty is empty — so the chart vanished on a fresh process where every run was failing, which is when someone looks at it. Now a selector.
- **The motifs-per-game tile is gone.** Its two counters sit on opposite sides of the durability boundary, so an interrupted month contributes motifs and zero games, and any clamp large enough to avoid dividing by zero turns the result into a four-order-of-magnitude spike. A tile that is wrong exactly when the system is unhealthy is worse than no tile.
- **Run duration used the HTTP latency bounds** (top bound 10ms), so every observation landed in overflow: fifteen series pinned at zero and a p95 that reads a flat 10ms. yodel grew per-distribution bounds. *(This bullet said `+Inf` until commit 7 — see below.)*
- `lease_lost` has a tile so the outcomes add up; cached months have a result so cache effectiveness is visible; archive errors are counted, since `ChessClient` maps only 404 to empty and throws otherwise — 429s and 5xx were invisible. Empty months no longer feed 0 into games-per-month. Motif labels lowercase with `Locale.ROOT`.

## Tests — where the panel was most useful

- **`TestOneD4Queries_GoldenInstrumentNames` pinned almost nothing.** Substring containment over a joined blob: a prefix rename of every instrument passed, stripping `service_name` from all seventeen selectors passed, deleting every timeseries passed. The first is the exact failure its own comment claimed to prevent. Rewritten per selector on the idiom this file already uses for portrait, name set closed both ways.
- **The disk test from commit 3 matched commented-out lines and prefix typos** — `root_path: /hostfs-typo` passed, which is the state its own error message describes. Anchored on active lines.
- Bucket placement was unpinned (everything in bucket 0 passed). Every metrics test indexed one month, so `monthCount` and `totalIndexed` were indistinguishable. `interrupted` and `lease_lost` had **no test at all** — the wedge alarm was the one outcome uncovered on both sides. The motif label was pinned with one detector registered, so a hardcoded `"check"` passed. "One pipeline per process" was true and untested.

## Corrections to my own claims

Commit 3's message said "three of the five scrapers"; there are six. This PR previously said every emit site was mutation-checked — **false**, four survived. Both corrected.

One mutation is deliberately left alive: removing `@Singleton` from the factory method does not change the observed instance under Micronaut's defaults, so it is equivalent, not a gap. The test pins the property, not the annotation.

---

# 5 — the cursor[bot] round

## The blocker

Commit 3's filesystem scraper used `match_type: glob`. **filterset accepts only `strict` and `regexp`** (`internal/filter/filterset/config.go`, v0.155.0) — an unrecognised type is an error out of `CreateFilterSet`, which fails the `hostmetrics` receiver, and with it the `otlp` pipeline it shares. Deploying that takes *every* metric down, not just the panels it was meant to fix.

The same block was wrong a second way: the excludes were written `/hostfs/var/lib/docker/*`, but `root_path` is applied when the scraper reads usage, not when it filters, so a `/hostfs`-prefixed pattern matches nothing.

Both fixed and both pinned — one test asserts the config only uses match types the collector accepts, another that mount-point patterns are unprefixed. cursor's stronger suggestion, a dry-run against the pinned image, I declined at the time and have since done — commit 8, which also confirms this blocker empirically.

## The rest

The host-wide `process` scraper is dropped. Nothing in prom_proxy reads it and it emits a series set per process on the machine.

Everything else in this commit is the same shape: a place where commits 1–4 made an argument in a comment and left no test behind.

- **`index_run_duration_micros` is labelled by outcome**, and both averages over it select `outcome="completed"`. An interrupted run sat at the `MAX_RUN` ceiling by definition, so pooling it in made the tile read worst exactly when it was being used to judge how bad things were — the same reason the motifs-per-game tile was left out.
- **`run_failure_rate` names `failed|interrupted`** rather than negating `completed`. `lease_lost` is the fourth outcome and it is ordinary, so the negation put a floor under the failure line; it also opted every future outcome in by default. Pinned both ways: no query in the entry may select outcomes by exclusion.
- **`RUN_DURATION_BOUNDS` is pinned.** Commit 4 added the bounds and asserted `distributionCount == 1`, which holds just as well when every run lands in the overflow bucket of a 10ms histogram — the exact failure commit 4 said it was fixing. Deleting the `defineDistribution` call passed every one_d4 test.
- An empty month is counted, not averaged into games-per-month — and `GAMES_PER_MONTH` declares count-shaped bounds of its own (commit 6), so it no longer borrows the HTTP latency buckets that happened to fit.
- **`CustomMetrics` copies bounds at every crossing**, including the snapshot boundary — the one that could hand a caller the shared `BUCKET_BOUNDS` static. The `Distribution` constructor's clone is *gone*: with the snapshot copying, no test can tell its absence from its presence, and an unpinnable guard is one that decays.
- `OtlpHttpMetricsExporter.close()` flushes once however many owners call it.
- The filter carries no `@PreDestroy` **and is not `AutoCloseable`** (Micronaut closes those with no annotation at all). Commit 4 fixed the double close and explained it in a comment; a test now enforces it.
- The `.table-wrap--wide` rules are read off the stylesheet and asserted. The class-name check alone passed against a deleted rule, which is the whole bug. Needs `@types/node` for `node:fs`; npm also resynced two stale version ranges in the lockfile's mirror of `package.json`.

---

# 6 — the +Inf claim was wrong, and it was hiding something

Three comments in this PR said an all-overflow histogram reads `+Inf` at p95. **It does not.** When the rank falls in the `+Inf` bucket, `histogram_quantile` returns the upper bound of the highest *finite* bucket, so the tile answers a flat `10000` and goes on answering it. That is worse than the claim it replaces: the broken histogram reads like a fast service, not like a broken histogram. Corrected in `IndexWorker`, `CustomMetrics` and `IndexWorkerTest`.

Chasing it surfaced that **the HTTP family has the same defect the run-duration histogram had**, and had it before this PR. `HttpServerMetrics.BUCKET_BOUNDS` is the OTel SDK default set — shaped for *milliseconds* — and this emitter records *microseconds*. Top bound 10ms. `server_pal` (Rust) and `futility/otel` (C++) inherit the same defaults from their SDKs and also record microseconds; neither configures a view. So **every service's p95 tile is capped at 10ms**, and anything touching Postgres is past that routinely. The `avg_duration_us` tile beside it is correct, since `_sum`/`_count` are unaffected — the disagreement between the two is how someone would eventually notice.

**Filed as #1286, not fixed here.** The three emitters have to move together or Java services stop being comparable to the rest on a query they share, and a bucket-layout change is not retroactive — both belong in their own diff. What is fixed here is the trap: a test pins Java's bounds equal to the OTel defaults and fails with the reason if they move alone (mutation-checked by shifting one bound). And `defineDistribution`'s javadoc no longer claims the default "suits anything request-shaped" — it does not suit that either.

---

# 7 — the dry-run I said I would not do

cursor's blocker came with a suggestion: *"a test that rejects `match_type: glob` and `/hostfs/`-prefixed mount points, **or better, a collector config dry-run against the pinned image**."* I did the first and declined the second, on the grounds that a docker-gated test skips silently wherever docker is absent — the failure mode this repo already has with the Postgres suites. That objection turns out to be answerable rather than disqualifying.

`scripts/validate-otel-config` starts the pinned collector against the real config and asserts it stays up. **Not `otelcol validate`** — that unmarshals the config and calls `Validate()` on it, which is weaker than building components, and the filterset error comes out of `CreateFilterSet` at scraper construction. The config has to actually start.

**It is self-validating**, which is what answers the silent-skip objection. Every run does the collector twice: once on the committed config expecting it to stay up, once on a copy with `match_type: glob` spliced back in expecting it to die. A docker that is missing, stubbed, or otherwise not discriminating fails one of the two halves, so the script cannot pass by doing nothing. Locally it was checked against three stub dockers — one that behaves (passes), one that always succeeds (fails the negative control), one that always fails (fails the positive). A missing binary returns 127 through `timeout`, not the 124 that means healthy, so absence is loud rather than quiet.

**Its first real run, on `5bd7e68`, passed and proved itself:**

```
otel-collector config dry-run against otel/opentelemetry-collector-contrib:0.155.0
  ok    the committed config builds its pipelines and stays up
  ok    match_type: glob is rejected by the collector (down:1)
```

The healthy run held the full 15s window; the `glob` copy died in 0.27s with exit 1. So the negative control fired against the actual pinned image — which independently confirms the blocker cursor found, rather than taking my reading of the source for it.

The image tag is read out of `docker-compose.observability.yml` rather than hardcoded, so the dry-run cannot drift onto a collector nobody runs.

It gets **its own CI job**, not a step in `test-deploy` — that one runs inside the `ci-base` container and this needs the runner's own docker. Path-gated on the three files that can change the answer.

`TestCIStillRunsTheCollectorDryRun` pins the wiring, since a workflow that stopped invoking the script would leave every other test in that file green. Exact line match rather than `strings.Contains`: containment survives a typo'd path, which is precisely how the golden-instrument test in this same PR managed to pin nothing.

## Mutation checks

Both `IndexWorker` pins, all three `CustomMetrics` copy sites, the exporter's `compareAndSet`, an injected `@PreDestroy` on the filter, the outcome label on the duration histogram, the empty-month guard, both prom_proxy selector changes, three edits to `index.css`, the HTTP-bounds guard, and the CI-wiring pin three ways (step commented out, path typo'd, `+x` removed). **All killed.**

**Two survived on the way there.** The first snapshot-aliasing assertion raised the *top* bound, which cannot move an observation to a different bucket — it passed against the aliased version. And the constructor clone had no observable effect at all, which is why it was removed rather than pinned.

---

## Verification

- **62/62** across `one_d4`, `yodel`, `prom_proxy`, `http_client` and `deploy/consolidated` with `--nocache_test_results`, against a **real Postgres 16.13**; PG-gated suites confirmed non-skipping from the JUnit XML. The cursor round re-ran **61/61** over the four packages it touches; commit 7 re-ran **59/59** over `yodel` and `one_d4`; commit 8 re-ran **61/61** over `deploy/consolidated`, `yodel`, `one_d4` and `prom_proxy`. The last three ran **without** `PG_TEST_DB_URL`, so the Postgres-gated one_d4 suites skipped there. CI runs them against the `postgres:18` service.
- **106/106** on `1d4_web`, plus `tsc --noEmit`. `buildifier_test` green, and no `MODULE.bazel.lock` churn.
- The new `validate-otel-config` job is green on `5bd7e68`, with its negative control firing — see above.
- Three context-booting `one_d4` suites needed `yodel:micronaut` in their runtime deps — the integration the binary already carries.
- **The three-lens panel did not run against commits 7 or 8.** Commit 7 is three comment corrections and one guard test; commit 8 is a CI script plus its wiring pin. Both are mutation-checked; neither got a panel, and I would rather say so than let the header imply otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA