### PR TITLE
#1285 re-review follow-ups, then #1287: microsecond histogram buckets across all three rails, cache-hit scene complexity, and a count/rate toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ traps that only surface in CI), [`docs/BUILD_AND_IDE.md`](docs/BUILD_AND_IDE.md)
 ## Commands
 
 ```bash
-scripts/diff-build origin/main   # what CI's build-and-test runs
+scripts/diff-build origin/main   # what CI's build-and-test runs — COMMIT FIRST, see below
 scripts/format-all               # bazel + java + cc + scala formatters
 scripts/mutation-check -f FILE -t 'TEST CMD' 's/OLD/NEW/'
 bazel test //domains/<path>/...
@@ -36,6 +36,12 @@ Bazel formatting do.
 
 ## Things that bite
 
+- **`scripts/diff-build` destroys uncommitted work.** It runs
+  `git checkout <base> --force` and back to hash both revisions, and `--force`
+  discards every modification to a tracked file. Untracked files survive, which
+  makes the loss look partial and easy to misread. There is no prompt and no
+  stash. Commit before running it, or run `bazel test` on the affected targets
+  instead — that is the same build without the checkout.
 - **`BUILD.bazel` `srcs` are listed by name**, with two globbing exceptions
   (`yochat_lib`, `wordchains_ios`). Elsewhere a new file not listed doesn't
   compile under Bazel and its tests don't run — while `go test ./...` or

--- a/deploy/consolidated/deploy_config_test.go
+++ b/deploy/consolidated/deploy_config_test.go
@@ -257,12 +257,42 @@ func TestMountPointExcludesAreWrittenFromTheHostsPerspective(t *testing.T) {
 		case strings.HasPrefix(line, "exclude_fs_types:"), strings.HasPrefix(line, "network:"):
 			inExcludeBlock = false
 		case inExcludeBlock && strings.HasPrefix(line, "- "):
-			pattern := strings.TrimPrefix(line, "- ")
+			// The patterns are anchored (see the test below), so compare the path part.
+			pattern := strings.TrimPrefix(strings.TrimPrefix(line, "- "), "^")
 			if strings.HasPrefix(pattern, hostfsMountPath+"/") {
 				t.Errorf("mount-point exclude %q is prefixed with %s; filtering happens before"+
 					" root_path is applied, so this can never match", pattern, hostfsMountPath)
 			}
 		}
+	}
+}
+
+// filterset's regexp matcher is Go's MatchString, which looks for the pattern
+// anywhere in the string rather than at the front. These excludes are all meant
+// as path prefixes, and unanchored they overreach: `/dev/.*` drops `/mnt/dev/data`
+// too. The panel still renders, just missing a volume nobody thought to exclude —
+// the same shape of quiet wrongness as the /hostfs prefix above.
+func TestMountPointExcludesAreAnchored(t *testing.T) {
+	inExcludeBlock := false
+	seen := 0
+	for _, line := range activeLines(t, "o11y/otel-collector.yml") {
+		switch {
+		case strings.HasPrefix(line, "exclude_mount_points:"):
+			inExcludeBlock = true
+		case strings.HasPrefix(line, "exclude_fs_types:"), strings.HasPrefix(line, "network:"):
+			inExcludeBlock = false
+		case inExcludeBlock && strings.HasPrefix(line, "- "):
+			seen++
+			pattern := strings.TrimPrefix(line, "- ")
+			if !strings.HasPrefix(pattern, "^") {
+				t.Errorf("mount-point exclude %q is unanchored; filterset matches it anywhere in"+
+					" the path, so it also excludes mounts that merely contain it", pattern)
+			}
+		}
+	}
+	// Without this the test passes just as well against a deleted exclude block.
+	if seen == 0 {
+		t.Fatal("found no mount-point excludes to check; this test is not reading the config")
 	}
 }
 

--- a/deploy/consolidated/o11y/otel-collector.yml
+++ b/deploy/consolidated/o11y/otel-collector.yml
@@ -39,15 +39,21 @@ receivers:
         # Paths are the host's, unprefixed: root_path is applied when the scraper
         # reads usage, not when it filters, so a /hostfs-prefixed pattern matches
         # nothing.
+        #
+        # Anchored with ^. filterset's regexp matcher is Go's MatchString, which
+        # looks for the pattern anywhere in the string, so an unanchored /dev/.*
+        # also excludes /mnt/dev/data — a real volume, dropped off the usage
+        # panel because its path happens to contain one of these. These are meant
+        # as prefixes, so they say so.
         exclude_mount_points:
           mount_points:
-            - /var/lib/docker/.*
-            - /var/lib/kubelet/.*
-            - /snap/.*
-            - /run/.*
-            - /dev/.*
-            - /sys/.*
-            - /proc/.*
+            - ^/var/lib/docker/.*
+            - ^/var/lib/kubelet/.*
+            - ^/snap/.*
+            - ^/run/.*
+            - ^/dev/.*
+            - ^/sys/.*
+            - ^/proc/.*
           match_type: regexp
         exclude_fs_types:
           fs_types:

--- a/domains/graphics/apis/portrait/tracer_service.cc
+++ b/domains/graphics/apis/portrait/tracer_service.cc
@@ -1,9 +1,11 @@
 #include "domains/graphics/apis/portrait/tracer_service.h"
 
 #include <exception>
+#include <map>
 #include <memory>
 #include <new>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "absl/log/log.h"
@@ -53,6 +55,7 @@ absl::StatusOr<TraceResponse> TracerService::trace(TraceRequest& trace_request) 
 
     auto cached_png = lookupCache(trace_request);
     if (cached_png.has_value()) {
+      recordSceneComplexity(trace_request.scene, /*cache_hit=*/true);
       auto duration = std::chrono::steady_clock::now() - start_time;
       metrics_->RecordLatency("trace_request_duration",
                               std::chrono::duration_cast<std::chrono::microseconds>(duration),
@@ -62,11 +65,7 @@ absl::StatusOr<TraceResponse> TracerService::trace(TraceRequest& trace_request) 
 
     auto [scene, perspective, output] = trace_request;
 
-    // Record scene complexity metrics
-    // Distributions, not gauges: RecordGauge is an up-down delta;
-    // absolute per-request counts belong in a histogram.
-    metrics_->RecordDistribution("scene_sphere_count", static_cast<double>(scene.spheres.size()));
-    metrics_->RecordDistribution("scene_light_count", static_cast<double>(scene.lights.size()));
+    recordSceneComplexity(scene, /*cache_hit=*/false);
 
     auto image = do_trace(scene, perspective, output);
     auto png_bytes = pngpp::imageToPng(image);
@@ -116,6 +115,23 @@ absl::StatusOr<TraceResponse> TracerService::trace(TraceRequest& trace_request) 
     metrics_->RecordCounter("trace_requests_failed", 1, {{"error", "rendering_failed"}});
     return absl::InternalError("render failed");
   }
+}
+
+void TracerService::recordSceneComplexity(const Scene& scene, bool cache_hit) {
+  // Distributions, not gauges: RecordGauge is an up-down delta; absolute
+  // per-request counts belong in a histogram.
+  //
+  // The label matches the one RecordLatency already puts on
+  // trace_request_duration, so the two read the same way and a query can join
+  // them. Unlabelled, these series were a mean over renders that the dashboard
+  // presented as a mean over requests; with it, prom_proxy asks for offered
+  // load by summing across the label and for render cost by selecting
+  // cache_hit="false" (#1287).
+  const std::map<std::string, std::string> labels{{"cache_hit", cache_hit ? "true" : "false"}};
+  metrics_->RecordDistribution("scene_sphere_count", static_cast<double>(scene.spheres.size()),
+                               labels);
+  metrics_->RecordDistribution("scene_light_count", static_cast<double>(scene.lights.size()),
+                               labels);
 }
 
 Image<RGB_Double> TracerService::do_trace(Scene& scene, Perspective& perspective,

--- a/domains/graphics/apis/portrait/tracer_service.h
+++ b/domains/graphics/apis/portrait/tracer_service.h
@@ -70,6 +70,17 @@ class TracerService {
                             const std::vector<std::uint8_t>& png_bytes);
 
  private:
+  /// Records spheres and lights for one accepted request, labelled by whether
+  /// the render cache answered it.
+  ///
+  /// Called on both paths deliberately. It used to run only after the cache
+  /// miss, which made `avg_spheres_1h` a mean over renders rather than over
+  /// requests — a defensible number under a label that claimed the other one,
+  /// and one that drifts further from offered load as the hit rate climbs. At
+  /// portrait's observed 50% hit rate the panel described half the traffic
+  /// (#1287). The label lets the dashboard ask for either.
+  void recordSceneComplexity(const Scene& scene, bool cache_hit);
+
   tracy::Scene toTracyScene(Scene& scene, const Output& output);
   std::vector<tracy::Sphere> tracify(const std::vector<Sphere>& spheres);
   std::vector<tracy::Light> tracify(const std::vector<Light>& lights);

--- a/domains/graphics/apis/portrait/tracer_service_test.cc
+++ b/domains/graphics/apis/portrait/tracer_service_test.cc
@@ -571,6 +571,94 @@ TEST_F(TracerServiceTest, ADifferentSceneMissesRatherThanReusingTheLastRender) {
   EXPECT_EQ(metrics->CounterTotal("cache_hits", TraceCacheLabels()), 0);
 }
 
+/// The labels scene complexity carries on each path.
+std::map<std::string, std::string> SceneLabels(bool cache_hit) {
+  return {{"cache_hit", cache_hit ? "true" : "false"}};
+}
+
+/// How many observations of `name` landed under exactly these labels — the
+/// count, where CounterTotal gives the sum. A mean needs both.
+int ObservationCount(const futility::otel::CapturingMetricsRecorder& metrics,
+                     const std::string& name, const std::map<std::string, std::string>& labels) {
+  int found = 0;
+  for (const futility::otel::CapturingMetricsRecorder::Entry& entry : metrics.Entries()) {
+    if (entry.name == name && entry.attributes == labels) ++found;
+  }
+  return found;
+}
+
+TEST_F(TracerServiceTest, SceneComplexityIsRecordedOnTheCacheHitPathToo) {
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>(kService);
+  TracerService service(10, metrics);
+  TraceRequest request{basic_scene_, basic_perspective_, basic_output_};
+
+  ASSERT_TRUE(service.trace(request).ok());
+  ASSERT_TRUE(service.trace(request).ok());
+
+  EXPECT_EQ(ObservationCount(*metrics, "scene_sphere_count", SceneLabels(false)), 1);
+  EXPECT_EQ(ObservationCount(*metrics, "scene_sphere_count", SceneLabels(true)), 1)
+      << "the cached request never reached the recorder";
+  EXPECT_EQ(ObservationCount(*metrics, "scene_light_count", SceneLabels(true)), 1);
+
+  // basic_scene_ is one sphere and two lights, on both paths.
+  EXPECT_EQ(metrics->CounterTotal("scene_sphere_count", SceneLabels(true)), 1);
+  EXPECT_EQ(metrics->CounterTotal("scene_light_count", SceneLabels(true)), 2);
+}
+
+/**
+ * The #1287 reading, in miniature: a workload whose two means differ.
+ *
+ * Four requests over two scenes — a 1-sphere scene asked for three times and
+ * rendered once, and a 5-sphere scene rendered once. Offered load is 8 spheres
+ * over 4 requests (2.0); render cost is 6 spheres over 2 renders (3.0). Before
+ * the cache-hit path recorded anything, the panel labelled `avg_spheres_1h`
+ * could only ever answer 3.0.
+ *
+ * The ratios are chosen so the two disagree, which the issue's own first batch
+ * did not manage: 33/11 and 9/3 are both exactly 3.0, so a homogeneous workload
+ * cannot tell the readings apart and neither could a test built on one.
+ */
+TEST_F(TracerServiceTest, ComplexityDistinguishesOfferedLoadFromRenderCost) {
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>(kService);
+  TracerService service(10, metrics);
+
+  TraceRequest light{basic_scene_, basic_perspective_, basic_output_};
+  ASSERT_TRUE(service.trace(light).ok());  // miss
+  ASSERT_TRUE(service.trace(light).ok());  // hit
+  ASSERT_TRUE(service.trace(light).ok());  // hit
+
+  Scene heavy_scene = basic_scene_;
+  for (int i = 0; i < 4; i++) {
+    Sphere extra;
+    extra.center = {static_cast<double>(i) + 2.0, 0.0, 5.0};
+    extra.radius = 0.5;
+    extra.color = {0, 0, 255};
+    extra.specular = 100.0;
+    extra.reflective = 0.1;
+    heavy_scene.spheres.push_back(extra);
+  }
+  TraceRequest heavy{heavy_scene, basic_perspective_, basic_output_};
+  ASSERT_TRUE(service.trace(heavy).ok());  // miss
+
+  const double rendered_spheres = metrics->CounterTotal("scene_sphere_count", SceneLabels(false));
+  const int renders = ObservationCount(*metrics, "scene_sphere_count", SceneLabels(false));
+  const double requested_spheres =
+      rendered_spheres + metrics->CounterTotal("scene_sphere_count", SceneLabels(true));
+  const int requests =
+      renders + ObservationCount(*metrics, "scene_sphere_count", SceneLabels(true));
+
+  EXPECT_EQ(renders, 2);
+  EXPECT_EQ(requests, 4);
+  EXPECT_EQ(rendered_spheres, 6.0);
+  EXPECT_EQ(requested_spheres, 8.0);
+
+  // Both readings are now available, and they are different numbers — which is
+  // the whole point of carrying the label.
+  EXPECT_EQ(requested_spheres / requests, 2.0) << "offered load: what callers asked to render";
+  EXPECT_EQ(rendered_spheres / renders, 3.0) << "render cost: what the tracer actually drew";
+  EXPECT_NE(requested_spheres / requests, rendered_spheres / renders);
+}
+
 TEST_F(TracerServiceTest, TheBespokeTraceCacheCountersAreGone) {
   auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>(kService);
   TracerService service(10, metrics);

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -169,6 +169,12 @@ type CustomMetricValue struct {
 	Label string  `json:"label"`
 	Value float64 `json:"value"`
 	Unit  string  `json:"unit"`
+	// True when this tile is counter-derived and so has both a count and a
+	// rate form (#1287). The UI needs it to know which tiles get a toggle:
+	// inferring it from the label or the unit would put one on the windowed
+	// means, whose rate form does not exist — they are already ratios of
+	// rates. Omitted when false so the fixed-form tiles stay as they were.
+	Toggleable bool `json:"toggleable,omitempty"`
 }
 
 type CustomMetricGroup struct {
@@ -177,10 +183,15 @@ type CustomMetricGroup struct {
 }
 
 type ServiceMetricsResponse struct {
-	Timestamp time.Time           `json:"timestamp"`
-	Service   string              `json:"service"`
-	Standard  StandardMetrics     `json:"standard"`
-	Custom    []CustomMetricGroup `json:"custom"`
+	Timestamp time.Time       `json:"timestamp"`
+	Service   string          `json:"service"`
+	Standard  StandardMetrics `json:"standard"`
+	// Which form the toggleable tiles below are in. Echoed rather than left
+	// implicit so a client that sent no ?view= still knows what it is looking
+	// at, and so the default can move without a silent reinterpretation of
+	// every counter tile on the page.
+	View   string              `json:"view"`
+	Custom []CustomMetricGroup `json:"custom"`
 }
 
 // ContainerDetail wraps a single container so the point-in-time endpoints all

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -7,11 +7,135 @@ import "fmt"
 // metric descriptors all read from here — adding an emitter is one entry,
 // no new routes, handlers, or UI code.
 
+// MetricView is which form a counter-derived tile is asked for (#1287).
+//
+// Two forms, not three. A counter can also be read cumulatively as sum(x),
+// which is what most of these tiles did before, but that is deliberately not
+// offered: a cumulative counter resets when its process does, so it reads low
+// after every deploy and cannot be compared across one. increase() is the
+// restart-corrected form and answers the same question.
+type MetricView string
+
+const (
+	// ViewCount is the number of events in the window: sum(increase(x[w])).
+	ViewCount MetricView = "count"
+	// ViewRate is events per second: sum(rate(x[w])).
+	ViewRate MetricView = "rate"
+)
+
+// DefaultView is what a request that names no view gets. Count, because most
+// of these tiles read as counts today and "N in the last five minutes" is the
+// more direct answer for an outcome counter; rate is one parameter away.
+const DefaultView = ViewCount
+
+// The window both views are computed over, unless a descriptor overrides it.
+const defaultCounterWindow = "5m"
+
+// The window for counters that are alarms rather than volumes.
+//
+// Some of these tiles answer "has this happened at all" — the comment on
+// runs_interrupted below says as much: anything above zero means a worker was
+// stuck long enough to be given up on. Over five minutes an interruption from
+// an hour ago reads zero and the alarm silently disarms, which is the failure
+// mode the tile exists to prevent. A day is long enough that a human looking
+// at the dashboard after the fact still sees it.
+const alarmWindow = "24h"
+
+// ValidView reports whether a client-supplied view is one this package builds
+// queries for. Callers must check before passing the value on: a view string
+// never reaches PromQL, but an unrecognised one would silently fall through to
+// the default and answer a different question than the one asked.
+func ValidView(view string) bool {
+	switch MetricView(view) {
+	case ViewCount, ViewRate:
+		return true
+	default:
+		return false
+	}
+}
+
 type customScalarDef struct {
 	Group string
 	Label string
 	Unit  string
+
+	// A tile with one fixed form — a gauge, a percentage, a windowed mean —
+	// carries its whole expression here and ignores the view.
 	Query string
+
+	// A counter-derived tile sets this instead: the bare selector both views
+	// are built from, e.g. `games_indexed_total{service_name="one_d4"}`. The
+	// proxy wraps it rather than the descriptor spelling out two expressions,
+	// so the two forms cannot drift into describing different series.
+	Counter string
+
+	// Overrides defaultCounterWindow for this tile. Ignored unless Counter is
+	// set.
+	Window string
+}
+
+// counter declares a toggleable tile over defaultCounterWindow.
+//
+// The label deliberately carries no _total or _per_sec suffix: the tile shows
+// whichever form was asked for, so a suffix naming one of them is wrong half
+// the time. The unit says which one is on screen.
+func counter(group, label, unit, selector string) customScalarDef {
+	return customScalarDef{Group: group, Label: label, Unit: unit, Counter: selector}
+}
+
+// counterOver is counter with an explicit window.
+func counterOver(group, label, unit, selector, window string) customScalarDef {
+	return customScalarDef{Group: group, Label: label, Unit: unit, Counter: selector, Window: window}
+}
+
+// scalar declares a tile with a single fixed form and no toggle.
+func scalar(group, label, unit, query string) customScalarDef {
+	return customScalarDef{Group: group, Label: label, Unit: unit, Query: query}
+}
+
+// Toggleable reports whether this tile has both a count and a rate form.
+func (d customScalarDef) Toggleable() bool { return d.Counter != "" }
+
+func (d customScalarDef) window() string {
+	if d.Window != "" {
+		return d.Window
+	}
+	return defaultCounterWindow
+}
+
+// QueryFor builds the expression for one view. A non-toggleable tile answers
+// with its fixed query whatever it is asked for.
+func (d customScalarDef) QueryFor(view MetricView) string {
+	if !d.Toggleable() {
+		return d.Query
+	}
+	fn := "increase"
+	if view == ViewRate {
+		fn = "rate"
+	}
+	return fmt.Sprintf("sum(%s(%s[%s]))", fn, d.Counter, d.window())
+}
+
+// AllQueries is every expression this descriptor can produce.
+//
+// Exists for the registry audits: they scan queries for unscoped selectors and
+// dead metric names, and a counter tile's Query field is empty, so scanning
+// that field alone would let every toggleable tile through unexamined. The
+// selectors those tiles are built from are exactly the ones worth checking.
+func (d customScalarDef) AllQueries() []string {
+	if !d.Toggleable() {
+		return []string{d.Query}
+	}
+	return []string{d.QueryFor(ViewCount), d.QueryFor(ViewRate)}
+}
+
+// UnitFor is the unit as displayed in that view. A rate is the tile's own unit
+// per second, or a bare "/s" when the quantity is unitless.
+func (d customScalarDef) UnitFor(view MetricView) string {
+	if !d.Toggleable() || view != ViewRate {
+		return d.Unit
+	}
+	return d.Unit + "/s"
 }
 
 type serviceEntry struct {
@@ -34,7 +158,34 @@ const (
 
 	portraitCacheHitPercent = portraitCacheHitRate + `/(` + portraitCacheHitRate + `+` +
 		portraitCacheMissRate + `)*100`
-	portraitCacheOpsRate = portraitCacheHitRate + `+` + portraitCacheMissRate
+
+	// Both cache counters as one selector, so the operations tile can be built
+	// in either view from a single expression. Selected by __name__ rather
+	// than summed as rate(hits)+rate(misses): that form is two instant vectors
+	// joined by binary matching, which yields nothing at all if one side has
+	// no series yet — a fresh process whose cache has only ever missed.
+	portraitCacheOps = `{__name__=~"cache_hits_total|cache_misses_total",` +
+		`service_name="portrait",cache="trace"}`
+)
+
+// Scene complexity is recorded on both cache paths and labelled by cache_hit
+// (#1287). Summing across the label is offered load — what callers asked to
+// render; selecting cache_hit="false" is render cost — what the tracer drew.
+// The panel used to show only the second under a name that read like the
+// first.
+//
+// Series recorded before that change carry no cache_hit label at all, so they
+// contribute to the requested figures and are invisible to the rendered ones
+// until they age out of the window.
+const (
+	portraitSpheresRequested = `sum(rate(scene_sphere_count_sum[1h]))/` +
+		`sum(rate(scene_sphere_count_count[1h]))`
+	portraitSpheresRendered = `sum(rate(scene_sphere_count_sum{cache_hit="false"}[1h]))/` +
+		`sum(rate(scene_sphere_count_count{cache_hit="false"}[1h]))`
+	portraitLightsRequested = `sum(rate(scene_light_count_sum[1h]))/` +
+		`sum(rate(scene_light_count_count[1h]))`
+	portraitLightsRendered = `sum(rate(scene_light_count_sum{cache_hit="false"}[1h]))/` +
+		`sum(rate(scene_light_count_count{cache_hit="false"}[1h]))`
 )
 
 // Catalog order doubles as the UI's tab order.
@@ -43,26 +194,27 @@ var serviceOrder = []string{"golf_hub", "mcpserver", "microgpt-serve", "mithril"
 var serviceRegistry = map[string]serviceEntry{
 	"golf_hub": {
 		CustomScalars: []customScalarDef{
-			{"Sessions", "active", "sessions", `sum(stream_sessions_active_gauge)`},
-			{"Sessions", "started_total", "", `sum(stream_sessions_total)`},
-			{"Sessions", "resumed_total", "", `sum(stream_sessions_total{resumed="true"})`},
-			{"Sessions", "refused_total", "", `sum(stream_admissions_refused_total)`},
-			{"Sessions", "disconnects_total", "", `sum(stream_disconnects_total)`},
-			{"Sessions", "seats_expired_total", "", `sum(stream_seats_expired_total)`},
-			{"Activity", "commands_per_sec", "/s", `sum(rate(stream_commands_total[5m]))`},
-			{"Activity", "events_per_sec", "/s", `sum(rate(stream_events_total[5m]))`},
-			{"Activity", "rejections_per_sec", "/s", `sum(rate(stream_rejections_total[5m]))`},
-			{"Activity", "rate_limited_per_sec", "/s", `sum(rate(stream_rate_limited_total[5m]))`},
+			scalar("Sessions", "active", "sessions", `sum(stream_sessions_active_gauge)`),
+			counter("Sessions", "started", "", `stream_sessions_total`),
+			counter("Sessions", "resumed", "", `stream_sessions_total{resumed="true"}`),
+			counter("Sessions", "refused", "", `stream_admissions_refused_total`),
+			counter("Sessions", "disconnects", "", `stream_disconnects_total`),
+			counter("Sessions", "seats_expired", "", `stream_seats_expired_total`),
+			counter("Activity", "commands", "", `stream_commands_total`),
+			counter("Activity", "events", "", `stream_events_total`),
+			counter("Activity", "rejections", "", `stream_rejections_total`),
+			counter("Activity", "rate_limited", "", `stream_rate_limited_total`),
 			// Room chat (#1226): outcome counts and stages only — the emitter
 			// never labels by room, player, or text. catch_up_rows is a
 			// per-drain distribution, so its windowed average is how far
-			// behind a wake found an instance (the lag signal).
-			{"Chat", "messages_per_sec", "/s", `sum(rate(chat_appends_total{result="stored"}[5m]))`},
-			{"Chat", "stored_total", "", `sum(chat_appends_total{result="stored"})`},
-			{"Chat", "delivered_rows_per_sec", "/s", `sum(rate(chat_rows_delivered_total[5m]))`},
-			{"Chat", "catch_up_rows_avg_5m", "rows", `sum(rate(chat_catch_up_rows_sum[5m]))/sum(rate(chat_catch_up_rows_count[5m]))`},
-			{"Chat", "history_replays_total", "", `sum(chat_history_replays_total)`},
-			{"Chat", "failures_total", "", `sum(chat_failures_total)`},
+			// behind a wake found an instance (the lag signal), which is a
+			// mean rather than a count and so has no rate form.
+			counter("Chat", "messages", "", `chat_appends_total{result="stored"}`),
+			counter("Chat", "delivered_rows", "rows", `chat_rows_delivered_total`),
+			scalar("Chat", "catch_up_rows_avg_5m", "rows",
+				`sum(rate(chat_catch_up_rows_sum[5m]))/sum(rate(chat_catch_up_rows_count[5m]))`),
+			counter("Chat", "history_replays", "", `chat_history_replays_total`),
+			counterOver("Chat", "failures", "", `chat_failures_total`, alarmWindow),
 		},
 		CustomTimeseries: map[string]string{
 			"sessions_active":    `sum(stream_sessions_active_gauge)`,
@@ -80,12 +232,12 @@ var serviceRegistry = map[string]serviceEntry{
 	},
 	"microgpt-serve": {
 		CustomScalars: []customScalarDef{
-			{"Requests by endpoint", "generate_total", "", `sum(microgpt_requests_total{endpoint="generate"})`},
-			{"Requests by endpoint", "chat_total", "", `sum(microgpt_requests_total{endpoint="chat"})`},
-			{"Inference", "tokens_generated_total", "tokens", `sum(microgpt_tokens_generated_total)`},
-			{"Inference", "tokens_per_sec", "tokens/s", `sum(rate(microgpt_tokens_generated_total[5m]))`},
-			{"Inference", "avg_duration_ms", "ms", `sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`},
-			{"Inference", "conversations_total", "", `sum(microgpt_conversations_total)`},
+			counter("Requests by endpoint", "generate", "", `microgpt_requests_total{endpoint="generate"}`),
+			counter("Requests by endpoint", "chat", "", `microgpt_requests_total{endpoint="chat"}`),
+			counter("Inference", "tokens_generated", "tokens", `microgpt_tokens_generated_total`),
+			scalar("Inference", "avg_duration_ms", "ms",
+				`sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`),
+			counter("Inference", "conversations", "", `microgpt_conversations_total`),
 		},
 		CustomTimeseries: map[string]string{
 			"tokens_per_second": `sum(rate(microgpt_tokens_generated_total[5m]))`,
@@ -100,29 +252,37 @@ var serviceRegistry = map[string]serviceEntry{
 	// emitter never labels by player or by game, so no series here is per-user.
 	"one_d4": {
 		CustomScalars: []customScalarDef{
-			{"Indexing", "games_indexed_total", "games", `sum(games_indexed_total{service_name="one_d4"})`},
-			{"Indexing", "games_per_sec", "/s", `sum(rate(games_indexed_total{service_name="one_d4"}[5m]))`},
-			{"Indexing", "runs_completed_total", "", `sum(index_runs_total{service_name="one_d4",outcome="completed"})`},
-			{"Indexing", "runs_failed_total", "", `sum(index_runs_total{service_name="one_d4",outcome="failed"})`},
+			counter("Indexing", "games_indexed", "games", `games_indexed_total{service_name="one_d4"}`),
+			counter("Indexing", "runs_completed", "", `index_runs_total{service_name="one_d4",outcome="completed"}`),
+			// The three outcomes below are alarms rather than volumes, so they
+			// count over a day. A failed run an hour ago is still the thing an
+			// operator opened this page to find.
+			counterOver("Indexing", "runs_failed", "",
+				`index_runs_total{service_name="one_d4",outcome="failed"}`, alarmWindow),
 			// A wedge cut loose by the MAX_RUN ceiling lands here (#1282). Anything
 			// above zero means a worker was stuck long enough to be given up on.
-			{"Indexing", "runs_interrupted_total", "", `sum(index_runs_total{service_name="one_d4",outcome="interrupted"})`},
+			counterOver("Indexing", "runs_interrupted", "",
+				`index_runs_total{service_name="one_d4",outcome="interrupted"}`, alarmWindow),
 			// Emitted since the ceiling landed, and listed so the four outcomes add up to
 			// index_runs_total. A range changing hands mid-run is ordinary; a rising count
-			// beside a flat interrupted count is contention, not a wedge.
-			{"Indexing", "runs_lease_lost_total", "", `sum(index_runs_total{service_name="one_d4",outcome="lease_lost"})`},
+			// beside a flat interrupted count is contention, not a wedge — which only
+			// reads that way if the two share a window, hence the same one.
+			counterOver("Indexing", "runs_lease_lost", "",
+				`index_runs_total{service_name="one_d4",outcome="lease_lost"}`, alarmWindow),
 			// Windowed averages over the histograms: rate(sum)/rate(count) is the
-			// mean per run in the window, the same shape portrait uses.
+			// mean per run in the window, the same shape portrait uses. Means, so
+			// no rate form.
 			// Completed runs only. The histogram is labelled by outcome, and an interrupted
 			// run is one that sat at the MAX_RUN ceiling — pooling those in makes the average
 			// spike at exactly the moment someone is reading it to size a real run.
-			{"Indexing", "avg_run_seconds_1h", "s", `sum(rate(index_run_duration_micros_sum{service_name="one_d4",outcome="completed"}[1h]))/sum(rate(index_run_duration_micros_count{service_name="one_d4",outcome="completed"}[1h]))/1000000`},
-			{"Indexing", "avg_games_per_month_1h", "games", `sum(rate(index_games_per_month_sum{service_name="one_d4"}[1h]))/sum(rate(index_games_per_month_count{service_name="one_d4"}[1h]))`},
-			{"Indexing", "empty_months_total", "", `sum(index_months_total{service_name="one_d4",result="empty"})`},
-			{"Indexing", "cached_months_total", "", `sum(index_months_total{service_name="one_d4",result="cached"})`},
-			{"Indexing", "archive_fetches_per_sec", "/s", `sum(rate(chess_com_archive_fetches_total{service_name="one_d4"}[5m]))`},
-			{"Motifs", "occurrences_per_sec", "/s", `sum(rate(motif_occurrences_total{service_name="one_d4"}[5m]))`},
-			{"Motifs", "occurrences_total", "", `sum(motif_occurrences_total{service_name="one_d4"})`},
+			scalar("Indexing", "avg_run_seconds_1h", "s",
+				`sum(rate(index_run_duration_micros_sum{service_name="one_d4",outcome="completed"}[1h]))/sum(rate(index_run_duration_micros_count{service_name="one_d4",outcome="completed"}[1h]))/1000000`),
+			scalar("Indexing", "avg_games_per_month_1h", "games",
+				`sum(rate(index_games_per_month_sum{service_name="one_d4"}[1h]))/sum(rate(index_games_per_month_count{service_name="one_d4"}[1h]))`),
+			counter("Indexing", "empty_months", "", `index_months_total{service_name="one_d4",result="empty"}`),
+			counter("Indexing", "cached_months", "", `index_months_total{service_name="one_d4",result="cached"}`),
+			counter("Indexing", "archive_fetches", "", `chess_com_archive_fetches_total{service_name="one_d4"}`),
+			counter("Motifs", "occurrences", "", `motif_occurrences_total{service_name="one_d4"}`),
 			// No motifs-per-game tile. The two counters are recorded on opposite sides of
 			// the durability boundary — motifs per game inside the drain loop, games only
 			// after the month's flush and period write succeed — so an interrupted or
@@ -154,18 +314,24 @@ var serviceRegistry = map[string]serviceEntry{
 	"posterize": {},
 	"portrait": {
 		CustomScalars: []customScalarDef{
-			{"Render cache", "hit_rate_percent", "%", portraitCacheHitPercent},
-			{"Render cache", "operations_per_sec", "/s", portraitCacheOpsRate},
+			scalar("Render cache", "hit_rate_percent", "%", portraitCacheHitPercent),
+			counter("Render cache", "operations", "", portraitCacheOps),
 			// Windowed averages over RecordDistribution histograms:
-			// rate(sum)/rate(count) = mean per request in the window.
-			{"Scene complexity", "avg_spheres_1h", "spheres", `sum(rate(scene_sphere_count_sum[1h]))/sum(rate(scene_sphere_count_count[1h]))`},
-			{"Scene complexity", "avg_lights_1h", "lights", `sum(rate(scene_light_count_sum[1h]))/sum(rate(scene_light_count_count[1h]))`},
+			// rate(sum)/rate(count) = mean per observation in the window.
+			// Requested is every accepted request; rendered is the cache
+			// misses the tracer actually drew.
+			scalar("Scene complexity", "avg_spheres_requested_1h", "spheres", portraitSpheresRequested),
+			scalar("Scene complexity", "avg_spheres_rendered_1h", "spheres", portraitSpheresRendered),
+			scalar("Scene complexity", "avg_lights_requested_1h", "lights", portraitLightsRequested),
+			scalar("Scene complexity", "avg_lights_rendered_1h", "lights", portraitLightsRendered),
 		},
 		CustomTimeseries: map[string]string{
-			"cache_hit_rate":        portraitCacheHitPercent,
-			"cache_operations_rate": portraitCacheOpsRate,
-			"scene_sphere_count":    `sum(rate(scene_sphere_count_sum[5m]))/sum(rate(scene_sphere_count_count[5m]))`,
-			"scene_light_count":     `sum(rate(scene_light_count_sum[5m]))/sum(rate(scene_light_count_count[5m]))`,
+			"cache_hit_rate":          portraitCacheHitPercent,
+			"cache_operations_rate":   `sum(rate(` + portraitCacheOps + `[5m]))`,
+			"scene_spheres_requested": `sum(rate(scene_sphere_count_sum[5m]))/sum(rate(scene_sphere_count_count[5m]))`,
+			"scene_spheres_rendered":  `sum(rate(scene_sphere_count_sum{cache_hit="false"}[5m]))/sum(rate(scene_sphere_count_count{cache_hit="false"}[5m]))`,
+			"scene_lights_requested":  `sum(rate(scene_light_count_sum[5m]))/sum(rate(scene_light_count_count[5m]))`,
+			"scene_lights_rendered":   `sum(rate(scene_light_count_sum{cache_hit="false"}[5m]))/sum(rate(scene_light_count_count{cache_hit="false"}[5m]))`,
 		},
 	},
 }
@@ -174,6 +340,13 @@ var serviceRegistry = map[string]serviceEntry{
 // http_server_* instruments labeled by service_name, so one parameterized
 // query set covers all of them. service is always a registry key, never
 // caller input.
+//
+// Not driven by ?view=. StandardMetrics is a fixed struct whose JSON keys the
+// UI reads by name, and it already carries both forms — RequestsTotal beside
+// RatePerSec — so there is nothing here for a toggle to choose between.
+// RequestsTotal did change: it was sum(x), cumulative since process start, and
+// is now the same windowed count the custom tiles use. The field name is left
+// alone so the UI keeps rendering it while it lives in another repo.
 func standardScalarQueries(service string) []struct {
 	Query string
 	Field func(*StandardMetrics) *float64
@@ -183,7 +356,7 @@ func standardScalarQueries(service string) []struct {
 		Query string
 		Field func(*StandardMetrics) *float64
 	}{
-		{`sum(http_server_requests_total{service_name=` + s + `})`,
+		{`sum(increase(http_server_requests_total{service_name=` + s + `}[` + defaultCounterWindow + `]))`,
 			func(m *StandardMetrics) *float64 { return &m.RequestsTotal }},
 		{`sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`,
 			func(m *StandardMetrics) *float64 { return &m.RatePerSec }},

--- a/domains/platform/apis/prom_proxy/service_handlers.go
+++ b/domains/platform/apis/prom_proxy/service_handlers.go
@@ -88,12 +88,28 @@ func (h *MetricsHandler) GetServiceMetrics(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// An absent view is the default; a present one has to be a view this
+	// package builds queries for. Rejected rather than defaulted, for the
+	// reason the time range is: silently answering a different question than
+	// the one asked is worse than a 400, and a typo in a toggle is invisible
+	// once the number renders.
+	view := DefaultView
+	if raw := r.URL.Query().Get("view"); raw != "" {
+		if !ValidView(raw) {
+			problem := mucks.NewBadRequest("Invalid view. Valid options: count, rate")
+			mucks.JsonError(w, problem)
+			return
+		}
+		view = MetricView(raw)
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
 	response := &ServiceMetricsResponse{
 		Timestamp: time.Now().UTC(),
 		Service:   name,
+		View:      string(view),
 		Custom:    []CustomMetricGroup{},
 	}
 
@@ -111,7 +127,7 @@ func (h *MetricsHandler) GetServiceMetrics(w http.ResponseWriter, r *http.Reques
 	groupIndex := map[string]int{}
 	for _, def := range entry.CustomScalars {
 		value := 0.0
-		resp, err := h.promClient.Query(ctx, def.Query)
+		resp, err := h.promClient.Query(ctx, def.QueryFor(view))
 		if err == nil && len(resp.Data.Result) > 0 {
 			if val, err := extractFloatValue(&resp.Data.Result[0]); err == nil {
 				value = val
@@ -124,9 +140,10 @@ func (h *MetricsHandler) GetServiceMetrics(w http.ResponseWriter, r *http.Reques
 			response.Custom = append(response.Custom, CustomMetricGroup{Title: def.Group})
 		}
 		response.Custom[i].Metrics = append(response.Custom[i].Metrics, CustomMetricValue{
-			Label: def.Label,
-			Value: value,
-			Unit:  def.Unit,
+			Label:      def.Label,
+			Value:      value,
+			Unit:       def.UnitFor(view),
+			Toggleable: def.Toggleable(),
 		})
 	}
 

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -615,4 +615,20 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 		assert.NotRegexp(t, `outcome\s*!=|outcome\s*!~`, query,
 			"timeseries %s selects outcomes by exclusion", key)
 	}
+
+	// Exclusion is not the only way back to a wrong failure line, and the check above only
+	// forbids the one spelling. Reverting to outcome=~"failed|interrupted|lease_lost", or to a
+	// bare sum over index_runs_total with no outcome at all, uses no negation and passes it. So
+	// the set is pinned positively, the way the duration guard pins outcome="completed".
+	failureRate, ok := entry.CustomTimeseries["run_failure_rate"]
+	require.True(t, ok, "one_d4 lost its run_failure_rate timeseries")
+	outcomeMatch := regexp.MustCompile(`outcome=~?"([^"]*)"`).FindStringSubmatch(failureRate)
+	require.NotNil(t, outcomeMatch,
+		"run_failure_rate names no outcome at all, so every run counts as a failure: %s",
+		failureRate)
+	assert.ElementsMatch(t, []string{"failed", "interrupted"},
+		strings.Split(outcomeMatch[1], "|"),
+		"run_failure_rate must name exactly failed|interrupted — lease_lost is ordinary and puts a"+
+			" permanent floor under the line, and anything wider counts healthy runs as"+
+			" failures: %s", failureRate)
 }

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -66,6 +66,81 @@ func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
 // than being flagged.
 var cacheSelectorPattern = regexp.MustCompile(`\bcache_[a-z_]+\b(\{[^}]*\})?`)
 
