### PR TITLE
prom_proxy: count/rate as separate always-present series across the Serving and Trends charts

### DIFF
--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -26,15 +26,11 @@ type DataPoint struct {
 
 // TimeSeriesResponse wraps timeseries data with metadata
 type TimeSeriesResponse struct {
-	TimeRange string    `json:"time_range"`
-	StartTime time.Time `json:"start_time"`
-	EndTime   time.Time `json:"end_time"`
-	Step      string    `json:"step"`
-	// Which form request_rate is in (#1287, extended to the Serving charts).
-	// Omitted from the host and container timeseries endpoints, which have no
-	// toggleable series and so never set it — see GetServiceMetricsTimeSeries.
-	View   string       `json:"view,omitempty"`
-	Series []TimeSeries `json:"series"`
+	TimeRange string       `json:"time_range"`
+	StartTime time.Time    `json:"start_time"`
+	EndTime   time.Time    `json:"end_time"`
+	Step      string       `json:"step"`
+	Series    []TimeSeries `json:"series"`
 }
 
 // GetTimeRangeConfig returns duration and step for a given time range

--- a/domains/platform/apis/prom_proxy/models.go
+++ b/domains/platform/apis/prom_proxy/models.go
@@ -26,11 +26,15 @@ type DataPoint struct {
 
 // TimeSeriesResponse wraps timeseries data with metadata
 type TimeSeriesResponse struct {
-	TimeRange string       `json:"time_range"`
-	StartTime time.Time    `json:"start_time"`
-	EndTime   time.Time    `json:"end_time"`
-	Step      string       `json:"step"`
-	Series    []TimeSeries `json:"series"`
+	TimeRange string    `json:"time_range"`
+	StartTime time.Time `json:"start_time"`
+	EndTime   time.Time `json:"end_time"`
+	Step      string    `json:"step"`
+	// Which form request_rate is in (#1287, extended to the Serving charts).
+	// Omitted from the host and container timeseries endpoints, which have no
+	// toggleable series and so never set it — see GetServiceMetricsTimeSeries.
+	View   string       `json:"view,omitempty"`
+	Series []TimeSeries `json:"series"`
 }
 
 // GetTimeRangeConfig returns duration and step for a given time range

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -182,9 +182,12 @@ func tsFixed(query string) customTimeseriesDef {
 }
 
 // expandCustomTimeseries flattens a service's Trends descriptors into the
-// panel keys a timeseries response actually carries.
+// panel keys a timeseries response actually carries. A toggleable entry
+// contributes two, so the capacity hint doubles the map's own length —
+// only ever a hint, but len(custom) undercounts by up to 2x whenever the
+// registry is mostly toggleable entries, which is the common case.
 func expandCustomTimeseries(custom map[string]customTimeseriesDef, step string) map[string]string {
-	out := make(map[string]string, len(custom))
+	out := make(map[string]string, len(custom)*2)
 	for key, def := range custom {
 		for panelKey, query := range def.panels(key, step) {
 			out[panelKey] = query
@@ -281,7 +284,13 @@ var serviceRegistry = map[string]serviceEntry{
 		// only ever asked for the rate panel keeps reading the same series
 		// name it always did.
 		CustomTimeseries: map[string]customTimeseriesDef{
-			"sessions_active":    tsFixed(`sum(stream_sessions_active_gauge)`),
+			"sessions_active": tsFixed(`sum(stream_sessions_active_gauge)`),
+			// Fixed rather than tsCounter(stream_sessions_total): this key
+			// predates the toggle and is already a count, over a plain 5m
+			// window rather than the chart's own step. Making it toggleable
+			// would rename it away from "session_starts" (tsCounter's base
+			// key becomes both the _rate and _count panel name), breaking
+			// the one client-facing name this key has ever had.
 			"session_starts":     tsFixed(`sum(increase(stream_sessions_total[5m]))`),
 			"command":            tsCounter(`stream_commands_total`),
 			"event":              tsCounter(`stream_events_total`),

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -375,14 +375,37 @@ func standardScalarQueries(service string) []struct {
 	}
 }
 
+// standardRequestRateQuery is the one standard timeseries built from a
+// counter, so it is also the one with a count form (#1287 extended to the
+// Serving charts).
+//
+// The count form buckets per step rather than over a fixed window like the
+// scalar tiles' 5m: a chart wants one count per point, and increase() over a
+// window wider than the gap between points would make adjacent buckets
+// overlap and double-count requests that land near a boundary. container_
+// handlers' "restarts" series already windows a range query by its own step
+// for the same reason.
+func standardRequestRateQuery(service, step string, view MetricView) string {
+	s := fmt.Sprintf("%q", service)
+	if view == ViewCount {
+		return `sum(increase(http_server_requests_total{service_name=` + s + `}[` + step + `]))`
+	}
+	return `sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`
+}
+
 // Keys are mirrored by STANDARD_SERIES in the UI's ServiceDashboard
 // (muchq.github.io); keep them in sync, and keep CustomTimeseries keys
 // from colliding with them — a colliding custom series is classified as
 // standard by the UI and silently never charts.
-func standardTimeseriesQueries(service string) map[string]string {
+//
+// Only request_rate answers to view: it is the only one of the five built
+// from a counter. The other four are already ratios, quantiles, or a gauge —
+// none of them has a count form to switch to, the same reasoning that keeps
+// the scalar block's windowed-mean tiles fixed-form in QueryFor above.
+func standardTimeseriesQueries(service, step string, view MetricView) map[string]string {
 	s := fmt.Sprintf("%q", service)
 	return map[string]string{
-		"request_rate":       `sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`,
+		"request_rate":       standardRequestRateQuery(service, step, view),
 		"error_rate_percent": `sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m]))/(sum(rate(http_server_requests_success_total{service_name=` + s + `}[5m]))+sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m])))*100`,
 		"avg_duration_us":    `sum(rate(http_server_request_duration_microseconds_sum{service_name=` + s + `}[5m]))/sum(rate(http_server_request_duration_microseconds_count{service_name=` + s + `}[5m]))`,
 		"p95_duration_us":    `histogram_quantile(0.95,sum by (le) (rate(http_server_request_duration_microseconds_bucket{service_name=` + s + `}[5m])))`,

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -375,9 +375,22 @@ func standardScalarQueries(service string) []struct {
 	}
 }
 
-// standardRequestRateQuery is the one standard timeseries built from a
-// counter, so it is also the one with a count form (#1287 extended to the
-// Serving charts).
+// Keys are mirrored by STANDARD_SERIES in the UI's ServiceDashboard
+// (muchq.github.io); keep them in sync, and keep CustomTimeseries keys
+// from colliding with them — a colliding custom series is classified as
+// standard by the UI and silently never charts.
+//
+// request_count sits beside request_rate rather than replacing it under a
+// ?view=-selected meaning, on the same reasoning #1287 already spelled out
+// for the scalar block: a toggle that changes what an existing key means is
+// a deploy hazard between two services that ship independently — a proxy new
+// enough to answer the count form and a UI old enough to still expect rate()
+// under that name would silently mislabel the chart, and the reverse is just
+// as possible depending on rollout order. Two names, one always rate() and
+// one always increase(), means either side can deploy first: an old UI never
+// asks for request_count and keeps reading request_rate exactly as before: a
+// new UI reading an old proxy simply finds no request_count series, the same
+// "nothing there yet" a chart already renders for any absent series.
 //
 // The count form buckets per step rather than over a fixed window like the
 // scalar tiles' 5m: a chart wants one count per point, and increase() over a
@@ -385,27 +398,16 @@ func standardScalarQueries(service string) []struct {
 // overlap and double-count requests that land near a boundary. container_
 // handlers' "restarts" series already windows a range query by its own step
 // for the same reason.
-func standardRequestRateQuery(service, step string, view MetricView) string {
-	s := fmt.Sprintf("%q", service)
-	if view == ViewCount {
-		return `sum(increase(http_server_requests_total{service_name=` + s + `}[` + step + `]))`
-	}
-	return `sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`
-}
-
-// Keys are mirrored by STANDARD_SERIES in the UI's ServiceDashboard
-// (muchq.github.io); keep them in sync, and keep CustomTimeseries keys
-// from colliding with them — a colliding custom series is classified as
-// standard by the UI and silently never charts.
 //
-// Only request_rate answers to view: it is the only one of the five built
-// from a counter. The other four are already ratios, quantiles, or a gauge —
-// none of them has a count form to switch to, the same reasoning that keeps
-// the scalar block's windowed-mean tiles fixed-form in QueryFor above.
-func standardTimeseriesQueries(service, step string, view MetricView) map[string]string {
+// Only request_rate/request_count answer to a counter: they're the only pair
+// built from one. The other three are already ratios, a quantile, or a
+// gauge — none has a count form, the same reasoning that keeps the scalar
+// block's windowed-mean tiles fixed-form in QueryFor above.
+func standardTimeseriesQueries(service, step string) map[string]string {
 	s := fmt.Sprintf("%q", service)
 	return map[string]string{
-		"request_rate":       standardRequestRateQuery(service, step, view),
+		"request_rate":       `sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`,
+		"request_count":      `sum(increase(http_server_requests_total{service_name=` + s + `}[` + step + `]))`,
 		"error_rate_percent": `sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m]))/(sum(rate(http_server_requests_success_total{service_name=` + s + `}[5m]))+sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m])))*100`,
 		"avg_duration_us":    `sum(rate(http_server_request_duration_microseconds_sum{service_name=` + s + `}[5m]))/sum(rate(http_server_request_duration_microseconds_count{service_name=` + s + `}[5m]))`,
 		"p95_duration_us":    `histogram_quantile(0.95,sum by (le) (rate(http_server_request_duration_microseconds_bucket{service_name=` + s + `}[5m])))`,

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -138,9 +138,67 @@ func (d customScalarDef) UnitFor(view MetricView) string {
 	return d.Unit + "/s"
 }
 
+// customTimeseriesDef is one chart in a service's Trends section.
+//
+// A fixed one — a gauge, a ratio, a windowed mean — carries its whole
+// expression in Query, the timeseries analogue of customScalarDef.Query. A
+// counter-derived one sets Counter instead: the bare selector, wrapped into
+// two panels rather than one whose meaning depends on ?view= — see the
+// request_rate/request_count comment on standardTimeseriesQueries for why.
+// The map key is the panel's base name; panels() appends _rate/_count to it,
+// so a toggleable entry never has to spell either suffix twice.
+type customTimeseriesDef struct {
+	Query   string
+	Counter string
+}
+
+func (d customTimeseriesDef) toggleable() bool { return d.Counter != "" }
+
+// panels is the key(s) this descriptor contributes to a timeseries response:
+// the map key unchanged for a fixed chart, key_rate/key_count for a
+// counter-derived one. step is the chart's own bucket width, the same
+// per-point windowing request_count uses and for the same reason: increase()
+// over a fixed window wider than the gap between points would make adjacent
+// buckets overlap and double-count.
+func (d customTimeseriesDef) panels(key, step string) map[string]string {
+	if !d.toggleable() {
+		return map[string]string{key: d.Query}
+	}
+	return map[string]string{
+		key + "_rate":  fmt.Sprintf("sum(rate(%s[%s]))", d.Counter, defaultCounterWindow),
+		key + "_count": fmt.Sprintf("sum(increase(%s[%s]))", d.Counter, step),
+	}
+}
+
+// tsCounter declares a toggleable Trends chart: its map key is the base
+// name, and panels() expands it into <base>_rate and <base>_count.
+func tsCounter(selector string) customTimeseriesDef {
+	return customTimeseriesDef{Counter: selector}
+}
+
+// tsFixed declares a Trends chart with one form and no toggle.
+func tsFixed(query string) customTimeseriesDef {
+	return customTimeseriesDef{Query: query}
+}
+
+// expandCustomTimeseries flattens a service's Trends descriptors into the
+// panel keys a timeseries response actually carries.
+func expandCustomTimeseries(custom map[string]customTimeseriesDef, step string) map[string]string {
+	out := make(map[string]string, len(custom))
+	for key, def := range custom {
+		for panelKey, query := range def.panels(key, step) {
+			out[panelKey] = query
+		}
+	}
+	return out
+}
+
 type serviceEntry struct {
-	CustomScalars    []customScalarDef
-	CustomTimeseries map[string]string
+	CustomScalars []customScalarDef
+	// Keyed by base name; a toggleable entry expands to two panel keys — see
+	// customTimeseriesDef.panels — so this map's own keys are not always the
+	// series names a timeseries response carries.
+	CustomTimeseries map[string]customTimeseriesDef
 }
 
 // Portrait's render cache emits the standard cache family (#1209) from
@@ -216,18 +274,24 @@ var serviceRegistry = map[string]serviceEntry{
 			counter("Chat", "history_replays", "", `chat_history_replays_total`),
 			counterOver("Chat", "failures", "", `chat_failures_total`, alarmWindow),
 		},
-		CustomTimeseries: map[string]string{
-			"sessions_active":    `sum(stream_sessions_active_gauge)`,
-			"session_starts":     `sum(increase(stream_sessions_total[5m]))`,
-			"command_rate":       `sum(rate(stream_commands_total[5m]))`,
-			"event_rate":         `sum(rate(stream_events_total[5m]))`,
-			"rejection_rate":     `sum(rate(stream_rejections_total[5m]))`,
-			"disconnect_rate":    `sum(rate(stream_disconnects_total[5m]))`,
-			"rate_limited_rate":  `sum(rate(stream_rate_limited_total[5m]))`,
-			"chat_message_rate":  `sum(rate(chat_appends_total{result="stored"}[5m]))`,
-			"chat_delivery_rate": `sum(rate(chat_rows_delivered_total[5m]))`,
-			"chat_failure_rate":  `sum(rate(chat_failures_total[5m]))`,
-			"chat_catch_up_rows": `sum(rate(chat_catch_up_rows_sum[5m]))/sum(rate(chat_catch_up_rows_count[5m]))`,
+		// command/event/rejection/disconnect/rate_limited/chat_message/
+		// chat_delivery/chat_failure are all toggleable: each expands to a
+		// _rate and a _count panel (see customTimeseriesDef.panels). Base
+		// names match the pre-toggle _rate keys exactly, so a client that
+		// only ever asked for the rate panel keeps reading the same series
+		// name it always did.
+		CustomTimeseries: map[string]customTimeseriesDef{
+			"sessions_active":    tsFixed(`sum(stream_sessions_active_gauge)`),
+			"session_starts":     tsFixed(`sum(increase(stream_sessions_total[5m]))`),
+			"command":            tsCounter(`stream_commands_total`),
+			"event":              tsCounter(`stream_events_total`),
+			"rejection":          tsCounter(`stream_rejections_total`),
+			"disconnect":         tsCounter(`stream_disconnects_total`),
+			"rate_limited":       tsCounter(`stream_rate_limited_total`),
+			"chat_message":       tsCounter(`chat_appends_total{result="stored"}`),
+			"chat_delivery":      tsCounter(`chat_rows_delivered_total`),
+			"chat_failure":       tsCounter(`chat_failures_total`),
+			"chat_catch_up_rows": tsFixed(`sum(rate(chat_catch_up_rows_sum[5m]))/sum(rate(chat_catch_up_rows_count[5m]))`),
 		},
 	},
 	"microgpt-serve": {
@@ -239,9 +303,13 @@ var serviceRegistry = map[string]serviceEntry{
 				`sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`),
 			counter("Inference", "conversations", "", `microgpt_conversations_total`),
 		},
-		CustomTimeseries: map[string]string{
-			"tokens_per_second": `sum(rate(microgpt_tokens_generated_total[5m]))`,
-			"avg_duration_ms":   `sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`,
+		// "tokens" replaces the old "tokens_per_second" key: that name baked
+		// in one form the way request_rate used to, and toggling it points
+		// at tokens_rate/tokens_count instead. No other consumer names the
+		// old key (grep confirms this is the only place it appeared).
+		CustomTimeseries: map[string]customTimeseriesDef{
+			"tokens":          tsCounter(`microgpt_tokens_generated_total`),
+			"avg_duration_ms": tsFixed(`sum(rate(microgpt_request_duration_ms_sum[5m]))/sum(rate(microgpt_request_duration_ms_count[5m]))`),
 		},
 	},
 	// The Java services (#1212): yodel's standard instruments only, no
@@ -291,9 +359,9 @@ var serviceRegistry = map[string]serviceEntry{
 			// small enough to turn the result into a four-order-of-magnitude spike. A tile
 			// that is wrong exactly when the system is unhealthy is worse than no tile.
 		},
-		CustomTimeseries: map[string]string{
-			"games_indexed_rate":  `sum(rate(games_indexed_total{service_name="one_d4"}[5m]))`,
-			"run_completion_rate": `sum(rate(index_runs_total{service_name="one_d4",outcome="completed"}[5m]))`,
+		CustomTimeseries: map[string]customTimeseriesDef{
+			"games_indexed":  tsCounter(`games_indexed_total{service_name="one_d4"}`),
+			"run_completion": tsCounter(`index_runs_total{service_name="one_d4",outcome="completed"}`),
 			// Selected, not subtracted. In PromQL sum() over no matching series is an
 			// empty vector, and vector-minus-empty is empty rather than the left side —
 			// so a total-minus-completed form renders nothing on a fresh process whose
@@ -303,9 +371,9 @@ var serviceRegistry = map[string]serviceEntry{
 			// is ordinary. A range changing hands mid-run happens whenever two pollers
 			// overlap, so counting it here puts a permanent floor under the failure line
 			// and buries the two outcomes that do mean something went wrong.
-			"run_failure_rate":    `sum(rate(index_runs_total{service_name="one_d4",outcome=~"failed|interrupted"}[5m]))`,
-			"run_duration_avg_us": `sum(rate(index_run_duration_micros_sum{service_name="one_d4",outcome="completed"}[5m]))/sum(rate(index_run_duration_micros_count{service_name="one_d4",outcome="completed"}[5m]))`,
-			"motif_rate":          `sum(rate(motif_occurrences_total{service_name="one_d4"}[5m]))`,
+			"run_failure":         tsCounter(`index_runs_total{service_name="one_d4",outcome=~"failed|interrupted"}`),
+			"run_duration_avg_us": tsFixed(`sum(rate(index_run_duration_micros_sum{service_name="one_d4",outcome="completed"}[5m]))/sum(rate(index_run_duration_micros_count{service_name="one_d4",outcome="completed"}[5m]))`),
+			"motif":               tsCounter(`motif_occurrences_total{service_name="one_d4"}`),
 		},
 	},
 	// Wordchains: server_pal's standard instruments only, no custom set.
@@ -325,13 +393,19 @@ var serviceRegistry = map[string]serviceEntry{
 			scalar("Scene complexity", "avg_lights_requested_1h", "lights", portraitLightsRequested),
 			scalar("Scene complexity", "avg_lights_rendered_1h", "lights", portraitLightsRendered),
 		},
-		CustomTimeseries: map[string]string{
-			"cache_hit_rate":          portraitCacheHitPercent,
-			"cache_operations_rate":   `sum(rate(` + portraitCacheOps + `[5m]))`,
-			"scene_spheres_requested": `sum(rate(scene_sphere_count_sum[5m]))/sum(rate(scene_sphere_count_count[5m]))`,
-			"scene_spheres_rendered":  `sum(rate(scene_sphere_count_sum{cache_hit="false"}[5m]))/sum(rate(scene_sphere_count_count{cache_hit="false"}[5m]))`,
-			"scene_lights_requested":  `sum(rate(scene_light_count_sum[5m]))/sum(rate(scene_light_count_count[5m]))`,
-			"scene_lights_rendered":   `sum(rate(scene_light_count_sum{cache_hit="false"}[5m]))/sum(rate(scene_light_count_count{cache_hit="false"}[5m]))`,
+		// cache_hit_rate keeps its _rate-shaped name despite being fixed-form:
+		// it is a ratio (hits over hits+misses), not a counter-derived rate,
+		// so it has no _count sibling and the name predates this file's
+		// convention of that suffix meaning "toggleable." Renaming it would
+		// only cost clarity for a chart that was never going to pair with
+		// anything.
+		CustomTimeseries: map[string]customTimeseriesDef{
+			"cache_hit_rate":          tsFixed(portraitCacheHitPercent),
+			"cache_operations":        tsCounter(portraitCacheOps),
+			"scene_spheres_requested": tsFixed(`sum(rate(scene_sphere_count_sum[5m]))/sum(rate(scene_sphere_count_count[5m]))`),
+			"scene_spheres_rendered":  tsFixed(`sum(rate(scene_sphere_count_sum{cache_hit="false"}[5m]))/sum(rate(scene_sphere_count_count{cache_hit="false"}[5m]))`),
+			"scene_lights_requested":  tsFixed(`sum(rate(scene_light_count_sum[5m]))/sum(rate(scene_light_count_count[5m]))`),
+			"scene_lights_rendered":   tsFixed(`sum(rate(scene_light_count_sum{cache_hit="false"}[5m]))/sum(rate(scene_light_count_count{cache_hit="false"}[5m]))`),
 		},
 	},
 }
@@ -399,16 +473,24 @@ func standardScalarQueries(service string) []struct {
 // handlers' "restarts" series already windows a range query by its own step
 // for the same reason.
 //
-// Only request_rate/request_count answer to a counter: they're the only pair
-// built from one. The other three are already ratios, a quantile, or a
-// gauge — none has a count form, the same reasoning that keeps the scalar
-// block's windowed-mean tiles fixed-form in QueryFor above.
+// request_rate/request_count and error_rate_percent/error_count are the two
+// pairs built from a counter: total requests and failed requests. Everything
+// else here — avg/p95 latency, active requests — is a ratio, a quantile, or a
+// gauge, none of which has a count form, the same reasoning that keeps the
+// scalar block's windowed-mean tiles fixed-form in QueryFor above.
+//
+// error_count is the count of failures, not "the error rate as a count" —
+// there's no such thing, since error_rate_percent is already a ratio of two
+// rates rather than a windowed read of one counter. A failure count is the
+// closest counter-derived analogue, the same relationship request_count has
+// to request_rate.
 func standardTimeseriesQueries(service, step string) map[string]string {
 	s := fmt.Sprintf("%q", service)
 	return map[string]string{
 		"request_rate":       `sum(rate(http_server_requests_total{service_name=` + s + `}[5m]))`,
 		"request_count":      `sum(increase(http_server_requests_total{service_name=` + s + `}[` + step + `]))`,
 		"error_rate_percent": `sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m]))/(sum(rate(http_server_requests_success_total{service_name=` + s + `}[5m]))+sum(rate(http_server_requests_failure_total{service_name=` + s + `}[5m])))*100`,
+		"error_count":        `sum(increase(http_server_requests_failure_total{service_name=` + s + `}[` + step + `]))`,
 		"avg_duration_us":    `sum(rate(http_server_request_duration_microseconds_sum{service_name=` + s + `}[5m]))/sum(rate(http_server_request_duration_microseconds_count{service_name=` + s + `}[5m]))`,
 		"p95_duration_us":    `histogram_quantile(0.95,sum by (le) (rate(http_server_request_duration_microseconds_bucket{service_name=` + s + `}[5m])))`,
 		"active_requests":    `sum(http_server_requests_active_gauge{service_name=` + s + `})`,

--- a/domains/platform/apis/prom_proxy/service_handlers.go
+++ b/domains/platform/apis/prom_proxy/service_handlers.go
@@ -165,6 +165,19 @@ func (h *MetricsHandler) GetServiceMetricsTimeSeries(w http.ResponseWriter, r *h
 		return
 	}
 
+	// Same contract as GetServiceMetrics: an absent view defaults rather than
+	// offering a third, implicit answer, and an unrecognised one is a 400
+	// rather than a silent fallback.
+	view := DefaultView
+	if raw := r.URL.Query().Get("view"); raw != "" {
+		if !ValidView(raw) {
+			problem := mucks.NewBadRequest("Invalid view. Valid options: count, rate")
+			mucks.JsonError(w, problem)
+			return
+		}
+		view = MetricView(raw)
+	}
+
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
@@ -177,10 +190,11 @@ func (h *MetricsHandler) GetServiceMetricsTimeSeries(w http.ResponseWriter, r *h
 		StartTime: startTime,
 		EndTime:   endTime,
 		Step:      step,
+		View:      string(view),
 		Series:    []TimeSeries{},
 	}
 
-	queries := standardTimeseriesQueries(name)
+	queries := standardTimeseriesQueries(name, step, view)
 	for metricName, query := range entry.CustomTimeseries {
 		queries[metricName] = query
 	}

--- a/domains/platform/apis/prom_proxy/service_handlers.go
+++ b/domains/platform/apis/prom_proxy/service_handlers.go
@@ -180,11 +180,12 @@ func (h *MetricsHandler) GetServiceMetricsTimeSeries(w http.ResponseWriter, r *h
 		Series:    []TimeSeries{},
 	}
 
-	// request_rate and request_count both come back unconditionally — no
-	// ?view= here, see standardTimeseriesQueries for why a toggled meaning on
-	// one shared key is a deploy hazard this avoids.
+	// request_rate/request_count and every toggleable Trends chart's
+	// _rate/_count pair all come back unconditionally — no ?view= here, see
+	// standardTimeseriesQueries for why a toggled meaning on one shared key
+	// is a deploy hazard this avoids.
 	queries := standardTimeseriesQueries(name, step)
-	for metricName, query := range entry.CustomTimeseries {
+	for metricName, query := range expandCustomTimeseries(entry.CustomTimeseries, step) {
 		queries[metricName] = query
 	}
 

--- a/domains/platform/apis/prom_proxy/service_handlers.go
+++ b/domains/platform/apis/prom_proxy/service_handlers.go
@@ -165,19 +165,6 @@ func (h *MetricsHandler) GetServiceMetricsTimeSeries(w http.ResponseWriter, r *h
 		return
 	}
 
-	// Same contract as GetServiceMetrics: an absent view defaults rather than
-	// offering a third, implicit answer, and an unrecognised one is a 400
-	// rather than a silent fallback.
-	view := DefaultView
-	if raw := r.URL.Query().Get("view"); raw != "" {
-		if !ValidView(raw) {
-			problem := mucks.NewBadRequest("Invalid view. Valid options: count, rate")
-			mucks.JsonError(w, problem)
-			return
-		}
-		view = MetricView(raw)
-	}
-
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
@@ -190,11 +177,13 @@ func (h *MetricsHandler) GetServiceMetricsTimeSeries(w http.ResponseWriter, r *h
 		StartTime: startTime,
 		EndTime:   endTime,
 		Step:      step,
-		View:      string(view),
 		Series:    []TimeSeries{},
 	}
 
-	queries := standardTimeseriesQueries(name, step, view)
+	// request_rate and request_count both come back unconditionally — no
+	// ?view= here, see standardTimeseriesQueries for why a toggled meaning on
+	// one shared key is a deploy hazard this avoids.
+	queries := standardTimeseriesQueries(name, step)
 	for metricName, query := range entry.CustomTimeseries {
 		queries[metricName] = query
 	}

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -49,7 +49,7 @@ func TestRegistry_OrderAndEntriesAgree(t *testing.T) {
 // authors to avoid this; this pins it.
 func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
 	for _, name := range serviceOrder {
-		standard := standardTimeseriesQueries(name, "5m", DefaultView)
+		standard := standardTimeseriesQueries(name, "5m")
 		for key := range serviceRegistry[name].CustomTimeseries {
 			_, shadows := standard[key]
 			assert.False(t, shadows, "service %q custom series %q shadows a standard series", name, key)
@@ -454,9 +454,9 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testin
 		assert.GreaterOrEqual(t, series.MetricName, previous)
 		previous = series.MetricName
 	}
-	// The five standard series plus golf's ten custom series.
+	// The six standard series plus golf's ten custom series.
 	expected := []string{
-		"request_rate", "error_rate_percent", "avg_duration_us", "p95_duration_us",
+		"request_rate", "request_count", "error_rate_percent", "avg_duration_us", "p95_duration_us",
 		"active_requests",
 		"sessions_active", "session_starts", "command_rate", "event_rate",
 		"rejection_rate", "disconnect_rate",
@@ -469,61 +469,63 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testin
 	}
 }
 
-// --- The count/rate toggle on the Serving charts -----------------------
+// --- The Serving chart's count/rate pair --------------------------------
 
-// request_rate is a literal pin, the same way TestStandardQueries_GoldenStrings
-// pins the scalar block: a typo in the shared instrument name should fail
-// loudly rather than hide behind the enumeration in TestRegistry_*.
+// Both literal pins, the same way TestStandardQueries_GoldenStrings pins the
+// scalar block: a typo in the shared instrument name should fail loudly
+// rather than hide behind the enumeration in TestRegistry_*.
 //
-// The count form windows by step (5m here, standing in for whatever
-// GetTimeRangeConfig picked), not by the scalar tiles' fixed 5m — see
-// standardRequestRateQuery for why a fixed window would overlap and
-// double-count.
-func TestStandardTimeseriesQueries_RequestRateTogglesFormAndBucketsByStep(t *testing.T) {
+// request_count windows by step (5m here, standing in for whatever
+// GetTimeRangeConfig picked) rather than the scalar tiles' fixed 5m — see
+// standardTimeseriesQueries for why a fixed window would overlap and
+// double-count. request_rate is untouched: unlike the scalar block's
+// counter-derived custom tiles, this pair doesn't share a query built by
+// switching a function name, precisely so neither series' meaning depends on
+// a query parameter — see the same comment for why.
+func TestStandardTimeseriesQueries_RequestRateAndCountAreIndependentSeries(t *testing.T) {
+	queries := standardTimeseriesQueries("golf_hub", "5m")
 	assert.Equal(t,
 		`sum(rate(http_server_requests_total{service_name="golf_hub"}[5m]))`,
-		standardTimeseriesQueries("golf_hub", "5m", ViewRate)["request_rate"])
+		queries["request_rate"])
 	assert.Equal(t,
 		`sum(increase(http_server_requests_total{service_name="golf_hub"}[5m]))`,
-		standardTimeseriesQueries("golf_hub", "5m", ViewCount)["request_rate"])
-	// A different step changes the count form's window but not the rate
-	// form's — rate's is fixed at 5m regardless of how far apart the chart's
+		queries["request_count"])
+
+	// A different step changes request_count's window but not request_rate's
+	// — that one is fixed at 5m regardless of how far apart the chart's
 	// points are.
+	withStep := standardTimeseriesQueries("golf_hub", "30s")
 	assert.Equal(t,
 		`sum(increase(http_server_requests_total{service_name="golf_hub"}[30s]))`,
-		standardTimeseriesQueries("golf_hub", "30s", ViewCount)["request_rate"])
-	assert.Equal(t,
-		`sum(rate(http_server_requests_total{service_name="golf_hub"}[5m]))`,
-		standardTimeseriesQueries("golf_hub", "30s", ViewRate)["request_rate"])
+		withStep["request_count"])
+	assert.Equal(t, queries["request_rate"], withStep["request_rate"])
 }
 
-// The other four standard series have no counter behind them — a ratio, a
-// quantile, and a gauge — so the view toggle must not perturb them, the same
-// contract QueryFor holds for a fixed-form scalar tile.
-func TestStandardTimeseriesQueries_OnlyRequestRateAnswersToView(t *testing.T) {
-	count := standardTimeseriesQueries("portrait", "5m", ViewCount)
-	rate := standardTimeseriesQueries("portrait", "5m", ViewRate)
+// The other three standard series have no counter behind them — a ratio, a
+// quantile, and a gauge — so unlike request_rate/request_count they get no
+// count-form sibling.
+func TestStandardTimeseriesQueries_OnlyRequestHasACountForm(t *testing.T) {
+	queries := standardTimeseriesQueries("portrait", "5m")
 	for _, key := range []string{"error_rate_percent", "avg_duration_us", "p95_duration_us", "active_requests"} {
-		assert.Equal(t, rate[key], count[key], "%s changed under the view toggle", key)
+		assert.NotContains(t, queries, key+"_count", "%s unexpectedly grew a count-form sibling", key)
 	}
-	assert.NotEqual(t, rate["request_rate"], count["request_rate"])
 }
 
-func TestMetricsHandler_GetServiceMetricsTimeSeries_ViewSelectsRequestRateForm(t *testing.T) {
+func TestMetricsHandler_GetServiceMetricsTimeSeries_RequestCountBucketsByTheRangesStep(t *testing.T) {
 	countQuery := `sum(increase(http_server_requests_total{service_name="golf_hub"}[1h]))`
 	handler := &MetricsHandler{
 		promClient: &mockPrometheusClient{
 			queryRangeResponses: map[string]*QueryResponse{
-				countQuery: rangeResponse("request_rate"),
+				countQuery: rangeResponse("request_count"),
 			},
 		},
 	}
 
-	// The 7d range steps at 1h (models.go's GetTimeRangeConfig), which the
-	// count form's window has to match — a mismatch here means the mock's
+	// The 7d range steps at 1h (models.go's GetTimeRangeConfig), which
+	// request_count's window has to match — a mismatch here means the mock's
 	// exact-string lookup misses and the series comes back empty, catching a
 	// step that was hardcoded instead of threaded through.
-	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/7d?view=count", nil)
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/7d", nil)
 	req.SetPathValue("name", "golf_hub")
 	req.SetPathValue("range", "7d")
 	w := httptest.NewRecorder()
@@ -533,24 +535,26 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_ViewSelectsRequestRateForm(t
 
 	var response TimeSeriesResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	assert.Equal(t, "count", response.View)
 
-	var requestRate *TimeSeries
+	var requestCount *TimeSeries
 	for i := range response.Series {
-		if response.Series[i].MetricName == "request_rate" {
-			requestRate = &response.Series[i]
+		if response.Series[i].MetricName == "request_count" {
+			requestCount = &response.Series[i]
 		}
 	}
-	require.NotNil(t, requestRate, "request_rate missing from the response")
-	require.Len(t, requestRate.Values, 2, "the mock's fixture didn't answer — the handler built a different query than expected")
+	require.NotNil(t, requestCount, "request_count missing from the response")
+	require.Len(t, requestCount.Values, 2, "the mock's fixture didn't answer — the handler built a different query than expected")
 }
 
-func TestMetricsHandler_GetServiceMetricsTimeSeries_DefaultViewIsCount(t *testing.T) {
+// No ?view= on this route at all: request_rate and request_count both come
+// back on every request, unconditionally, regardless of query parameters —
+// there is nothing here to reject as invalid.
+func TestMetricsHandler_GetServiceMetricsTimeSeries_IgnoresViewParam(t *testing.T) {
 	handler := &MetricsHandler{
 		promClient: &mockPrometheusClient{queryRangeResponse: rangeResponse("series")},
 	}
 
-	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/1d", nil)
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/1d?view=cumulative", nil)
 	req.SetPathValue("name", "golf_hub")
 	req.SetPathValue("range", "1d")
 	w := httptest.NewRecorder()
@@ -560,25 +564,12 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_DefaultViewIsCount(t *testin
 
 	var response TimeSeriesResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	// Matches DefaultView on the scalar endpoint, so a page that never sends
-	// ?view= reads the same form on both its tiles and its Serving chart.
-	assert.Equal(t, string(DefaultView), response.View)
-}
-
-func TestMetricsHandler_GetServiceMetricsTimeSeries_InvalidViewIsRejected(t *testing.T) {
-	handler := &MetricsHandler{}
-
-	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/1d?view=cumulative", nil)
-	req.SetPathValue("name", "golf_hub")
-	req.SetPathValue("range", "1d")
-	w := httptest.NewRecorder()
-
-	handler.GetServiceMetricsTimeSeries(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-
-	var response map[string]interface{}
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	assert.Contains(t, response["detail"], "Invalid view")
+	names := map[string]bool{}
+	for _, series := range response.Series {
+		names[series.MetricName] = true
+	}
+	assert.True(t, names["request_rate"])
+	assert.True(t, names["request_count"])
 }
 
 func TestMetricsHandler_GetHostMetrics_Success(t *testing.T) {
@@ -914,14 +905,8 @@ func TestRegistry_NoTileReadsACounterCumulatively(t *testing.T) {
 		for _, q := range standardScalarQueries(name) {
 			check(t, "standard scalar "+name, q.Query)
 		}
-		// Both views: request_rate's two forms build from increase() and
-		// rate() respectively, and only checking one would leave the other
-		// unexamined the same way AllQueries() exists to check both forms of
-		// a custom scalar tile.
-		for _, view := range []MetricView{ViewCount, ViewRate} {
-			for key, query := range standardTimeseriesQueries(name, "5m", view) {
-				check(t, "standard timeseries "+name+"/"+key+" ("+string(view)+")", query)
-			}
+		for key, query := range standardTimeseriesQueries(name, "5m") {
+			check(t, "standard timeseries "+name+"/"+key, query)
 		}
 	}
 }

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -49,7 +49,7 @@ func TestRegistry_OrderAndEntriesAgree(t *testing.T) {
 // authors to avoid this; this pins it.
 func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
 	for _, name := range serviceOrder {
-		standard := standardTimeseriesQueries(name)
+		standard := standardTimeseriesQueries(name, "5m", DefaultView)
 		for key := range serviceRegistry[name].CustomTimeseries {
 			_, shadows := standard[key]
 			assert.False(t, shadows, "service %q custom series %q shadows a standard series", name, key)
@@ -469,6 +469,118 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testin
 	}
 }
 
+// --- The count/rate toggle on the Serving charts -----------------------
+
+// request_rate is a literal pin, the same way TestStandardQueries_GoldenStrings
+// pins the scalar block: a typo in the shared instrument name should fail
+// loudly rather than hide behind the enumeration in TestRegistry_*.
+//
+// The count form windows by step (5m here, standing in for whatever
+// GetTimeRangeConfig picked), not by the scalar tiles' fixed 5m — see
+// standardRequestRateQuery for why a fixed window would overlap and
+// double-count.
+func TestStandardTimeseriesQueries_RequestRateTogglesFormAndBucketsByStep(t *testing.T) {
+	assert.Equal(t,
+		`sum(rate(http_server_requests_total{service_name="golf_hub"}[5m]))`,
+		standardTimeseriesQueries("golf_hub", "5m", ViewRate)["request_rate"])
+	assert.Equal(t,
+		`sum(increase(http_server_requests_total{service_name="golf_hub"}[5m]))`,
+		standardTimeseriesQueries("golf_hub", "5m", ViewCount)["request_rate"])
+	// A different step changes the count form's window but not the rate
+	// form's — rate's is fixed at 5m regardless of how far apart the chart's
+	// points are.
+	assert.Equal(t,
+		`sum(increase(http_server_requests_total{service_name="golf_hub"}[30s]))`,
+		standardTimeseriesQueries("golf_hub", "30s", ViewCount)["request_rate"])
+	assert.Equal(t,
+		`sum(rate(http_server_requests_total{service_name="golf_hub"}[5m]))`,
+		standardTimeseriesQueries("golf_hub", "30s", ViewRate)["request_rate"])
+}
+
+// The other four standard series have no counter behind them — a ratio, a
+// quantile, and a gauge — so the view toggle must not perturb them, the same
+// contract QueryFor holds for a fixed-form scalar tile.
+func TestStandardTimeseriesQueries_OnlyRequestRateAnswersToView(t *testing.T) {
+	count := standardTimeseriesQueries("portrait", "5m", ViewCount)
+	rate := standardTimeseriesQueries("portrait", "5m", ViewRate)
+	for _, key := range []string{"error_rate_percent", "avg_duration_us", "p95_duration_us", "active_requests"} {
+		assert.Equal(t, rate[key], count[key], "%s changed under the view toggle", key)
+	}
+	assert.NotEqual(t, rate["request_rate"], count["request_rate"])
+}
+
+func TestMetricsHandler_GetServiceMetricsTimeSeries_ViewSelectsRequestRateForm(t *testing.T) {
+	countQuery := `sum(increase(http_server_requests_total{service_name="golf_hub"}[1h]))`
+	handler := &MetricsHandler{
+		promClient: &mockPrometheusClient{
+			queryRangeResponses: map[string]*QueryResponse{
+				countQuery: rangeResponse("request_rate"),
+			},
+		},
+	}
+
+	// The 7d range steps at 1h (models.go's GetTimeRangeConfig), which the
+	// count form's window has to match — a mismatch here means the mock's
+	// exact-string lookup misses and the series comes back empty, catching a
+	// step that was hardcoded instead of threaded through.
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/7d?view=count", nil)
+	req.SetPathValue("name", "golf_hub")
+	req.SetPathValue("range", "7d")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "count", response.View)
+
+	var requestRate *TimeSeries
+	for i := range response.Series {
+		if response.Series[i].MetricName == "request_rate" {
+			requestRate = &response.Series[i]
+		}
+	}
+	require.NotNil(t, requestRate, "request_rate missing from the response")
+	require.Len(t, requestRate.Values, 2, "the mock's fixture didn't answer — the handler built a different query than expected")
+}
+
+func TestMetricsHandler_GetServiceMetricsTimeSeries_DefaultViewIsCount(t *testing.T) {
+	handler := &MetricsHandler{
+		promClient: &mockPrometheusClient{queryRangeResponse: rangeResponse("series")},
+	}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/1d", nil)
+	req.SetPathValue("name", "golf_hub")
+	req.SetPathValue("range", "1d")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	// Matches DefaultView on the scalar endpoint, so a page that never sends
+	// ?view= reads the same form on both its tiles and its Serving chart.
+	assert.Equal(t, string(DefaultView), response.View)
+}
+
+func TestMetricsHandler_GetServiceMetricsTimeSeries_InvalidViewIsRejected(t *testing.T) {
+	handler := &MetricsHandler{}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/1d?view=cumulative", nil)
+	req.SetPathValue("name", "golf_hub")
+	req.SetPathValue("range", "1d")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Contains(t, response["detail"], "Invalid view")
+}
+
 func TestMetricsHandler_GetHostMetrics_Success(t *testing.T) {
 	// One constant scalar response everywhere: the container-list query
 	// yields a "caddy" row, and every follow-up scalar reads 42.5.
@@ -802,8 +914,14 @@ func TestRegistry_NoTileReadsACounterCumulatively(t *testing.T) {
 		for _, q := range standardScalarQueries(name) {
 			check(t, "standard scalar "+name, q.Query)
 		}
-		for key, query := range standardTimeseriesQueries(name) {
-			check(t, "standard timeseries "+name+"/"+key, query)
+		// Both views: request_rate's two forms build from increase() and
+		// rate() respectively, and only checking one would leave the other
+		// unexamined the same way AllQueries() exists to check both forms of
+		// a custom scalar tile.
+		for _, view := range []MetricView{ViewCount, ViewRate} {
+			for key, query := range standardTimeseriesQueries(name, "5m", view) {
+				check(t, "standard timeseries "+name+"/"+key+" ("+string(view)+")", query)
+			}
 		}
 	}
 }

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -60,6 +60,31 @@ func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
 	}
 }
 
+// Two CustomTimeseries entries can collide on their own without ever
+// naming a standard series: a fixed def literally named "foo_rate" beside
+// a toggleable def with base "foo" both expand to the same "foo_rate"
+// panel. expandCustomTimeseries's map assignment is last-wins on that, so
+// one def's query silently overwrites the other's rather than erroring —
+// exactly the footgun portrait's cache_hit_rate (fixed) sits next to were
+// anyone to add a toggleable "cache_hit" counter beside it.
+//
+// Counting keys in vs. panels out is what catches this: a keys() diff can't
+// tell "two defs produced the same key" from "one key, as expected", but a
+// collision always drops the total panel count below the sum of what each
+// def contributes on its own.
+func TestRegistry_CustomTimeseriesPanelKeysAreUniquePerService(t *testing.T) {
+	for _, name := range serviceOrder {
+		custom := serviceRegistry[name].CustomTimeseries
+		wantPanels := 0
+		for key, def := range custom {
+			wantPanels += len(def.panels(key, "5m"))
+		}
+		gotPanels := len(expandCustomTimeseries(custom, "5m"))
+		assert.Equal(t, wantPanels, gotPanels,
+			"service %q has two CustomTimeseries entries whose panels collide", name)
+	}
+}
+
 // Any reference to a cache metric, with whatever label selector follows it.
 //
 // Deliberately broader than cache_hits_total|cache_misses_total: a selector
@@ -579,6 +604,42 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_RequestCountBucketsByTheRang
 	}
 	require.NotNil(t, requestCount, "request_count missing from the response")
 	require.Len(t, requestCount.Values, 2, "the mock's fixture didn't answer — the handler built a different query than expected")
+}
+
+// The failure-counter analogue of the request_count test above: error_count
+// windows by the range's own step too, and it's a different selector
+// (http_server_requests_failure_total, not _total) from request_count, so
+// a copy-paste that left it reading the wrong counter would still pass a
+// test that only checked the window.
+func TestMetricsHandler_GetServiceMetricsTimeSeries_ErrorCountBucketsByTheRangesStep(t *testing.T) {
+	countQuery := `sum(increase(http_server_requests_failure_total{service_name="golf_hub"}[1h]))`
+	handler := &MetricsHandler{
+		promClient: &mockPrometheusClient{
+			queryRangeResponses: map[string]*QueryResponse{
+				countQuery: rangeResponse("error_count"),
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/7d", nil)
+	req.SetPathValue("name", "golf_hub")
+	req.SetPathValue("range", "7d")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+	var errorCount *TimeSeries
+	for i := range response.Series {
+		if response.Series[i].MetricName == "error_count" {
+			errorCount = &response.Series[i]
+		}
+	}
+	require.NotNil(t, errorCount, "error_count missing from the response")
+	require.Len(t, errorCount.Values, 2, "the mock's fixture didn't answer — the handler built a different query than expected")
 }
 
 // No ?view= on this route at all: request_rate and request_count both come

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -50,7 +50,10 @@ func TestRegistry_OrderAndEntriesAgree(t *testing.T) {
 func TestRegistry_CustomTimeseriesKeysDoNotShadowStandardSeries(t *testing.T) {
 	for _, name := range serviceOrder {
 		standard := standardTimeseriesQueries(name, "5m")
-		for key := range serviceRegistry[name].CustomTimeseries {
+		// Expanded panel keys, not the def map's own keys: a toggleable
+		// entry's map key ("command") never appears in a response — only its
+		// _rate/_count panels do, and those are what could collide.
+		for key := range expandCustomTimeseries(serviceRegistry[name].CustomTimeseries, "5m") {
 			_, shadows := standard[key]
 			assert.False(t, shadows, "service %q custom series %q shadows a standard series", name, key)
 		}
@@ -135,7 +138,7 @@ func allQueriesFor(entry serviceEntry) []string {
 	for _, def := range entry.CustomScalars {
 		queries = append(queries, def.AllQueries()...)
 	}
-	for _, query := range entry.CustomTimeseries {
+	for _, query := range expandCustomTimeseries(entry.CustomTimeseries, "5m") {
 		queries = append(queries, query)
 	}
 	return queries
@@ -149,9 +152,14 @@ func allQueriesFor(entry serviceEntry) []string {
 func TestRegistry_PortraitCacheQueriesUseTheStandardFamily(t *testing.T) {
 	portrait := serviceRegistry["portrait"]
 
-	// The panels the UI renders by key.
+	// The panels the UI actually receives: cache_hit_rate is fixed-form and
+	// keeps its def-map key; cache_operations is toggleable, so its def-map
+	// key ("cache_operations") never reaches a response — only its expanded
+	// _rate/_count panels do.
 	require.Contains(t, portrait.CustomTimeseries, "cache_hit_rate")
-	require.Contains(t, portrait.CustomTimeseries, "cache_operations_rate")
+	panels := expandCustomTimeseries(portrait.CustomTimeseries, "5m")
+	require.Contains(t, panels, "cache_operations_rate")
+	require.Contains(t, panels, "cache_operations_count")
 
 	queries := allQueriesFor(portrait)
 	require.NotEmpty(t, queries)
@@ -454,14 +462,21 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_StandardPlusCustom(t *testin
 		assert.GreaterOrEqual(t, series.MetricName, previous)
 		previous = series.MetricName
 	}
-	// The six standard series plus golf's ten custom series.
+	// The seven standard series plus golf's nineteen custom panels: three
+	// fixed-form charts, and eight toggleable ones each expanding to a
+	// _rate/_count pair.
 	expected := []string{
-		"request_rate", "request_count", "error_rate_percent", "avg_duration_us", "p95_duration_us",
-		"active_requests",
-		"sessions_active", "session_starts", "command_rate", "event_rate",
-		"rejection_rate", "disconnect_rate",
-		"chat_message_rate", "chat_delivery_rate", "chat_failure_rate", "chat_catch_up_rows",
-		"rate_limited_rate",
+		"request_rate", "request_count", "error_rate_percent", "error_count",
+		"avg_duration_us", "p95_duration_us", "active_requests",
+		"sessions_active", "session_starts", "chat_catch_up_rows",
+		"command_rate", "command_count",
+		"event_rate", "event_count",
+		"rejection_rate", "rejection_count",
+		"disconnect_rate", "disconnect_count",
+		"rate_limited_rate", "rate_limited_count",
+		"chat_message_rate", "chat_message_count",
+		"chat_delivery_rate", "chat_delivery_count",
+		"chat_failure_rate", "chat_failure_count",
 	}
 	assert.Len(t, names, len(expected))
 	for _, name := range expected {
@@ -501,12 +516,32 @@ func TestStandardTimeseriesQueries_RequestRateAndCountAreIndependentSeries(t *te
 	assert.Equal(t, queries["request_rate"], withStep["request_rate"])
 }
 
-// The other three standard series have no counter behind them — a ratio, a
-// quantile, and a gauge — so unlike request_rate/request_count they get no
-// count-form sibling.
-func TestStandardTimeseriesQueries_OnlyRequestHasACountForm(t *testing.T) {
+// error_rate_percent is itself a ratio of two rates with no count form of its
+// own, but the failure counter it's built from does — error_count is that
+// counter's own count/rate pair, the same relationship request_count has to
+// request_rate, not "the error rate as a count".
+func TestStandardTimeseriesQueries_ErrorCountIsTheFailureCounterNotTheRatio(t *testing.T) {
+	queries := standardTimeseriesQueries("golf_hub", "5m")
+	assert.Equal(t,
+		`sum(increase(http_server_requests_failure_total{service_name="golf_hub"}[5m]))`,
+		queries["error_count"])
+
+	withStep := standardTimeseriesQueries("golf_hub", "30s")
+	assert.Equal(t,
+		`sum(increase(http_server_requests_failure_total{service_name="golf_hub"}[30s]))`,
+		withStep["error_count"])
+	// error_rate_percent itself never changes: it isn't wrapped in rate()/
+	// increase() over a counter the way request_rate/error_count are, so
+	// there's no window to swap out.
+	assert.Equal(t, queries["error_rate_percent"], withStep["error_rate_percent"])
+}
+
+// avg/p95 latency and active requests have no counter behind them at all — a
+// ratio-of-rates, a quantile, and a gauge — so unlike the two request/error
+// pairs they get no count-form sibling.
+func TestStandardTimeseriesQueries_LatencyAndActiveHaveNoCountForm(t *testing.T) {
 	queries := standardTimeseriesQueries("portrait", "5m")
-	for _, key := range []string{"error_rate_percent", "avg_duration_us", "p95_duration_us", "active_requests"} {
+	for _, key := range []string{"avg_duration_us", "p95_duration_us", "active_requests"} {
 		assert.NotContains(t, queries, key+"_count", "%s unexpectedly grew a count-form sibling", key)
 	}
 }
@@ -570,6 +605,83 @@ func TestMetricsHandler_GetServiceMetricsTimeSeries_IgnoresViewParam(t *testing.
 	}
 	assert.True(t, names["request_rate"])
 	assert.True(t, names["request_count"])
+}
+
+// --- Custom Trends charts, extended with the same count/rate pairing -------
+
+// A toggleable custom chart expands to exactly two panels, keyed off the
+// def-map key rather than spelling either suffix in the descriptor — the
+// same shape standardRequestRateQuery's sibling gets, so a Trends chart and
+// the Serving chart can't drift onto different conventions.
+func TestCustomTimeseriesDef_ToggleableExpandsToRateAndCountBucketedByStep(t *testing.T) {
+	def := tsCounter(`stream_commands_total`)
+	panels := def.panels("command", "30s")
+	assert.Equal(t, map[string]string{
+		"command_rate":  `sum(rate(stream_commands_total[5m]))`,
+		"command_count": `sum(increase(stream_commands_total[30s]))`,
+	}, panels)
+
+	// The rate form is fixed at the scalar tiles' 5m regardless of step —
+	// only the count form windows per point.
+	withStep := def.panels("command", "1h")
+	assert.Equal(t, panels["command_rate"], withStep["command_rate"])
+	assert.NotEqual(t, panels["command_count"], withStep["command_count"])
+}
+
+// A fixed custom chart keeps its map key unchanged and ignores step
+// entirely — there's no window in it to bucket.
+func TestCustomTimeseriesDef_FixedFormKeepsItsOwnKey(t *testing.T) {
+	def := tsFixed(`sum(stream_sessions_active_gauge)`)
+	panels := def.panels("sessions_active", "30s")
+	assert.Equal(t, map[string]string{"sessions_active": `sum(stream_sessions_active_gauge)`}, panels)
+}
+
+// End to end through the handler: a toggleable custom chart's two panels
+// both land in the response, and the count form is bucketed by the range's
+// own step exactly like request_count.
+func TestMetricsHandler_GetServiceMetricsTimeSeries_CustomCounterPanelBucketsByStep(t *testing.T) {
+	countQuery := `sum(increase(stream_commands_total[1h]))`
+	handler := &MetricsHandler{
+		promClient: &mockPrometheusClient{
+			queryRangeResponses: map[string]*QueryResponse{
+				countQuery: rangeResponse("command_count"),
+			},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/metrics/v1/service/golf_hub/timeseries/7d", nil)
+	req.SetPathValue("name", "golf_hub")
+	req.SetPathValue("range", "7d")
+	w := httptest.NewRecorder()
+
+	handler.GetServiceMetricsTimeSeries(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response TimeSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+	var commandCount *TimeSeries
+	for i := range response.Series {
+		if response.Series[i].MetricName == "command_count" {
+			commandCount = &response.Series[i]
+		}
+	}
+	require.NotNil(t, commandCount, "command_count missing from the response")
+	require.Len(t, commandCount.Values, 2, "the mock's fixture didn't answer — the handler built a different query than expected")
+}
+
+// microgpt-serve's tokens_per_second baked one form into its name the way
+// request_rate used to; "tokens" replaces it so the chart can toggle. No
+// other file names the old key (grep confirmed it before the rename), so
+// this is the only place a caller could still expect it.
+func TestRegistry_MicrogptTokensReplacesTokensPerSecond(t *testing.T) {
+	panels := expandCustomTimeseries(serviceRegistry["microgpt-serve"].CustomTimeseries, "5m")
+	assert.Contains(t, panels, "tokens_rate")
+	assert.Contains(t, panels, "tokens_count")
+	assert.NotContains(t, panels, "tokens_per_second")
+	assert.Equal(t,
+		`sum(rate(microgpt_tokens_generated_total[5m]))`,
+		panels["tokens_rate"])
 }
 
 func TestMetricsHandler_GetHostMetrics_Success(t *testing.T) {
@@ -714,7 +826,8 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 		// what keeps the counter tiles in scope at all.
 		labelled["scalar "+def.Label] = def.AllQueries()
 	}
-	for key, query := range entry.CustomTimeseries {
+	// Both panels of a toggleable timeseries entry, for the same reason.
+	for key, query := range expandCustomTimeseries(entry.CustomTimeseries, "5m") {
 		labelled["timeseries "+key] = []string{query}
 	}
 
@@ -747,7 +860,7 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 	for _, def := range entry.CustomScalars {
 		joined += strings.Join(def.AllQueries(), "\n") + "\n"
 	}
-	for _, query := range entry.CustomTimeseries {
+	for _, query := range expandCustomTimeseries(entry.CustomTimeseries, "5m") {
 		joined += query + "\n"
 	}
 	for _, label := range []string{`outcome="completed"`, `outcome="failed"`,
@@ -783,7 +896,7 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 				"scalar %s selects outcomes by exclusion", def.Label)
 		}
 	}
-	for key, query := range entry.CustomTimeseries {
+	for key, query := range expandCustomTimeseries(entry.CustomTimeseries, "5m") {
 		assert.NotRegexp(t, `outcome\s*!=|outcome\s*!~`, query,
 			"timeseries %s selects outcomes by exclusion", key)
 	}
@@ -792,17 +905,18 @@ func TestOneD4QueriesNameRealInstrumentsAndScopeThem(t *testing.T) {
 	// forbids the one spelling. Reverting to outcome=~"failed|interrupted|lease_lost", or to a
 	// bare sum over index_runs_total with no outcome at all, uses no negation and passes it. So
 	// the set is pinned positively, the way the duration guard pins outcome="completed".
-	failureRate, ok := entry.CustomTimeseries["run_failure_rate"]
-	require.True(t, ok, "one_d4 lost its run_failure_rate timeseries")
-	outcomeMatch := regexp.MustCompile(`outcome=~?"([^"]*)"`).FindStringSubmatch(failureRate)
+	runFailure, ok := entry.CustomTimeseries["run_failure"]
+	require.True(t, ok, "one_d4 lost its run_failure timeseries")
+	require.True(t, runFailure.toggleable(), "run_failure stopped being counter-derived")
+	outcomeMatch := regexp.MustCompile(`outcome=~?"([^"]*)"`).FindStringSubmatch(runFailure.Counter)
 	require.NotNil(t, outcomeMatch,
-		"run_failure_rate names no outcome at all, so every run counts as a failure: %s",
-		failureRate)
+		"run_failure names no outcome at all, so every run counts as a failure: %s",
+		runFailure.Counter)
 	assert.ElementsMatch(t, []string{"failed", "interrupted"},
 		strings.Split(outcomeMatch[1], "|"),
-		"run_failure_rate must name exactly failed|interrupted — lease_lost is ordinary and puts a"+
+		"run_failure must name exactly failed|interrupted — lease_lost is ordinary and puts a"+
 			" permanent floor under the line, and anything wider counts healthy runs as"+
-			" failures: %s", failureRate)
+			" failures: %s", runFailure.Counter)
 }
 
 // --- The count/rate toggle (#1287) ------------------------------------------
@@ -899,7 +1013,7 @@ func TestRegistry_NoTileReadsACounterCumulatively(t *testing.T) {
 				check(t, "scalar "+name+"/"+def.Label, query)
 			}
 		}
-		for key, query := range entry.CustomTimeseries {
+		for key, query := range expandCustomTimeseries(entry.CustomTimeseries, "5m") {
 			check(t, "timeseries "+name+"/"+key, query)
 		}
 		for _, q := range standardScalarQueries(name) {


### PR DESCRIPTION
## Summary

- The dashboard's count/rate toggle (#1287) only ever affected custom scalar tiles — the Serving section's charts and the per-service Trends charts stayed stuck on their rate form. Companion frontend PR: muchq/muchq.github.io#258.
- `request_rate` (unchanged: `sum(rate(...[5m]))`) now sits beside a new, always-present `request_count` (`sum(increase(...[step]))`, bucketed by the chart's own step). Same pairing for `error_rate_percent`/`error_count` — the failure counter's own count/rate pair, not "the error rate as a count".
- No `?view=` on the timeseries endpoint at all, and no key's meaning depends on a query parameter. That's deliberate: threading `?view=` through here would repeat the exact hazard #1287 avoided for the scalar block's own request fields (`RequestsTotal` beside `RatePerSec`, not one field whose meaning flips) — the UI and this proxy deploy independently, so a shared key's meaning changing between deploys is a real mislabeling window regardless of which side ships first.
- `CustomTimeseries` entries are now `customTimeseriesDef` (`tsFixed` for one form, `tsCounter` for a toggleable one) instead of bare query strings. A toggleable entry's map key is a base name that `panels()` expands into `<base>_rate`/`<base>_count` — mirroring how `customScalarDef` already builds two forms from one selector, but as two keys rather than one.
- `microgpt-serve`'s `tokens_per_second` baked one form into its name the way `request_rate` used to, so it's renamed to `tokens` (→ `tokens_rate`/`tokens_count`).
- Added a registry audit (`TestRegistry_CustomTimeseriesPanelKeysAreUniquePerService`) guarding against two `CustomTimeseries` entries silently colliding on the same expanded panel key.

## Deploy order

Serving-chart lookups are safe in either order: an old UI never asks for `request_count`/`error_count` and an old proxy simply has nothing for a new UI's `findSeries('*_count')` to find — no mislabeling either way. Trends is asymmetric: an old UI enumerates every series outside its own hardcoded standard set, so a backend-first rollout would dump `request_count`, `error_count`, and every custom `_count` panel into Trends as unwanted extra charts until the UI catches up. **Frontend-first (or together) avoids that window** — frontend-first against an old backend is safe, since `groupTrends` only pairs a `_rate`/`_count` chart when both siblings exist.

## Test plan

- [x] `go test ./domains/platform/apis/prom_proxy/...` — passing