### PR TITLE
golf_hub: seed restored presence from rows so boot catch-up stops injecting phantom roomState (#1276)

### DIFF
--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -872,6 +872,83 @@ TEST_F(GolfHubStreamFixture, ResumingOnAFreshInstanceReplaysChatHistory) {
   EXPECT_GT(history->messages[1].messageId, history->messages[0].messageId);
 }
 
+// The boot-time twin of ActiveSignalRefreshesHeldRoom's contract: a
+// channel-active with nothing new in the rows projects nothing. A fresh
+// instance restores members from the same rows the catch-up re-reads, so
+// its first LISTEN-landed signal must be a no-op — when the restore
+// instead seeded presence as disconnected, every boot manufactured a
+// memory-vs-rows mismatch and the "only when rows moved" guard projected
+// a roomState that could land inside a resuming seat's hydration,
+// between its snapshot and its chat replay (#1276 sighting #4, on
+// #1293's CI run of StatsSurviveARestart). The seed must copy the row in
+// both polarities — alice crashed connected, carol parked disconnected —
+// so neither "seed false" nor "seed true" can hide in a one-sided room.
+TEST_F(GolfHubStreamFixture, BootCatchUpProjectsNothingWhenRowsNeverMoved) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  auto carol = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value() && carol.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+  ASSERT_TRUE(carol->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "roomState").has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "roomState").has_value());
+  // carol's clean close parks her seat and writes her row disconnected;
+  // alice's park broadcast is the proof the flip landed before the
+  // "crash". alice and bob crash with the process, rows still connected.
+  carol->stream.Close();
+  auto parked = ReceiveCase(alice->stream, "roomState");
+  ASSERT_TRUE(parked.has_value());
+  for (const auto& player : parked->as_roomState_or_null()->players) {
+    if (player.playerId == carol->player_id) EXPECT_FALSE(player.connected);
+  }
+  store_->Flush();
+
+  auto instance = BuildSecondInstance(vault_, store_, chat_store_);
+  ASSERT_NE(instance, nullptr);
+  auto resumed = OpenSeatVia(*instance->client, bob->resume_token);
+  ASSERT_TRUE(resumed.has_value());
+
+  // The documented hydration order, strictly — the frames the injected
+  // projection was observed splitting.
+  auto ready = NextEvent(resumed->stream);
+  ASSERT_TRUE(ready.has_value());
+  ASSERT_EQ(std::string(ready->case_name()), "sessionReady");
+  auto snapshot = NextEvent(resumed->stream);
+  ASSERT_TRUE(snapshot.has_value());
+  ASSERT_EQ(std::string(snapshot->case_name()), "roomState");
+  // The snapshot projects the restored seeds: row truth in both
+  // directions, not a blanket value.
+  const auto* lobby = snapshot->as_roomState_or_null();
+  ASSERT_NE(lobby, nullptr);
+  ASSERT_EQ(lobby->players.size(), 3u);
+  for (const auto& player : lobby->players) {
+    EXPECT_EQ(player.connected, player.playerId != carol->player_id)
+        << "restored presence for " << player.playerId << " does not match its row";
+  }
+  auto replay = NextEvent(resumed->stream);
+  ASSERT_TRUE(replay.has_value());
+  ASSERT_EQ(std::string(replay->case_name()), "roomChatHistory");
+
+  // The LISTEN-landed signals, called directly so no listener timing is
+  // in play. Neither alice nor carol resumed here — their rows are what
+  // a crashed instance leaves behind — yet nothing has moved since the
+  // restore read these same rows, so both catch-ups must stay quiet.
+  instance->handler->OnChannelActive(RoomChannel(room_id));
+  instance->handler->OnChannelActive(ChatChannel(room_id));
+  auto leftover = resumed->stream.Receive(std::chrono::milliseconds(50));
+  EXPECT_TRUE(!leftover.ok() || !leftover->has_value())
+      << "boot catch-up projected a frame though no row moved";
+}
+
 TEST_F(GolfHubStreamFixture, JoinHistoryIsCappedAtTheRetentionLimit) {
   auto alice = OpenSeat();
   ASSERT_TRUE(alice.has_value());

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -178,10 +178,16 @@ absl::Status HubHandler::RestoreFromStore() {
   const std::lock_guard<std::mutex> lock(mu_);
   for (const std::string& room_id : snapshot->rooms) rooms_[room_id];
   for (const HubStore::MemberRow& row : snapshot->members) {
-    // Sockets did not survive the restart: everyone restores
-    // disconnected and flips back on resume.
+    // Presence seeds from the row, the fleet truth ReconcileRoomLocked
+    // already adopts on every wake. Seeding false here instead made the
+    // first channel-active after a boot see phantom movement and inject
+    // a roomState into a resuming seat's hydration (#1276 sighting #4).
+    // A member whose socket died with the old process reads connected
+    // until they resume or leave; no one owns flipping a crashed
+    // instance's rows, and inventing a local answer just diverges from
+    // what every other instance projects.
     Member member;
-    member.connected = false;
+    member.connected = row.connected;
     member.games_played = row.games_played;
     member.games_won = row.games_won;
     member.total_score = row.total_score;

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -122,8 +122,8 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// For main's SIGTERM path: Drain, then transport Stop.
   Registry& registry() { return registry_; }
 
-  /// Boot-time restore of the store's snapshot: rooms, members (everyone
-  /// disconnected until they resume), and games. Call before the
+  /// Boot-time restore of the store's snapshot: rooms, members (presence
+  /// seeded from their rows), and games. Call before the
   /// transport serves; no-op without a store. Undecodable rows were
   /// already dropped (loudly) by the store — an error here means the
   /// snapshot itself couldn't be read.

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -238,12 +238,20 @@ class PgGolfHubFixture : public GolfHubStreamFixture {
 
   bool WaitForListenerCount(const std::string& room_id, int count) {
     pg::Client db(url_);
-    const std::string statement = "LISTEN \"" + RoomChannel(room_id) + "\"";
+    // pg_stat_activity.query is a backend's *last* statement. The poll
+    // thread LISTENs a room's two channels in sorted order (chat before
+    // room), but a wake between AttachListener's two Listen() calls can
+    // split them across passes and leave the chat LISTEN as the one that
+    // sticks. Either statement therefore counts: both are only ever
+    // wanted together, so a backend showing one has the other active or
+    // lands it within the same pass.
+    const std::string room_statement = "LISTEN \"" + RoomChannel(room_id) + "\"";
+    const std::string chat_statement = "LISTEN \"" + ChatChannel(room_id) + "\"";
     for (int i = 0; i < 50; ++i) {
       auto result = db.Exec(
           "SELECT count(*) FROM pg_stat_activity"
-          " WHERE datname = current_database() AND query = $1",
-          {statement});
+          " WHERE datname = current_database() AND query IN ($1, $2)",
+          {room_statement, chat_statement});
       if (result.ok() && result->Get(0, 0).has_value() &&
           std::atoi(result->Get(0, 0)->c_str()) >= count) {
         return true;
@@ -710,8 +718,8 @@ TEST_F(PgGolfHubFixture, ConnectedFlagFollowsPresence) {
     EXPECT_TRUE(rows.members[0].connected);
   }
 
-  // Across a restart the row keeps its last written value; the member
-  // restores disconnected in memory and flips the row back on resume.
+  // Across a restart the row keeps its last written value, the restore
+  // adopts it as presence truth, and the resume re-affirms it.
   const std::string token = alice->resume_token;
   RestartHub();
   auto alice_back = OpenSeat(token);


### PR DESCRIPTION
## Summary

The `pg_hub_e2e_test` red on #1293 was **not** #1276 recurring. The upstream half of that fix held — smithy-cpp#173 (terminal-waiter send-before-receive, pinned by #1291 at `4208f791`) plus its tests-only follow-up smithy-cpp#174, and `TwoInstancesShareOneGame` passed in 495ms on the failing run. What failed was `StatsSurviveARestart`, in 65ms, on an assertion: an extra `roomState` frame injected into resume hydration where `roomChatHistory` was promised.

That extra frame is a regression from #1289's own room catch-up. The channel-active path projects "only when rows moved" by comparing memory against rows — but `RestoreFromStore` seeded restored members `connected=false` while their rows still said `true` (a crash writes no goodbyes). So the first channel-active after **every** restart saw a phantom mismatch, re-projected the room, and raced the resume hydration (`Play` holds no lock across `BroadcastRoom` and `SendChatHistory`). Whether CI saw it depended only on whether the fresh listener's `LISTEN` landed before `OpenSeat` or during it.

## Fix

`RestoreFromStore` seeds `member.connected` from the row. Rows are the fleet presence truth `ReconcileRoomLocked` has adopted on every wake since before #1289 — the `false` seed never survived past the first wake, so this deletes a boot-window fiction (and restores the no-flood property #1289's guard was built for) rather than any behavior something kept. With memory matching rows at boot, the first channel-active is a no-op in every interleaving; `StatsSurviveARestart`'s strict hydration order is deterministic again, and the strictness stays — it is the canary for this class of injection.

Also fixes a second, unrelated 1-in-20 flake the 20× soak surfaced: `WaitForListenerCount` greps `pg_stat_activity` for the room `LISTEN` as a backend's *last* statement, but a wake between `AttachListener`'s two `Listen()` calls splits `SyncChannels`' sorted pass and leaves the chat `LISTEN` as the statement that sticks — invisible to the poll forever. The helper now matches either of the room's two statements (they are only ever wanted together).

## Tests

New `BootCatchUpProjectsNothingWhenRowsNeverMoved` lives in the **memory** suite — no pg gate, so it runs on every CI pass, unlike the pg suite whose near-zero exposure #1276 documented. It pins both polarities (alice crashes connected, carol parks disconnected, bob resumes): the hydration snapshot must mirror the rows exactly, and direct `OnChannelActive` calls on both channels must stay silent.

| Check | Result |
|---|---|
| `hub_e2e_test` (incl. new test) | PASSED |
| `scripts/mutation-check` on the seed line: `= false` (revert), `= true`, `= !row.connected` | all killed (`= true` previously survived the entire suite) |
| Full golf_hub + pg suites vs postgres 16 | 16/16 PASSED |
| `pg_hub_e2e_test` soak | 30/30 after both fixes (1/20 before the helper fix — the listener-count flake, not the hydration race) |
| clang-format on changed files | clean |

Review panel ran (concurrency, test-quality, semantics lenses, each refuting its own findings); both surviving findings — a stale header doc and the `= true` mutation gap — are addressed in the commit. The panel's one advisory (restored members are never reaped; a deploy turns 5-minute grace into forever-membership) is tracked as #1295 with a live symptom in muchq.github.io#260.

Fixes #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUrPZEoRVcJ6qUe794xhvD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUrPZEoRVcJ6qUe794xhvD)_