### PR TITLE
Fix one_d4 healthcheck and unify http_server_* instrument descriptions

### DIFF
--- a/deploy/consolidated/compose.yaml
+++ b/deploy/consolidated/compose.yaml
@@ -288,7 +288,22 @@ services:
           cpus: '0.5'
           memory: 512M
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
+      # The base (@java_base, azul/zulu-openjdk) has bash, head and grep but no
+      # curl and no wget, so the probe talks HTTP over bash's /dev/tcp rather
+      # than shelling out to a client. The previous curl form never ran at all:
+      # every attempt exited on "executable file not found", so the container
+      # sat permanently unhealthy while serving fine.
+      #
+      # `timeout` bounds the probe itself. Compose's `timeout:` below only
+      # decides when Docker calls the attempt failed — it does not kill the
+      # process, so a probe blocked on a server that accepts and then stalls
+      # would otherwise leak a bash and an open socket every interval.
+      #
+      # The status line is matched rather than just the connect, which catches a
+      # container whose HTTP stack is up but misrouting. It is not a database
+      # check: /health answers 200 with {"status":"DOWN"} when Postgres is
+      # unreachable, so only a non-2xx — or no answer at all — fails this.
+      test: ["CMD", "timeout", "4", "bash", "-c", 'exec 3<>/dev/tcp/127.0.0.1/8080 && printf "GET /health HTTP/1.0\r\n\r\n" >&3 && head -1 <&3 | grep -q " 200"']
       interval: 30s
       timeout: 5s
       retries: 3

