### PR TITLE
Bump smithy-cpp past #173 (terminal-waiter send-before-receive)

### DIFF
--- a/bazel/smithy.MODULE.bazel
+++ b/bazel/smithy.MODULE.bazel
@@ -1,13 +1,21 @@
 bazel_dep(name = "smithy_cpp", version = "0.0.0")
 
 # smithy_cpp is not published to the Bazel Central Registry yet, so the module
-# version above is a placeholder and the source comes from the pinned release
-# tarball below. The integrity hash pins the contents, so a re-pointed tag
-# fails loudly rather than silently changing the build.
+# version above is a placeholder and the source comes from the pinned archive
+# below. The integrity hash pins the contents, so a re-pointed URL fails
+# loudly rather than silently changing the build.
 # Evaluation: https://github.com/muchq/MoonBase/issues/1168
+#
+# Pinned past muchq/smithy-cpp#173 (4208f791): terminal transitions fire the
+# parked send before the parked receive so End()/Close cannot deadlock when a
+# harvested send waiter still holds the stream pin. Golf hub e2e Quiesce is
+# defense-in-depth for unread wake frames; the End() hang that motivated it
+# is fixed upstream here.
 archive_override(
     module_name = "smithy_cpp",
-    integrity = "sha256-m08PFnKnnuGomq1yX6R0unbjAGhIX6gZx4FEo2Dcqec=",
-    strip_prefix = "smithy-cpp-0.1.0",
-    urls = ["https://github.com/muchq/smithy-cpp/archive/refs/tags/v0.1.0.tar.gz"],
+    integrity = "sha256-xHxCkCYRt/JIachM/q2SmPF2JvZbk5Jo4oCNZCyJ6+A=",
+    strip_prefix = "smithy-cpp-4208f791464c55520da6db0e4c491da9402c7508",
+    urls = [
+        "https://github.com/muchq/smithy-cpp/archive/4208f791464c55520da6db0e4c491da9402c7508.tar.gz",
+    ],
 )