+// The other shape a selector can take: {__name__=~"a|b",labels}. One
+// expression covering two metric names has to be written this way, which
+// portrait's operations tile now is — a count and a rate form built from one
+// selector over both cache counters.
+var nameMatcherPattern = regexp.MustCompile(`\{[^}]*__name__=~"([^"]*)"[^}]*\}`)
+
+type cacheSelector struct {
+	name   string
+	labels string
+	raw    string
+}
+
+// Every cache_* selector in a query, in either shape. The label block is
+// reported the same way for both, because in both it is the same braces —
+// only where the metric name sits differs.
+//
+// The __name__ form is consumed first and blanked out before the bare-name
+// pattern runs. Without that the names inside the quoted alternation match as
+// if they were bare selectors, and report no labels at all: the check would
+// then fail on the one selector that is in fact fully scoped.
+func cacheSelectorsIn(query string) []cacheSelector {
+	var found []cacheSelector
+	remainder := query
+
+	for _, match := range nameMatcherPattern.FindAllStringSubmatch(query, -1) {
+		for _, name := range strings.Split(match[1], "|") {
+			if !strings.HasPrefix(name, "cache_") {
+				continue
+			}
+			found = append(found, cacheSelector{name: name, labels: match[0], raw: match[0]})
+		}
+		remainder = strings.Replace(remainder, match[0], "{}", 1)
+	}
+
+	for _, loc := range cacheSelectorPattern.FindAllStringSubmatchIndex(remainder, -1) {
+		// A cache_* token followed by '=' is a label name, not a metric name:
+		// scene complexity is labelled cache_hit="false" (#1287), and matching
+		// that would report a selector with no labels and fail every scoping
+		// check below. RE2 has no lookahead, so the position is checked here
+		// rather than in the pattern.
+		//
+		// Narrow on purpose. Skipping anything that merely *contains* a label
+		// matcher would skip the real selectors too, since cache="trace" sits
+		// inside every one of them.
+		if end := loc[1]; end < len(remainder) && remainder[end] == '=' {
+			continue
+		}
+		whole := remainder[loc[0]:loc[1]]
+		labels := ""
+		if loc[2] >= 0 {
+			labels = remainder[loc[2]:loc[3]]
+		}
+		found = append(found, cacheSelector{
+			name:   strings.SplitN(whole, "{", 2)[0],
+			labels: labels,
+			raw:    whole,
+		})
+	}
+	return found
+}
+
+// Every expression a service's entry can produce, scalars in both views plus
+// the timeseries. Counter-derived tiles keep their expression in Counter
+// rather than Query, so a scan of Query alone would silently skip them.
+func allQueriesFor(entry serviceEntry) []string {
+	var queries []string
+	for _, def := range entry.CustomScalars {
+		queries = append(queries, def.AllQueries()...)
+	}
+	for _, query := range entry.CustomTimeseries {
+		queries = append(queries, query)
+	}
+	return queries
+}
+
 // Portrait's cache queries follow the emitter: aura::Cache emits the
 // standard cache family labeled by service and cache, so the bespoke
 // trace_cache_* series no longer exist to be queried. A rename on one side