--- a/deploy/consolidated/deploy_config_test.go
+++ b/deploy/consolidated/deploy_config_test.go
@@ -18,6 +18,7 @@ package deploy_test
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -340,4 +341,177 @@ func TestCIStillRunsTheCollectorDryRun(t *testing.T) {
 	if info.Mode()&0o111 == 0 {
 		t.Errorf("%s is not executable (%v); CI runs it directly", script, info.Mode())
 	}
+}
+
+// A healthcheck probe has to exist inside the image it runs in.
+//
+// The images built by //bazel/rules:oci.bzl carry their base plus one binary,
+// and no base we use installs an HTTP client — there is no curl and no wget in
+// any of them. A probe that shells out to either does not fail the way a sick
+// container fails. It fails on the first attempt and every attempt after it,
+// with
+//
+//	OCI runtime exec failed: exec: "curl": executable file not found in $PATH
+//
+// which Docker counts as a failed probe like any other. one_d4 sat permanently
+// unhealthy that way while serving traffic normally, and any depends_on
+// waiting on service_healthy would have blocked on it forever.
+//
+// Nothing catches this earlier: `docker compose config` validates the YAML, not
+// the PATH, and no test in the service's own language can see the image it
+// ships in. Probes here talk HTTP over bash's /dev/tcp instead — a redirection
+// the shell implements itself, so it cannot be missing the way a binary can.
+var binariesOurImagesLack = []*regexp.Regexp{
+	regexp.MustCompile(`\bcurl\b`),
+	regexp.MustCompile(`\bwget\b`),
+}
+
+func TestHealthchecksDoNotShellOutToBinariesOurImagesLack(t *testing.T) {
+	probes := healthcheckProbes(t, "compose.yaml")
+
+	// Guards the guard. Every one of these has been the state of this test at
+	// some point during review: no services parsed, services parsed but no
+	// healthcheck recognised, and — the one that shipped — a healthcheck found
+	// whose command lines were never read.
+	if len(probes) == 0 {
+		t.Fatal("parsed no healthchecks out of compose.yaml; this test is reading nothing")
+	}
+	if _, ok := probes["one_d4"]; !ok {
+		t.Fatal("no healthcheck found for one_d4, which has one; the parser has gone stale")
+	}
+
+	for service, probe := range probes {
+		// Third-party images ship their own tooling — postgres has pg_isready.
+		// The constraint is specific to what oci.bzl puts in an image.
+		if !strings.Contains(probe.image, "ghcr.io/muchq/") {
+			continue
+		}
+		for _, line := range probe.lines {
+			for _, binary := range binariesOurImagesLack {
+				if binary.MatchString(line) {
+					t.Errorf("%s's healthcheck invokes %s, which is not in the image: %q\n"+
+						"Every probe would fail on \"executable file not found\" while the "+
+						"service is healthy. Use bash's /dev/tcp, as one_d4 does.",
+						service, binary, line)
+				}
+			}
+		}
+	}
+}
+
+// A healthcheck must be readable where it is written.
+//
+// The guard above reads the probe command as text, so a healthcheck assembled
+// from a YAML anchor elsewhere in the file is one it cannot see: the merge key
+// is all that appears here, and it names no binary at all. Rather than grow a
+// YAML evaluator, refuse the construct — the probes are three lines each and
+// have no reason to be shared.
+func TestHealthchecksAreWrittenInPlaceRatherThanMerged(t *testing.T) {
+	for service, probe := range healthcheckProbes(t, "compose.yaml") {
+		for _, line := range probe.lines {
+			if strings.HasPrefix(line, "<<:") || strings.Contains(line, " *") {
+				t.Errorf("%s's healthcheck is merged from an anchor (%q). Write it inline: the "+
+					"binary guard reads these lines as text and an alias hides the command.",
+					service, line)
+			}
+		}
+	}
+}
+
+type healthcheckProbe struct {
+	image string
+	lines []string
+}
+
+// healthcheckProbes returns each service's healthcheck block, keyed by service.
+//
+// The lines are every line of the block, not just the one starting `test:`.
+// Compose accepts the command as an inline list, as a block sequence, or as a
+// folded scalar, and only the first keeps the command on the `test:` line —
+// `docker compose config` itself normalises to the second. An earlier version
+// of this read only `test:`-prefixed lines and so passed on the exact form the
+// tooling emits, which is the kind of hole that makes a guard worse than none.
+func healthcheckProbes(t *testing.T, name string) map[string]healthcheckProbe {
+	t.Helper()
+	probes := map[string]healthcheckProbe{}
+
+	for service, block := range composeServiceLines(t, name) {
+		image := ""
+		var lines []string
+		healthcheckIndent := -1
+
+		for _, raw := range block {
+			trimmed := strings.TrimSpace(raw)
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			indent := len(raw) - len(strings.TrimLeft(raw, " "))
+
+			if strings.HasPrefix(trimmed, "image:") {
+				image = trimmed
+			}
+			if trimmed == "healthcheck:" {
+				healthcheckIndent = indent
+				continue
+			}
+			if healthcheckIndent < 0 {
+				continue
+			}
+			if indent <= healthcheckIndent {
+				healthcheckIndent = -1 // The next key ends the block.
+				continue
+			}
+			lines = append(lines, trimmed)
+		}
+
+		if len(lines) > 0 {
+			probes[service] = healthcheckProbe{image: image, lines: lines}
+		}
+	}
+	return probes
+}
+
+// composeServiceLines returns each compose service's raw lines, keyed by
+// service name. Raw rather than trimmed: the healthcheck block is delimited by
+// indentation, so trimming here would destroy the only thing that marks where
+// it ends.
+func composeServiceLines(t *testing.T, name string) map[string][]string {
+	t.Helper()
+	services := map[string][]string{}
+	current := ""
+	var block []string
+
+	flush := func() {
+		if current != "" && len(block) > 0 {
+			services[current] = block
+		}
+		block = nil
+	}
+
+	inServices := false
+	for _, line := range strings.Split(readConfig(t, name), "\n") {
+		if !strings.HasPrefix(line, " ") && strings.TrimSpace(line) != "" {
+			flush()
+			current = ""
+			inServices = strings.TrimSpace(line) == "services:"
+			continue
+		}
+		if !inServices {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// A two-space-indented key starts the next service. Comments at that
+		// indentation are not keys and must not end the block.
+		if !strings.HasPrefix(line, "   ") && !strings.HasPrefix(trimmed, "#") {
+			flush()
+			current = strings.TrimSuffix(trimmed, ":")
+			continue
+		}
+		block = append(block, line)
+	}
+	flush()
+	return services
 }

--- a/domains/platform/libs/futility/otel/BUILD.bazel
+++ b/domains/platform/libs/futility/otel/BUILD.bazel
@@ -1,8 +1,12 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 # Read as text by //domains/platform/libs/otel_contract, which pins this rail's
-# latency bucket bounds equal to yodel's and server_pal's.
-exports_files(["otel_provider.h"])
+# latency bucket bounds and http_server_* descriptions equal to yodel's and
+# server_pal's.
+exports_files([
+    "http_instrument_descriptions.h",
+    "otel_provider.h",
+])
 
 cc_library(
     name = "otel_provider",
@@ -17,12 +21,22 @@ cc_library(
     ],
 )
 
+# The descriptions the shared http_server_* instruments are exported with.
+# Header-only and dependency-free so both the recorder that creates the
+# instruments and any test can name one declaration site.
+cc_library(
+    name = "http_instrument_descriptions",
+    hdrs = ["http_instrument_descriptions.h"],
+    visibility = ["//visibility:public"],
+)
+
 cc_library(
     name = "metrics",
     srcs = ["metrics.cc"],
     hdrs = ["metrics.h"],
     visibility = ["//visibility:public"],
     deps = [
+        ":http_instrument_descriptions",
         ":otel_provider",
         "@com_google_absl//absl/strings",
         "@opentelemetry-cpp//api",
@@ -60,6 +74,20 @@ cc_test(
     size = "small",
     srcs = ["otel_provider_test.cc"],
     deps = [
+        ":otel_provider",
+        "@googletest//:gtest_main",
+        "@opentelemetry-cpp//exporters/memory:in_memory_metric_data",
+        "@opentelemetry-cpp//exporters/memory:in_memory_metric_exporter_factory",
+    ],
+)
+
+cc_test(
+    name = "http_instrument_descriptions_test",
+    size = "small",
+    srcs = ["http_instrument_descriptions_test.cc"],
+    deps = [
+        ":http_instrument_descriptions",
+        ":metrics",
         ":otel_provider",
         "@googletest//:gtest_main",
         "@opentelemetry-cpp//exporters/memory:in_memory_metric_data",

--- a/domains/platform/libs/futility/otel/README.md
+++ b/domains/platform/libs/futility/otel/README.md
@@ -13,12 +13,14 @@ This module provides:
   `http_server_request_duration`, `http_server_requests_success` /
   `_failure`), transport-agnostic so every service exports the same names
   and labels
+- **http_instrument_descriptions.h**: The descriptions those shared
+  instruments are exported with, pinned equal to the Java and Rust rails
 
 ## Quick Start
 
 ```cpp
-#include "cpp/futility/otel/otel_provider.h"
-#include "cpp/futility/otel/metrics.h"
+#include "domains/platform/libs/futility/otel/otel_provider.h"
+#include "domains/platform/libs/futility/otel/metrics.h"
 
 using namespace futility::otel;
 
@@ -170,12 +172,39 @@ http_metrics.RecordRequestStart("/api/users", "GET");
 http_metrics.RecordRequestComplete("/api/users", "GET", 200, duration_us);
 ```
 
+## Instrument Descriptions
+
+The `http_server_*` instruments are reported by services in all three
+languages, and every one of them lands in the same collector. The collector
+merges series by instrument name and keeps the **first** description it sees,
+logging
+
+```
+Instrument description conflict, using existing
+```
+
+for every later one that disagrees — once per export interval, for as long as
+both services run. An empty description conflicts with a non-empty one just as
+loudly, so declining to describe an instrument is not a way to stay out of it.
+
+`MetricsRecorder` therefore looks each instrument up in
+`http_instrument_descriptions.h` at creation, and
+`RegisterLatencyBucketView` leaves the view's description empty so it does not
+stamp one sentence over every `*_microseconds` histogram it matches.
+Service-defined instruments get no description, which is correct: only one
+service reports them, so there is nothing to conflict with.
+
+The table is pinned equal to yodel's and server_pal's by
+[`//domains/platform/libs/otel_contract`](../../otel_contract). Changing a
+description means changing it in all three.
+
 ## Bazel Targets
 
 ```python
 deps = [
-    "//cpp/futility/otel:otel_provider",
-    "//cpp/futility/otel:metrics",
-    "//cpp/futility/otel:http_metrics",
+    "//domains/platform/libs/futility/otel:otel_provider",
+    "//domains/platform/libs/futility/otel:metrics",
+    "//domains/platform/libs/futility/otel:http_metrics",
+    "//domains/platform/libs/futility/otel:http_instrument_descriptions",
 ]
 ```

--- a/domains/platform/libs/futility/otel/http_instrument_descriptions.h
+++ b/domains/platform/libs/futility/otel/http_instrument_descriptions.h
@@ -1,0 +1,58 @@
+#pragma once
+
+/// @file http_instrument_descriptions.h
+/// @brief The descriptions the shared http_server_* instruments are exported with.
+///
+/// These are a cross-language contract, not documentation. Every service's
+/// metrics land in one collector, which merges series by instrument name across
+/// services written in all three languages. Its Prometheus exporter keeps the
+/// first description it sees for a name and logs
+///
+///     Instrument description conflict, using existing
+///
+/// for every later one that disagrees — once per export interval, for as long
+/// as both services run. An empty description conflicts with a non-empty one
+/// just as loudly as two different sentences do, so a rail that declines to
+/// describe an instrument is not staying out of the argument.
+///
+/// //domains/platform/libs/otel_contract pins these equal to yodel's and
+/// server_pal's declarations.
+
+#include <string_view>
+
+namespace futility::otel {
+
+struct HttpInstrumentDescription {
+  std::string_view instrument_name;
+  const char* description;
+};
+
+/// Keyed by the instrument name as created, which is the name that reaches the
+/// collector — so the gauge and the histogram appear here with the _gauge and
+/// _microseconds suffixes MetricsRecorder appends, not the stems its callers
+/// pass in.
+inline constexpr HttpInstrumentDescription kHttpInstrumentDescriptions[] = {
+    {"http_server_requests", "HTTP requests received"},
+    {"http_server_requests_success", "HTTP requests completed successfully (2xx-3xx)"},
+    {"http_server_requests_failure", "HTTP requests that returned 4xx or 5xx"},
+    {"http_server_requests_active_gauge", "HTTP requests currently in flight"},
+    {"http_server_request_duration_microseconds", "HTTP request duration in microseconds"},
+};
+
+/// The canonical description for `instrument_name`, or "" when the name is not
+/// one of the shared rails.
+///
+/// Empty is the right answer for everything else: a service-defined instrument
+/// like scene_sphere_count is reported by one service, so there is no second
+/// declaration for it to disagree with, and the SDK omits an empty description
+/// rather than exporting a blank one.
+constexpr const char* DescriptionFor(std::string_view instrument_name) {
+  for (const auto& entry : kHttpInstrumentDescriptions) {
+    if (entry.instrument_name == instrument_name) {
+      return entry.description;
+    }
+  }
+  return "";
+}
+
+}  // namespace futility::otel

--- a/domains/platform/libs/futility/otel/http_instrument_descriptions_test.cc
+++ b/domains/platform/libs/futility/otel/http_instrument_descriptions_test.cc
@@ -1,0 +1,184 @@
+#include "domains/platform/libs/futility/otel/http_instrument_descriptions.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "domains/platform/libs/futility/otel/metrics.h"
+#include "domains/platform/libs/futility/otel/otel_provider.h"
+#include "opentelemetry/exporters/memory/in_memory_metric_data.h"
+#include "opentelemetry/exporters/memory/in_memory_metric_exporter_factory.h"
+#include "opentelemetry/metrics/noop.h"
+#include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
+#include "opentelemetry/sdk/metrics/instruments.h"
+#include "opentelemetry/sdk/metrics/meter_provider_factory.h"
+
+// The descriptions this rail exports, exercised rather than declared.
+//
+// //domains/platform/libs/otel_contract pins the table in
+// http_instrument_descriptions.h equal to yodel's and server_pal's, but it
+// reads the header as text — a table nothing applies would satisfy it exactly
+// as well as one that reaches the collector. Two things stand between the
+// table and the wire, and both have been wrong: MetricsRecorder creates every
+// instrument and did so with no description at all, and RegisterLatencyBucketView
+// matches every *_microseconds histogram and used to stamp its own sentence
+// over whatever the instrument declared.
+//
+// So this drives a real MeterProvider, records through the recorder services
+// actually use, and reads the description back off the exported instrument
+// descriptor.
+
+namespace futility::otel {
+namespace {
+
+namespace metrics_sdk = opentelemetry::sdk::metrics;
+namespace memory_exporter = opentelemetry::exporter::memory;
+
+class ExportedDescriptionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    data_ = std::make_shared<memory_exporter::CircularBufferInMemoryMetricData>(64);
+
+    auto provider = metrics_sdk::MeterProviderFactory::Create();
+    provider_ = std::shared_ptr<metrics_sdk::MeterProvider>(provider.release());
+
+    metrics_sdk::PeriodicExportingMetricReaderOptions options;
+    // Long enough that the background thread never races the explicit
+    // ForceFlush below; the flush is what actually drives the export.
+    options.export_interval_millis = std::chrono::milliseconds(60000);
+    options.export_timeout_millis = std::chrono::milliseconds(5000);
+    provider_->AddMetricReader(metrics_sdk::PeriodicExportingMetricReaderFactory::Create(
+        memory_exporter::InMemoryMetricExporterFactory::Create(data_), options));
+
+    // The view is part of what is under test here, not scaffolding: it is the
+    // half of this that used to overwrite descriptions.
+    RegisterLatencyBucketView(*provider_);
+
+    // MetricsRecorder reads the global provider, which is how every service
+    // reaches it too.
+    opentelemetry::metrics::Provider::SetMeterProvider(
+        std::shared_ptr<opentelemetry::metrics::MeterProvider>(provider_));
+  }
+
+  void TearDown() override {
+    // The no-op provider, not an empty pointer: GetMeterProvider() is
+    // documented never to return nullptr, and MetricsRecorder's constructor
+    // dereferences it. Clearing it would leave any later test in this binary
+    // one MetricsRecorder away from a segfault.
+    opentelemetry::metrics::Provider::SetMeterProvider(
+        std::shared_ptr<opentelemetry::metrics::MeterProvider>(
+            new opentelemetry::metrics::NoopMeterProvider()));
+  }
+
+  /// The descriptor the SDK exported for `instrument_name`, after everything —
+  /// instrument creation and the view — has had its say.
+  ///
+  /// Returns the whole descriptor rather than the description alone so that an
+  /// instrument that was never exported is distinguishable from one exported
+  /// with an empty description; the tests below assert both cases.
+  metrics_sdk::InstrumentDescriptor ExportedDescriptorFor(const std::string& instrument_name) {
+    provider_->ForceFlush();
+
+    bool found = false;
+    metrics_sdk::InstrumentDescriptor descriptor;
+    for (const auto& resource_metrics : data_->Get()) {
+      for (const auto& scope : resource_metrics->scope_metric_data_) {
+        for (const auto& metric : scope.metric_data_) {
+          if (metric.instrument_descriptor.name_ != instrument_name) continue;
+          found = true;
+          descriptor = metric.instrument_descriptor;
+        }
+      }
+    }
+
+    EXPECT_TRUE(found) << instrument_name << " was never exported";
+    return descriptor;
+  }
+
+  std::string ExportedDescriptionFor(const std::string& instrument_name) {
+    return ExportedDescriptorFor(instrument_name).description_;
+  }
+
+  std::shared_ptr<memory_exporter::CircularBufferInMemoryMetricData> data_;
+  std::shared_ptr<metrics_sdk::MeterProvider> provider_;
+};
+
+// Every shared counter, not just the first one. The cross-language pin in
+// otel_contract reads this rail's table as text, so it cannot tell a table
+// entry from a sentence about one; these are the assertions that require the
+// table to have actually reached an exported instrument. _success and _failure
+// were the two that nothing here covered, and _success is the instrument the
+// en-dash conflict was about.
+TEST_F(ExportedDescriptionTest, EverySharedCounterCarriesItsCanonicalDescription) {
+  MetricsRecorder recorder("test-service");
+  recorder.RecordCounter("http_server_requests", 1);
+  recorder.RecordCounter("http_server_requests_success", 1);
+  recorder.RecordCounter("http_server_requests_failure", 1);
+
+  EXPECT_EQ(ExportedDescriptionFor("http_server_requests"), "HTTP requests received");
+  EXPECT_EQ(ExportedDescriptionFor("http_server_requests_success"),
+            "HTTP requests completed successfully (2xx-3xx)");
+  EXPECT_EQ(ExportedDescriptionFor("http_server_requests_failure"),
+            "HTTP requests that returned 4xx or 5xx");
+}
+
+// The unit is the same contract as the description and fails far more quietly.
+// The collector's Prometheus exporter folds a non-empty unit into the metric
+// NAME (http_server_requests_total becomes
+// http_server_requests_microseconds_total), so a rail that sets one does not
+// log a conflict — it silently forks the series and drops off every prom_proxy
+// panel, which selects by literal name. All three rails leave it empty today;
+// this pins that for the one rail whose instrument creation this commit
+// touched.
+TEST_F(ExportedDescriptionTest, TheSharedInstrumentsDeclareNoUnit) {
+  MetricsRecorder recorder("test-service");
+  recorder.RecordCounter("http_server_requests", 1);
+  recorder.RecordGauge("http_server_requests_active", 1);
+  recorder.RecordLatency("http_server_request_duration", std::chrono::microseconds(1));
+
+  for (const auto& name : {"http_server_requests", "http_server_requests_active_gauge",
+                           "http_server_request_duration_microseconds"}) {
+    EXPECT_EQ(ExportedDescriptorFor(name).unit_, "")
+        << name << " declares a unit; the collector folds it into the metric name";
+  }
+}
+
+// The gauge's exported name is not the name its caller passes: RecordGauge
+// appends _gauge. Looking the description up under the stem finds nothing and
+// exports an empty one, which conflicts with yodel just as loudly as a wrong
+// sentence would.
+TEST_F(ExportedDescriptionTest, TheActiveGaugeIsDescribedUnderItsSuffixedName) {
+  MetricsRecorder recorder("test-service");
+  recorder.RecordGauge("http_server_requests_active", 1);
+
+  EXPECT_EQ(ExportedDescriptionFor("http_server_requests_active_gauge"),
+            "HTTP requests currently in flight");
+}
+
+// The regression that produced the collector's log flood. The latency view
+// matches this instrument, so whatever it says about descriptions lands here.
+TEST_F(ExportedDescriptionTest, TheLatencyHistogramKeepsItsDescriptionThroughTheBucketView) {
+  MetricsRecorder recorder("test-service");
+  recorder.RecordLatency("http_server_request_duration", std::chrono::microseconds(1));
+
+  EXPECT_EQ(ExportedDescriptionFor("http_server_request_duration_microseconds"),
+            "HTTP request duration in microseconds");
+}
+
+// And the other side of the same view: it matches every *_microseconds
+// histogram, including ones no other service reports. A description set on the
+// view rather than the instrument is applied to all of them indiscriminately,
+// which is how portrait's render timer came to be labelled as HTTP latency.
+TEST_F(ExportedDescriptionTest, AServiceDefinedLatencyIsLeftUndescribed) {
+  MetricsRecorder recorder("test-service");
+  recorder.RecordLatency("trace_request_duration", std::chrono::microseconds(1));
+
+  EXPECT_EQ(ExportedDescriptionFor("trace_request_duration_microseconds"), "");
+}
+
+}  // namespace
+}  // namespace futility::otel

--- a/domains/platform/libs/futility/otel/metrics.cc
+++ b/domains/platform/libs/futility/otel/metrics.cc
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "domains/platform/libs/futility/otel/http_instrument_descriptions.h"
 #include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/metrics/provider.h"
@@ -49,8 +50,9 @@ void MetricsRecorder::RecordCounter(const std::string& metric_name, int64_t valu
                                     const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;
 
-  auto* counter = FindOrCreate(counters_, metric_name,
-                               [&] { return meter_->CreateUInt64Counter(metric_name); });
+  auto* counter = FindOrCreate(counters_, metric_name, [&] {
+    return meter_->CreateUInt64Counter(metric_name, DescriptionFor(metric_name));
+  });
   if (counter != nullptr) {
     RecordWithAttributes(attributes, [&](auto&&... labels) {
       counter->Add(static_cast<uint64_t>(value), std::forward<decltype(labels)>(labels)...);
@@ -66,8 +68,9 @@ void MetricsRecorder::RecordLatency(const std::string& metric_name,
   // Cache key is the instrument name, so a latency "x" (instrument
   // x_microseconds) can never alias a distribution "x".
   const std::string instrument_name = metric_name + "_microseconds";
-  auto* histogram = FindOrCreate(histograms_, instrument_name,
-                                 [&] { return meter_->CreateUInt64Histogram(instrument_name); });
+  auto* histogram = FindOrCreate(histograms_, instrument_name, [&] {
+    return meter_->CreateUInt64Histogram(instrument_name, DescriptionFor(instrument_name));
+  });
   if (histogram != nullptr) {
     RecordWithAttributes(attributes, [&](auto&&... labels) {
       histogram->Record(static_cast<uint64_t>(duration.count()),
@@ -83,8 +86,9 @@ void MetricsRecorder::RecordDistribution(const std::string& metric_name, double 
   // are non-negative quantities by contract, so drop anything else.
   if (!std::isfinite(value) || value < 0.0) return;
 
-  auto* histogram = FindOrCreate(histograms_, metric_name,
-                                 [&] { return meter_->CreateUInt64Histogram(metric_name); });
+  auto* histogram = FindOrCreate(histograms_, metric_name, [&] {
+    return meter_->CreateUInt64Histogram(metric_name, DescriptionFor(metric_name));
+  });
   if (histogram != nullptr) {
     RecordWithAttributes(attributes, [&](auto&&... labels) {
       histogram->Record(static_cast<uint64_t>(value), std::forward<decltype(labels)>(labels)...);
@@ -96,8 +100,11 @@ void MetricsRecorder::RecordGauge(const std::string& metric_name, double value,
                                   const std::map<std::string, std::string>& attributes) {
   if (!meter_) return;
 
+  // Cache key stays the stem the caller passed; the instrument, and so the
+  // description lookup, take the _gauge name the collector actually sees.
+  const std::string instrument_name = metric_name + "_gauge";
   auto* gauge = FindOrCreate(gauges_, metric_name, [&] {
-    return meter_->CreateInt64UpDownCounter(metric_name + "_gauge");
+    return meter_->CreateInt64UpDownCounter(instrument_name, DescriptionFor(instrument_name));
   });
   if (gauge != nullptr) {
     RecordWithAttributes(attributes, [&](auto&&... labels) {

--- a/domains/platform/libs/futility/otel/otel_provider.cc
+++ b/domains/platform/libs/futility/otel/otel_provider.cc
@@ -5,6 +5,7 @@
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter.h"
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
+#include "opentelemetry/metrics/noop.h"
 #include "opentelemetry/metrics/provider.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h"
@@ -22,10 +23,11 @@
 namespace futility::otel {
 
 // The only way to give a histogram explicit bounds in opentelemetry-cpp: the
-// API's CreateUInt64Histogram takes a name and nothing else, so a view on the
-// provider is what turns kHttpLatencyBucketBoundsMicros into the layout the
-// SDK actually aggregates into. Without it every histogram silently gets the
-// millisecond-shaped SDK defaults (#1286).
+// API's CreateUInt64Histogram takes a name, a description and a unit, but no
+// boundaries, so a view on the provider is what turns
+// kHttpLatencyBucketBoundsMicros into the layout the SDK actually aggregates
+// into. Without it every histogram silently gets the millisecond-shaped SDK
+// defaults (#1286).
 //
 // Matched on the name suffix rather than on http_server_request_duration_
 // microseconds alone. MetricsRecorder::RecordLatency appends _microseconds to
@@ -56,9 +58,17 @@ void RegisterLatencyBucketView(opentelemetry::sdk::metrics::MeterProvider& meter
   // Empty view name keeps the instrument's own name (meter.cc only overrides
   // when the view names something). Renaming the stream here would point every
   // service's duration series at a name prom_proxy does not query.
+  //
+  // The description is empty for the same reason and by the same rule. This
+  // view matches every *_microseconds histogram, so any description written
+  // here is stamped onto all of them — it cannot be right for more than one.
+  // Leaving it empty lets each instrument keep the description it declared,
+  // which for the shared rails is the one pinned in
+  // http_instrument_descriptions.h; a sentence here instead would overwrite
+  // that and put this rail back in conflict with yodel and server_pal.
   auto view = opentelemetry::sdk::metrics::ViewFactory::Create(
-      /*name=*/"", "Latency in microseconds, bucketed for 100us to 10s",
-      opentelemetry::sdk::metrics::AggregationType::kHistogram, histogram_config);
+      /*name=*/"", /*description=*/"", opentelemetry::sdk::metrics::AggregationType::kHistogram,
+      histogram_config);
 
   meter_provider.AddView(std::move(instrument_selector), std::move(meter_selector),
                          std::move(view));
@@ -114,9 +124,14 @@ OtelProvider::OtelProvider(const OtelConfig& config) : metrics_enabled_(config.e
 
 OtelProvider::~OtelProvider() {
   if (metrics_enabled_ && meter_provider_) {
-    // Reset global provider to default
+    // Restore the no-op provider, not an empty pointer. The API guarantees
+    // GetMeterProvider() never returns nullptr, and MetricsRecorder's
+    // constructor dereferences it without checking — so clearing the singleton
+    // turns any recorder built after this destructor into a crash rather than
+    // into the no-op the guarantee promises.
     opentelemetry::metrics::Provider::SetMeterProvider(
-        std::shared_ptr<opentelemetry::v1::metrics::MeterProvider>{});
+        std::shared_ptr<opentelemetry::v1::metrics::MeterProvider>(
+            new opentelemetry::metrics::NoopMeterProvider()));
     meter_provider_.reset();
   }
 }

--- a/domains/platform/libs/otel_contract/BUILD.bazel
+++ b/domains/platform/libs/otel_contract/BUILD.bazel
@@ -6,14 +6,19 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "otel_contract_test",
     size = "small",
-    srcs = ["http_latency_buckets_test.go"],
+    srcs = [
+        "http_instrument_descriptions_test.go",
+        "http_latency_buckets_test.go",
+    ],
     # Read as text rather than linked. There is no build configuration in which
     # a Go test could link all three, and the declaration site is what has to
     # agree — the constant, not a value some running process reports.
     data = [
+        "//domains/platform/libs/futility/otel:http_instrument_descriptions.h",
         "//domains/platform/libs/futility/otel:otel_provider.h",
         "//domains/platform/libs/server_pal:src/lib.rs",
         "//domains/platform/libs/yodel:src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java",
+        "//domains/platform/libs/yodel:src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java",
     ],
     deps = [
         "@com_github_stretchr_testify//assert",

--- a/domains/platform/libs/otel_contract/http_instrument_descriptions_test.go
+++ b/domains/platform/libs/otel_contract/http_instrument_descriptions_test.go
@@ -1,0 +1,188 @@
+package otel_contract
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The five instruments every HTTP service reports, whatever it is written in.
+// A rail that stops declaring one of these has not gone quiet — it has started
+// reporting an instrument with no description, which is its own conflict.
+var sharedHttpInstruments = []string{
+	"http_server_requests",
+	"http_server_requests_success",
+	"http_server_requests_failure",
+	"http_server_requests_active_gauge",
+	"http_server_request_duration_microseconds",
+}
+
+// Where each rail declares its http_server_* descriptions, and the patterns
+// that lift (instrument name, description) pairs out of it. Each rail needs
+// more than one pattern because none of them writes all five the same way: the
+// counters go through a shared helper and the gauge and histogram do not.
+//
+// Every pattern captures the name first and the description second. Paths are
+// relative to this package, which is where rules_go runs the test from.
+var descriptionRails = []struct {
+	name     string
+	path     string
+	patterns []*regexp.Regexp
+}{
+	{
+		name: "futility/otel (C++)",
+		path: "../futility/otel/http_instrument_descriptions.h",
+		patterns: []*regexp.Regexp{
+			// {"http_server_requests", "HTTP requests received"},
+			regexp.MustCompile(`\{"(http_server_[a-z_]*)",\s*"([^"]*)"\}`),
+		},
+	},
+	{
+		name: "yodel (Java)",
+		path: "../yodel/src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java",
+		patterns: []*regexp.Regexp{
+			// sum("http_server_requests", "HTTP requests received", ...)
+			regexp.MustCompile(`"(http_server_[a-z_]*)",\s*\n\s*"([^"]*)"`),
+			// metric.put("name", "..."); metric.put("description", "...");
+			regexp.MustCompile(`"name",\s*"(http_server_[a-z_]*)"\);\s*\n\s*metric\.put\("description",\s*"([^"]*)"\)`),
+		},
+	},
+	{
+		name: "server_pal (Rust)",
+		path: "../server_pal/src/lib.rs",
+		patterns: []*regexp.Regexp{
+			// http_counter(&CELL, "http_server_requests", "HTTP requests received")
+			regexp.MustCompile(`"(http_server_[a-z_]*)",\s*\n\s*"([^"]*)",`),
+			// .i64_up_down_counter("...").with_description("...")
+			regexp.MustCompile(`\("(http_server_[a-z_]*)"\)\s*\n\s*\.with_description\("([^"]*)"\)`),
+		},
+	},
+}
+
+// descriptionsFrom returns the instrument-name-to-description map a rail
+// declares, restricted to the shared instruments. Names outside that set are
+// ignored: a service is free to invent instruments, and only the shared ones
+// are reported by more than one rail and so only they can conflict.
+func descriptionsFrom(t *testing.T, path string, patterns []*regexp.Regexp) map[string]string {
+	t.Helper()
+	source, err := os.ReadFile(path)
+	require.NoError(t, err, "cannot read %s — has the data dependency been dropped?", path)
+	source = withoutCommentLines(source)
+
+	shared := map[string]bool{}
+	for _, name := range sharedHttpInstruments {
+		shared[name] = true
+	}
+
+	found := map[string]string{}
+	for _, pattern := range patterns {
+		for _, match := range pattern.FindAllSubmatch(source, -1) {
+			name, description := string(match[1]), string(match[2])
+			if !shared[name] {
+				continue
+			}
+			if existing, seen := found[name]; seen {
+				require.Equal(t, existing, description,
+					"%s declares %s twice with different descriptions", path, name)
+				continue
+			}
+			found[name] = description
+		}
+	}
+
+	// Guards the parse itself. Every pattern here is matching source text, so a
+	// refactor that reformats a declaration breaks the match rather than the
+	// build, and a rail this test silently stopped reading is a rail it stopped
+	// checking — the failure mode the bucket pin was written to avoid too.
+	for _, name := range sharedHttpInstruments {
+		require.Contains(t, found, name,
+			"no description found for %s in %s. If the declaration was reshaped, update the "+
+				"pattern here: a rail this test cannot parse is one it no longer pins.",
+			name, path)
+	}
+	return found
+}
+
+// withoutCommentLines blanks whole-line comments in C++, Java and Rust source.
+//
+// Every rail's declaration file explains this contract in prose, and the prose
+// quotes the strings — the C++ header reproduces a table entry in its own doc
+// comment. Matching over comments lets a rail satisfy the pin with an example
+// while declaring nothing: delete the real entry, leave the sentence that
+// describes it, and both tests below still pass while the service exports an
+// empty description. Lines are blanked rather than removed so that patterns
+// spanning a newline cannot bridge across the gap a deleted line would leave.
+func withoutCommentLines(source []byte) []byte {
+	lines := strings.Split(string(source), "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		for _, marker := range []string{"//", "/*", "*/", "*"} {
+			if strings.HasPrefix(trimmed, marker) {
+				lines[i] = ""
+				break
+			}
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// The three emitters describe the shared instruments identically.
+//
+// All of them report into one collector, which merges series by instrument
+// name across services. Its Prometheus exporter keeps the first description it
+// sees for a name and logs "Instrument description conflict, using existing"
+// for every later one that disagrees — once per export interval, for as long as
+// both services run. The series still export, so the only symptom is a log the
+// collector floods with, which is why this drifted unnoticed until it was
+// three-way.
+//
+// An empty description conflicts with a non-empty one exactly as loudly, so
+// "this rail just won't say" is not a way out; it is how futility got here.
+func TestHttpInstrumentDescriptionsMatchAcrossAllThreeEmitters(t *testing.T) {
+	byRail := map[string]map[string]string{}
+	for _, rail := range descriptionRails {
+		byRail[rail.name] = descriptionsFrom(t, rail.path, rail.patterns)
+	}
+	require.Len(t, byRail, len(descriptionRails), "two rails share a name")
+
+	reference := descriptionRails[0]
+	want := byRail[reference.name]
+	for _, rail := range descriptionRails[1:] {
+		assert.Equal(t, want, byRail[rail.name],
+			"%s and %s describe the shared HTTP instruments differently. They have to move "+
+				"together — the collector merges these series by name across all three, and keeps "+
+				"only the first description it sees.", reference.name, rail.name)
+	}
+}
+
+// And that the agreed descriptions are ASCII.
+//
+// The drift this test was written for was a single en-dash in server_pal's
+// "(2xx–3xx)" against yodel's "(2xx-3xx)". Nothing renders it: the two strings
+// are indistinguishable in a diff, in a review, and on a dashboard, and differ
+// only to the byte comparison the collector actually makes. Equality above
+// would be satisfied by all three rails adopting the en-dash together, so pin
+// the property that makes the mismatch visible in the first place.
+func TestHttpInstrumentDescriptionsAreAscii(t *testing.T) {
+	for _, rail := range descriptionRails {
+		t.Run(rail.name, func(t *testing.T) {
+			for name, description := range descriptionsFrom(t, rail.path, rail.patterns) {
+				assert.NotEmpty(t, description,
+					"%s describes %s with an empty string, which conflicts with every rail "+
+						"that describes it at all", rail.name, name)
+
+				for _, r := range description {
+					require.LessOrEqual(t, r, unicode.MaxASCII,
+						"%s describes %s with the non-ASCII character %q. It reads the same as "+
+							"its ASCII twin and exports as a different string: %q",
+						rail.name, name, r, description)
+				}
+			}
+		})
+	}
+}

--- a/domains/platform/libs/server_pal/src/lib.rs
+++ b/domains/platform/libs/server_pal/src/lib.rs
@@ -232,10 +232,13 @@ async fn http_metrics_middleware(req: Request, next: Next) -> Response {
     let status = resp.status().as_u16();
 
     if status < 400 {
+        // The range is spelled with an ASCII hyphen, matching yodel and
+        // futility. An en-dash reads identically here and exports as a
+        // different string, which is the conflict otel_contract now pins.
         http_counter(
             &HTTP_SUCCESS,
             "http_server_requests_success",
-            "HTTP requests completed successfully (2xx–3xx)",
+            "HTTP requests completed successfully (2xx-3xx)",
         )
         .add(1, &attrs);
     } else {

--- a/domains/platform/libs/yodel/BUILD.bazel
+++ b/domains/platform/libs/yodel/BUILD.bazel
@@ -1,8 +1,12 @@
 load("//bazel/rules:java.bzl", "artifact", "java_library", "java_test_suite")
 
 # Read as text by //domains/platform/libs/otel_contract, which pins this rail's
-# latency bucket bounds equal to futility/otel's and server_pal's.
-exports_files(["src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java"])
+# latency bucket bounds and http_server_* descriptions equal to futility/otel's
+# and server_pal's.
+exports_files([
+    "src/main/java/com/muchq/platform/yodel/HttpServerMetrics.java",
+    "src/main/java/com/muchq/platform/yodel/OtlpJsonEncoder.java",
+])
 
 java_library(
     name = "yodel",


### PR DESCRIPTION
Two things found while chasing missing metrics on the consolidated host.

one_d4's healthcheck shelled out to curl, which isn't in the image, so every probe failed on "executable file not found" and the container read unhealthy while serving fine. Now probes over bash's /dev/tcp, wrapped in timeout since compose's `timeout:` marks an attempt failed without killing the process.

The three rails also disagreed on descriptions for the shared http_server_* instruments, so the collector logged a conflict every export interval: futility set none at all and its latency view stamped one sentence over every *_microseconds histogram it matched, and server_pal had an en-dash where the others have a hyphen. Descriptions now live in one header applied at instrument creation, with the view's left empty. Won't quiet down until everything's deployed, since the first description wins.