### PR TITLE
Fix lost LISTEN/NOTIFY wakeup that hung TwoInstancesShareOneGame (#1276)

### DIFF
--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -317,10 +317,13 @@ cc_library(
 # skips otherwise.
 cc_test(
     name = "pg_hub_e2e_test",
-    # Small on purpose: the 60s stall on TwoInstancesShareOneGame
-    # (#1241, #1276) is a lost wakeup, not marginal slowness — normal
-    # runtime is ~2s. The tight ceiling turns a recurrence into a loud
-    # red instead of a quietly slow pass; do not raise it.
+    # Small on purpose (#1241, #1276): normal runtime is ~2s; the tight
+    # ceiling turns a recurrence into a loud red. Two independent hang
+    # shapes share the signature — a lost LISTEN/NOTIFY wakeup (fixed in
+    # pg::Listener) and a TearDown End() deadlock when unread wake
+    # frames pin the async delivery chain (worked around here by
+    # QuiesceCrossTable; root cause is send-before-receive ordering in
+    # smithy-cpp). Do not raise the ceiling.
     size = "small",
     srcs = [
         "pg_hub_e2e_test.cc",

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -317,10 +317,10 @@ cc_library(
 # skips otherwise.
 cc_test(
     name = "pg_hub_e2e_test",
-    # Small on purpose, even after the one-off 60s stall observed on
-    # #1241 (never reproduced across 40 local runs on postgres 16 and
-    # 18; the whole suite runs in ~2s): the tight ceiling is what turns
-    # a recurrence into a loud red instead of a quietly slow pass.
+    # Small on purpose: the 60s stall on TwoInstancesShareOneGame
+    # (#1241, #1276) is a lost wakeup, not marginal slowness — normal
+    # runtime is ~2s. The tight ceiling turns a recurrence into a loud
+    # red instead of a quietly slow pass; do not raise it.
     size = "small",
     srcs = [
         "pg_hub_e2e_test.cc",

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -305,47 +305,55 @@ void HubHandler::AttachListener(pg::Listener* listener) {
 }
 
 void HubHandler::OnNotify(const std::string& channel, const std::string& payload) {
+  WakeChannel(channel, payload, /*from_active=*/false);
+}
+
+void HubHandler::OnChannelActive(const std::string& channel) {
+  WakeChannel(channel, /*payload=*/"", /*from_active=*/true);
+}
+
+void HubHandler::WakeChannel(const std::string& channel, const std::string& payload,
+                             bool from_active) {
   constexpr std::string_view kChatPrefix = "chat_";
   if (absl::StartsWith(channel, kChatPrefix)) {
     // Own wakes pump too, deliberately: the cursor makes it a no-op in
     // the common case, and it is what recovers an append whose
-    // connection died between COMMIT and the reply.
+    // connection died between COMMIT and the reply. Active has no
+    // payload, so the own-instance filter never applies here.
     PumpChat(std::string(channel.substr(kChatPrefix.size())));
     return;
   }
-  if (payload == instance_id_) return;  // our own commit; locals already heard it
+  // Notify echoes of our own commit are skipped; locals already heard
+  // them. Active signals carry no instance id — always a catch-up.
+  if (!from_active && payload == instance_id_) return;
   constexpr std::string_view kPrefix = "room_";
   if (!absl::StartsWith(channel, kPrefix)) return;
-  const std::string room_id = channel.substr(kPrefix.size());
-  Outbox outbox;
+  // Notify always re-projects (wake contract). Active only projects when
+  // rows moved — reconnect re-LISTENs every room and must not flood.
+  CatchUpRoom(std::string(channel.substr(kPrefix.size())), /*project_always=*/!from_active);
+}
+
+void HubHandler::CatchUpRoom(const std::string& room_id, bool project_always) {
   {
     const std::lock_guard<std::mutex> lock(mu_);
     // Only rooms we hold: a stale wake for a dropped room must not
     // resurrect it (join is the one path that materializes rooms).
     if (!rooms_.contains(room_id)) return;
-    RefreshRoomLocked(room_id, outbox);
   }
-  Deliver(outbox);
-}
-
-void HubHandler::OnChannelActive(const std::string& channel) {
-  // Rows committed while we were not subscribed queued no notification.
-  // Chat heals from its cursor; rooms re-read and re-project like a wake
-  // (#1276) — the notify-only path is not enough around (re)LISTEN.
-  constexpr std::string_view kChatPrefix = "chat_";
-  if (absl::StartsWith(channel, kChatPrefix)) {
-    PumpChat(std::string(channel.substr(kChatPrefix.size())));
+  // Off mu_: reconnect fires this once per room on the poll thread; holding
+  // the lock across Flush+LoadRoom would stall every move/chat/join for
+  // the whole burst. Same shape as PumpChat.
+  store_->Flush();
+  auto rows = store_->LoadRoom(room_id);
+  if (!rows.ok()) {
+    LOG(WARNING) << "room " << room_id << " catch-up failed: " << rows.status();
     return;
   }
-  constexpr std::string_view kPrefix = "room_";
-  if (!absl::StartsWith(channel, kPrefix)) return;
-  const std::string room_id = channel.substr(kPrefix.size());
   Outbox outbox;
   {
     const std::lock_guard<std::mutex> lock(mu_);
-    // Same membership guard as OnNotify: never materialize from a wake.
     if (!rooms_.contains(room_id)) return;
-    RefreshRoomLocked(room_id, outbox);
+    ReconcileRoomLocked(room_id, *rows, outbox, project_always);
   }
   Deliver(outbox);
 }
@@ -353,7 +361,8 @@ void HubHandler::OnChannelActive(const std::string& channel) {
 void HubHandler::RefreshRoomLocked(const std::string& room_id, Outbox& outbox) {
   // The flush means this read can never be older than our own truth;
   // holding mu_ across it means nothing local moves in between. The
-  // writer thread needs no lock we hold, so it drains freely.
+  // writer thread needs no lock we hold, so it drains freely. Join uses
+  // this path to materialize; notify/active use CatchUpRoom instead.
   store_->Flush();
   auto rows = store_->LoadRoom(room_id);
   if (!rows.ok()) {
@@ -361,15 +370,15 @@ void HubHandler::RefreshRoomLocked(const std::string& room_id, Outbox& outbox) {
     LOG(WARNING) << "room " << room_id << " refresh failed: " << rows.status();
     return;
   }
-  ReconcileRoomLocked(room_id, *rows, outbox);
+  ReconcileRoomLocked(room_id, *rows, outbox, /*project_always=*/true);
 }
 
-void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore::RoomRows& rows,
-                                     Outbox& outbox) {
+bool HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore::RoomRows& rows,
+                                     Outbox& outbox, bool project_always) {
   if (!rows.exists) {
     // Deleted by another instance; nothing local can outrank that.
     const auto room = rooms_.find(room_id);
-    if (room == rooms_.end()) return;
+    if (room == rooms_.end()) return false;
     for (const auto& [member_id, member] : room->second.members) {
       if (auto it = player_room_.find(member_id);
           it != player_room_.end() && it->second == room_id) {
@@ -384,7 +393,7 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
     chat_store_->DropRoom(room_id);
     chat_cursors_.erase(room_id);
     UnlistenRoomLocked(room_id);
-    return;
+    return true;
   }
 
   const bool materialized = !rooms_.contains(room_id);
@@ -394,6 +403,8 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
   // no member exists locally yet, so no append can commit behind it and
   // then be stepped over — the adoption race a wake-time seed would have.
   if (materialized) SeedChatCursorLocked(room_id);
+
+  bool changed = materialized;
 
   // Members mirror the rows: every instance writes its own players'
   // rows, and the refresh flush made ours current.
@@ -407,8 +418,23 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
     members.emplace(row.player_id, member);
     player_room_[row.player_id] = room_id;
   }
+  if (members.size() != room.members.size()) {
+    changed = true;
+  } else {
+    for (const auto& [id, member] : members) {
+      const auto prior = room.members.find(id);
+      if (prior == room.members.end() || prior->second.connected != member.connected ||
+          prior->second.games_played != member.games_played ||
+          prior->second.games_won != member.games_won ||
+          prior->second.total_score != member.total_score) {
+        changed = true;
+        break;
+      }
+    }
+  }
   for (const auto& [member_id, member] : room.members) {
     if (members.contains(member_id)) continue;
+    changed = true;
     if (auto it = player_room_.find(member_id); it != player_room_.end() && it->second == room_id) {
       player_room_.erase(it);
       player_game_.erase(member_id);
@@ -433,10 +459,12 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
       if (row.state.has_value()) entry.state.emplace(*row.state);
       for (const std::string& member_id : entry.roster) player_game_[member_id] = row.game_id;
       room.games.emplace(row.game_id, std::move(entry));
+      changed = true;
       continue;
     }
     GameEntry& entry = game->second;
     if (row.version <= entry.version) continue;  // ours is current
+    changed = true;
     for (const std::string& member_id : entry.roster) {
       // A member the new roster dropped left the game remotely.
       if (std::find(row.roster.begin(), row.roster.end(), member_id) == row.roster.end()) {
@@ -457,6 +485,7 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
       ++game;
       continue;
     }
+    changed = true;
     // Deleted remotely: a disbanded lobby or a finished game's cleanup.
     for (const std::string& member_id : game->second.roster) {
       if (auto it = player_game_.find(member_id);
@@ -467,10 +496,13 @@ void HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
     game = room.games.erase(game);
   }
 
-  // The wake contract: re-read, then re-project — local viewers get
-  // current views whether or not anything above changed.
-  for (const auto& [game_id, entry] : room.games) StageGameViewsLocked(game_id, entry, outbox);
-  StageRoomStateLocked(room_id, outbox);
+  // Notify wake contract: always re-project. Active catch-up: only when
+  // something moved, so a no-op reconnect does not fill session queues.
+  if (changed || project_always) {
+    for (const auto& [game_id, entry] : room.games) StageGameViewsLocked(game_id, entry, outbox);
+    StageRoomStateLocked(room_id, outbox);
+  }
+  return changed;
 }
 
 void HubHandler::DropGameLocked(const GameRef& ref) {

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -329,13 +329,25 @@ void HubHandler::OnNotify(const std::string& channel, const std::string& payload
 }
 
 void HubHandler::OnChannelActive(const std::string& channel) {
-  // Only chat needs the signal: a room wake re-reads everything anyway,
-  // but chat delivery is cursor-driven, and rows committed while we were
-  // not subscribed queued no notification for us.
+  // Rows committed while we were not subscribed queued no notification.
+  // Chat heals from its cursor; rooms re-read and re-project like a wake
+  // (#1276) — the notify-only path is not enough around (re)LISTEN.
   constexpr std::string_view kChatPrefix = "chat_";
   if (absl::StartsWith(channel, kChatPrefix)) {
     PumpChat(std::string(channel.substr(kChatPrefix.size())));
+    return;
   }
+  constexpr std::string_view kPrefix = "room_";
+  if (!absl::StartsWith(channel, kPrefix)) return;
+  const std::string room_id = channel.substr(kPrefix.size());
+  Outbox outbox;
+  {
+    const std::lock_guard<std::mutex> lock(mu_);
+    // Same membership guard as OnNotify: never materialize from a wake.
+    if (!rooms_.contains(room_id)) return;
+    RefreshRoomLocked(room_id, outbox);
+  }
+  Deliver(outbox);
 }
 
 void HubHandler::RefreshRoomLocked(const std::string& room_id, Outbox& outbox) {

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -148,9 +148,9 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// The listener's channel-active target; runs on the listener's
   /// thread. Fired on first LISTEN and again after every reconnect's
   /// re-LISTEN — the "you may have missed notifications" signal.
-  /// Chat channels pump from the cursor; room channels refresh like a
-  /// wake (#1276), because rows committed while we were not subscribed
-  /// queued no notification for us.
+  /// Chat channels pump from the cursor; room channels catch up with a
+  /// re-read (#1276) but only re-project when rows actually moved, so a
+  /// reconnect across many rooms does not flood session queues.
   void OnChannelActive(const std::string& channel);
 
  private:
@@ -311,13 +311,27 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
                            const std::optional<golf::GameState>& state,
                            const std::vector<HubStore::StatsDelta>* finish);
 
+  /// Shared chat/room dispatch for OnNotify and OnChannelActive.
+  /// `from_active` skips the own-instance filter (active has no payload)
+  /// and uses change-gated projection for rooms so reconnect catch-up
+  /// does not re-fan identical state.
+  void WakeChannel(const std::string& channel, const std::string& payload, bool from_active);
+
+  /// Notify/active catch-up for a held room: Flush+LoadRoom off mu_
+  /// (PumpChat's pattern), then reconcile under the lock. Keeps the
+  /// listener poll thread from holding mu_ across DB round trips on a
+  /// reconnect storm.
+  void CatchUpRoom(const std::string& room_id, bool project_always);
+
   /// The wake handler's body: flush our own queue (so the read is never
   /// older than local truth), re-read the room's rows, reconcile, and
   /// re-project views to local members. Also the join path's fallback —
   /// it materializes a room another instance created. Callers hold mu_.
   void RefreshRoomLocked(const std::string& room_id, Outbox& outbox);
-  void ReconcileRoomLocked(const std::string& room_id, const HubStore::RoomRows& rows,
-                           Outbox& outbox);
+  /// Returns whether local membership/games changed. When
+  /// `project_always` is false, skips re-project on a no-op catch-up.
+  bool ReconcileRoomLocked(const std::string& room_id, const HubStore::RoomRows& rows,
+                           Outbox& outbox, bool project_always = true);
   /// Erases the game and its player mappings without any events — for
   /// games the database says no longer exist.
   void DropGameLocked(const GameRef& ref);

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -146,10 +146,11 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   void OnNotify(const std::string& channel, const std::string& payload);
 
   /// The listener's channel-active target; runs on the listener's
-  /// thread. A chat channel becoming active (first LISTEN, or re-LISTEN
-  /// after a reconnect) pumps that room: anything committed while we
-  /// were not subscribed never queued a notification, so the cursor
-  /// read is the only thing that closes the gap.
+  /// thread. Fired on first LISTEN and again after every reconnect's
+  /// re-LISTEN — the "you may have missed notifications" signal.
+  /// Chat channels pump from the cursor; room channels refresh like a
+  /// wake (#1276), because rows committed while we were not subscribed
+  /// queued no notification for us.
   void OnChannelActive(const std::string& channel);
 
  private:

--- a/domains/games/apis/golf_hub/hub_store_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_store_race_test.cc
@@ -181,6 +181,45 @@ class HubStoreRaceFixture : public GolfHubStreamFixture {
   std::shared_ptr<GatedHubStore> gated_store_ = std::make_shared<GatedHubStore>();
 };
 
+// Room catch-up on channel-active (#1276): rows committed while an
+// instance was not subscribed queued no notification; the active signal
+// must re-read and re-project like a wake — same contract as chat's
+// ActiveSignalHealsAMissedNotify.
+TEST_F(HubStoreRaceFixture, ActiveSignalRefreshesHeldRoom) {
+  auto remote = BuildInstance();
+  ASSERT_NE(remote, nullptr);
+  auto alice = OpenSeat();
+  auto bob = OpenSeatVia(*remote->client);
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+                  [&] { return ReceiveCase(alice->stream, "sessionReady"); }, remote.get())
+                  .has_value());
+  ASSERT_TRUE(ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+                  [&] { return ReceiveCase(bob->stream, "sessionReady"); }, remote.get())
+                  .has_value());
+
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+      [&] { return ReceiveCase(alice->stream, "roomState"); }, remote.get());
+  ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
+
+  moonbase::golf::JoinRoom join_room;
+  join_room.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join_room)).ok());
+  ASSERT_TRUE(ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+                  [&] { return ReceiveCase(bob->stream, "roomState"); }, remote.get())
+                  .has_value());
+
+  // No OnNotify: the active signal alone must carry bob onto alice's
+  // projection the way a missed wake would after (re)LISTEN.
+  handler_->OnChannelActive(RoomChannel(room_id));
+  auto refreshed = ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+      [&] { return ReceiveCase(alice->stream, "roomState"); }, remote.get());
+  ASSERT_TRUE(refreshed.has_value());
+  EXPECT_EQ(refreshed->as_roomState_or_null()->players.size(), 2u);
+}
+
 TEST_F(HubStoreRaceFixture, DelayedFinishWakeReadsRetainedTerminalRow) {
   auto remote = BuildInstance();
   ASSERT_NE(remote, nullptr);

--- a/domains/games/apis/golf_hub/hub_store_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_store_race_test.cc
@@ -220,6 +220,39 @@ TEST_F(HubStoreRaceFixture, ActiveSignalRefreshesHeldRoom) {
   EXPECT_EQ(refreshed->as_roomState_or_null()->players.size(), 2u);
 }
 
+// Membership guard on room active: never materialize from a catch-up.
+TEST_F(HubStoreRaceFixture, ActiveSignalForUnheldRoomIsIgnored) {
+  auto remote = BuildInstance();
+  ASSERT_NE(remote, nullptr);
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+                  [&] { return ReceiveCase(alice->stream, "sessionReady"); }, remote.get())
+                  .has_value());
+  ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+      [&] { return ReceiveCase(alice->stream, "roomState"); }, remote.get());
+  ASSERT_TRUE(created.has_value());
+  const std::string room_id = created->as_roomState_or_null()->roomId;
+
+  // Remote never materialized this room; a phantom channel is not a room.
+  remote->handler->OnChannelActive(RoomChannel(room_id));
+  remote->handler->OnChannelActive(RoomChannel("never-existed"));
+
+  // Primary stays healthy and can still host a join the ordinary way.
+  auto bob = OpenSeatVia(*remote->client);
+  ASSERT_TRUE(bob.has_value());
+  ASSERT_TRUE(ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+                  [&] { return ReceiveCase(bob->stream, "sessionReady"); }, remote.get())
+                  .has_value());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveWithin<std::optional<moonbase::golf::GolfEvents>>(
+                  [&] { return ReceiveCase(bob->stream, "roomState"); }, remote.get())
+                  .has_value());
+}
+
 TEST_F(HubStoreRaceFixture, DelayedFinishWakeReadsRetainedTerminalRow) {
   auto remote = BuildInstance();
   ASSERT_NE(remote, nullptr);

--- a/domains/games/apis/golf_hub/pg_chat_store_test.cc
+++ b/domains/games/apis/golf_hub/pg_chat_store_test.cc
@@ -164,7 +164,8 @@ TEST_F(PgChatStoreTest, MigrationIsIdempotentAndDefinesTheContract) {
 TEST_F(PgChatStoreTest, AppendCommitsARowAndNotifiesItsChatChannel) {
   Received received;
   pg::Listener listener(
-      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); });
+      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); },
+      /*on_active=*/nullptr);
   listener.Listen(golf_hub::ChatChannel("R1"));
   ConfirmSubscribed(golf_hub::ChatChannel("R1"), received);
 
