### PR TITLE
1d4: move Game link and Indexed date into the expanded game view

### DIFF
--- a/domains/games/apps/1d4_web/src/__tests__/GameDetailPanel.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameDetailPanel.test.tsx
@@ -45,6 +45,25 @@ describe('GameDetailPanel', () => {
     expect(screen.getByText(/1-0/)).toBeInTheDocument();
   });
 
+  it('shows a link to view the game on its source site', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    const link = screen.getByRole('link', { name: /View game/ });
+    expect(link).toHaveAttribute('href', 'https://chess.com/game/1');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('omits the view-game link when gameUrl is absent', () => {
+    const game = { ...mockGame, gameUrl: '' };
+    render(<GameDetailPanel game={game} onClose={() => {}} />);
+    expect(screen.queryByRole('link', { name: /View game/ })).not.toBeInTheDocument();
+  });
+
+  it('shows the indexed-at date', () => {
+    render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
+    // 1700001000 seconds = 2023-11-14
+    expect(screen.getByText(/indexed 2023-11-14/)).toBeInTheDocument();
+  });
+
   it('calls onClose when close button is clicked', () => {
     const onClose = vi.fn();
     render(<GameDetailPanel game={mockGame} onClose={onClose} />);

--- a/domains/games/apps/1d4_web/src/__tests__/GameDetailPanel.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameDetailPanel.test.tsx
@@ -50,6 +50,10 @@ describe('GameDetailPanel', () => {
     const link = screen.getByRole('link', { name: /View game/ });
     expect(link).toHaveAttribute('href', 'https://chess.com/game/1');
     expect(link).toHaveAttribute('target', '_blank');
+    // target="_blank" without this hands the opened tab a window.opener
+    // handle back to us. Asserted because the two attributes have to travel
+    // together and only one of them is visible in review.
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('omits the view-game link when gameUrl is absent', () => {
@@ -62,6 +66,15 @@ describe('GameDetailPanel', () => {
     render(<GameDetailPanel game={mockGame} onClose={() => {}} />);
     // 1700001000 seconds = 2023-11-14
     expect(screen.getByText(/indexed 2023-11-14/)).toBeInTheDocument();
+  });
+
+  // The negative half. formatDate returns '' for a missing value, so dropping
+  // the `game.indexedAt &&` guard renders a bare "indexed " with no date —
+  // which no positive assertion above can see.
+  it('omits the indexed label entirely when indexedAt is absent', () => {
+    const game = { ...mockGame, indexedAt: 0 };
+    render(<GameDetailPanel game={game} onClose={() => {}} />);
+    expect(screen.queryByText(/indexed/)).not.toBeInTheDocument();
   });
 
   it('calls onClose when close button is clicked', () => {

--- a/domains/games/apps/1d4_web/src/__tests__/GameResultsTable.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameResultsTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import GameResultsTable from '../components/GameResultsTable';
 import type { GameRow } from '../types';
@@ -74,6 +75,57 @@ describe('GameResultsTable', () => {
     fireEvent.click(screen.getByText('Carol'));
     expect(screen.queryByText('Alice vs Bob')).not.toBeInTheDocument();
     expect(screen.getByText('Carol vs Dave')).toBeInTheDocument();
+  });
+
+  // The regression this whole affordance exists for, driven the way a keyboard
+  // user would drive it: no fireEvent.click anywhere. Moving the game link into
+  // the panel left the table body with nothing focusable, so a keyboard user
+  // could not open a game at all. Tab has to reach the toggle and Enter has to
+  // open it — asserting the button merely exists would not prove either.
+  it('opens the panel by keyboard alone', async () => {
+    const user = userEvent.setup();
+    render(<GameResultsTable games={[game1]} />);
+    expect(screen.queryByText('Alice vs Bob')).not.toBeInTheDocument();
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Alice' })).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(screen.getByText('Alice vs Bob')).toBeInTheDocument();
+  });
+
+  it('opens the panel with Space as well as Enter', async () => {
+    const user = userEvent.setup();
+    render(<GameResultsTable games={[game1]} />);
+    await user.tab();
+    await user.keyboard(' ');
+    expect(screen.getByText('Alice vs Bob')).toBeInTheDocument();
+  });
+
+  // Closing unmounts the panel. If focus is not put back deliberately it lands
+  // on <body>, dropping the keyboard user at the top of the document with their
+  // place in the table lost.
+  it('returns focus to the toggle when the panel is closed', async () => {
+    const user = userEvent.setup();
+    render(<GameResultsTable games={[game1]} />);
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    await user.click(screen.getByRole('button', { name: 'Close panel' }));
+    expect(screen.queryByText('Alice vs Bob')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Alice' })).toHaveFocus();
+  });
+
+  // Tab order has to run row → its panel, or "next" from the toggle jumps past
+  // the content the toggle just revealed.
+  it('places the panel immediately after its toggle in the tab order', async () => {
+    const user = userEvent.setup();
+    render(<GameResultsTable games={[game1]} />);
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    await user.tab();
+    expect(screen.getByRole('link', { name: /View game/ })).toHaveFocus();
   });
 
   it('clears detail panel when games prop changes', () => {

--- a/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
@@ -120,9 +120,40 @@ describe('GameTable', () => {
     expect(screen.getByText('Carol')).toBeInTheDocument();
   });
 
+  // The whole point of the column set is that it is short. Without this,
+  // re-adding a Game or Indexed column — the two that crushed Motifs — is a
+  // silently green change. Asserted as an exact list rather than two absence
+  // checks so any twelfth column has to be a deliberate edit here too.
+  it('shows only the nine columns that earn their width', () => {
+    render(<GameTable games={mockGames} />);
+    const headers = Array.from(
+      screen.getByRole('table').querySelectorAll('thead th')
+    ).map((th) => th.textContent);
+    expect(headers).toEqual([
+      'White',
+      'Black',
+      'White ELO',
+      'Black ELO',
+      'Time',
+      'ECO',
+      'Result',
+      'Played',
+      'Motifs',
+    ]);
+  });
+
+  // The negative half of the move: the link and the indexed date left the table
+  // for GameDetailPanel, so the table body must hold no link at all. This also
+  // pins the accessibility fact that the row is the only affordance here — if
+  // that ever changes, this test should be the thing that notices.
+  it('renders no links in the table body — the game link lives in the detail panel', () => {
+    render(<GameTable games={mockGames} />);
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
   // jsdom has no layout, so this cannot assert the rendered result — only that
-  // the hook the stylesheet hangs the fix on is still here. Eleven columns do
-  // not fit a laptop, and without the modifier the browser keeps honouring
+  // the hook the stylesheet hangs the fix on is still here. Nine columns still
+  // do not fit a laptop, and without the modifier the browser keeps honouring
   // width:100% by crushing the last ones instead of letting the wrapper scroll:
   // ISO dates break after the month and motif badges split mid-word.
   it('marks the games table as wide so its columns scroll instead of being crushed', () => {
@@ -146,7 +177,18 @@ describe('GameTable', () => {
     const rule = (selector: string) =>
       css.match(new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`))?.[1] ?? '';
 
-    expect(rule('.table-wrap--wide table')).toMatch(/min-width:\s*\d/);
+    // Not just `\d`: that matched `0` and `4px` as happily as `52rem`, so it
+    // could not tell a real floor from a zeroed or unit-less one. Pin the unit
+    // and a lower bound instead. The band is wide on purpose — the exact number
+    // is a judgement call, but a floor below the table's own min-content
+    // (measured 816px with short usernames) is inert, and one far above it
+    // reintroduces the laptop scrolling this modifier exists to bound.
+    const minWidth = rule('.table-wrap--wide table').match(
+      /min-width:\s*(\d+(?:\.\d+)?)rem/
+    );
+    expect(minWidth).not.toBeNull();
+    expect(Number(minWidth![1])).toBeGreaterThanOrEqual(48);
+    expect(Number(minWidth![1])).toBeLessThanOrEqual(64);
     expect(rule('.table-wrap--wide td')).toMatch(/white-space:\s*nowrap/);
     // Badges wrap between themselves; only mid-badge breaking is the bug.
     expect(rule('.table-wrap--wide td .motifs')).toMatch(/white-space:\s*normal/);

--- a/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
@@ -53,13 +53,6 @@ describe('GameTable', () => {
     expect(screen.getByText('Carol')).toBeInTheDocument();
   });
 
-  it('renders external links for game URLs', () => {
-    render(<GameTable games={mockGames} sortBy="" sortDir="asc" onSort={() => {}} />);
-    const links = screen.getAllByRole('link', { name: 'View' });
-    expect(links).toHaveLength(2);
-    expect(links[0]).toHaveAttribute('href', 'https://chess.com/game/1');
-  });
-
   it('calls onSort when a sortable column header is clicked', () => {
     const onSort = vi.fn();
     render(<GameTable games={mockGames} sortBy="" sortDir="asc" onSort={onSort} />);
@@ -70,7 +63,7 @@ describe('GameTable', () => {
   it('does not call onSort for non-sortable columns', () => {
     const onSort = vi.fn();
     render(<GameTable games={mockGames} sortBy="" sortDir="asc" onSort={onSort} />);
-    fireEvent.click(screen.getByText('Game'));
+    fireEvent.click(screen.getByText('Motifs'));
     expect(onSort).not.toHaveBeenCalled();
   });
 
@@ -98,9 +91,8 @@ describe('GameTable', () => {
 
   it('formats unix timestamps as YYYY-MM-DD dates', () => {
     render(<GameTable games={mockGames} sortBy="" sortDir="asc" onSort={() => {}} />);
-    // 1700000000 seconds = 2023-11-14 (both playedAt and indexedAt land on same day)
-    const dateCells = screen.getAllByText('2023-11-14');
-    expect(dateCells.length).toBeGreaterThanOrEqual(1);
+    // 1700000000 seconds = 2023-11-14 (mockGames[0].playedAt)
+    expect(screen.getByText('2023-11-14')).toBeInTheDocument();
   });
 
   it('shows game detail accordion inline when selectedGame matches a row', () => {

--- a/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GameTable.test.tsx
@@ -143,12 +143,59 @@ describe('GameTable', () => {
   });
 
   // The negative half of the move: the link and the indexed date left the table
-  // for GameDetailPanel, so the table body must hold no link at all. This also
-  // pins the accessibility fact that the row is the only affordance here — if
-  // that ever changes, this test should be the thing that notices.
+  // for GameDetailPanel, so the table body must hold no link at all. The way
+  // back to the game is the White-cell toggle plus the panel, covered below.
   it('renders no links in the table body — the game link lives in the detail panel', () => {
     render(<GameTable games={mockGames} />);
     expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  // A <tr onClick> is not focusable and has no keyboard semantics, so when the
+  // game link left the table the body had no keyboard affordance at all and
+  // the panel became pointer-only. These pin the button that fixed that.
+  it('renders the White cell as a button that reports its collapsed state', () => {
+    render(<GameTable games={mockGames} onRowClick={() => {}} />);
+    const toggle = screen.getByRole('button', { name: 'Alice' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    // Dangling references are worse than none: no panel exists to point at.
+    expect(toggle).not.toHaveAttribute('aria-controls');
+  });
+
+  it('reports the expanded state and points at the panel it opened', () => {
+    render(
+      <GameTable
+        games={mockGames}
+        onRowClick={() => {}}
+        selectedGame={mockGames[0]}
+        onClose={() => {}}
+      />
+    );
+    const toggle = screen.getByRole('button', { name: 'Alice' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    const panelId = toggle.getAttribute('aria-controls');
+    expect(panelId).toBeTruthy();
+    // The id has to resolve, or a screen reader follows it nowhere.
+    expect(document.getElementById(panelId!)).not.toBeNull();
+  });
+
+  // The row's own onClick still fires for mouse users. Without stopPropagation
+  // on the button both handlers run, the toggle flips twice, and the panel
+  // lands back exactly where it started — a click that visibly does nothing.
+  // The existing "calls onRowClick with the correct game" test cannot see this:
+  // toHaveBeenCalledWith passes just as well when called twice.
+  it('toggles exactly once when the White button is clicked', () => {
+    const onRowClick = vi.fn();
+    render(<GameTable games={mockGames} onRowClick={onRowClick} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Alice' }));
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledWith(mockGames[0]);
+  });
+
+  // Non-expandable tables must not grow a dead control.
+  it('leaves the White cell as plain text when the table cannot expand', () => {
+    render(<GameTable games={mockGames} />);
+    expect(screen.queryByRole('button', { name: 'Alice' })).not.toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
   });
 
   // jsdom has no layout, so this cannot assert the rendered result — only that

--- a/domains/games/apps/1d4_web/src/components/GameDetailPanel.tsx
+++ b/domains/games/apps/1d4_web/src/components/GameDetailPanel.tsx
@@ -179,16 +179,33 @@ export default function GameDetailPanel({ game, onClose }: Props) {
           <span className="text-muted" style={{ marginLeft: '0.75rem', fontSize: '0.875rem' }}>
             {game.result} · {game.timeClass} · {game.eco}
           </span>
+          {game.indexedAt && (
+            <span className="text-muted" style={{ marginLeft: '0.75rem', fontSize: '0.875rem' }}>
+              indexed {formatDate(game.indexedAt)}
+            </span>
+          )}
         </div>
-        <button
-          type="button"
-          className="btn"
-          onClick={onClose}
-          aria-label="Close panel"
-          style={{ padding: '0 0.5rem' }}
-        >
-          ×
-        </button>
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexShrink: 0 }}>
+          {game.gameUrl && (
+            <a
+              href={game.gameUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn"
+            >
+              View game ↗
+            </a>
+          )}
+          <button
+            type="button"
+            className="btn"
+            onClick={onClose}
+            aria-label="Close panel"
+            style={{ padding: '0 0.5rem' }}
+          >
+            ×
+          </button>
+        </div>
       </div>
 
       {!game.pgn && (

--- a/domains/games/apps/1d4_web/src/components/GameTable.tsx
+++ b/domains/games/apps/1d4_web/src/components/GameTable.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useId, useRef } from 'react';
 import type { GameRow } from '../types';
 import MotifBadge from './MotifBadge';
 import GameDetailPanel from './GameDetailPanel';
@@ -30,9 +30,49 @@ function formatDate(val: string | number | null | undefined): string {
   return isNaN(date.getTime()) ? '—' : date.toISOString().slice(0, 10);
 }
 
-function renderCell(colId: string, game: GameRow): React.ReactNode {
+/** How the White cell expands its row. Absent when the table isn't expandable. */
+interface RowToggle {
+  onToggle: () => void;
+  isExpanded: boolean;
+  panelId: string;
+  register: (el: HTMLButtonElement | null) => void;
+}
+
+function renderCell(
+  colId: string,
+  game: GameRow,
+  toggle: RowToggle | null
+): React.ReactNode {
   const g = game as unknown as Record<string, unknown>;
   switch (colId) {
+    // The White cell doubles as the row's expand control. The row's own
+    // onClick stays for mouse users, but a <tr> is not focusable and has no
+    // keyboard semantics, so before this the detail panel — and with it the
+    // only link to the game on chess.com — could not be reached without a
+    // pointer. A real <button> buys Enter/Space and expand/collapse state for
+    // free, and costs no column width.
+    case 'whiteUsername':
+      return toggle ? (
+        <button
+          type="button"
+          className="row-toggle"
+          ref={toggle.register}
+          aria-expanded={toggle.isExpanded}
+          // Only while the panel exists: aria-controls pointing at an absent
+          // id is a dangling reference.
+          aria-controls={toggle.isExpanded ? toggle.panelId : undefined}
+          onClick={(e) => {
+            // Without this the row handler fires too and toggles a second
+            // time, landing back exactly where it started.
+            e.stopPropagation();
+            toggle.onToggle();
+          }}
+        >
+          {game.whiteUsername}
+        </button>
+      ) : (
+        game.whiteUsername
+      );
     case 'motifs':
       return (
         <span className="motifs">
@@ -74,6 +114,21 @@ export default function GameTable({
   selectedGame,
   onClose,
 }: Props) {
+  // Unique per mounted table, so two tables on one page can't mint the same
+  // panel id for aria-controls to point at.
+  const idPrefix = useId();
+  const toggleRefs = useRef(new Map<string, HTMLButtonElement | null>());
+  const panelIdFor = (game: GameRow, i: number) =>
+    `${idPrefix}panel-${game.gameUrl || i}`;
+
+  // Closing returns focus to the button that opened the panel. Without it the
+  // × unmounts the focused element and the keyboard user is dropped back to
+  // the top of the document, which is its own way of being unusable.
+  function handleClose() {
+    if (selectedGame) toggleRefs.current.get(selectedGame.gameUrl)?.focus();
+    onClose?.();
+  }
+
   return (
     <div className="table-wrap table-wrap--wide">
       <table>
@@ -95,29 +150,38 @@ export default function GameTable({
           </tr>
         </thead>
         <tbody>
-          {games.map((game, i) => (
-            <Fragment key={game.gameUrl || i}>
-              <tr
-                onClick={onRowClick ? () => onRowClick(game) : undefined}
-                style={{ cursor: onRowClick ? 'pointer' : 'default' }}
-                className={selectedGame?.gameUrl === game.gameUrl ? 'selected' : undefined}
-              >
-                {COLUMNS.map((col) => (
-                  <td key={col.id}>{renderCell(col.id, game)}</td>
-                ))}
-              </tr>
-              {selectedGame?.gameUrl === game.gameUrl && (
-                <tr>
-                  <td colSpan={COLUMNS.length} style={{ padding: 0 }}>
-                    <GameDetailPanel
-                      game={selectedGame}
-                      onClose={onClose ?? (() => {})}
-                    />
-                  </td>
+          {games.map((game, i) => {
+            const isExpanded = selectedGame?.gameUrl === game.gameUrl;
+            const panelId = panelIdFor(game, i);
+            const toggle: RowToggle | null = onRowClick
+              ? {
+                  onToggle: () => onRowClick(game),
+                  isExpanded,
+                  panelId,
+                  register: (el) => toggleRefs.current.set(game.gameUrl, el),
+                }
+              : null;
+            return (
+              <Fragment key={game.gameUrl || i}>
+                <tr
+                  onClick={onRowClick ? () => onRowClick(game) : undefined}
+                  style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                  className={isExpanded ? 'selected' : undefined}
+                >
+                  {COLUMNS.map((col) => (
+                    <td key={col.id}>{renderCell(col.id, game, toggle)}</td>
+                  ))}
                 </tr>
-              )}
-            </Fragment>
-          ))}
+                {isExpanded && selectedGame && (
+                  <tr id={panelId}>
+                    <td colSpan={COLUMNS.length} style={{ padding: 0 }}>
+                      <GameDetailPanel game={selectedGame} onClose={handleClose} />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/domains/games/apps/1d4_web/src/components/GameTable.tsx
+++ b/domains/games/apps/1d4_web/src/components/GameTable.tsx
@@ -4,8 +4,11 @@ import MotifBadge from './MotifBadge';
 import GameDetailPanel from './GameDetailPanel';
 
 
+// The game link and indexed-at timestamp live in GameDetailPanel instead of
+// here — eleven columns left the motifs column, the one that actually needs
+// room, squeezed to nothing on a laptop-width screen. Click the row to get
+// both back.
 const COLUMNS = [
-  { id: 'gameUrl', label: 'Game', sort: false },
   { id: 'whiteUsername', label: 'White', sort: true },
   { id: 'blackUsername', label: 'Black', sort: true },
   { id: 'whiteElo', label: 'White ELO', sort: true },
@@ -14,7 +17,6 @@ const COLUMNS = [
   { id: 'eco', label: 'ECO', sort: true },
   { id: 'result', label: 'Result', sort: true },
   { id: 'playedAt', label: 'Played', sort: true },
-  { id: 'indexedAt', label: 'Indexed', sort: true },
   { id: 'motifs', label: 'Motifs', sort: false },
 ];
 
@@ -28,27 +30,9 @@ function formatDate(val: string | number | null | undefined): string {
   return isNaN(date.getTime()) ? '—' : date.toISOString().slice(0, 10);
 }
 
-function renderCell(
-  colId: string,
-  game: GameRow,
-  onRowClick?: (g: GameRow) => void
-): React.ReactNode {
+function renderCell(colId: string, game: GameRow): React.ReactNode {
   const g = game as unknown as Record<string, unknown>;
   switch (colId) {
-    case 'gameUrl':
-      return game.gameUrl ? (
-        <a
-          href={game.gameUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="external"
-          onClick={(e) => e.stopPropagation()}
-        >
-          View
-        </a>
-      ) : (
-        '—'
-      );
     case 'motifs':
       return (
         <span className="motifs">
@@ -65,7 +49,6 @@ function renderCell(
     case 'blackElo':
       return formatElo(g[colId] as number | null);
     case 'playedAt':
-    case 'indexedAt':
       return formatDate(g[colId] as string | number | null);
     default:
       return String(g[colId] ?? '—');
@@ -120,7 +103,7 @@ export default function GameTable({
                 className={selectedGame?.gameUrl === game.gameUrl ? 'selected' : undefined}
               >
                 {COLUMNS.map((col) => (
-                  <td key={col.id}>{renderCell(col.id, game, onRowClick)}</td>
+                  <td key={col.id}>{renderCell(col.id, game)}</td>
                 ))}
               </tr>
               {selectedGame?.gameUrl === game.gameUrl && (

--- a/domains/games/apps/1d4_web/src/index.css
+++ b/domains/games/apps/1d4_web/src/index.css
@@ -140,10 +140,6 @@ body {
   cursor: not-allowed;
 }
 
-a.btn {
-  text-decoration: none;
-}
-
 /* Cards / panels */
 .panel {
   background: var(--surface);
@@ -196,11 +192,15 @@ table {
 }
 
 /* The games table carries nine columns (the game link and indexed-at date
-   moved into GameDetailPanel — see GameTable.tsx). Without a floor the browser
-   keeps honouring width:100% by crushing the last ones instead of letting the
-   wrapper scroll, and the motif badges — the narrowest column's content — get
-   cut mid-word. Scoped to this table so the shorter index-requests table still
-   fits a phone without a scrollbar. */
+   moved into GameDetailPanel — see GameTable.tsx). This is a floor, not the
+   thing keeping badges intact: because the `nowrap` rule below makes every
+   cell's min-content its full text, the table's own intrinsic minimum already
+   sits near this value — measured 816px with short usernames and 993px with
+   ones like `only_strong_moves`, against the 832px below. So it binds only at
+   the short end, and what actually stops a badge being cut mid-word is
+   `white-space: nowrap` on `.motif-badge`. Kept because the short-username
+   case is real, and scoped to this table so the shorter index-requests table
+   still fits a phone without a scrollbar. */
 .table-wrap--wide table {
   min-width: 52rem;
 }
@@ -244,15 +244,6 @@ th .sort-icon {
 
 th.sorted-asc .sort-icon::after { content: " ↑"; }
 th.sorted-desc .sort-icon::after { content: " ↓"; }
-
-td a.external {
-  color: var(--accent);
-  text-decoration: none;
-}
-
-td a.external:hover {
-  text-decoration: underline;
-}
 
 /* Motif badges */
 .motifs {

--- a/domains/games/apps/1d4_web/src/index.css
+++ b/domains/games/apps/1d4_web/src/index.css
@@ -245,6 +245,32 @@ th .sort-icon {
 th.sorted-asc .sort-icon::after { content: " ↑"; }
 th.sorted-desc .sort-icon::after { content: " ↓"; }
 
+/* The White cell is the row's expand control — a real button so the detail
+   panel is keyboard-reachable (see GameTable.tsx). Tailwind preflight already
+   zeroes padding/margin/border and inherits font and colour, so this only has
+   to undo the button-ness that would otherwise read as a control in a column
+   of plain usernames. */
+.row-toggle {
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.row-toggle:hover {
+  color: var(--accent);
+}
+
+/* Which row the open panel belongs to. The panel renders in a separate <tr>,
+   so without this the connection between the two is left to proximity. Uses
+   neither --surface nor --border flat: the table sits inside a .panel that is
+   already --surface, so that reads as no highlight at all, and --border is
+   exactly what .motif-badge paints its chips with, so the badges in the
+   highlighted row dissolve into it. Sitting between the two keeps both
+   contrasts. */
+tr.selected td {
+  background: color-mix(in oklab, var(--border) 55%, var(--surface));
+}
+
 /* Motif badges */
 .motifs {
   display: flex;

--- a/domains/games/apps/1d4_web/src/index.css
+++ b/domains/games/apps/1d4_web/src/index.css
@@ -140,6 +140,10 @@ body {
   cursor: not-allowed;
 }
 
+a.btn {
+  text-decoration: none;
+}
+
 /* Cards / panels */
 .panel {
   background: var(--surface);
@@ -191,13 +195,14 @@ table {
   font-size: 0.875rem;
 }
 
-/* The games table carries eleven columns. Without a floor the browser keeps
-   honouring width:100% by crushing the last ones instead of letting the wrapper
-   scroll, and the motif badges — the narrowest column's content — get cut
-   mid-word. Scoped to this table so the shorter index-requests table still fits
-   a phone without a scrollbar. */
+/* The games table carries nine columns (the game link and indexed-at date
+   moved into GameDetailPanel — see GameTable.tsx). Without a floor the browser
+   keeps honouring width:100% by crushing the last ones instead of letting the
+   wrapper scroll, and the motif badges — the narrowest column's content — get
+   cut mid-word. Scoped to this table so the shorter index-requests table still
+   fits a phone without a scrollbar. */
 .table-wrap--wide table {
-  min-width: 64rem;
+  min-width: 52rem;
 }
 
 /* Every value in this table is an atom — a username, an ELO, an ISO date. None


### PR DESCRIPTION
## Summary

The 1d4 games table carried eleven columns, and on desktop that left Motifs — the one column whose content is genuinely variable — squeezed to nothing: badges rendered cut off mid-word ("pi", "d", "cl" instead of "pin", "discovered attack", "checkmate").

**Commit 1 — the move.** Dropped the "Game" (View link) and "Indexed" columns from `GameTable`, taking it to nine. Both now live in `GameDetailPanel`, the expanded row view that already opens on row click: a "View game" button and an `indexed <date>` label in its header.

**Commit 2 — review panel follow-ups.** Three independent read-only agents (correctness, UX/a11y/CSS, tests/CI); every surviving finding verified by hand, several by measuring in a real browser rather than reasoning about the cascade.

- Nothing pinned the new column set, so re-adding a Game or Indexed column was a silently green change. Now an exact header-list assertion, plus one pinning that the table body holds no links.
- Added the missing negative for the `indexedAt` guard — `formatDate` returns `''` for a missing value, so dropping the guard rendered a bare `indexed ` with no date.
- Asserted `rel="noopener noreferrer"` travels with `target="_blank"`.
- The `min-width` assertion was `/min-width:\s*\d/`, which passed just as happily against `0` and `4px` as against `52rem`. Now pins the unit and a band.
- Deleted two dead rules: `td a.external` styled only the link this PR moved, and an `a.btn { text-decoration: none }` rule added in commit 1 turned out to be a no-op — Tailwind preflight already sets `a { text-decoration: inherit }`.
- Measured the `min-width` floor instead of trusting its comment: with `white-space: nowrap` making each cell's min-content its full text, the table's intrinsic minimum is 816px at short usernames and 993px at ones like `only_strong_moves`, against an 832px floor. It binds only at the short end, and what actually keeps a badge from being cut mid-word is `white-space: nowrap` on `.motif-badge`. The comment now says that rather than over-claiming.

**Commit 3 — the White cell becomes the row's expand control.** Commit 1 had a real cost the panel caught: a `<tr onClick>` is not focusable and carries no keyboard semantics, so moving the link into the panel left `<tbody>` with **zero focusable elements**. Measured in Chromium — Tab went from the search box straight past the table to Pagination, leaving a keyboard user no route to a game's URL at all (WCAG 2.1.1, Level A).

- The White username now renders as a real `<button>` with `aria-expanded`, so Enter and Space work and the state is announced. No column width cost — the table stays at nine.
- The row's own `onClick` stays for mouse users. The button stops propagation; without it both handlers fire, the toggle flips twice, and the click visibly does nothing.
- `aria-controls` points at the panel row, and only while that row exists.
- Closing returns focus to the button that opened it, rather than unmounting the focused element and dropping the user at the top of the document.
- Gave `tr.selected` a rule — it was a `className` with nothing behind it, and expanding is now a first-class keyboard action. Sits between `--surface` and `--border`, because the table is inside a `.panel` that is already `--surface` and `--border` is what `.motif-badge` paints its chips with, so either flat value dissolves one of the two contrasts.

## Test plan

- [x] `npx vitest run` — 119 passing (108 before this PR)
- [x] `npx tsc --noEmit` and `npx vite build` — clean
- [x] `scripts/mutation-check` on every new/tightened assertion — all killed, including the three the old `min-width` regex let through (`0`, `52px`, `120rem`) and the four on the toggle (`stopPropagation`, `aria-expanded`, `aria-controls`, focus restore)
- [x] Verified in Chromium at 375 / 1024 / 1280 / 1440px: motif badges render as complete unbroken labels, and the panel header does **not** widen the table (scrollWidth 993px open and closed, refuting one panel finding)
- [x] Keyboard round-trip in Chromium: Tab reaches the toggle → Enter opens the panel → Tab lands on "View game" → `aria-controls` resolves → closing restores focus to the toggle. Toggle's computed font, colour, background and alignment are identical to the plain cell beside it.

## Known limitation

At a 375px viewport the relocated "View game" link sits at x≈754, inside the table's horizontal scroll rather than in column 1 where it used to be. The toggle button is at x≈0 and reachable, so the panel opens fine on a phone; reaching the link inside it still needs a sideways scroll. `docs/ROADMAP.md` tracks a mobile card layout as unstarted Phase 4 work, which is where that belongs.