@@ -78,13 +153,7 @@ func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
 	require.Contains(t, portrait.CustomTimeseries, "cache_hit_rate")
 	require.Contains(t, portrait.CustomTimeseries, "cache_operations_rate")
 
-	var queries []string
-	for _, def := range portrait.CustomScalars {
-		queries = append(queries, def.Query)
-	}
-	for _, query := range portrait.CustomTimeseries {
-		queries = append(queries, query)
-	}
+	queries := allQueriesFor(portrait)
 	require.NotEmpty(t, queries)
 
 	seen := map[string]int{}
@@ -96,14 +165,12 @@ func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
 		// so asserting the query as a whole contains the labels passes while
 		// either half of it is unscoped — and an unscoped half silently sums
 		// every service's caches into portrait's panel.
-		for _, match := range cacheSelectorPattern.FindAllStringSubmatch(query, -1) {
-			name := strings.SplitN(match[0], "{", 2)[0]
-			seen[name]++
-			labels := match[1]
-			assert.Contains(t, labels, `service_name="portrait"`,
-				"selector %q is not scoped to portrait, in %s", match[0], query)
-			assert.Contains(t, labels, `cache="trace"`,
-				"selector %q does not name which cache, in %s", match[0], query)
+		for _, selector := range cacheSelectorsIn(query) {
+			seen[selector.name]++
+			assert.Contains(t, selector.labels, `service_name="portrait"`,
+				"selector %q is not scoped to portrait, in %s", selector.raw, query)
+			assert.Contains(t, selector.labels, `cache="trace"`,
+				"selector %q does not name which cache, in %s", selector.raw, query)
 		}
 	}
 