--- a/domains/games/apis/golf_hub/BUILD.bazel
+++ b/domains/games/apis/golf_hub/BUILD.bazel
@@ -318,12 +318,11 @@ cc_library(
 cc_test(
     name = "pg_hub_e2e_test",
     # Small on purpose (#1241, #1276): normal runtime is ~2s; the tight
-    # ceiling turns a recurrence into a loud red. Two independent hang
-    # shapes share the signature — a lost LISTEN/NOTIFY wakeup (fixed in
-    # pg::Listener) and a TearDown End() deadlock when unread wake
-    # frames pin the async delivery chain (worked around here by
-    # QuiesceCrossTable; root cause is send-before-receive ordering in
-    # smithy-cpp). Do not raise the ceiling.
+    # ceiling turns a recurrence into a loud red. Two hang shapes share
+    # the signature — a lost LISTEN/NOTIFY wakeup (fixed in pg::Listener)
+    # and a TearDown End() deadlock on unread wake frames (smithy-cpp#173
+    # send-before-receive; QuiesceCrossTable still drains for deterministic
+    # teardown). Do not raise the ceiling.
     size = "small",
     srcs = [
         "pg_hub_e2e_test.cc",

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -254,11 +254,9 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
   }
 
   // Pulls already-queued frames off a seat so the registry's async
-  // delivery chain can finish. Leaving those frames unread parks
-  // TearDown in SharedViewOwner::End — a smithy-cpp close-ordering
-  // deadlock (receive completion runs ~AsyncEventStream→End→Close while
-  // a harvested send waiter still holds the pin). Quiesce is the
-  // fixture workaround; the real fix is send-before-receive in smithy.
+  // delivery chain can finish. smithy-cpp#173 (send-before-receive on
+  // terminal transitions) fixed the End()/Close deadlock; draining here
+  // still keeps TearDown deterministic when wake frames are unread.
   static void DrainPending(moonbase::golf::PlayClientStream& stream) {
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
     while (std::chrono::steady_clock::now() < deadline) {

--- a/domains/platform/libs/aura/middleware.cc
+++ b/domains/platform/libs/aura/middleware.cc
@@ -45,6 +45,8 @@ std::string KindName(smithy::http::BeastServerTransport::ConnectionEvent::Kind k
       return "read_timeout";
     case Kind::kDropped:
       return "dropped";
+    case Kind::kUpgradeFailure:
+      return "upgrade_failure";
   }
   // Reached only when a pin bump adds a Kind this mapping doesn't know yet
   // (-Wswitch flags the missing case, but it isn't an error here): surface

--- a/domains/platform/libs/aura/middleware_test.cc
+++ b/domains/platform/libs/aura/middleware_test.cc
@@ -324,6 +324,24 @@ TEST(ConnectionEventLogTest, LogsKindPeerDetailAndElapsed) {
   log.StopCapturingLogs();
 }
 
+// Failed WebSocket upgrades (smithy ConnectionEvent::kUpgradeFailure) must
+// name themselves — not fall through to unknown(N) after a pin bump.
+TEST(ConnectionEventLogTest, LogsUpgradeFailureKind) {
+  smithy::http::BeastServerTransport::ConnectionEvent event;
+  event.kind = smithy::http::BeastServerTransport::ConnectionEvent::Kind::kUpgradeFailure;
+  event.peer_address = "203.0.113.10:80";
+  event.detail = "handshake failed";
+  event.elapsed = std::chrono::milliseconds(12);
+
+  absl::ScopedMockLog log(absl::MockLogDefault::kIgnoreUnexpected);
+  EXPECT_CALL(log, Log(absl::LogSeverity::kWarning, testing::_,
+                       "connection_event kind=upgrade_failure peer=203.0.113.10:80 "
+                       "detail=handshake failed elapsed_ms=12"));
+  log.StartCapturingLogs();
+  aura::ConnectionEventLog()(event);
+  log.StopCapturingLogs();
+}
+
 // A 431 can fire before Beast parses the method or target; the adapter maps
 // those to a stable label instead of empty strings dashboards would drop.
 TEST(RejectionMetricsTest, UnparsedRejectionLandsOnStableLabels) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopts latest `smithy-cpp` main (`4208f791`, includes [muchq/smithy-cpp#173](https://github.com/muchq/smithy-cpp/pull/173)): terminal transitions fire the parked **send** before the parked **receive**, so `End()`/`Close` cannot deadlock when a harvested send waiter still holds the stream pin.

That is the TearDown hang shape surfaced by golf hub e2e under #1276 / #1289 (`QuiesceCrossTable` was the fixture workaround). No newer release tag than `v0.1.0` yet, so the pin moves from the tag tarball to the commit archive with integrity.

Also maps aura’s `ConnectionEvent` log kind for `kUpgradeFailure` (pin-bump `-Wswitch`).

## Changes

- `bazel/smithy.MODULE.bazel`: `archive_override` → `4208f791…` + integrity `sha256-xHxCkCYRt/JIachM/q2SmPF2JvZbk5Jo4oCNZCyJ6+A=`
- `aura` middleware: `kUpgradeFailure` → `upgrade_failure` + pin test
- Comment updates in `pg_hub_e2e_test` / `BUILD.bazel`: upstream fix noted; `QuiesceCrossTable` kept for deterministic unread-wake drain

`MODULE.bazel.lock` left untouched (sandbox override churn; pin is integrity-hashed in the archive_override).

## Relevance to #1276 / #1289

Directly relevant: #173 is the production-reachable End() deadlock that `QuiesceCrossTable` worked around. After this bump the root cause is fixed upstream; Quiesce remains as defense-in-depth for unread wake frames.

## Test plan

- [x] `bazel test //domains/games/apis/golf_hub:pg_hub_e2e_test //domains/games/apis/golf_hub:hub_store_race_test //domains/games/apis/golf_hub:smithy_contract_test //domains/platform/libs/pg:listener_test` — all PASSED (`pg_hub_e2e_test` 2.1s)
- [x] `//domains/platform/libs/aura:smithy_contract_test` + `middleware_test`; `//domains/graphics/apis/portrait/...` tests — PASSED
- [x] Confirmed `@smithy_cpp//runtime:…` resolves and rebuilds against the new archive

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc3bc-defe-7b9b-8734-c3180586b027?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc3bc-defe-7b9b-8734-c3180586b027&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