@@ -190,7 +191,8 @@ TEST_F(PgChatStoreTest, AppendCommitsARowAndNotifiesItsChatChannel) {
 TEST_F(PgChatStoreTest, RejectedAppendWritesNoRowAndNotifiesNobody) {
   Received received;
   pg::Listener listener(
-      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); });
+      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); },
+      /*on_active=*/nullptr);
   listener.Listen(golf_hub::ChatChannel("R1"));
   ConfirmSubscribed(golf_hub::ChatChannel("R1"), received);
 

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -254,8 +254,11 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
   }
 
   // Pulls already-queued frames off a seat so the registry's async
-  // delivery chain can finish. Cross-instance wakes re-project freely;
-  // leaving those frames unread is what parks TearDown in End() (#1276).
+  // delivery chain can finish. Leaving those frames unread parks
+  // TearDown in SharedViewOwner::End — a smithy-cpp close-ordering
+  // deadlock (receive completion runs ~AsyncEventStream→End→Close while
+  // a harvested send waiter still holds the pin). Quiesce is the
+  // fixture workaround; the real fix is send-before-receive in smithy.
   static void DrainPending(moonbase::golf::PlayClientStream& stream) {
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
     while (std::chrono::steady_clock::now() < deadline) {
@@ -275,80 +278,114 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     std::string game_id;
   };
 
-  // Stop both instances' listeners, then drain unread wake frames. Call
-  // before CrossTable/Instance go out of scope — a late OnChannelActive
-  // after DrainPending would refill the chain and TearDown hangs again.
-  void QuiesceCrossTable(Instance& remote, CrossTable& table) {
+  void DetachListeners(Instance& remote) {
     if (handler_ != nullptr) handler_->AttachListener(nullptr);
     listener_.reset();
     if (remote.handler != nullptr) remote.handler->AttachListener(nullptr);
     remote.listener.reset();
+  }
+
+  // Stop both instances' listeners, then drain unread wake frames. Call
+  // before CrossTable/Instance go out of scope — a late OnChannelActive
+  // after DrainPending would refill the chain and TearDown hangs again.
+  void QuiesceCrossTable(Instance& remote, CrossTable& table) {
+    DetachListeners(remote);
     DrainPending(table.alice.stream);
     DrainPending(table.bob.stream);
   }
 
-  // Ensures QuiesceCrossTable runs on success and on ASSERT failure alike.
+  void QuiesceSeats(Instance& remote, Seat& alice, Seat& bob) {
+    DetachListeners(remote);
+    DrainPending(alice.stream);
+    DrainPending(bob.stream);
+  }
+
+  // Holds an optional<CrossTable>* so it can be armed *before*
+  // SeatedCrossTable returns — a lost wake during setup must still
+  // detach listeners, or named ADD_FAILURE text dies with a 60s SIGKILL.
   struct QuiesceOnScopeExit {
-    PgGolfHubFixture* fixture;
-    Instance* remote;
-    CrossTable* table;
+    PgGolfHubFixture* fixture = nullptr;
+    Instance* remote = nullptr;
+    std::optional<CrossTable>* table = nullptr;
+    Seat* alice = nullptr;
+    Seat* bob = nullptr;
     ~QuiesceOnScopeExit() {
-      if (fixture != nullptr && remote != nullptr && table != nullptr) {
-        fixture->QuiesceCrossTable(*remote, *table);
+      if (fixture == nullptr || remote == nullptr) return;
+      if (table != nullptr && table->has_value()) {
+        fixture->QuiesceCrossTable(*remote, **table);
+      } else if (alice != nullptr && bob != nullptr) {
+        fixture->QuiesceSeats(*remote, *alice, *bob);
+      } else {
+        fixture->DetachListeners(*remote);
       }
     }
   };
-  std::optional<CrossTable> SeatedCrossTable(Instance& remote) {
-    auto alice = OpenSeat();
-    if (!alice.has_value()) return std::nullopt;
-    if (!ReceiveCase(alice->stream, "sessionReady").has_value()) return std::nullopt;
-    auto bob = OpenSeatVia(*remote.client);
-    if (!bob.has_value()) return std::nullopt;
-    if (!ReceiveCase(bob->stream, "sessionReady").has_value()) return std::nullopt;
 
-    if (!alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok()) {
+  std::optional<CrossTable> SeatedCrossTable(Instance& remote) {
+    // Drain any seats we opened if setup fails mid-way — destroying the
+    // client stream while the server still has unread wake frames is the
+    // TearDown hang, and QuiesceOnScopeExit cannot see these locals.
+    struct Seats {
+      std::optional<Seat> alice;
+      std::optional<Seat> bob;
+      ~Seats() {
+        if (alice.has_value()) DrainPending(alice->stream);
+        if (bob.has_value()) DrainPending(bob->stream);
+      }
+    } seats;
+
+    seats.alice = OpenSeat();
+    if (!seats.alice.has_value()) return std::nullopt;
+    if (!ReceiveCase(seats.alice->stream, "sessionReady").has_value()) return std::nullopt;
+    seats.bob = OpenSeatVia(*remote.client);
+    if (!seats.bob.has_value()) return std::nullopt;
+    if (!ReceiveCase(seats.bob->stream, "sessionReady").has_value()) return std::nullopt;
+
+    if (!seats.alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{}))
+             .ok()) {
       return std::nullopt;
     }
-    auto created = ReceiveCase(alice->stream, "roomState");
+    auto created = ReceiveCase(seats.alice->stream, "roomState");
     if (!created.has_value()) return std::nullopt;
     const std::string room_id = created->as_roomState_or_null()->roomId;
     // The room's row must land before the other instance can look it
     // up, and the primary's LISTEN must be live before bob's join rider
     // fires — otherwise alice never learns of bob.
     store_->Flush();
-    if (!SyncListen(*alice, room_id)) return std::nullopt;
+    if (!SyncListen(*seats.alice, room_id)) return std::nullopt;
 
     moonbase::golf::JoinRoom join_room;
     join_room.roomId = room_id;
-    if (!bob->stream.Send(GolfCommands::FromJoinroom(join_room)).ok()) return std::nullopt;
+    if (!seats.bob->stream.Send(GolfCommands::FromJoinroom(join_room)).ok()) return std::nullopt;
     // bob's join materializes the room on his instance: his snapshot
     // already shows both members.
     if (!AwaitRoomState(
-             bob->stream,
+             seats.bob->stream,
              [](const moonbase::golf::RoomState& room) { return room.players.size() == 2; },
              "bob (remote) roomState with 2 players after join")
              .has_value()) {
       return std::nullopt;
     }
-    if (!SyncListen(*bob, room_id)) return std::nullopt;
+    if (!SyncListen(*seats.bob, room_id)) return std::nullopt;
     // The join's wake rider is how alice's instance learns of bob.
     if (!AwaitRoomState(
-             alice->stream,
+             seats.alice->stream,
              [](const moonbase::golf::RoomState& room) { return room.players.size() == 2; },
              "alice (primary) roomState with 2 players after bob's join wake")
              .has_value()) {
       return std::nullopt;
     }
 
-    if (!alice->stream.Send(Move(GolfMove::FromCreategame(moonbase::golf::CreateGame{}))).ok()) {
+    if (!seats.alice->stream.Send(Move(GolfMove::FromCreategame(moonbase::golf::CreateGame{})))
+             .ok()) {
       return std::nullopt;
     }
-    auto game_joined = ReceiveGolf(alice->stream, "gameJoined");
+    auto game_joined = ReceiveGolf(seats.alice->stream, "gameJoined");
     if (!game_joined.has_value()) return std::nullopt;
     const std::string game_id = game_joined->as_gameJoined_or_null()->view.gameId;
     // The create commit's wake carries the lobby game to bob.
     if (!AwaitRoomState(
-             bob->stream,
+             seats.bob->stream,
              [&](const moonbase::golf::RoomState& room) {
                for (const auto& game : room.games) {
                  if (game.gameId == game_id) return true;
@@ -362,31 +399,35 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
 
     moonbase::golf::JoinGame join_game;
     join_game.gameId = game_id;
-    if (!bob->stream.Send(Move(GolfMove::FromJoingame(join_game))).ok()) return std::nullopt;
-    if (!ReceiveGolf(bob->stream, "gameJoined").has_value()) return std::nullopt;
+    if (!seats.bob->stream.Send(Move(GolfMove::FromJoingame(join_game))).ok()) return std::nullopt;
+    if (!ReceiveGolf(seats.bob->stream, "gameJoined").has_value()) return std::nullopt;
     // alice's instance must adopt the two-seat roster before she starts.
     if (!AwaitGameView(
-             alice->stream,
+             seats.alice->stream,
              [](const moonbase::golf::GameView& view) { return view.players.size() == 2; },
              "alice (primary) gameView with 2 players after bob's seat wake")
              .has_value()) {
       return std::nullopt;
     }
 
-    if (!alice->stream.Send(Move(GolfMove::FromStartgame(moonbase::golf::StartGame{}))).ok()) {
+    if (!seats.alice->stream.Send(Move(GolfMove::FromStartgame(moonbase::golf::StartGame{})))
+             .ok()) {
       return std::nullopt;
     }
-    if (!ReceiveGolf(alice->stream, "gameStarted").has_value()) return std::nullopt;
+    if (!ReceiveGolf(seats.alice->stream, "gameStarted").has_value()) return std::nullopt;
     // bob's start signal is the projected deal (remote refresh sends
     // views, not the started event — the view is the contract).
     if (!AwaitGameView(
-             bob->stream,
+             seats.bob->stream,
              [](const moonbase::golf::GameView& view) { return view.phase != "waiting"; },
              "bob (remote) gameView dealt after alice's start wake")
              .has_value()) {
       return std::nullopt;
     }
-    return CrossTable{std::move(*alice), std::move(*bob), room_id, game_id};
+    CrossTable table{std::move(*seats.alice), std::move(*seats.bob), room_id, game_id};
+    seats.alice.reset();
+    seats.bob.reset();
+    return table;
   }
 
   // A store-side view of the rows, flushed first so staged writes are in.
@@ -690,9 +731,10 @@ TEST_F(PgGolfHubFixture, ConnectedFlagFollowsPresence) {
 TEST_F(PgGolfHubFixture, TwoInstancesShareOneGame) {
   auto remote = BuildInstance();
   ASSERT_NE(remote, nullptr);
-  auto table = SeatedCrossTable(*remote);
+  std::optional<CrossTable> table;
+  QuiesceOnScopeExit quiesce{this, remote.get(), &table};
+  table = SeatedCrossTable(*remote);
   ASSERT_TRUE(table.has_value());
-  QuiesceOnScopeExit quiesce{this, remote.get(), &*table};
   Seat& alice = table->alice;
   Seat& bob = table->bob;
 
@@ -765,9 +807,10 @@ TEST_F(PgGolfHubFixture, TwoInstancesShareOneGame) {
 TEST_F(PgGolfHubFixture, RemoteFinishRunsOneCeremonyEverywhere) {
   auto remote = BuildInstance();
   ASSERT_NE(remote, nullptr);
-  auto table = SeatedCrossTable(*remote);
+  std::optional<CrossTable> table;
+  QuiesceOnScopeExit quiesce{this, remote.get(), &table};
+  table = SeatedCrossTable(*remote);
   ASSERT_TRUE(table.has_value());
-  QuiesceOnScopeExit quiesce{this, remote.get(), &*table};
   Seat& alice = table->alice;
   Seat& bob = table->bob;
 
@@ -824,6 +867,27 @@ TEST_F(PgGolfHubFixture, RemoteFinishRunsOneCeremonyEverywhere) {
   }
 }
 
+// Pins QuiesceCrossTable: an injected unread wake must be drained, or
+// deleting the QuiesceOnScopeExit lines would leave this red.
+TEST_F(PgGolfHubFixture, QuiesceDrainsUnreadWakeFrames) {
+  auto remote = BuildInstance();
+  ASSERT_NE(remote, nullptr);
+  std::optional<CrossTable> table;
+  QuiesceOnScopeExit quiesce{this, remote.get(), &table};
+  table = SeatedCrossTable(*remote);
+  ASSERT_TRUE(table.has_value());
+
+  // Extra foreign wake leaves a roomState alice has not read.
+  handler_->OnNotify(RoomChannel(table->room_id), "foreign-wake");
+  QuiesceCrossTable(*remote, *table);
+  // Disarm the scope guard — listeners are already detached.
+  quiesce.fixture = nullptr;
+
+  auto leftover = table->alice.stream.Receive(std::chrono::milliseconds(50));
+  EXPECT_TRUE(!leftover.ok() || !leftover->has_value())
+      << "unread wake frame survived QuiesceCrossTable";
+}
+
 // Chat across the real wire (#1226 task 5): a message committed on one
 // instance reaches the other's members via its NOTIFY — or, when the
 // commit raced the receiving side's LISTEN, via the channel-active
@@ -838,6 +902,7 @@ TEST_F(PgGolfHubFixture, ChatCrossesInstancesBothWays) {
   auto bob = OpenSeatVia(*remote->client);
   ASSERT_TRUE(bob.has_value());
   ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  QuiesceOnScopeExit quiesce{this, remote.get(), /*table=*/nullptr, &*alice, &*bob};
 
   ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
   auto created = ReceiveCase(alice->stream, "roomState");
@@ -901,6 +966,7 @@ TEST_F(PgGolfHubFixture, ChatCommittedDuringListenerOutageArrivesAfterReconnect)
   auto bob = OpenSeatVia(*remote->client);
   ASSERT_TRUE(bob.has_value());
   ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  QuiesceOnScopeExit quiesce{this, remote.get(), /*table=*/nullptr, &*alice, &*bob};
 
   ASSERT_TRUE(alice->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
   auto created = ReceiveCase(alice->stream, "roomState");

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -33,27 +33,53 @@ using moonbase::golf::GolfMove;
 // Receives roomState frames until one satisfies the predicate — the
 // cross-instance tests converge on content, not frame counts, because a
 // wake re-projects everything and the frame count is timing-dependent.
+// `waiting_for` names the condition and which seat/instance cares, so a
+// lost wake fails with a diagnosis instead of `[ RUN ]` and silence (#1276).
 template <typename Predicate>
-std::optional<moonbase::golf::RoomState> AwaitRoomState(moonbase::golf::PlayClientStream& stream,
-                                                        Predicate&& predicate) {
+std::optional<moonbase::golf::RoomState> AwaitRoomState(
+    moonbase::golf::PlayClientStream& stream, Predicate&& predicate, const std::string& waiting_for,
+    std::chrono::milliseconds budget = kReceiveBudget) {
+  const auto deadline = std::chrono::steady_clock::now() + budget;
   for (int i = 0; i < 32; ++i) {
-    auto event = ReceiveCase(stream, "roomState");
-    if (!event.has_value()) return std::nullopt;
+    const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+        deadline - std::chrono::steady_clock::now());
+    if (remaining <= std::chrono::milliseconds::zero()) {
+      ADD_FAILURE() << "gave up waiting for " << waiting_for;
+      return std::nullopt;
+    }
+    auto event = ReceiveCase(stream, "roomState", remaining);
+    if (!event.has_value()) {
+      ADD_FAILURE() << "gave up waiting for " << waiting_for;
+      return std::nullopt;
+    }
     const auto* room = event->as_roomState_or_null();
     if (predicate(*room)) return *room;
   }
+  ADD_FAILURE() << "gave up waiting for " << waiting_for << " (frame budget)";
   return std::nullopt;
 }
 
 template <typename Predicate>
-std::optional<moonbase::golf::GameView> AwaitGameView(moonbase::golf::PlayClientStream& stream,
-                                                      Predicate&& predicate) {
+std::optional<moonbase::golf::GameView> AwaitGameView(
+    moonbase::golf::PlayClientStream& stream, Predicate&& predicate, const std::string& waiting_for,
+    std::chrono::milliseconds budget = kReceiveBudget) {
+  const auto deadline = std::chrono::steady_clock::now() + budget;
   for (int i = 0; i < 32; ++i) {
-    auto update = ReceiveGolf(stream, "gameState");
-    if (!update.has_value()) return std::nullopt;
+    const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+        deadline - std::chrono::steady_clock::now());
+    if (remaining <= std::chrono::milliseconds::zero()) {
+      ADD_FAILURE() << "gave up waiting for " << waiting_for;
+      return std::nullopt;
+    }
+    auto update = ReceiveGolf(stream, "gameState", remaining);
+    if (!update.has_value()) {
+      ADD_FAILURE() << "gave up waiting for " << waiting_for;
+      return std::nullopt;
+    }
     const auto& view = update->as_gameState_or_null()->view;
     if (predicate(view)) return view;
   }
+  ADD_FAILURE() << "gave up waiting for " << waiting_for << " (frame budget)";
   return std::nullopt;
 }
 
@@ -113,8 +139,9 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
         [handler](const std::string& channel, const std::string& payload) {
           handler->OnNotify(channel, payload);
         },
-        // The active signal is chat's catch-up trigger: rows committed
-        // before a (re)LISTEN landed never notified this instance.
+        // The active signal is the catch-up trigger for chat and rooms:
+        // rows committed before a (re)LISTEN landed never notified this
+        // instance (#1276).
         [handler](const std::string& channel) { handler->OnChannelActive(channel); });
     handler->AttachListener(listener.get());
     return listener;
@@ -198,11 +225,15 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     pg::Client db(url_);
     for (int i = 0; i < 10; ++i) {
       if (!db.Exec("SELECT pg_notify($1, 'listen-sync')", {RoomChannel(room_id)}).ok()) {
+        ADD_FAILURE() << "LISTEN sync poke failed for " << RoomChannel(room_id);
         return false;
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
     }
-    return ReceiveCase(seat.stream, "roomState").has_value();
+    if (ReceiveCase(seat.stream, "roomState").has_value()) return true;
+    ADD_FAILURE() << "LISTEN sync for " << RoomChannel(room_id)
+                  << " never produced roomState on seat " << seat.player_id;
+    return false;
   }
 
   bool WaitForListenerCount(const std::string& room_id, int count) {
@@ -257,16 +288,20 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     if (!bob->stream.Send(GolfCommands::FromJoinroom(join_room)).ok()) return std::nullopt;
     // bob's join materializes the room on his instance: his snapshot
     // already shows both members.
-    if (!AwaitRoomState(bob->stream, [](const moonbase::golf::RoomState& room) {
-           return room.players.size() == 2;
-         }).has_value()) {
+    if (!AwaitRoomState(
+             bob->stream,
+             [](const moonbase::golf::RoomState& room) { return room.players.size() == 2; },
+             "bob (remote) roomState with 2 players after join")
+             .has_value()) {
       return std::nullopt;
     }
     if (!SyncListen(*bob, room_id)) return std::nullopt;
     // The join's wake rider is how alice's instance learns of bob.
-    if (!AwaitRoomState(alice->stream, [](const moonbase::golf::RoomState& room) {
-           return room.players.size() == 2;
-         }).has_value()) {
+    if (!AwaitRoomState(
+             alice->stream,
+             [](const moonbase::golf::RoomState& room) { return room.players.size() == 2; },
+             "alice (primary) roomState with 2 players after bob's join wake")
+             .has_value()) {
       return std::nullopt;
     }
 
@@ -277,12 +312,16 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     if (!game_joined.has_value()) return std::nullopt;
     const std::string game_id = game_joined->as_gameJoined_or_null()->view.gameId;
     // The create commit's wake carries the lobby game to bob.
-    if (!AwaitRoomState(bob->stream, [&](const moonbase::golf::RoomState& room) {
-           for (const auto& game : room.games) {
-             if (game.gameId == game_id) return true;
-           }
-           return false;
-         }).has_value()) {
+    if (!AwaitRoomState(
+             bob->stream,
+             [&](const moonbase::golf::RoomState& room) {
+               for (const auto& game : room.games) {
+                 if (game.gameId == game_id) return true;
+               }
+               return false;
+             },
+             "bob (remote) roomState carrying alice's created game " + game_id)
+             .has_value()) {
       return std::nullopt;
     }
 
@@ -291,9 +330,11 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     if (!bob->stream.Send(Move(GolfMove::FromJoingame(join_game))).ok()) return std::nullopt;
     if (!ReceiveGolf(bob->stream, "gameJoined").has_value()) return std::nullopt;
     // alice's instance must adopt the two-seat roster before she starts.
-    if (!AwaitGameView(alice->stream, [](const moonbase::golf::GameView& view) {
-           return view.players.size() == 2;
-         }).has_value()) {
+    if (!AwaitGameView(
+             alice->stream,
+             [](const moonbase::golf::GameView& view) { return view.players.size() == 2; },
+             "alice (primary) gameView with 2 players after bob's seat wake")
+             .has_value()) {
       return std::nullopt;
     }
 
@@ -303,9 +344,11 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     if (!ReceiveGolf(alice->stream, "gameStarted").has_value()) return std::nullopt;
     // bob's start signal is the projected deal (remote refresh sends
     // views, not the started event — the view is the contract).
-    if (!AwaitGameView(bob->stream, [](const moonbase::golf::GameView& view) {
-           return view.phase != "waiting";
-         }).has_value()) {
+    if (!AwaitGameView(
+             bob->stream,
+             [](const moonbase::golf::GameView& view) { return view.phase != "waiting"; },
+             "bob (remote) gameView dealt after alice's start wake")
+             .has_value()) {
       return std::nullopt;
     }
     return CrossTable{std::move(*alice), std::move(*bob), room_id, game_id};
@@ -633,12 +676,16 @@ TEST_F(PgGolfHubFixture, TwoInstancesShareOneGame) {
       ASSERT_TRUE(seat->stream.Send(Move(GolfMove::FromPeekcard(peek))).ok());
     }
   }
-  ASSERT_TRUE(AwaitGameView(alice.stream, [](const moonbase::golf::GameView& view) {
-                return view.allPlayersPeeked;
-              }).has_value());
-  ASSERT_TRUE(AwaitGameView(bob.stream, [](const moonbase::golf::GameView& view) {
-                return view.allPlayersPeeked;
-              }).has_value());
+  ASSERT_TRUE(AwaitGameView(
+                  alice.stream,
+                  [](const moonbase::golf::GameView& view) { return view.allPlayersPeeked; },
+                  "alice (primary) allPlayersPeeked after cross-instance peeks")
+                  .has_value());
+  ASSERT_TRUE(AwaitGameView(
+                  bob.stream,
+                  [](const moonbase::golf::GameView& view) { return view.allPlayersPeeked; },
+                  "bob (remote) allPlayersPeeked after cross-instance peeks")
+                  .has_value());
 
   // alice's turn on her instance: hide, draw, discard...
   ASSERT_TRUE(alice.stream.Send(Move(GolfMove::FromHidecards(moonbase::golf::HideCards{}))).ok());
@@ -646,17 +693,25 @@ TEST_F(PgGolfHubFixture, TwoInstancesShareOneGame) {
   ASSERT_TRUE(
       alice.stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{}))).ok());
   // ...lands on bob's instance as two discards and the turn handoff.
-  ASSERT_TRUE(AwaitGameView(bob.stream, [&](const moonbase::golf::GameView& view) {
-                return view.discardCount == 2 && view.currentPlayerId == bob.player_id;
-              }).has_value());
+  ASSERT_TRUE(AwaitGameView(
+                  bob.stream,
+                  [&](const moonbase::golf::GameView& view) {
+                    return view.discardCount == 2 && view.currentPlayerId == bob.player_id;
+                  },
+                  "bob (remote) turn handoff after alice's discard wake")
+                  .has_value());
 
   // bob answers from his instance, and alice's projection follows.
   ASSERT_TRUE(bob.stream.Send(Move(GolfMove::FromDrawcard(moonbase::golf::DrawCard{}))).ok());
   ASSERT_TRUE(
       bob.stream.Send(Move(GolfMove::FromDiscarddrawn(moonbase::golf::DiscardDrawn{}))).ok());
-  ASSERT_TRUE(AwaitGameView(alice.stream, [&](const moonbase::golf::GameView& view) {
-                return view.discardCount == 3 && view.currentPlayerId == alice.player_id;
-              }).has_value());
+  ASSERT_TRUE(AwaitGameView(
+                  alice.stream,
+                  [&](const moonbase::golf::GameView& view) {
+                    return view.discardCount == 3 && view.currentPlayerId == alice.player_id;
+                  },
+                  "alice (primary) turn handoff after bob's discard wake")
+                  .has_value());
 
   // Every move was exactly one landed commit: 4 peeks + hide + 2 draws
   // + 2 discards continue the version sequence without a gap — a fork,
@@ -682,9 +737,13 @@ TEST_F(PgGolfHubFixture, RemoteFinishRunsOneCeremonyEverywhere) {
   // Quickest legal game: alice knocks unseen on her instance...
   ASSERT_TRUE(alice.stream.Send(Move(GolfMove::FromKnock(moonbase::golf::Knock{}))).ok());
   // ...and the knocked phase reaches bob's projection.
-  ASSERT_TRUE(AwaitGameView(bob.stream, [&](const moonbase::golf::GameView& view) {
-                return view.knockedPlayerId == alice.player_id;
-              }).has_value());
+  ASSERT_TRUE(AwaitGameView(
+                  bob.stream,
+                  [&](const moonbase::golf::GameView& view) {
+                    return view.knockedPlayerId == alice.player_id;
+                  },
+                  "bob (remote) knockedPlayerId after alice's knock wake")
+                  .has_value());
   // Hold Alice's listener behind the finish and the finishing instance's
   // writer drain. This makes the lost-handoff race deterministic.
   handler_->AttachListener(nullptr);

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -253,6 +253,17 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     return false;
   }
 
+  // Pulls already-queued frames off a seat so the registry's async
+  // delivery chain can finish. Cross-instance wakes re-project freely;
+  // leaving those frames unread is what parks TearDown in End() (#1276).
+  static void DrainPending(moonbase::golf::PlayClientStream& stream) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+    while (std::chrono::steady_clock::now() < deadline) {
+      auto received = stream.Receive(std::chrono::milliseconds(5));
+      if (!received.ok() || !received->has_value()) return;
+    }
+  }
+
   // alice on the primary instance, bob on `remote`, one room and one
   // started game between them. Every cross-instance step waits on the
   // events that prove the other instance caught up, so the flow is
@@ -262,6 +273,30 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
     Seat bob;
     std::string room_id;
     std::string game_id;
+  };
+
+  // Stop both instances' listeners, then drain unread wake frames. Call
+  // before CrossTable/Instance go out of scope — a late OnChannelActive
+  // after DrainPending would refill the chain and TearDown hangs again.
+  void QuiesceCrossTable(Instance& remote, CrossTable& table) {
+    if (handler_ != nullptr) handler_->AttachListener(nullptr);
+    listener_.reset();
+    if (remote.handler != nullptr) remote.handler->AttachListener(nullptr);
+    remote.listener.reset();
+    DrainPending(table.alice.stream);
+    DrainPending(table.bob.stream);
+  }
+
+  // Ensures QuiesceCrossTable runs on success and on ASSERT failure alike.
+  struct QuiesceOnScopeExit {
+    PgGolfHubFixture* fixture;
+    Instance* remote;
+    CrossTable* table;
+    ~QuiesceOnScopeExit() {
+      if (fixture != nullptr && remote != nullptr && table != nullptr) {
+        fixture->QuiesceCrossTable(*remote, *table);
+      }
+    }
   };
   std::optional<CrossTable> SeatedCrossTable(Instance& remote) {
     auto alice = OpenSeat();
@@ -657,6 +692,7 @@ TEST_F(PgGolfHubFixture, TwoInstancesShareOneGame) {
   ASSERT_NE(remote, nullptr);
   auto table = SeatedCrossTable(*remote);
   ASSERT_TRUE(table.has_value());
+  QuiesceOnScopeExit quiesce{this, remote.get(), &*table};
   Seat& alice = table->alice;
   Seat& bob = table->bob;
 
@@ -731,6 +767,7 @@ TEST_F(PgGolfHubFixture, RemoteFinishRunsOneCeremonyEverywhere) {
   ASSERT_NE(remote, nullptr);
   auto table = SeatedCrossTable(*remote);
   ASSERT_TRUE(table.has_value());
+  QuiesceOnScopeExit quiesce{this, remote.get(), &*table};
   Seat& alice = table->alice;
   Seat& bob = table->bob;
 

--- a/domains/games/apis/golf_hub/pg_hub_store_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_store_test.cc
@@ -138,7 +138,8 @@ TEST_F(PgHubStoreTest, CommitNotifiesExactlyTheSavesThatLand) {
 
   Received received;
   pg::Listener listener(
-      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); });
+      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); },
+      /*on_active=*/nullptr);
   listener.Listen(golf_hub::RoomChannel("R1"));
   ConfirmSubscribed(golf_hub::RoomChannel("R1"), received);
 
@@ -269,7 +270,8 @@ TEST_F(PgHubStoreTest, LoadRoomScopesToOneRoom) {
 TEST_F(PgHubStoreTest, NotifyOpFiresAfterItsBatch) {
   Received received;
   pg::Listener listener(
-      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); });
+      url_, [&](const std::string&, const std::string& payload) { received.Add(payload); },
+      /*on_active=*/nullptr);
   listener.Listen(golf_hub::kRoomsChannel);
   ConfirmSubscribed(golf_hub::kRoomsChannel, received);
 

--- a/domains/platform/libs/pg/listener.cc
+++ b/domains/platform/libs/pg/listener.cc
@@ -1,5 +1,7 @@
 #include "domains/platform/libs/pg/listener.h"
 
+#include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
 #include <unistd.h>
 
@@ -40,9 +42,14 @@ Listener::Listener(std::string conninfo, Callback on_notify, ActiveCallback on_a
       on_notify_(std::move(on_notify)),
       on_active_(std::move(on_active)) {
   int fds[2] = {-1, -1};
+  // O_NONBLOCK: a blocking drain that reads an exact multiple of the
+  // buffer size would issue one more read and hang forever on an empty
+  // pipe — another lost-wakeup shape with idle postgres (#1276).
   if (pipe(fds) == 0) {
     wake_read_ = fds[0];
     wake_write_ = fds[1];
+    fcntl(wake_read_, F_SETFL, O_NONBLOCK);
+    fcntl(wake_write_, F_SETFL, O_NONBLOCK);
   }
   thread_ = std::thread([this] { Loop(); });
 }
@@ -156,7 +163,14 @@ void Listener::Loop() {
 
     if (wake_read_ >= 0 && (fds[1].revents & POLLIN) != 0) {
       char drain[64];
-      while (read(wake_read_, drain, sizeof(drain)) == sizeof(drain)) {
+      while (true) {
+        const ssize_t n = read(wake_read_, drain, sizeof(drain));
+        if (n < 0) {
+          if (errno == EINTR) continue;
+          break;  // EAGAIN/EWOULDBLOCK: empty
+        }
+        if (n == 0) break;
+        if (n < static_cast<ssize_t>(sizeof(drain))) break;
       }
     }
     if ((fds[0].revents & POLLIN) != 0) {

--- a/domains/platform/libs/pg/listener.cc
+++ b/domains/platform/libs/pg/listener.cc
@@ -114,6 +114,13 @@ void Listener::SyncChannels(PGconn* conn) {
   }
 }
 
+void Listener::DrainNotifies(PGconn* conn) {
+  while (PGnotify* notify = PQnotifies(conn)) {
+    on_notify_(notify->relname, notify->extra == nullptr ? "" : notify->extra);
+    PQfreemem(notify);
+  }
+}
+
 void Listener::Loop() {
   std::unique_ptr<PGconn, decltype(&PQfinish)> conn(nullptr, &PQfinish);
   auto backoff = std::chrono::milliseconds(100);
@@ -135,6 +142,11 @@ void Listener::Loop() {
       active_.clear();  // fresh connection LISTENs from scratch
     }
     SyncChannels(conn.get());
+    // PQexec(LISTEN/UNLISTEN) reads the socket itself and can leave
+    // NOTIFY messages in libpq's queue with no POLLIN left for poll.
+    // Drain unconditionally: a single absorbed wake with no later
+    // socket event is how TwoInstancesShareOneGame hung (#1276).
+    DrainNotifies(conn.get());
 
     struct pollfd fds[2];
     fds[0] = {PQsocket(conn.get()), POLLIN, 0};
@@ -153,10 +165,7 @@ void Listener::Loop() {
         conn.reset();
         continue;
       }
-      while (PGnotify* notify = PQnotifies(conn.get())) {
-        on_notify_(notify->relname, notify->extra == nullptr ? "" : notify->extra);
-        PQfreemem(notify);
-      }
+      DrainNotifies(conn.get());
     }
   }
 }

--- a/domains/platform/libs/pg/listener.h
+++ b/domains/platform/libs/pg/listener.h
@@ -34,7 +34,10 @@ class Listener {
   /// at-least-once delivery does a catch-up read when it fires.
   using ActiveCallback = std::function<void(const std::string& channel)>;
 
-  Listener(std::string conninfo, Callback on_notify, ActiveCallback on_active = nullptr);
+  /// `on_active` is required: omitting it silently skips catch-up on
+  /// (re)LISTEN, which is how room/chat fans lose commits across a gap.
+  /// Pass an empty callback when the owner truly needs notify-only.
+  Listener(std::string conninfo, Callback on_notify, ActiveCallback on_active);
   ~Listener();
   Listener(const Listener&) = delete;
   Listener& operator=(const Listener&) = delete;

--- a/domains/platform/libs/pg/listener.h
+++ b/domains/platform/libs/pg/listener.h
@@ -15,8 +15,11 @@ namespace pg {
 /// thread delivers notifications to one callback. Channels come and go
 /// at runtime (the hub subscribes rooms as it learns them); a lost
 /// connection reconnects with backoff and re-LISTENs every subscribed
-/// channel. Dropped notifications during the gap are fine by protocol:
-/// a notify is only a wake-up, and every wake re-reads current state.
+/// channel. Dropped notifications during a disconnect gap are fine by
+/// protocol: a notify is only a wake-up, and every wake re-reads current
+/// state. Notifications absorbed into libpq during LISTEN/UNLISTEN are
+/// not dropped — the poll loop drains PQnotifies after every sync pass
+/// (#1276), not only when poll reports POLLIN.
 ///
 /// The callbacks run on the listener's thread. They may call Listen and
 /// Unlisten (they only flag work for the poll thread), but must not
@@ -44,10 +47,8 @@ class Listener {
  private:
   void Loop();
   void Wake();
-  /// (Re)connects and LISTENs the current channel set; returns false
-  /// when stopping.
-  bool ConnectLocked(std::unique_lock<std::mutex>& lock);
   void SyncChannels(PGconn* conn);
+  void DrainNotifies(PGconn* conn);
 
   const std::string conninfo_;
   const Callback on_notify_;

--- a/domains/platform/libs/pg/listener_test.cc
+++ b/domains/platform/libs/pg/listener_test.cc
@@ -41,9 +41,12 @@ class ListenerTest : public ::testing::Test {
 
 TEST_F(ListenerTest, DeliversNotificationsAndChannelChurn) {
   Received received;
-  pg::Listener listener(url_, [&](const std::string& channel, const std::string& payload) {
-    received.Add(channel, payload);
-  });
+  pg::Listener listener(
+      url_,
+      [&](const std::string& channel, const std::string& payload) {
+        received.Add(channel, payload);
+      },
+      /*on_active=*/nullptr);
   listener.Listen("room_ABC123");  // mixed case must survive quoting
 
   pg::Client client(url_);
@@ -134,6 +137,22 @@ TEST_F(ListenerTest, DrainsNotifyBufferedByListenExec) {
   bool holding = false;
   bool release = false;
 
+  // Always release the poll thread, even if an ASSERT below fires —
+  // otherwise ~Listener joins a callback that waits forever and the
+  // small target dies at 60s with no failure text.
+  struct ReleaseHold {
+    std::mutex& mu;
+    std::condition_variable& cv;
+    bool& release;
+    ~ReleaseHold() {
+      {
+        const std::lock_guard<std::mutex> lock(mu);
+        release = true;
+      }
+      cv.notify_all();
+    }
+  } release_hold{mu, cv, release};
+
   pg::Listener listener(
       url_,
       [&](const std::string& channel, const std::string& payload) {
@@ -141,7 +160,11 @@ TEST_F(ListenerTest, DrainsNotifyBufferedByListenExec) {
           std::unique_lock<std::mutex> lock(mu);
           holding = true;
           cv.notify_all();
-          cv.wait(lock, [&] { return release; });
+          // Bounded: a stuck test must not pin the poll thread until the
+          // Bazel ceiling.
+          if (!cv.wait_for(lock, std::chrono::seconds(30), [&] { return release; })) {
+            ADD_FAILURE() << "hold callback timed out waiting for release";
+          }
         }
         received.Add(channel, payload);
       },
@@ -159,16 +182,23 @@ TEST_F(ListenerTest, DrainsNotifyBufferedByListenExec) {
 
   // Poll thread is inside on_notify. Subscribe a new channel (wake →
   // SyncChannels → PQexec(LISTEN other)) and put the victim on the
-  // wire. PQexec will pull it into libpq's queue; poll then sees no
-  // POLLIN because the socket is already empty.
+  // wire. Once Exec returns, postgres has delivered to listening
+  // backends — the bytes sit in the listener socket while the poll
+  // thread is still held. Release then runs PQexec, which absorbs
+  // them into libpq's queue with no POLLIN left for poll.
   listener.Listen("other");
   ASSERT_TRUE(client.Exec("SELECT pg_notify('ch', 'victim')").ok());
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
   {
     const std::lock_guard<std::mutex> lock(mu);
     release = true;
   }
   cv.notify_all();
+
+  // SyncChannels ran iff "other" became active — pins the absorb path
+  // to a real LISTEN pass rather than a later POLLIN delivery.
+  ASSERT_TRUE(active.WaitForCount(2, std::chrono::seconds(10)))
+      << "LISTEN other never completed after release";
+  EXPECT_EQ(active.events[1].first, "other");
 
   ASSERT_TRUE(received.WaitForCount(2, std::chrono::seconds(10)))
       << "victim notify absorbed during LISTEN was never delivered";
@@ -181,9 +211,12 @@ TEST_F(ListenerTest, DrainsNotifyBufferedByListenExec) {
 
 TEST_F(ListenerTest, ReconnectsAndReListensAfterConnectionLoss) {
   Received received;
-  pg::Listener listener(url_, [&](const std::string& channel, const std::string& payload) {
-    received.Add(channel, payload);
-  });
+  pg::Listener listener(
+      url_,
+      [&](const std::string& channel, const std::string& payload) {
+        received.Add(channel, payload);
+      },
+      /*on_active=*/nullptr);
   listener.Listen("heal");
 
   pg::Client client(url_);

--- a/domains/platform/libs/pg/listener_test.cc
+++ b/domains/platform/libs/pg/listener_test.cc
@@ -122,6 +122,63 @@ TEST_F(ListenerTest, ActiveFiresOnSubscribeAndAgainAfterReconnect) {
   EXPECT_EQ(notified.events[1].second, "two");
 }
 
+// #1276: a NOTIFY read into libpq during PQexec(LISTEN) must still be
+// delivered when no later socket POLLIN arrives. Without an
+// unconditional drain after SyncChannels, the victim stays queued
+// forever and the owner hangs waiting for a wake that already happened.
+TEST_F(ListenerTest, DrainsNotifyBufferedByListenExec) {
+  Received received;
+  Received active;
+  std::mutex mu;
+  std::condition_variable cv;
+  bool holding = false;
+  bool release = false;
+
+  pg::Listener listener(
+      url_,
+      [&](const std::string& channel, const std::string& payload) {
+        if (payload == "hold") {
+          std::unique_lock<std::mutex> lock(mu);
+          holding = true;
+          cv.notify_all();
+          cv.wait(lock, [&] { return release; });
+        }
+        received.Add(channel, payload);
+      },
+      [&](const std::string& channel) { active.Add(channel, ""); });
+
+  listener.Listen("ch");
+  ASSERT_TRUE(active.WaitForCount(1, std::chrono::seconds(10)));
+
+  pg::Client client(url_);
+  ASSERT_TRUE(client.Exec("SELECT pg_notify('ch', 'hold')").ok());
+  {
+    std::unique_lock<std::mutex> lock(mu);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(10), [&] { return holding; }));
+  }
+
+  // Poll thread is inside on_notify. Subscribe a new channel (wake →
+  // SyncChannels → PQexec(LISTEN other)) and put the victim on the
+  // wire. PQexec will pull it into libpq's queue; poll then sees no
+  // POLLIN because the socket is already empty.
+  listener.Listen("other");
+  ASSERT_TRUE(client.Exec("SELECT pg_notify('ch', 'victim')").ok());
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  {
+    const std::lock_guard<std::mutex> lock(mu);
+    release = true;
+  }
+  cv.notify_all();
+
+  ASSERT_TRUE(received.WaitForCount(2, std::chrono::seconds(10)))
+      << "victim notify absorbed during LISTEN was never delivered";
+  const std::lock_guard<std::mutex> lock(received.mu);
+  ASSERT_EQ(received.events.size(), 2u);
+  EXPECT_EQ(received.events[0].second, "hold");
+  EXPECT_EQ(received.events[1].first, "ch");
+  EXPECT_EQ(received.events[1].second, "victim");
+}
+
 TEST_F(ListenerTest, ReconnectsAndReListensAfterConnectionLoss) {
   Received received;
   pg::Listener listener(url_, [&](const std::string& channel, const std::string& payload) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the intermittent `TwoInstancesShareOneGame` hang (#1276 / #1241): CI shows both hubs restore, then Bazel’s 60s `size = "small"` kill, with postgres idle. Do **not** raise the timeout.

Two cooperating failure modes share that signature:

1. **Lost wakeup in `pg::Listener`** — `PQexec(LISTEN/UNLISTEN)` can absorb a NOTIFY into libpq’s queue with no `POLLIN` left for `poll`.
2. **TearDown hang in `SharedViewOwner::End`** — unread wake projections leave a harvested async send waiter holding the pin while receive-first close ordering runs `~AsyncEventStream` → `End()` → `Close()` on the same stack. **This is a smithy-cpp defect** (fire send before receive in both transports); `QuiesceCrossTable` is the fixture workaround so the helper is not mystery scaffolding. Production trigger: peer close while a registry fan-out write is outstanding (golf_hub uses Beast + `async_delivery`).

## Fix

1. Drain `PQnotifies` after every `SyncChannels` pass.
2. Nonblocking wake pipe (`O_NONBLOCK` + `EAGAIN`-aware drain) so a full 64-byte read cannot hang the poll thread.
3. Room catch-up on `OnChannelActive` via shared `WakeChannel` / `CatchUpRoom`: Flush+Load **off `mu_`**, re-project **only when rows moved** (notify still always re-projects). Avoids reconnect/boot queue floods.
4. Named await deadlines; quiesce armed **before** `SeatedCrossTable`, drains seats on setup failure, covers chat cross-instance tests; pinned by `QuiesceDrainsUnreadWakeFrames`.
5. Hang-safe absorb regression test (release-on-unwind, bounded `wait_for`, no sleep; waits for `other` active to pin the LISTEN pass).
6. `Listener` requires `on_active` (pass `nullptr` explicitly for notify-only).
7. Keep `size = "small"`; BUILD comment states both hang shapes.

## Review follow-ups (`6b1371a`)

Addresses the panel on `6005605` / `deda1f5`: room catch-up storm, quiesce coverage gap, hang-prone absorb test, wake-pipe block, BUILD over-claim, unheld-room active guard test, merge of notify/active dispatch.

## Tests

| Check | Result |
|---|---|
| `listener_test` (incl. absorb + reconnect) | PASSED |
| `hub_store_race_test` (active refresh + unheld guard) | PASSED |
| `pg_hub_e2e_test` full | PASSED (~2s) |
| TwoInstances + QuiesceDrains + RemoteFinish ×20 | all pass, ~1.6s |

Sanitizers still exclude `golf_hub` / `pg` packages per `branch.yml`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc3bc-defe-7b9b-8734-c3180586b027?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc3bc-defe-7b9b-8734-c3180586b027&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