@@ -123,18 +190,10 @@ func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
 // panel.
 func TestRegistry_EveryCacheQueryNamesItsService(t *testing.T) {
 	for _, name := range serviceOrder {
-		entry := serviceRegistry[name]
-		queries := make([]string, 0, len(entry.CustomScalars)+len(entry.CustomTimeseries))
-		for _, def := range entry.CustomScalars {
-			queries = append(queries, def.Query)
-		}
-		for _, query := range entry.CustomTimeseries {
-			queries = append(queries, query)
-		}
-		for _, query := range queries {
-			for _, match := range cacheSelectorPattern.FindAllStringSubmatch(query, -1) {
-				assert.Contains(t, match[1], "service_name=",
-					"service %q has an unscoped cache selector %q", name, match[0])
+		for _, query := range allQueriesFor(serviceRegistry[name]) {
+			for _, selector := range cacheSelectorsIn(query) {
+				assert.Contains(t, selector.labels, "service_name=",
+					"service %q has an unscoped cache selector %q", name, selector.raw)
 			}
 		}
 	}
@@ -221,7 +280,7 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 		if def == omitted {
 			continue
 		}
-		responses[def.Query] = scalarResponse(fmt.Sprintf("%d", 200+i))
+		responses[def.QueryFor(DefaultView)] = scalarResponse(fmt.Sprintf("%d", 200+i))
 	}
 
 	handler := &MetricsHandler{promClient: &mockPrometheusClient{queryResponses: responses}}
@@ -249,6 +308,10 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 	assert.Equal(t, 106.0, response.Standard.P95DurationMicros)
 	assert.Equal(t, 107.0, response.Standard.ActiveRequests)
 
+	// An unasked-for view is the default, and it is stated rather than left
+	// for the client to assume.
+	assert.Equal(t, string(DefaultView), response.View)
+
 	// Custom groups keep registry order and every descriptor is present.
 	require.Len(t, response.Custom, 3)
 	assert.Equal(t, "Sessions", response.Custom[0].Title)
@@ -256,19 +319,20 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 	assert.Equal(t, "Chat", response.Custom[2].Title)
 	assert.Len(t, response.Custom[0].Metrics, 6)
 	assert.Len(t, response.Custom[1].Metrics, 4)
-	require.Len(t, response.Custom[2].Metrics, 6)
+	require.Len(t, response.Custom[2].Metrics, 5)
 
+	// A gauge: one form, so no toggle offered.
 	assert.Equal(t, CustomMetricValue{Label: "active", Value: 200.0, Unit: "sessions"},
 		response.Custom[0].Metrics[0])
-	assert.Equal(t, CustomMetricValue{Label: "commands_per_sec", Value: 206.0, Unit: "/s"},
+	assert.Equal(t, CustomMetricValue{Label: "commands", Value: 206.0, Toggleable: true},
 		response.Custom[1].Metrics[0])
-	assert.Equal(t, CustomMetricValue{Label: "rejections_per_sec", Value: 208.0, Unit: "/s"},
+	assert.Equal(t, CustomMetricValue{Label: "rejections", Value: 208.0, Toggleable: true},
 		response.Custom[1].Metrics[2])
 	// Chat starts at CustomScalars index 10, so its first value is 200+10.
-	assert.Equal(t, CustomMetricValue{Label: "messages_per_sec", Value: 210.0, Unit: "/s"},
+	assert.Equal(t, CustomMetricValue{Label: "messages", Value: 210.0, Toggleable: true},
 		response.Custom[2].Metrics[0])
 	// The omitted query's descriptor survives with a zero value.
-	last := response.Custom[2].Metrics[5]
+	last := response.Custom[2].Metrics[4]
 	assert.Equal(t, omitted.Label, last.Label)
 	assert.Equal(t, 0.0, last.Value)
 }
@@ -542,7 +606,10 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 
 	labelled := map[string][]string{}
 	for _, def := range entry.CustomScalars {
-		labelled["scalar "+def.Label] = []string{def.Query}
+		// Both views of a toggleable tile. They share a selector, so a scope
+		// or name error appears in both — but reading them from AllQueries is
+		// what keeps the counter tiles in scope at all.
+		labelled["scalar "+def.Label] = def.AllQueries()
 	}
 	for key, query := range entry.CustomTimeseries {
 		labelled["timeseries "+key] = []string{query}
@@ -575,7 +642,7 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 	// than erroring, so the tiles would read zero forever.
 	joined := strings.Join([]string{}, "")
 	for _, def := range entry.CustomScalars {
-		joined += def.Query + "\n"
+		joined += strings.Join(def.AllQueries(), "\n") + "\n"
 	}
 	for _, query := range entry.CustomTimeseries {
 		joined += query + "\n"
@@ -608,8 +675,10 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 	// failure line. It also opts every future outcome in by default: whoever adds a fifth
 	// label gets it counted as a failure without deciding that it is one.
 	for _, def := range entry.CustomScalars {
-		assert.NotRegexp(t, `outcome\s*!=|outcome\s*!~`, def.Query,
-			"scalar %s selects outcomes by exclusion", def.Label)
+		for _, query := range def.AllQueries() {
+			assert.NotRegexp(t, `outcome\s*!=|outcome\s*!~`, query,
+				"scalar %s selects outcomes by exclusion", def.Label)
+		}
 	}
 	for key, query := range entry.CustomTimeseries {
 		assert.NotRegexp(t, `outcome\s*!=|outcome\s*!~`, query,
@@ -631,4 +700,212 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 		"run_failure_rate must name exactly failed|interrupted — lease_lost is ordinary and puts a"+
 			" permanent floor under the line, and anything wider counts healthy runs as"+
 			" failures: %s", failureRate)
+}
+
+// --- The count/rate toggle (#1287) ------------------------------------------
+
+func TestMetricsHandler_GetServiceMetrics_RateViewSelectsTheRateForm(t *testing.T) {
+	entry := serviceRegistry["golf_hub"]
+	responses := map[string]*QueryResponse{}
+	for i, def := range entry.CustomScalars {
+		responses[def.QueryFor(ViewRate)] = scalarResponse(fmt.Sprintf("%d", 300+i))
+	}
+
+	handler := &MetricsHandler{promClient: &mockPrometheusClient{queryResponses: responses}}
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub?view=rate", nil)
+	req.SetPathValue("name", "golf_hub")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetrics(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response ServiceMetricsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "rate", response.View)
+
+	byLabel := map[string]CustomMetricValue{}
+	for _, group := range response.Custom {
+		for _, metric := range group.Metrics {
+			byLabel[metric.Label] = metric
+		}
+	}
+
+	// A unitless counter reads per-second; one with a unit keeps it and gains
+	// the suffix. Both come from the same descriptor, which in the count view
+	// answers "" and "rows".
+	assert.Equal(t, "/s", byLabel["commands"].Unit)
+	assert.Equal(t, "rows/s", byLabel["delivered_rows"].Unit)
+	assert.Equal(t, 306.0, byLabel["commands"].Value)
+
+	// The fixed-form tiles are untouched by the view: a gauge has no rate, and
+	// the windowed mean is already a ratio of two rates.
+	assert.Equal(t, "sessions", byLabel["active"].Unit)
+	assert.False(t, byLabel["active"].Toggleable)
+	assert.Equal(t, "rows", byLabel["catch_up_rows_avg_5m"].Unit)
+	assert.False(t, byLabel["catch_up_rows_avg_5m"].Toggleable)
+}
+
+func TestMetricsHandler_GetServiceMetrics_InvalidViewIsRejected(t *testing.T) {
+	handler := &MetricsHandler{}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub?view=cumulative", nil)
+	req.SetPathValue("name", "golf_hub")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetrics(w, req)
+
+	// Rejected rather than quietly defaulted. "cumulative" is the specific
+	// wrong answer someone will reach for, and defaulting would hand them a
+	// windowed count while they believed they were reading a lifetime total.
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Contains(t, response["detail"], "Invalid view")
+}
+
+// No tile reads a counter cumulatively any more (#1287).
+//
+// sum(x) over a monotonic counter is its value since the process started, so
+// it drops to zero on every deploy and cannot be compared across one. The
+// dashboard read twenty-one tiles that way. increase() answers the same
+// question and survives a restart.
+//
+// Gauges are exempt and have to be: sum(http_server_requests_active_gauge) is
+// the correct form for a level. The rule is about counters, which is what the
+// _total suffix marks.
+func TestRegistry_NoTileReadsACounterCumulatively(t *testing.T) {
+	bareCounterSum := regexp.MustCompile(`sum\(\s*[a-zA-Z_]*_total`)
+
+	check := func(t *testing.T, what, query string) {
+		t.Helper()
+		if !strings.Contains(query, "_total") {
+			return
+		}
+		assert.NotRegexp(t, bareCounterSum, query,
+			"%s sums a counter directly, so it resets on deploy: %s", what, query)
+		assert.True(t,
+			strings.Contains(query, "rate(") || strings.Contains(query, "increase("),
+			"%s reads a _total counter outside any rate() or increase(): %s", what, query)
+	}
+
+	for _, name := range serviceOrder {
+		entry := serviceRegistry[name]
+		for _, def := range entry.CustomScalars {
+			for _, query := range def.AllQueries() {
+				check(t, "scalar "+name+"/"+def.Label, query)
+			}
+		}
+		for key, query := range entry.CustomTimeseries {
+			check(t, "timeseries "+name+"/"+key, query)
+		}
+		for _, q := range standardScalarQueries(name) {
+			check(t, "standard scalar "+name, q.Query)
+		}
+		for key, query := range standardTimeseriesQueries(name) {
+			check(t, "standard timeseries "+name+"/"+key, query)
+		}
+	}
+}
+
+// The standard block's requests tile, pinned as a literal.
+//
+// It is the one converted tile whose JSON key could not change: StandardMetrics
+// is a fixed struct the UI reads by name, and the UI lives in another repo. So
+// requests_total now holds a windowed count under a name that still says total,
+// and only this assertion says which of the two it is.
+func TestStandardQueries_RequestsIsWindowedNotCumulative(t *testing.T) {
+	var requests string
+	for _, q := range standardScalarQueries("golf_hub") {
+		var probe StandardMetrics
+		if q.Field(&probe) == &probe.RequestsTotal {
+			requests = q.Query
+		}
+	}
+	require.NotEmpty(t, requests, "no query maps to RequestsTotal")
+	assert.Equal(t,
+		`sum(increase(http_server_requests_total{service_name="golf_hub"}[5m]))`,
+		requests)
+}
+
+// Counters that answer "has this happened" rather than "how fast" count over a
+// day.
+//
+// Over five minutes an interruption from an hour ago reads zero, and a tile
+// whose whole purpose is to be non-zero after something went wrong disarms
+// itself between the failure and someone looking at it.
+func TestRegistry_AlarmCountersCountOverALongWindow(t *testing.T) {
+	// First, that there is still a distinction to assert. Every check below
+	// compares against alarmWindow, so collapsing that constant onto the
+	// default would leave them all passing while the alarms quietly decayed on
+	// a five-minute clock — the exact regression, invisible to the test
+	// meant to catch it.
+	require.NotEqual(t, defaultCounterWindow, alarmWindow,
+		"the alarm window has collapsed onto the default one")
+
+	alarms := map[string][]string{
+		"one_d4":   {"runs_failed", "runs_interrupted", "runs_lease_lost"},
+		"golf_hub": {"failures"},
+	}
+
+	for service, labels := range alarms {
+		byLabel := map[string]customScalarDef{}
+		for _, def := range serviceRegistry[service].CustomScalars {
+			byLabel[def.Label] = def
+		}
+		for _, label := range labels {
+			def, ok := byLabel[label]
+			require.True(t, ok, "%s lost its %s tile", service, label)
+			require.True(t, def.Toggleable(), "%s/%s stopped being counter-derived", service, label)
+			assert.Equal(t, alarmWindow, def.window(),
+				"%s/%s is an alarm and must not decay inside a five-minute window", service, label)
+			assert.Contains(t, def.QueryFor(ViewCount), "["+alarmWindow+"]")
+		}
+	}
+}
+
+// A toggleable tile's label may not name one of its two forms.
+//
+// The label is what the dashboard prints beside the number. games_indexed_total
+// showing a per-second rate, or commands_per_sec showing a count, is a caption
+// that contradicts the value under it — and it is the exact state the registry
+// was in before the toggle, when the form was fixed at declaration time.
+func TestRegistry_ToggleableLabelsNameNoForm(t *testing.T) {
+	for _, name := range serviceOrder {
+		for _, def := range serviceRegistry[name].CustomScalars {
+			if !def.Toggleable() {
+				continue
+			}
+			assert.NotContains(t, def.Label, "_total",
+				"%s/%s names the count form but also has a rate form", name, def.Label)
+			assert.NotContains(t, def.Label, "_per_sec",
+				"%s/%s names the rate form but also has a count form", name, def.Label)
+		}
+	}
+}
+
+// Every counter tile builds both forms from one selector, and the two differ
+// only by the function wrapping it.
+//
+// Spelling the two expressions out separately in the descriptor is the obvious
+// alternative, and the failure it invites is silent: the count and rate tiles
+// drift onto different label selectors and the toggle starts switching between
+// two different questions rather than two views of one.
+func TestRegistry_BothViewsShareOneSelector(t *testing.T) {
+	for _, name := range serviceOrder {
+		for _, def := range serviceRegistry[name].CustomScalars {
+			if !def.Toggleable() {
+				assert.Equal(t, def.Query, def.QueryFor(ViewRate),
+					"%s/%s is fixed-form but changed under a view", name, def.Label)
+				continue
+			}
+			count := def.QueryFor(ViewCount)
+			rate := def.QueryFor(ViewRate)
+			assert.NotEqual(t, count, rate)
+			assert.Equal(t, strings.Replace(count, "increase(", "rate(", 1), rate,
+				"%s/%s builds its two views from different expressions", name, def.Label)
+			assert.Contains(t, count, def.Counter)
+			assert.Contains(t, rate, def.Counter)
+		}
+	}
 }

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -835,13 +835,22 @@ func TestStandardQueries_RequestsIsWindowedNotCumulative(t *testing.T) {
 // whose whole purpose is to be non-zero after something went wrong disarms
 // itself between the failure and someone looking at it.
 func TestRegistry_AlarmCountersCountOverALongWindow(t *testing.T) {
-	// First, that there is still a distinction to assert. Every check below
-	// compares against alarmWindow, so collapsing that constant onto the
-	// default would leave them all passing while the alarms quietly decayed on
-	// a five-minute clock — the exact regression, invisible to the test
-	// meant to catch it.
-	require.NotEqual(t, defaultCounterWindow, alarmWindow,
-		"the alarm window has collapsed onto the default one")
+	// First, that the window is actually long. Every check below compares
+	// against the alarmWindow constant, so the constant itself is the thing
+	// that has to be pinned — otherwise shrinking it leaves every assertion
+	// comparing against the shrunken value and still passing, which is the
+	// regression these tiles exist to prevent, invisible to the test meant to
+	// catch it.
+	//
+	// A floor rather than "not the default": alarmWindow = "6m" differs from
+	// the default and still fails the purpose, since a failure from an hour
+	// ago has already decayed out of it. An hour is the loosest bound that
+	// still means "someone who looks after the fact sees it".
+	window, err := time.ParseDuration(alarmWindow)
+	require.NoError(t, err, "alarmWindow is not a duration Go can parse: %q", alarmWindow)
+	require.GreaterOrEqual(t, window, time.Hour,
+		"alarmWindow is %s — long enough to differ from the default, too short to still be "+
+			"non-zero when someone reads the dashboard after the failure", alarmWindow)
 
 	alarms := map[string][]string{
 		"one_d4":   {"runs_failed", "runs_interrupted", "runs_lease_lost"},
@@ -908,4 +917,58 @@ func TestRegistry_BothViewsShareOneSelector(t *testing.T) {
 			assert.Contains(t, rate, def.Counter)
 		}
 	}
+}
+
+// The two new JSON keys, asserted on the raw payload rather than through the
+// struct.
+//
+// Every other handler test unmarshals into ServiceMetricsResponse, which means
+// it reads the keys back through the same tags it wrote them with — renaming
+// `json:"view"` to `json:"metric_view"` would keep all of them green while the
+// UI, which lives in another repo and reads by name, silently loses the field.
+// The same reasoning already covers requests_total's *value*; these are the
+// keys it applies to.
+func TestMetricsHandler_GetServiceMetrics_JsonKeysAreStable(t *testing.T) {
+	entry := serviceRegistry["golf_hub"]
+	responses := map[string]*QueryResponse{}
+	for i, def := range entry.CustomScalars {
+		responses[def.QueryFor(DefaultView)] = scalarResponse(fmt.Sprintf("%d", 400+i))
+	}
+
+	handler := &MetricsHandler{promClient: &mockPrometheusClient{queryResponses: responses}}
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub", nil)
+	req.SetPathValue("name", "golf_hub")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetrics(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+	assert.Equal(t, "count", raw["view"], `the response must carry a top-level "view" key`)
+
+	groups, ok := raw["custom"].([]interface{})
+	require.True(t, ok, "custom is not an array")
+	require.NotEmpty(t, groups)
+
+	tiles := map[string]map[string]interface{}{}
+	for _, group := range groups {
+		for _, tile := range group.(map[string]interface{})["metrics"].([]interface{}) {
+			metric := tile.(map[string]interface{})
+			tiles[metric["label"].(string)] = metric
+		}
+	}
+
+	counter, ok := tiles["commands"]
+	require.True(t, ok, "golf_hub lost its commands tile")
+	assert.Equal(t, true, counter["toggleable"],
+		`a counter tile must carry "toggleable": true for the UI to offer the switch`)
+
+	// And the negative half: omitempty means a fixed-form tile has no key at
+	// all, which is what tells the UI not to draw a toggle it cannot honour.
+	gauge, ok := tiles["active"]
+	require.True(t, ok, "golf_hub lost its active tile")
+	_, present := gauge["toggleable"]
+	assert.False(t, present,
+		"a fixed-form tile must omit the key entirely, not send false: %v", gauge)
 }

--- a/domains/platform/libs/futility/otel/BUILD.bazel
+++ b/domains/platform/libs/futility/otel/BUILD.bazel
@@ -1,5 +1,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
+# Read as text by //domains/platform/libs/otel_contract, which pins this rail's
+# latency bucket bounds equal to yodel's and server_pal's.
+exports_files(["otel_provider.h"])
+
 cc_library(
     name = "otel_provider",
     srcs = ["otel_provider.cc"],

--- a/domains/platform/libs/futility/otel/BUILD.bazel
+++ b/domains/platform/libs/futility/otel/BUILD.bazel
@@ -56,6 +56,18 @@ cc_library(
 )
 
 cc_test(
+    name = "otel_provider_test",
+    size = "small",
+    srcs = ["otel_provider_test.cc"],
+    deps = [
+        ":otel_provider",
+        "@googletest//:gtest_main",
+        "@opentelemetry-cpp//exporters/memory:in_memory_metric_data",
+        "@opentelemetry-cpp//exporters/memory:in_memory_metric_exporter_factory",
+    ],
+)
+
+cc_test(
     name = "http_metrics_test",
     size = "small",
     srcs = ["http_metrics_test.cc"],

--- a/domains/platform/libs/futility/otel/otel_provider.cc
+++ b/domains/platform/libs/futility/otel/otel_provider.cc
@@ -6,15 +6,67 @@
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
 #include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h"
 #include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
 #include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
+#include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/sdk/metrics/meter_provider_factory.h"
+#include "opentelemetry/sdk/metrics/view/instrument_selector_factory.h"
+#include "opentelemetry/sdk/metrics/view/meter_selector_factory.h"
+#include "opentelemetry/sdk/metrics/view/view_factory.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/semconv/service_attributes.h"
 
 namespace futility::otel {
+
+namespace {
+
+// The only way to give a histogram explicit bounds in opentelemetry-cpp: the
+// API's CreateUInt64Histogram takes a name and nothing else, so a view on the
+// provider is what turns kHttpLatencyBucketBoundsMicros into the layout the
+// SDK actually aggregates into. Without it every histogram silently gets the
+// millisecond-shaped SDK defaults (#1286).
+//
+// Matched on the name suffix rather than on http_server_request_duration_
+// microseconds alone. MetricsRecorder::RecordLatency appends _microseconds to
+// whatever it is handed and is the only thing in the codebase that produces
+// that suffix, so every instrument it mints has the same unit and the same
+// defect — portrait's trace_request_duration_microseconds sits near a second
+// per render and was capped at the same 10ms as the HTTP family.
+// RecordDistribution keeps the bare name it was given, so scene_sphere_count
+// and its kin are not caught by this and keep the default layout, which is
+// what they want.
+void RegisterLatencyBucketView(opentelemetry::sdk::metrics::MeterProvider& meter_provider) {
+  auto histogram_config =
+      std::make_shared<opentelemetry::sdk::metrics::HistogramAggregationConfig>();
+  histogram_config->boundaries_.assign(kHttpLatencyBucketBoundsMicros.begin(),
+                                       kHttpLatencyBucketBoundsMicros.end());
+
+  auto instrument_selector = opentelemetry::sdk::metrics::InstrumentSelectorFactory::Create(
+      opentelemetry::sdk::metrics::InstrumentType::kHistogram, ".*_microseconds",
+      /*unit=*/"");
+
+  // Empty name/version/schema each match everything: MeterSelector builds
+  // exact-match predicates, and PredicateFactory maps an empty exact pattern
+  // to MatchEverything. It has to match everything here — MetricsRecorder
+  // names its meter after the service, so there is no one meter name to pin.
+  auto meter_selector = opentelemetry::sdk::metrics::MeterSelectorFactory::Create(
+      /*name=*/"", /*version=*/"", /*schema=*/"");
+
+  // Empty view name keeps the instrument's own name (meter.cc only overrides
+  // when the view names something). Renaming the stream here would point every
+  // service's duration series at a name prom_proxy does not query.
+  auto view = opentelemetry::sdk::metrics::ViewFactory::Create(
+      /*name=*/"", "Latency in microseconds, bucketed for 100us to 10s",
+      opentelemetry::sdk::metrics::AggregationType::kHistogram, histogram_config);
+
+  meter_provider.AddView(std::move(instrument_selector), std::move(meter_selector),
+                         std::move(view));
+}
+
+}  // namespace
 
 OtelProvider::OtelProvider(const OtelConfig& config) : metrics_enabled_(config.enable_metrics) {
   if (!config.enable_metrics) {
@@ -56,6 +108,8 @@ OtelProvider::OtelProvider(const OtelConfig& config) : metrics_enabled_(config.e
 
   // Add metric reader to meter provider
   meter_provider->AddMetricReader(std::move(reader));
+
+  RegisterLatencyBucketView(*meter_provider);
 
   // Set global meter provider
   meter_provider_ = std::move(meter_provider);

--- a/domains/platform/libs/futility/otel/otel_provider.cc
+++ b/domains/platform/libs/futility/otel/otel_provider.cc
@@ -21,8 +21,6 @@
 
 namespace futility::otel {
 
-namespace {
-
 // The only way to give a histogram explicit bounds in opentelemetry-cpp: the
 // API's CreateUInt64Histogram takes a name and nothing else, so a view on the
 // provider is what turns kHttpLatencyBucketBoundsMicros into the layout the
@@ -65,8 +63,6 @@ void RegisterLatencyBucketView(opentelemetry::sdk::metrics::MeterProvider& meter
   meter_provider.AddView(std::move(instrument_selector), std::move(meter_selector),
                          std::move(view));
 }
-
-}  // namespace
 
 OtelProvider::OtelProvider(const OtelConfig& config) : metrics_enabled_(config.enable_metrics) {
   if (!config.enable_metrics) {

--- a/domains/platform/libs/futility/otel/otel_provider.h
+++ b/domains/platform/libs/futility/otel/otel_provider.h
@@ -32,6 +32,7 @@
 #include <string>
 
 #include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
 
 namespace futility::otel {
 
@@ -57,6 +58,20 @@ namespace futility::otel {
 inline constexpr std::array<double, 15> kHttpLatencyBucketBoundsMicros = {
     100,   250,    500,    1000,   2500,    5000,    10000,   25000,
     50000, 100000, 250000, 500000, 1000000, 2500000, 10000000};
+
+/// @brief Registers the explicit-bucket view for latency histograms.
+///
+/// Called by OtelProvider's constructor; exposed so a test can drive it
+/// against an in-memory reader. Without a view, opentelemetry-cpp gives every
+/// histogram the SDK's millisecond-shaped defaults, which is #1286 — and the
+/// bucket constant alone cannot pin that, since a constant nothing applies is
+/// exactly the bug.
+///
+/// Matches any histogram whose name ends in `_microseconds`, which is the
+/// suffix MetricsRecorder::RecordLatency appends and nothing else produces.
+/// RecordDistribution keeps its bare name and is deliberately left on the
+/// defaults.
+void RegisterLatencyBucketView(opentelemetry::sdk::metrics::MeterProvider& meter_provider);
 
 /// @brief Configuration for the OpenTelemetry provider.
 struct OtelConfig {

--- a/domains/platform/libs/futility/otel/otel_provider.h
+++ b/domains/platform/libs/futility/otel/otel_provider.h
@@ -26,6 +26,7 @@
 /// Environment Variables:
 /// - OTEL_EXPORTER_OTLP_ENDPOINT: Overrides config.otlp_endpoint if set.
 
+#include <array>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -33,6 +34,29 @@
 #include "opentelemetry/metrics/provider.h"
 
 namespace futility::otel {
+
+/// @brief Explicit bucket boundaries, in microseconds, for latency histograms.
+///
+/// Runs from 100µs to 10s. Registered as an SDK view by OtelProvider, because
+/// opentelemetry-cpp offers no way to pass bounds to CreateUInt64Histogram —
+/// without a view every histogram gets the SDK defaults.
+///
+/// Those defaults (0, 5, 10, ... 10000) are shaped for milliseconds. Every
+/// MetricsRecorder::RecordLatency observation is microseconds, so the top
+/// finite bucket meant 10ms: anything slower landed in +Inf, and
+/// histogram_quantile answers the highest finite bound when the rank lands
+/// there, so p95 read a flat 10000 no matter how slow the service got (#1286).
+/// Confirmed in production on portrait, which was serving at a real p95 near
+/// one second while its tile held steady at 10ms (#1287).
+///
+/// yodel (Java, HttpServerMetrics.BUCKET_BOUNDS) and server_pal (Rust,
+/// HTTP_LATENCY_BUCKET_BOUNDS_MICROS) declare this same set. prom_proxy runs
+/// one histogram_quantile expression across all three languages, which only
+/// compares like with like if the layouts match — so the three move together
+/// or not at all. //domains/platform/libs/otel_contract pins them equal.
+inline constexpr std::array<double, 15> kHttpLatencyBucketBoundsMicros = {
+    100,   250,    500,    1000,   2500,    5000,    10000,   25000,
+    50000, 100000, 250000, 500000, 1000000, 2500000, 10000000};
 
 /// @brief Configuration for the OpenTelemetry provider.
 struct OtelConfig {

--- a/domains/platform/libs/futility/otel/otel_provider_test.cc
+++ b/domains/platform/libs/futility/otel/otel_provider_test.cc
@@ -1,0 +1,182 @@
+#include "domains/platform/libs/futility/otel/otel_provider.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "opentelemetry/exporters/memory/in_memory_metric_data.h"
+#include "opentelemetry/exporters/memory/in_memory_metric_exporter_factory.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
+#include "opentelemetry/sdk/metrics/meter_provider_factory.h"
+
+// The view #1286 turns on, exercised rather than described.
+//
+// //domains/platform/libs/otel_contract pins the three rails' bucket constants
+// equal to each other, but a constant is only half the fix: on this rail
+// nothing applies it except RegisterLatencyBucketView, and a constant nothing
+// applies is precisely the bug that issue is about. Deleting the AddView call,
+// or changing the instrument predicate so it stops matching, would leave the
+// contract test green and put every C++ latency histogram back on the SDK's
+// millisecond defaults.
+//
+// So this drives a real MeterProvider through an in-memory reader and reads
+// the boundaries back off an exported histogram.
+
+namespace futility::otel {
+namespace {
+
+namespace metrics_sdk = opentelemetry::sdk::metrics;
+namespace memory_exporter = opentelemetry::exporter::memory;
+
+constexpr const char* kScope = "otel_provider_test";
+
+class LatencyBucketViewTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    data_ = std::make_shared<memory_exporter::SimpleAggregateInMemoryMetricData>();
+
+    auto provider = metrics_sdk::MeterProviderFactory::Create();
+    provider_ = std::shared_ptr<metrics_sdk::MeterProvider>(provider.release());
+
+    metrics_sdk::PeriodicExportingMetricReaderOptions options;
+    // Long enough that the background thread never races the explicit
+    // ForceFlush below; the flush is what actually drives the export.
+    options.export_interval_millis = std::chrono::milliseconds(60000);
+    options.export_timeout_millis = std::chrono::milliseconds(5000);
+    provider_->AddMetricReader(metrics_sdk::PeriodicExportingMetricReaderFactory::Create(
+        memory_exporter::InMemoryMetricExporterFactory::Create(data_), options));
+  }
+
+  /// Records one observation into a histogram of this name and returns the
+  /// bucket boundaries the SDK actually aggregated it into.
+  std::vector<double> BoundariesFor(const std::string& instrument_name) {
+    auto meter = provider_->GetMeter(kScope, "1.0.0");
+    auto histogram = meter->CreateUInt64Histogram(instrument_name);
+    histogram->Record(1, opentelemetry::context::Context{});
+    provider_->ForceFlush();
+
+    const auto& series = data_->Get(kScope, instrument_name);
+    EXPECT_FALSE(series.empty()) << instrument_name << " exported no data point";
+    if (series.empty()) return {};
+
+    const auto& point = series.begin()->second;
+    const auto* histogram_point =
+        opentelemetry::nostd::get_if<metrics_sdk::HistogramPointData>(&point);
+    EXPECT_NE(histogram_point, nullptr) << instrument_name << " did not export as a histogram";
+    if (histogram_point == nullptr) return {};
+
+    return histogram_point->boundaries_;
+  }
+
+  std::shared_ptr<memory_exporter::SimpleAggregateInMemoryMetricData> data_;
+  std::shared_ptr<metrics_sdk::MeterProvider> provider_;
+};
+
+TEST_F(LatencyBucketViewTest, AMicrosecondsHistogramGetsTheExplicitBounds) {
+  RegisterLatencyBucketView(*provider_);
+
+  const std::vector<double> expected(kHttpLatencyBucketBoundsMicros.begin(),
+                                     kHttpLatencyBucketBoundsMicros.end());
+  EXPECT_EQ(BoundariesFor("http_server_request_duration_microseconds"), expected);
+}
+
+// The suffix match is the whole predicate, so the other instrument that carries
+// it has to be covered by name. portrait's render timing sits near a second and
+// was capped at the same 10ms as the HTTP family until this view existed
+// (#1287) — a predicate narrowed to the http_server_ prefix would pass the test
+// above and silently re-break this one.
+TEST_F(LatencyBucketViewTest, PortraitsRenderTimerIsCoveredByTheSamePredicate) {
+  RegisterLatencyBucketView(*provider_);
+
+  const std::vector<double> expected(kHttpLatencyBucketBoundsMicros.begin(),
+                                     kHttpLatencyBucketBoundsMicros.end());
+  EXPECT_EQ(BoundariesFor("trace_request_duration_microseconds"), expected);
+}
+
+// And the negative half. RecordDistribution keeps whatever bare name it is
+// given, and those instruments count spheres and lights and rows — quantities
+// in the single digits, which a layout starting at 100µs would collapse into
+// one bucket. A predicate widened to "every histogram" passes both tests above
+// and quietly ruins these.
+TEST_F(LatencyBucketViewTest, ADistributionKeepsTheDefaultLayout) {
+  RegisterLatencyBucketView(*provider_);
+
+  const std::vector<double> latency(kHttpLatencyBucketBoundsMicros.begin(),
+                                    kHttpLatencyBucketBoundsMicros.end());
+  const std::vector<double> actual = BoundariesFor("scene_sphere_count");
+
+  EXPECT_FALSE(actual.empty());
+  EXPECT_NE(actual, latency)
+      << "scene_sphere_count was caught by the latency view; a scene with three spheres now "
+         "lands in the same bucket as one with ninety";
+}
+
+// The control that makes the three above mean something: without the view, the
+// microseconds histogram gets the SDK defaults. If this ever starts failing,
+// the SDK changed its defaults and the assertions above may be passing for a
+// reason other than the view.
+TEST_F(LatencyBucketViewTest, WithoutTheViewTheSameInstrumentGetsTheSdkDefaults) {
+  const std::vector<double> latency(kHttpLatencyBucketBoundsMicros.begin(),
+                                    kHttpLatencyBucketBoundsMicros.end());
+  const std::vector<double> actual = BoundariesFor("http_server_request_duration_microseconds");
+
+  EXPECT_FALSE(actual.empty());
+  EXPECT_NE(actual, latency)
+      << "the explicit bounds appeared without RegisterLatencyBucketView being called, so the "
+         "other tests in this file prove nothing about it";
+}
+
+// Everything above drives RegisterLatencyBucketView directly, which leaves the
+// call site itself unpinned: deleting the one line in OtelProvider's
+// constructor puts production back on the SDK defaults with all four of those
+// tests still green. This closes that by going through the constructor and
+// reading the view off the provider it publishes globally.
+TEST(OtelProviderWiringTest, TheConstructorRegistersTheView) {
+  auto data = std::make_shared<memory_exporter::SimpleAggregateInMemoryMetricData>();
+
+  OtelConfig config;
+  config.service_name = "otel_provider_wiring_test";
+  config.enable_metrics = true;
+  // Nothing listens here. The OTLP reader the constructor installs is flushed
+  // alongside ours and fails to connect, which is fine — the export under test
+  // is the in-memory one. A port that refuses immediately keeps that failure
+  // from costing the export timeout.
+  config.otlp_endpoint = "http://127.0.0.1:1/v1/metrics";
+  config.export_interval = std::chrono::seconds(3600);
+
+  OtelProvider provider(config);
+  auto published =
+      std::static_pointer_cast<metrics_sdk::MeterProvider>(provider.GetMeterProvider());
+  ASSERT_NE(published, nullptr);
+
+  metrics_sdk::PeriodicExportingMetricReaderOptions options;
+  options.export_interval_millis = std::chrono::milliseconds(60000);
+  options.export_timeout_millis = std::chrono::milliseconds(1000);
+  published->AddMetricReader(metrics_sdk::PeriodicExportingMetricReaderFactory::Create(
+      memory_exporter::InMemoryMetricExporterFactory::Create(data), options));
+
+  auto meter = published->GetMeter(kScope, "1.0.0");
+  auto histogram = meter->CreateUInt64Histogram("http_server_request_duration_microseconds");
+  histogram->Record(1, opentelemetry::context::Context{});
+  published->ForceFlush();
+
+  const auto& series = data->Get(kScope, "http_server_request_duration_microseconds");
+  ASSERT_FALSE(series.empty()) << "the provider exported no data point";
+  const auto* point =
+      opentelemetry::nostd::get_if<metrics_sdk::HistogramPointData>(&series.begin()->second);
+  ASSERT_NE(point, nullptr);
+
+  const std::vector<double> expected(kHttpLatencyBucketBoundsMicros.begin(),
+                                     kHttpLatencyBucketBoundsMicros.end());
+  EXPECT_EQ(point->boundaries_, expected)
+      << "OtelProvider built a provider without the latency view, so every service on this rail "
+         "is back on the SDK's millisecond defaults (#1286)";
+}
+
+}  // namespace
+}  // namespace futility::otel

--- a/domains/platform/libs/otel_contract/BUILD.bazel
+++ b/domains/platform/libs/otel_contract/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+# Cross-language pins for the metric contract prom_proxy reads. No library and
+# no importable code: the sources under test are Java, C++ and Rust, and the
+# properties pinned here are the ones that only exist between them.
+go_test(
+    name = "otel_contract_test",
+    size = "small",
+    srcs = ["http_latency_buckets_test.go"],
+    # Read as text rather than linked. There is no build configuration in which
+    # a Go test could link all three, and the declaration site is what has to
+    # agree — the constant, not a value some running process reports.
+    data = [
+        "//domains/platform/libs/futility/otel:otel_provider.h",
+        "//domains/platform/libs/server_pal:src/lib.rs",
+        "//domains/platform/libs/yodel:src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java",
+    ],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/domains/platform/libs/otel_contract/http_latency_buckets_test.go
+++ b/domains/platform/libs/otel_contract/http_latency_buckets_test.go
@@ -1,0 +1,136 @@
+// Package otel_contract holds cross-language pins for the metric contract the
+// three emitters share.
+//
+// Nothing imports it. It exists because prom_proxy asks one PromQL question of
+// Java, Rust and C++ services alike, and several of the properties that makes
+// correct are properties no single language's test can see.
+package otel_contract
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Where each rail declares the HTTP latency bucket boundaries, and the pattern
+// that lifts the literal out of it. Paths are relative to this package, which
+// is where rules_go runs the test from; a dropped data dependency shows up as
+// a read error rather than a skipped rail.
+var rails = []struct {
+	name    string
+	path    string
+	pattern *regexp.Regexp
+}{
+	{
+		name:    "yodel (Java)",
+		path:    "../yodel/src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java",
+		pattern: regexp.MustCompile(`BUCKET_BOUNDS\s*=\s*\{([^}]*)\}`),
+	},
+	{
+		name:    "futility/otel (C++)",
+		path:    "../futility/otel/otel_provider.h",
+		pattern: regexp.MustCompile(`kHttpLatencyBucketBoundsMicros\s*=\s*\{([^}]*)\}`),
+	},
+	{
+		name:    "server_pal (Rust)",
+		path:    "../server_pal/src/lib.rs",
+		pattern: regexp.MustCompile(`HTTP_LATENCY_BUCKET_BOUNDS_MICROS\s*:\s*\[f64;\s*\d+\]\s*=\s*\[([^\]]*)\]`),
+	},
+}
+
+var numberPattern = regexp.MustCompile(`\d+(?:\.\d+)?`)
+
+// The layout the three emitters used to share, and the reason #1286 exists:
+// the OTel SDK defaults, which are shaped for milliseconds. Read as
+// microseconds the top bound is 10ms, so every slower request lands in +Inf
+// and histogram_quantile answers a flat 10000 forever.
+var otelSdkMillisecondDefaults = []float64{
+	0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
+}
+
+func boundsFrom(t *testing.T, path string, pattern *regexp.Regexp) []float64 {
+	t.Helper()
+	source, err := os.ReadFile(path)
+	require.NoError(t, err, "cannot read %s — has the data dependency been dropped?", path)
+
+	match := pattern.FindSubmatch(source)
+	require.NotNil(t, match,
+		"no bucket-bounds declaration found in %s. If the constant was renamed, rename it here "+
+			"too: an unparseable rail is one this test stops checking.", path)
+
+	var bounds []float64
+	for _, literal := range numberPattern.FindAllString(string(match[1]), -1) {
+		value, err := strconv.ParseFloat(literal, 64)
+		require.NoError(t, err)
+		bounds = append(bounds, value)
+	}
+	require.NotEmpty(t, bounds, "parsed an empty bucket set out of %s", path)
+	return bounds
+}
+
+// The three emitters declare the same HTTP latency buckets.
+//
+// prom_proxy charts p95 for every service through one histogram_quantile
+// expression, whatever language the service is written in. Quantiles are read
+// off bucket counts, so that expression only compares like with like while the
+// layouts match — one rail widening alone makes its services quietly
+// incomparable to the rest on a chart that still renders.
+//
+// This is the guard #1286 asked for. Before it, the only thing keeping the
+// three aligned was a comment in each asking the next person not to touch it.
+func TestHttpLatencyBucketsMatchAcrossAllThreeEmitters(t *testing.T) {
+	byRail := map[string][]float64{}
+	for _, rail := range rails {
+		byRail[rail.name] = boundsFrom(t, rail.path, rail.pattern)
+	}
+	require.Len(t, byRail, len(rails), "two rails share a name")
+
+	reference := rails[0]
+	want := byRail[reference.name]
+	for _, rail := range rails[1:] {
+		assert.Equal(t, want, byRail[rail.name],
+			"%s and %s declare different HTTP latency buckets. They have to move together — "+
+				"prom_proxy's p95 query spans all three, and a mismatched layout makes those "+
+				"services incomparable on one chart.", reference.name, rail.name)
+	}
+}
+
+// And that the shared layout is the fixed one, not the broken one.
+//
+// Equality alone is satisfied by all three reverting together, which is
+// exactly what a well-meaning "restore the SDK defaults" change would look
+// like. These are the properties that make the layout right for microseconds.
+func TestHttpLatencyBucketsAreShapedForMicroseconds(t *testing.T) {
+	for _, rail := range rails {
+		t.Run(rail.name, func(t *testing.T) {
+			bounds := boundsFrom(t, rail.path, rail.pattern)
+
+			assert.NotEqual(t, otelSdkMillisecondDefaults, bounds,
+				"%s is back on the OTel SDK defaults. Those are millisecond-shaped; this emitter "+
+					"records microseconds, so the top bound means 10ms and p95 pins there (#1286).",
+				rail.name)
+
+			for i := 1; i < len(bounds); i++ {
+				require.Greater(t, bounds[i], bounds[i-1],
+					"%s bounds must ascend: %v then %v", rail.name, bounds[i-1], bounds[i])
+			}
+
+			assert.Positive(t, bounds[0],
+				"%s starts at or below zero, wasting the first bucket on values no duration takes",
+				rail.name)
+
+			// One second in microseconds. portrait was observed serving at a
+			// real p95 near that (#1287) against a 10ms ceiling, so a top bound
+			// below it puts the same class of traffic back in the overflow
+			// bucket that hid the defect the first time.
+			assert.GreaterOrEqual(t, bounds[len(bounds)-1], 1_000_000.0,
+				"%s tops out at %v microseconds, which a slow request will exceed — and "+
+					"histogram_quantile answers the top finite bound when it does",
+				rail.name, bounds[len(bounds)-1])
+		})
+	}
+}

--- a/domains/platform/libs/server_pal/BUILD.bazel
+++ b/domains/platform/libs/server_pal/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 
 # Read as text by //domains/platform/libs/otel_contract, which pins this rail's
 # latency bucket bounds equal to yodel's and futility/otel's.
@@ -14,4 +14,19 @@ rust_library(
     visibility = ["//visibility:public"],
     deps = [
     ] + all_crate_deps(),
+)
+
+# Unit tests compiled into the crate. Covers the view predicate behind #1286 —
+# the bucket constant is pinned by //domains/platform/libs/otel_contract, but a
+# constant nothing selects on is the bug that issue is about.
+#
+# This target is new. lib.rs already carried a #[cfg(test)] module, and without
+# a rust_test nothing ever compiled it, let alone ran it — `cargo test` would
+# have, but CI builds through Bazel. Adding the target is what surfaced that its
+# tower dev-dependency was missing from the graph.
+rust_test(
+    name = "server_pal_test",
+    size = "small",
+    crate = ":server_pal",
+    deps = all_crate_deps(normal_dev = True),
 )

--- a/domains/platform/libs/server_pal/BUILD.bazel
+++ b/domains/platform/libs/server_pal/BUILD.bazel
@@ -1,6 +1,10 @@
 load("@crates//:defs.bzl", "all_crate_deps")
 load("@rules_rust//rust:defs.bzl", "rust_library")
 
+# Read as text by //domains/platform/libs/otel_contract, which pins this rail's
+# latency bucket bounds equal to yodel's and futility/otel's.
+exports_files(["src/lib.rs"])
+
 rust_library(
     name = "server_pal",
     srcs = [

--- a/domains/platform/libs/server_pal/src/lib.rs
+++ b/domains/platform/libs/server_pal/src/lib.rs
@@ -53,6 +53,20 @@ static HTTP_FAILURE: OnceLock<Counter<u64>> = OnceLock::new();
 static HTTP_ACTIVE: OnceLock<UpDownCounter<i64>> = OnceLock::new();
 static HTTP_DURATION: OnceLock<Histogram<f64>> = OnceLock::new();
 
+/// Whether an instrument of this name should get the explicit latency buckets.
+///
+/// A free function rather than an inline condition purely so it can be tested:
+/// `Instrument` has no public constructor, so a test cannot drive the view
+/// closure itself, and the predicate is the half of that closure with a
+/// decision in it.
+///
+/// The suffix is the contract. `RecordLatency`-equivalent instruments end in
+/// `_microseconds` and want a layout reaching 10s; distributions over counts
+/// keep their bare names and want the SDK defaults, which start near zero.
+fn wants_latency_buckets(instrument_name: &str) -> bool {
+    instrument_name.ends_with("_microseconds")
+}
+
 /// Initialise the global OTel meter provider when
 /// OTEL_EXPORTER_OTLP_ENDPOINT is set; a no-op None otherwise. Callers
 /// keep the returned provider alive for the process lifetime — dropping
@@ -112,8 +126,6 @@ pub fn init_otel() -> Option<SdkMeterProvider> {
         }
     };
 
-    // Resource::builder() picks up OTEL_SERVICE_NAME and
-    // OTEL_RESOURCE_ATTRIBUTES via the built-in EnvResourceDetector.
     // Matched on the suffix rather than on the one HTTP instrument name: any
     // histogram whose name says it holds microseconds wants this layout, and
     // pinning the single name would leave the next one to rediscover #1286.
@@ -125,7 +137,7 @@ pub fn init_otel() -> Option<SdkMeterProvider> {
     // silent default-bucket path this exists to eliminate — so it is
     // deliberately not used: a broken constant should be loud.
     let latency_buckets = |i: &Instrument| {
-        if !i.name().ends_with("_microseconds") {
+        if !wants_latency_buckets(i.name()) {
             return None;
         }
         Some(
@@ -139,6 +151,8 @@ pub fn init_otel() -> Option<SdkMeterProvider> {
         )
     };
 
+    // Resource::builder() picks up OTEL_SERVICE_NAME and
+    // OTEL_RESOURCE_ATTRIBUTES via the built-in EnvResourceDetector.
     let provider = SdkMeterProvider::builder()
         .with_reader(PeriodicReader::builder(exporter).build())
         .with_resource(Resource::builder().build())
@@ -395,5 +409,61 @@ mod tests {
             let resp = app.clone().oneshot(make_request()).await.unwrap();
             assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         }
+    }
+}
+
+#[cfg(test)]
+mod latency_bucket_tests {
+    use super::*;
+
+    /// The predicate behind `init_otel`'s view.
+    ///
+    /// `//domains/platform/libs/otel_contract` pins this rail's bucket constant
+    /// equal to the Java and C++ ones, but a constant is only half the fix —
+    /// nothing applies it except the view, and a view whose predicate stops
+    /// matching leaves the constant correct and the histograms on the SDK's
+    /// millisecond defaults, which is #1286 exactly.
+    #[test]
+    fn latency_instruments_are_selected_and_others_are_not() {
+        assert!(wants_latency_buckets(
+            "http_server_request_duration_microseconds"
+        ));
+        // portrait's render timer, on the C++ rail, carries the same suffix and
+        // the same defect; narrowing this to an http_server_ prefix would put
+        // that class of instrument back on the defaults (#1287).
+        assert!(wants_latency_buckets("trace_request_duration_microseconds"));
+
+        // Distributions keep their bare names. Against bounds starting at 100µs
+        // every one of these — spheres, lights, rows — collapses into bucket 0.
+        assert!(!wants_latency_buckets("scene_sphere_count"));
+        assert!(!wants_latency_buckets("chat_catch_up_rows"));
+        assert!(!wants_latency_buckets("http_server_requests_total"));
+
+        // Suffix, not substring. Both of these contain the token and neither
+        // ends with it, so relaxing `ends_with` to `contains` fails here rather
+        // than silently widening the view over instruments it was never meant
+        // to reshape.
+        assert!(!wants_latency_buckets("request_microseconds_histogram"));
+        assert!(!wants_latency_buckets("microseconds_elapsed_total"));
+    }
+
+    /// The constant itself is shaped for microseconds, ascending, and reaches
+    /// far enough that a one-second request is not in the overflow bucket.
+    ///
+    /// otel_contract asserts the same properties by parsing this file as text;
+    /// this asserts them against the compiled value, so a mismatch between what
+    /// the file says and what rustc sees cannot hide.
+    #[test]
+    fn the_bounds_are_ascending_and_reach_ten_seconds() {
+        let bounds = HTTP_LATENCY_BUCKET_BOUNDS_MICROS;
+        assert!(bounds[0] > 0.0);
+        for pair in bounds.windows(2) {
+            assert!(pair[1] > pair[0], "bounds must ascend: {pair:?}");
+        }
+        assert_eq!(*bounds.last().unwrap(), 10_000_000.0);
+        assert!(
+            bounds.iter().any(|b| *b >= 1_000_000.0),
+            "a one-second request must land in a finite bucket"
+        );
     }
 }

--- a/domains/platform/libs/server_pal/src/lib.rs
+++ b/domains/platform/libs/server_pal/src/lib.rs
@@ -11,7 +11,7 @@ use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
 use opentelemetry_otlp::{MetricExporter, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
-use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::metrics::{Aggregation, Instrument, PeriodicReader, SdkMeterProvider, Stream};
 use std::env;
 use std::time::Duration;
 use tokio::net::TcpListener;
@@ -25,6 +25,27 @@ use tower_http::trace::TraceLayer;
 use tower_http::validate_request::ValidateRequestHeaderLayer;
 
 const DEFAULT_PORT: u16 = 8080;
+
+/// Explicit bucket boundaries, in microseconds, for latency histograms —
+/// 100µs to 10s.
+///
+/// Without a view the SDK applies its own defaults (0, 5, 10, ... 10000),
+/// which are shaped for milliseconds. `http_server_request_duration_
+/// microseconds` records microseconds, so that top finite bucket meant 10ms:
+/// every slower request landed in +Inf, and `histogram_quantile` answers the
+/// highest finite bound when the rank falls there, so p95 read a flat 10000
+/// however slow the service actually was (#1286). Seen in production on
+/// portrait at a real p95 near a second (#1287).
+///
+/// yodel (Java, `HttpServerMetrics.BUCKET_BOUNDS`) and futility/otel (C++,
+/// `kHttpLatencyBucketBoundsMicros`) declare this same set. prom_proxy runs one
+/// `histogram_quantile` expression across all three languages, which only
+/// compares like with like if the layouts match — so the three move together or
+/// not at all. `//domains/platform/libs/otel_contract` pins them equal.
+pub const HTTP_LATENCY_BUCKET_BOUNDS_MICROS: [f64; 15] = [
+    100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 25000.0, 50000.0, 100000.0, 250000.0,
+    500000.0, 1000000.0, 2500000.0, 10000000.0,
+];
 
 static HTTP_REQUESTS: OnceLock<Counter<u64>> = OnceLock::new();
 static HTTP_SUCCESS: OnceLock<Counter<u64>> = OnceLock::new();
@@ -93,9 +114,35 @@ pub fn init_otel() -> Option<SdkMeterProvider> {
 
     // Resource::builder() picks up OTEL_SERVICE_NAME and
     // OTEL_RESOURCE_ATTRIBUTES via the built-in EnvResourceDetector.
+    // Matched on the suffix rather than on the one HTTP instrument name: any
+    // histogram whose name says it holds microseconds wants this layout, and
+    // pinning the single name would leave the next one to rediscover #1286.
+    // Nothing here records a non-latency quantity under that suffix.
+    //
+    // build() returns Err only for a malformed stream (unsorted or empty
+    // boundaries), which for a const array is a compile-time-shaped mistake
+    // rather than a runtime one. .ok() therefore reads as "no view" — the
+    // silent default-bucket path this exists to eliminate — so it is
+    // deliberately not used: a broken constant should be loud.
+    let latency_buckets = |i: &Instrument| {
+        if !i.name().ends_with("_microseconds") {
+            return None;
+        }
+        Some(
+            Stream::builder()
+                .with_aggregation(Aggregation::ExplicitBucketHistogram {
+                    boundaries: HTTP_LATENCY_BUCKET_BOUNDS_MICROS.to_vec(),
+                    record_min_max: true,
+                })
+                .build()
+                .expect("HTTP_LATENCY_BUCKET_BOUNDS_MICROS must be a valid histogram layout"),
+        )
+    };
+
     let provider = SdkMeterProvider::builder()
         .with_reader(PeriodicReader::builder(exporter).build())
         .with_resource(Resource::builder().build())
+        .with_view(latency_buckets)
         .build();
 
     opentelemetry::global::set_meter_provider(provider.clone());

--- a/domains/platform/libs/yodel/BUILD.bazel
+++ b/domains/platform/libs/yodel/BUILD.bazel
@@ -1,5 +1,9 @@
 load("//bazel/rules:java.bzl", "artifact", "java_library", "java_test_suite")
 
+# Read as text by //domains/platform/libs/otel_contract, which pins this rail's
+# latency bucket bounds equal to futility/otel's and server_pal's.
+exports_files(["src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java"])
+
 java_library(
     name = "yodel",
     srcs = [

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -27,10 +27,10 @@ import java.util.regex.Pattern;
  *   <li><b>Counters</b> — monotonic totals. The collector's Prometheus exporter appends {@code
  *       _total}, so a counter named {@code games_indexed} is queried as {@code
  *       games_indexed_total}.
- *   <li><b>Distributions</b> — histograms over the same bucket bounds the HTTP duration histogram
- *       uses, exported as {@code _sum}/{@code _count}/{@code _bucket}. A windowed mean is then
- *       {@code rate(x_sum[5m])/rate(x_count[5m])}, which is how portrait — a C++ service, on
- *       futility/otel — reports scene complexity.
+ *   <li><b>Distributions</b> — histograms exported as {@code _sum}/{@code _count}/{@code _bucket},
+ *       over bounds the instrument declares for itself via {@link #defineDistribution}. A windowed
+ *       mean is then {@code rate(x_sum[5m])/rate(x_count[5m])}, which is how portrait — a C++
+ *       service, on futility/otel — reports scene complexity.
  * </ul>
  *
  * <p>Labels are for bounded, low-cardinality dimensions — an outcome, a stage, a motif name. Never
@@ -47,6 +47,23 @@ public final class CustomMetrics {
    * that shows up as an empty chart weeks later rather than as anything a test would catch.
    */
   private static final Pattern VALID_NAME = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+
+  /**
+   * Bounds for a distribution that never declared any: the OTel SDK defaults, spanning 0 to 10000.
+   *
+   * <p>Deliberately <em>not</em> {@link HttpServerMetrics#BUCKET_BOUNDS}. It used to be, back when
+   * that array also held the SDK defaults. #1286 reshaped it for microsecond latency out to 10s,
+   * which is the right layout for request durations and the wrong one for everything else — against
+   * those bounds a distribution over small counts puts every observation in the first bucket, which
+   * is a worse default than what it replaced. Latency is one instrument's concern; this is the
+   * fallback for arbitrary ones, so the two moved apart.
+   *
+   * <p>Still only a fallback, and still not a good one for most instruments — see {@link
+   * #defineDistribution}.
+   */
+  static final double[] DEFAULT_BOUNDS = {
+    0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000
+  };
 
   private final ConcurrentHashMap<Series, LongAdder> counters = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<Series, Distribution> distributions = new ConcurrentHashMap<>();
@@ -74,15 +91,18 @@ public final class CustomMetrics {
   /**
    * Declares the bucket bounds for a distribution, ahead of the first observation.
    *
-   * <p>The default is the set the HTTP latency histogram uses, which tops out at 10ms — a ceiling
-   * that is too low even for the requests it was chosen for (#1286), and hopeless for anything
-   * else. A distribution over minutes, or over counts in the thousands, puts every observation in
-   * the overflow bucket. Declare bounds for any instrument that is not sub-10ms request latency;
-   * treat inheriting this default as a bug rather than a choice. The mean still reads correctly off
-   * {@code _sum}/{@code _count}, so the damage is quiet — fifteen bucket series pinned at zero, and
-   * any quantile over them answering the top bound rather than the truth. {@code
-   * histogram_quantile} falls back to the highest finite bucket when the rank lands in {@code
-   * +Inf}, so the chart shows 10ms forever instead of showing nothing.
+   * <p>The default is {@link #DEFAULT_BOUNDS}, which tops out at 10000 and is a guess about no
+   * instrument in particular. A distribution over minutes, or over counts in the millions, puts
+   * every observation in the overflow bucket; one over single-digit counts puts every observation
+   * in the first two. Declare bounds for anything whose range you know — which is nearly everything
+   * — and treat inheriting this default as a bug rather than a choice.
+   *
+   * <p>The damage from getting it wrong is quiet, which is what makes it worth saying twice. The
+   * mean still reads correctly off {@code _sum}/{@code _count}, so the tile beside the broken one
+   * stays right. What breaks is every quantile: {@code histogram_quantile} falls back to the
+   * highest finite bucket when the rank lands in {@code +Inf}, so the chart answers the top bound
+   * forever rather than showing nothing. That is exactly how #1286 hid in the HTTP histogram until
+   * someone put real traffic through it (#1287).
    *
    * <p>Call before recording. Bounds must be ascending, and a later call for the same name is
    * ignored rather than allowed to reshape a histogram mid-flight — the collector treats bucket
@@ -110,7 +130,7 @@ public final class CustomMetrics {
 
   /** The bounds a distribution will use, whether declared or defaulted. */
   public double[] boundsFor(String name) {
-    return boundsByName.getOrDefault(name, HttpServerMetrics.BUCKET_BOUNDS).clone();
+    return boundsByName.getOrDefault(name, DEFAULT_BOUNDS).clone();
   }
 
   /** Records one observation of {@code name} with no labels. */
@@ -138,7 +158,7 @@ public final class CustomMetrics {
     distributions
         .computeIfAbsent(
             series(name, labels),
-            s -> new Distribution(boundsByName.getOrDefault(name, HttpServerMetrics.BUCKET_BOUNDS)))
+            s -> new Distribution(boundsByName.getOrDefault(name, DEFAULT_BOUNDS)))
         .record(value);
   }
 
@@ -241,9 +261,9 @@ public final class CustomMetrics {
 
     Distribution(double[] bounds) {
       // Held by reference, deliberately: for an undeclared distribution this is the shared
-      // HttpServerMetrics.BUCKET_BOUNDS static, and for a declared one it is the array
-      // boundsByName already owns. Neither escapes — boundsFor and snapshot both copy — and a
-      // clone here would be a third copy no test can distinguish from its absence.
+      // DEFAULT_BOUNDS static, and for a declared one it is the array boundsByName already
+      // owns. Neither escapes — boundsFor and snapshot both copy — and a clone here would be a
+      // third copy no test can distinguish from its absence.
       this.bounds = bounds;
       buckets = new LongAdder[bounds.length + 1];
       for (int i = 0; i < buckets.length; i++) {

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -16,9 +16,10 @@ import java.util.regex.Pattern;
  *
  * <p>Until this existed a Java service could say how many requests it served and nothing about what
  * it did with them, which is why every Java entry in prom_proxy's registry was empty
- * (https://github.com/muchq/MoonBase/issues/1212). The C++ and Rust rails already had the
- * equivalent — futility/otel's counters and server_pal's {@code RecordDistribution} — so this is
- * Java catching up to them rather than a new idea.
+ * (https://github.com/muchq/MoonBase/issues/1212). The C++ rail already had the equivalent —
+ * futility/otel's {@code RecordCounter} and {@code RecordDistribution} — so this is Java catching
+ * up to it rather than a new idea. The Rust rail has not caught up: server_pal exposes only the
+ * HTTP family, which is why mithril and posterize are still empty entries in that same registry.
  *
  * <p>Two instrument kinds, matching what the dashboard can already render:
  *
@@ -28,7 +29,8 @@ import java.util.regex.Pattern;
  *       games_indexed_total}.
  *   <li><b>Distributions</b> — histograms over the same bucket bounds the HTTP duration histogram
  *       uses, exported as {@code _sum}/{@code _count}/{@code _bucket}. A windowed mean is then
- *       {@code rate(x_sum[5m])/rate(x_count[5m])}, which is how portrait reports scene complexity.
+ *       {@code rate(x_sum[5m])/rate(x_count[5m])}, which is how portrait — a C++ service, on
+ *       futility/otel — reports scene complexity.
  * </ul>
  *
  * <p>Labels are for bounded, low-cardinality dimensions — an outcome, a stage, a motif name. Never

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java
@@ -16,17 +16,26 @@ import java.util.concurrent.atomic.LongAdder;
  * (https://github.com/muchq/MoonBase/issues/1212).
  */
 public final class HttpServerMetrics {
-  // The OTel SDK default explicit bucket boundaries. The C++ and Rust emitters
-  // record microseconds against these same defaults, and the dashboard's
-  // histogram_quantile and avg queries are built on them.
+  // Microsecond-shaped bucket boundaries for the HTTP duration histogram,
+  // running from 100µs out to 10s (#1286).
   //
-  // Known wrong, and left wrong deliberately: the defaults are shaped for
-  // milliseconds, so read as microseconds they top out at 10ms and every p95
-  // tile is capped there (#1286). Matching the other two emitters is what keeps
-  // the shared query comparable across languages, so this moves when they do,
-  // not before. Do not "fix" this array on its own.
+  // These replace the OTel SDK defaults, which are shaped for milliseconds:
+  // read as microseconds they topped out at 10ms, so every request slower than
+  // that landed in +Inf and histogram_quantile answered a flat 10000 forever —
+  // observed in production on portrait at a real p95 of ~1s (#1287).
+  //
+  // The C++ (futility/otel) and Rust (server_pal) emitters configure SDK views
+  // with this same set, because prom_proxy's histogram_quantile query is shared
+  // across all three languages and only compares like with like if the layouts
+  // match. //domains/platform/libs/otel_contract pins them equal; if you change
+  // this array, change the other two in the same commit or that test fails.
+  //
+  // Not retroactive: Prometheus keeps the old `le` series, so quantiles over a
+  // window spanning the rollout read from both layouts and are wrong until the
+  // old series age out.
   static final double[] BUCKET_BOUNDS = {
-    0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000
+    100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000, 1000000, 2500000,
+    10000000
   };
 
   private final String serviceName;

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
@@ -175,17 +175,42 @@ public class CustomMetricsTest {
     assertThat(d.bounds()).containsExactly(1_000.0, 1_000_000.0, 60_000_000.0);
     assertThat(d.bucketCounts()).containsExactly(1L, 0L, 1L, 1L);
     assertThat(metrics.boundsFor("run_micros")).containsExactly(1_000.0, 1_000_000.0, 60_000_000.0);
-    assertThat(metrics.boundsFor("undeclared")).isEqualTo(HttpServerMetrics.BUCKET_BOUNDS);
+    assertThat(metrics.boundsFor("undeclared")).isEqualTo(CustomMetrics.DEFAULT_BOUNDS);
+  }
+
+  /**
+   * The fallback for an undeclared distribution is not the HTTP latency layout.
+   *
+   * <p>It was, until #1286 reshaped {@link HttpServerMetrics#BUCKET_BOUNDS} for microseconds out to
+   * 10s. Left aliased, that fix would have quietly made this default worse than what it replaced:
+   * against bounds starting at 100, every distribution over small counts — spheres in a scene,
+   * games in a month, rows in a drain — collapses into bucket 0, and its quantiles go with it.
+   *
+   * <p>Pinned as a non-equality because the failure it guards is someone re-collapsing the two back
+   * into one constant, which reads like a tidy-up and passes every other test in this file.
+   */
+  @Test
+  public void theUndeclaredDefaultIsNotTheHttpLatencyLayout() {
+    assertThat(CustomMetrics.DEFAULT_BOUNDS)
+        .as(
+            "an undeclared distribution must not inherit the HTTP duration histogram's "
+                + "microsecond bounds — those start at 100 and reach 10s, which buckets every "
+                + "small-count instrument into slot 0")
+        .isNotEqualTo(HttpServerMetrics.BUCKET_BOUNDS);
+    assertThat(CustomMetrics.DEFAULT_BOUNDS[0])
+        .as("the generic default has to start low enough to separate single-digit observations")
+        .isLessThan(HttpServerMetrics.BUCKET_BOUNDS[0]);
   }
 
   /**
    * Every array that crosses this class's boundary is a copy, in both directions.
    *
    * <p>The interesting one is the last: an undeclared distribution buckets on {@link
-   * HttpServerMetrics#BUCKET_BOUNDS}, a shared static. If that reference reached a snapshot, one
-   * caller editing what looks like its own result would rebucket the HTTP latency histogram — and
-   * every other undeclared distribution in the process — for the rest of the run. Nothing would
-   * throw; the exported {@code explicitBounds} would simply stop describing the buckets beside it.
+   * CustomMetrics#DEFAULT_BOUNDS}, a shared static. If that reference reached a snapshot, one
+   * caller editing what looks like its own result would rebucket every other undeclared
+   * distribution in the process — in every {@code CustomMetrics} instance, since the array is
+   * static — for the rest of the run. Nothing would throw; the exported {@code explicitBounds}
+   * would simply stop describing the buckets beside it.
    */
   @Test
   public void boundsArraysAreCopiedOnEveryCrossing() {
@@ -213,7 +238,7 @@ public class CustomMetricsTest {
     CustomMetrics other = new CustomMetrics();
     other.record("undeclared", 1);
     other.distributionSnapshot().get(0).bounds()[0] = 999;
-    assertThat(HttpServerMetrics.BUCKET_BOUNDS[0])
+    assertThat(CustomMetrics.DEFAULT_BOUNDS[0])
         .as("the shared default set is not reachable through a snapshot")
         .isNotEqualTo(999.0);
   }
@@ -254,8 +279,8 @@ public class CustomMetricsTest {
   }
 
   private static int indexOfBound(double bound) {
-    for (int i = 0; i < HttpServerMetrics.BUCKET_BOUNDS.length; i++) {
-      if (HttpServerMetrics.BUCKET_BOUNDS[i] == bound) {
+    for (int i = 0; i < CustomMetrics.DEFAULT_BOUNDS.length; i++) {
+      if (CustomMetrics.DEFAULT_BOUNDS[i] == bound) {
         return i;
       }
     }
@@ -268,7 +293,7 @@ public class CustomMetricsTest {
     metrics.record("month_duration_micros", 999_999.0);
 
     long[] buckets = metrics.distributionSnapshot().get(0).bucketCounts();
-    assertThat(buckets[HttpServerMetrics.BUCKET_BOUNDS.length])
+    assertThat(buckets[CustomMetrics.DEFAULT_BOUNDS.length])
         .as("a value past the largest bound must still be counted, not dropped")
         .isEqualTo(1L);
   }

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/HttpServerMetricsTest.java
@@ -61,45 +61,71 @@ public class HttpServerMetricsTest {
   public void durationsLandInUpperInclusiveBuckets() {
     HttpServerMetrics metrics = new HttpServerMetrics("svc", 0L);
     metrics.recordRequestStart("GET");
-    metrics.recordRequestComplete("GET", 200, 5.0); // on the boundary: bucket for <=5
+    metrics.recordRequestComplete("GET", 200, 100.0); // on the boundary: bucket for <=100
     metrics.recordRequestStart("GET");
-    metrics.recordRequestComplete("GET", 200, 6.0); // bucket for <=10
+    metrics.recordRequestComplete("GET", 200, 101.0); // bucket for <=250
     metrics.recordRequestStart("GET");
-    metrics.recordRequestComplete("GET", 200, 20_000.0); // overflow bucket
+    metrics.recordRequestComplete("GET", 200, 20_000_000.0); // 20s: overflow bucket
 
     long[] buckets = metrics.snapshot().get(0).bucketCounts();
     assertThat(buckets).hasSize(HttpServerMetrics.BUCKET_BOUNDS.length + 1);
-    assertThat(buckets[1]).isEqualTo(1); // (0, 5]
-    assertThat(buckets[2]).isEqualTo(1); // (5, 10]
-    assertThat(buckets[buckets.length - 1]).isEqualTo(1); // (10000, +Inf)
+    assertThat(buckets[0]).isEqualTo(1); // [0, 100]
+    assertThat(buckets[1]).isEqualTo(1); // (100, 250]
+    assertThat(buckets[buckets.length - 1]).isEqualTo(1); // (10000000, +Inf)
   }
 
   /**
-   * The HTTP bounds are wrong and may not be fixed here alone (#1286).
+   * The #1286 regression, replayed as the traffic that exposed it (#1287).
    *
-   * <p>They are the OTel SDK defaults, which are shaped for milliseconds; this emitter records
-   * microseconds, so the top bound is 10ms and every p95 tile is capped there. The Rust
-   * (server_pal) and C++ (futility/otel) emitters inherit the same defaults from their SDKs and
-   * record microseconds too, and prom_proxy charts all three through one shared PromQL expression.
-   * Widening Java's array on its own would leave those services answering the same query on a
-   * different bucket layout — a worse state than the one it fixes, and a silent one.
+   * <p>Against the old millisecond-shaped defaults the top finite bound was 10000 — 10ms, read as
+   * microseconds — so both batches below landed in {@code +Inf} together. {@code
+   * histogram_quantile} answers the highest finite bound when the rank falls in the overflow
+   * bucket, so p95 read a flat 10000 whether the service was serving in 8ms or in a second. That is
+   * the whole defect: not a chart that breaks, a chart that lies and holds steady while doing it.
    *
-   * <p>So this test does not assert the bounds are right. It asserts they still match the defaults
-   * the other two emitters get, and fails the moment Java drifts alone.
+   * <p>Asserted as separation rather than as placement. Pinning "the 1s requests are in bucket 12"
+   * passes against any layout that happens to have twelve slots below a second; what has to be true
+   * is that the fast batch and the slow batch land in <em>different, finite</em> buckets, because
+   * that is the only property a quantile can read.
    */
   @Test
-  public void httpBoundsStayMatchedToTheOtherEmittersUntilAllThreeMove() {
-    double[] otelSdkDefaults = {
-      0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000
-    };
+  public void aSecondLongRequestNoLongerFallsOffTheTopOfTheHistogram() {
+    HttpServerMetrics metrics = new HttpServerMetrics("portrait", 0L);
+    // The two batches from #1287: 11 light requests around 8.6ms, 5 heavy ones around 1s.
+    for (int i = 0; i < 11; i++) {
+      metrics.recordRequestStart("POST");
+      metrics.recordRequestComplete("POST", 200, 8_669.5);
+    }
+    for (int i = 0; i < 5; i++) {
+      metrics.recordRequestStart("POST");
+      metrics.recordRequestComplete("POST", 200, 1_000_000.0);
+    }
 
-    assertThat(HttpServerMetrics.BUCKET_BOUNDS)
-        .as(
-            "yodel's HTTP bounds no longer match the OTel SDK defaults that server_pal (Rust) and "
-                + "futility/otel (C++) inherit. If this is the #1286 fix, it has to land in all "
-                + "three emitters together — prom_proxy's p95 query spans them. If it is not, "
-                + "Java services have quietly become incomparable to every other service.")
-        .isEqualTo(otelSdkDefaults);
+    long[] buckets = metrics.snapshot().get(0).bucketCounts();
+    int light = bucketIndexFor(8_669.5);
+    int heavy = bucketIndexFor(1_000_000.0);
+
+    assertThat(heavy)
+        .as("a 1s request must land in a finite bucket, not the overflow slot p95 collapses onto")
+        .isLessThan(HttpServerMetrics.BUCKET_BOUNDS.length);
+    assertThat(light)
+        .as("8.6ms and 1s have to be distinguishable, or no quantile between them can be right")
+        .isLessThan(heavy);
+    assertThat(buckets[light]).isEqualTo(11);
+    assertThat(buckets[heavy]).isEqualTo(5);
+    assertThat(buckets[buckets.length - 1])
+        .as("nothing in a realistic HTTP workload belongs past the top bound")
+        .isZero();
+  }
+
+  /** Upper-inclusive first match, the same rule {@code HttpServerMetrics} buckets by. */
+  private static int bucketIndexFor(double micros) {
+    for (int i = 0; i < HttpServerMetrics.BUCKET_BOUNDS.length; i++) {
+      if (micros <= HttpServerMetrics.BUCKET_BOUNDS[i]) {
+        return i;
+      }
+    }
+    return HttpServerMetrics.BUCKET_BOUNDS.length;
   }
 
   @Test

--- a/scripts/validate-otel-config
+++ b/scripts/validate-otel-config
@@ -52,6 +52,20 @@ fi
 
 echo "otel-collector config dry-run against $IMAGE"
 
+# Pull before anything is timed. `timeout` wraps `docker run`, which pulls on a
+# cold cache — so on a runner without the image a pull slower than WINDOW gets
+# killed at 124, the exact code that means "healthy" here, and the first half
+# passes without the collector ever having parsed the config. The mutant run
+# then finds warm layers, starts, dies on glob, and the negative control passes
+# too. Both halves green having proved nothing, which is the self-validating
+# property failing in the one place it is load-bearing. Today's runner had the
+# image cached; a cold one would not.
+if ! docker pull "$IMAGE" > "$WORK/pull.log" 2>&1; then
+  echo "could not pull $IMAGE — this dry-run cannot prove anything without it" >&2
+  cat "$WORK/pull.log" >&2
+  exit 1
+fi
+
 # Echoes "up" if the collector was still running when the window closed, or
 # "down:<code>" if it exited on its own. A collector that builds its pipelines
 # runs until something stops it, so being killed by the timeout (124) is the


### PR DESCRIPTION
Two commits. The first is the four small follow-ups this PR opened with; the second implements #1287 and is much the larger of the two.

> **Correction to `637ef31`'s commit message.** That message claims the Rust rail could not be compiled in the authoring sandbox. **That is wrong** — `//domains/platform/libs/server_pal:server_pal` builds, and `posterize`'s `rust_test`, which links it, passes. The mistake: an early bazel failure was actually disk exhaustion and got misattributed to `crate_universe` not fetching through the proxy, and a later `cargo check` failure on rustc 1.94.1 vs the workspace's required 1.97.1 is a *host cargo* limitation that has nothing to do with the build, since bazel uses rules_rust's own pinned toolchain. The commit message is left as pushed rather than force-rewritten under a running CI job; this note is the correction. Everything below reflects what was actually verified.

---

# Commit 2 — #1287 (`637ef31`)

Three of that issue's four sections. §3 is a deploy roll, not code.

## §1 — the histogram buckets

This is #1286's fix, landing in all three rails at once because prom_proxy runs one `histogram_quantile` expression across Java, Rust and C++ services and it only compares like with like when the bucket layouts match.

Every emitter recorded **microseconds** into the OTel SDK's default bounds, which are shaped for **milliseconds**. The top finite bound therefore meant 10ms; anything slower landed in `+Inf`; and `histogram_quantile` answers the highest finite bound when the rank falls there. So p95 read a flat `10000` forever, and held steady while doing it — #1287 caught it in production on portrait at a real p95 near a second.

New layout is 100µs → 10s. Java sets its array directly. **C++ and Rust had no bounds mechanism at all** — neither SDK lets you pass boundaries to the histogram factory — so both now register views. Both match on the `_microseconds` suffix rather than the single HTTP instrument name: `RecordLatency` appends that suffix to whatever it is handed and is the only producer of it, so portrait's `trace_request_duration_microseconds` had exactly the same defect and the same 10ms cap. `RecordDistribution` keeps its bare name and is deliberately not caught.

**A consequence worth calling out.** yodel's `CustomMetrics` fell back to `HttpServerMetrics.BUCKET_BOUNDS` for undeclared distributions. Reshaping that array for microsecond latency would have quietly made the fallback *worse* than what it replaced — against bounds starting at 100, every distribution over small counts collapses into bucket 0. `CustomMetrics.DEFAULT_BOUNDS` now holds the old SDK defaults, and a test pins the two as **not** equal, since re-merging them reads like a tidy-up and would pass every other test in the file.

`//domains/platform/libs/otel_contract` is the drift guard #1286 asked for. It reads the declaration out of all three sources and asserts they match — and separately that the shared layout is microsecond-shaped rather than the SDK defaults, because equality alone is satisfied by all three reverting together.

## §2 — scene complexity measured renders, not requests

`tracer_service.cc` returned on a cache hit before reaching the `RecordDistribution` calls, so `avg_spheres_1h` was a mean over *renders* under a label that read like a mean over *requests* — drifting further from offered load as the hit rate climbed. At portrait's observed 50% hit rate the panel described half the traffic.

Both paths now record, labelled by `cache_hit`, matching what `RecordLatency` already did in the same function. The registry splits the tiles into `requested` and `rendered` so both readings exist and are named.

The test uses a workload whose two means actually differ — 8 spheres over 4 requests (2.0) against 6 over 2 renders (3.0). #1287 notes that its own first batch couldn't separate the readings, since 33/11 and 9/3 are both 3.0; a test built on a homogeneous workload would have the same blind spot.

## §4 — count/rate toggle on counter tiles

`?view=count|rate`. A descriptor now carries a bare selector and the proxy wraps it in `increase()` or `rate()`, so the two forms cannot drift onto different series. Four counters that spent two tiles each on one series collapse to one.

**Cumulative is not offered.** `sum(x)` resets when its process does, so it reads low after every deploy — which is §3 of that same issue, an image that hadn't rolled. The 21 tiles that read that way are now `increase()` over a window.

Three alarm counters — `runs_failed`, `runs_interrupted`, `runs_lease_lost` — plus chat `failures` count over **24h** instead of 5m. A tile whose purpose is to be non-zero after something went wrong must not disarm itself between the failure and someone looking at the dashboard.

`StandardMetrics` is not view-driven: its JSON keys are a fixed struct the UI reads by name, and it already carries both forms. `requests_total` did convert to a windowed count, keeping its name so the UI — which lives in another repo — keeps rendering it. A golden-string test is the only thing that now says which of the two that field holds.

## Verification

- **Six mutation checks, all killed**: `alarmWindow` collapsed onto the default; the count form switched to `rate`; `requests_total` reverted to cumulative; and one bound altered in *each* of the three rails, to prove the contract test genuinely reads all three rather than passing on a parse failure.
- The alarm-window test was **vacuous** in its first form — collapsing the constant left every assertion comparing against the collapsed value and still passing. Strengthened before the mutation would kill it.
- **`scripts/diff-build origin/main`: 44/44 pass**, covering prom_proxy, yodel, otel_contract, portrait, posterize, mithril, aura, futility/otel, one_d4 and mcpserver.
- **All three rails compile, Rust included.** `server_pal` builds to an rlib and `posterize:test_posterize` links and passes against it. See the correction at the top — an earlier draft of this description claimed otherwise.
- **No review panel ran against this commit.**

---

# Commit 1 — #1285 re-review follow-ups (`9128c9f`)

Four things, none of which blocked #1285 — three are cursor[bot]'s remaining non-blocking items from the re-review at `5bd7e68`, which arrived after that PR had merged; the fourth is a doc error found while looking at them.

**The dry-run could pass without validating anything.** `run_collector` wraps `docker run` in `timeout`, and `docker run` pulls on a cold cache. On a runner without the image, a pull slower than `WINDOW` gets killed at **124** — the exact code that here means *"the collector stayed up"*. The positive half then passes having never parsed the config; the mutant run that follows finds warm layers, starts, dies on `glob`, and the negative control passes too. Both halves green, nothing proved — the self-validating property failing in the one place it is load-bearing. The pull now happens once, before anything is timed, and a failed pull exits non-zero. *This is the one change here that could not be exercised locally: docker client, no daemon.*

**Mount-point excludes were unanchored.** filterset's `regexp` matcher is Go's `MatchString`, which looks for the pattern anywhere in the string, so `/dev/.*` also excluded `/mnt/dev/data` — a real volume silently dropped off the usage panel. Anchored with `^` and pinned by `TestMountPointExcludesAreAnchored`, which fatals if it finds no patterns at all so it cannot pass by matching nothing.

**`run_failure_rate` was pinned only against exclusion.** The check forbade `outcome!=` and `outcome!~`, leaving two routes back to a wrong failure line that use no negation: widening to `failed|interrupted|lease_lost`, or dropping the selector for a bare total. The set is now asserted positively.

**`RecordDistribution` was attributed to the wrong language.** `CustomMetrics`' javadoc had it as server_pal's; it is futility/otel's, the same C++ library as the counters named beside it. The sentence also claimed the Rust rail already had the equivalent, and it does not — which is why `mithril` and `posterize` are still empty registry entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012URbCariWNbKb58XsrQtSA