### PR TITLE
golf_hub: boot-grace reap for restored members (#1295)

### DIFF
--- a/domains/games/apis/golf_hub/hub_chat_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_chat_race_test.cc
@@ -113,20 +113,6 @@ class GatedChatStore final : public ChatStore {
   TestGate released_;
 };
 
-// Secondary instances mint from their own space so two hubs can never
-// hand out the same player id.
-class RemoteIdGenerator final : public IdGenerator {
- public:
-  std::string PlayerId() override { return "remote-player-" + std::to_string(++players_); }
-  std::string RoomId() override { return "remote-room-" + std::to_string(++rooms_); }
-  std::string GameCode() override { return "RGAME" + std::to_string(++games_); }
-
- private:
-  int players_ = 0;
-  int rooms_ = 0;
-  int games_ = 0;
-};
-
 class HubChatRaceFixture : public GolfHubStreamFixture {
  protected:
   struct Instance {

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -204,23 +204,6 @@ class NotAMemberChatStore final : public ChatStore {
   std::shared_ptr<ChatStore> delegate_;
 };
 
-// Distinct id space for the second instance (the hub_store_race_test /
-// pg suite pattern): two SequentialIdGenerators would both mint
-// "player-1", and a fresh seat on the second instance would then hold
-// the first instance's player id — a seat conflict for that player's
-// own resume.
-class RemoteIdGenerator final : public IdGenerator {
- public:
-  std::string PlayerId() override { return "remote-player-" + std::to_string(++players_); }
-  std::string RoomId() override { return "remote-room-" + std::to_string(++rooms_); }
-  std::string GameCode() override { return "RGAME" + std::to_string(++games_); }
-
- private:
-  int players_ = 0;
-  int rooms_ = 0;
-  int games_ = 0;
-};
-
 std::unique_ptr<SecondInstance> BuildSecondInstance(
     std::shared_ptr<TicketVault> vault, std::shared_ptr<HubStore> store,
     std::shared_ptr<ChatStore> chat_store,

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -1103,6 +1103,132 @@ TEST_F(GolfHubStreamFixture, ShareLinkJoinSucceedsOnceBootGraceClearsStaleMember
   EXPECT_EQ(joined->as_roomState_or_null()->players.size(), 2u);
 }
 
+// The fleet half of the boot cohort's contract (#1295): a seat restored
+// with its row at connected belongs to whatever session owns that row —
+// here, alice live on this generation — and must never enter the
+// sibling's cohort at all. Otherwise her park during the sibling's boot
+// window would be reaped at its boot deadline instead of running her
+// own full grace on this generation's registry. bob, parked before the
+// boot with his row at disconnected, is the canary that proves the
+// deadline fired and the drain ran.
+TEST_F(GolfHubStreamFixture, BootGraceNeverClaimsASeatRestoredConnected) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  bob->stream.Close();
+  AwaitSnapshot(*store_, [&](const HubStore::Snapshot& snapshot) {
+    for (const auto& member : snapshot.members) {
+      if (member.player_id == bob->player_id) return !member.connected;
+    }
+    return false;
+  });
+
+  // The sibling boots while alice is live: her row reads connected.
+  auto instance =
+      BuildSecondInstance(vault_, store_, chat_store_,
+                          std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"),
+                          /*grace=*/std::chrono::seconds(1));
+  ASSERT_NE(instance, nullptr);
+  // She parks inside the sibling's boot window; this generation's
+  // registry arms her grace (60s here — far past the test).
+  alice->stream.Close();
+
+  // bob's reap is the deadline's proof; alice must outlive it.
+  auto reaped = AwaitSnapshot(
+      *store_,
+      [&](const HubStore::Snapshot& snapshot) {
+        for (const auto& member : snapshot.members) {
+          if (member.player_id == bob->player_id) return false;
+        }
+        return true;
+      },
+      std::chrono::seconds(6));
+  ASSERT_EQ(reaped.members.size(), 1u);
+  EXPECT_EQ(reaped.members[0].player_id, alice->player_id)
+      << "a seat restored connected was claimed by the sibling's boot cohort";
+}
+
+// The same contract's second window: a seat that entered the cohort
+// parked, but whose row a reconcile later observed at connected —
+// bob resumes on this generation mid-window — is ceded to that row's
+// owner for good. His second park then runs this generation's full
+// grace, not the remainder of the sibling's boot deadline. carol is
+// the parked-ghost canary again.
+TEST_F(GolfHubStreamFixture, BootGraceCedesASeatObservedConnectedMidWindow) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  auto carol = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value() && carol.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(carol->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "roomState").has_value());
+  bob->stream.Close();
+  carol->stream.Close();
+  AwaitSnapshot(*store_, [](const HubStore::Snapshot& snapshot) {
+    int disconnected = 0;
+    for (const auto& member : snapshot.members) {
+      if (!member.connected) ++disconnected;
+    }
+    return disconnected == 2;
+  });
+
+  // The sibling boots with bob and carol both parked — both cohort.
+  auto instance =
+      BuildSecondInstance(vault_, store_, chat_store_,
+                          std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"),
+                          /*grace=*/std::chrono::seconds(2));
+  ASSERT_NE(instance, nullptr);
+
+  // bob resumes on this generation: his row flips to connected, and the
+  // sibling's LISTEN-landed reconcile observes it (direct call, no
+  // listener timing) — the cede under test.
+  auto bob_back = OpenSeat(bob->resume_token);
+  ASSERT_TRUE(bob_back.has_value());
+  ASSERT_TRUE(ReceiveCase(bob_back->stream, "sessionReady").has_value());
+  instance->handler->OnChannelActive(RoomChannel(room_id));
+  // He parks again, still inside the sibling's window: this
+  // generation's registry owns his fresh grace now.
+  bob_back->stream.Close();
+  AwaitSnapshot(*store_, [&](const HubStore::Snapshot& snapshot) {
+    for (const auto& member : snapshot.members) {
+      if (member.player_id == bob->player_id) return !member.connected;
+    }
+    return false;
+  });
+
+  // carol's reap proves the deadline fired; ceded bob must outlive it.
+  auto reaped = AwaitSnapshot(
+      *store_,
+      [&](const HubStore::Snapshot& snapshot) {
+        for (const auto& member : snapshot.members) {
+          if (member.player_id == carol->player_id) return false;
+        }
+        return true;
+      },
+      std::chrono::seconds(6));
+  std::set<std::string> survivors;
+  for (const auto& member : reaped.members) survivors.insert(member.player_id);
+  EXPECT_TRUE(survivors.contains(alice->player_id));
+  EXPECT_TRUE(survivors.contains(bob->player_id))
+      << "a seat whose row a reconcile observed connected was still reaped by the boot cohort";
+}
+
 TEST_F(GolfHubStreamFixture, JoinHistoryIsCappedAtTheRetentionLimit) {
   auto alice = OpenSeat();
   ASSERT_TRUE(alice.has_value());

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -986,14 +986,17 @@ HubStore::Snapshot AwaitSnapshot(HubStore& store,
   }
 }
 
-// The boot cohort (#1295): a restart converts a parked member's grace
-// into forever-membership, because the registry that owned their timer
-// died with the process. The successor's one boot deadline reaps what
-// no session reclaims — under the same row check as session expiry, so
-// each spare mode gets a seat here: bob's row says connected (a live
-// seat "elsewhere" — this generation), and carol resumes on the new
-// instance before the deadline. Only alice, parked with her row at
-// disconnected and never coming back, is the ghost.
+// The boot cohort's happy path (#1295): a restart converts a parked
+// member's grace into forever-membership, because the registry that
+// owned their timer died with the process. The successor's one boot
+// deadline reaps what no session reclaims — alice, parked and never
+// coming back — while bob (row connected) and carol (resumes here)
+// survive. A smoke of the whole flow, not a unique pin of any one
+// guard: the restore filter alone spares bob, and carol's Play erase
+// and the drain's row check are indistinguishable from her survival.
+// The per-guard pins live in BootGraceNeverClaimsASeatRestoredConnected
+// (filter), BootGraceCedesASeatObservedConnectedMidWindow (cede), and
+// BootGraceDrainSparesARowThatTurnedConnectedUnobserved (drain check).
 TEST_F(GolfHubStreamFixture, BootGraceReapsParkedGhostAndSparesLiveSeats) {
   auto alice = OpenSeat();
   auto bob = OpenSeat();
@@ -1047,29 +1050,42 @@ TEST_F(GolfHubStreamFixture, BootGraceReapsParkedGhostAndSparesLiveSeats) {
   EXPECT_TRUE(survivors.contains(carol->player_id)) << "resumed seat was reaped";
 }
 
-// The muchq.github.io#260 symptom, hub half: a visitor parked in one
-// room follows a share link into another, and the stale membership the
-// old process's death fossilized must not answer "room unavailable or
-// already in a room" forever. Once the boot grace clears it, the resume
-// carries no room and the join lands.
+// The muchq.github.io#260 symptom, hub half, both timelines. While a
+// fossil membership is live, a resume lands back in it and a share-link
+// join is refused with the exact #260 answer — that mid-window shape is
+// the frontend's to fix (leave first), pinned here so the hub half is
+// not mistaken for the whole fix. What the hub owes is the other
+// timeline: the fossil must not answer that way *forever*. Once the
+// boot grace clears it, a resume carries no room and the join lands.
 TEST_F(GolfHubStreamFixture, ShareLinkJoinSucceedsOnceBootGraceClearsStaleMembership) {
   auto alice = OpenSeat();
-  ASSERT_TRUE(alice.has_value());
+  auto dave = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && dave.has_value());
   ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(dave->stream, "sessionReady").has_value());
   const std::string old_room = CreateRoomFor(*alice);
   ASSERT_FALSE(old_room.empty());
+  moonbase::golf::JoinRoom join_old;
+  join_old.roomId = old_room;
+  ASSERT_TRUE(dave->stream.Send(GolfCommands::FromJoinroom(join_old)).ok());
+  ASSERT_TRUE(ReceiveCase(dave->stream, "roomState").has_value());
   alice->stream.Close();
+  dave->stream.Close();
   AwaitSnapshot(*store_, [](const HubStore::Snapshot& snapshot) {
-    return snapshot.members.size() == 1 && !snapshot.members[0].connected;
+    int disconnected = 0;
+    for (const auto& member : snapshot.members) {
+      if (!member.connected) ++disconnected;
+    }
+    return disconnected == 2;
   });
 
   auto instance =
       BuildSecondInstance(vault_, store_, chat_store_,
                           std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"),
-                          /*grace=*/std::chrono::seconds(1));
+                          /*grace=*/std::chrono::seconds(2));
   ASSERT_NE(instance, nullptr);
   // The share link's room, created on the new instance while the old
-  // membership ages out.
+  // memberships age out.
   auto bob = OpenSeatVia(*instance->client);
   ASSERT_TRUE(bob.has_value());
   ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
@@ -1078,25 +1094,47 @@ TEST_F(GolfHubStreamFixture, ShareLinkJoinSucceedsOnceBootGraceClearsStaleMember
   ASSERT_TRUE(created.has_value());
   const std::string shared_room = created->as_roomState_or_null()->roomId;
 
-  // The reap deletes alice's membership, and with it her empty room.
+  // dave follows the share link mid-window: his resume lands in the
+  // fossil (which also spares him from the cohort), and the bare join
+  // gets #260's exact answer. Production v2 always resumes first, so
+  // this is the shape the frontend's leave-before-join exists for.
+  auto dave_back = OpenSeatVia(*instance->client, dave->resume_token);
+  ASSERT_TRUE(dave_back.has_value());
+  auto dave_ready = ReceiveCase(dave_back->stream, "sessionReady");
+  ASSERT_TRUE(dave_ready.has_value());
+  ASSERT_TRUE(dave_ready->as_sessionReady_or_null()->roomId.has_value());
+  EXPECT_EQ(*dave_ready->as_sessionReady_or_null()->roomId, old_room);
+  moonbase::golf::JoinRoom join_shared;
+  join_shared.roomId = shared_room;
+  ASSERT_TRUE(dave_back->stream.Send(GolfCommands::FromJoinroom(join_shared)).ok());
+  auto refused = ReceiveCase(dave_back->stream, "commandRejected");
+  ASSERT_TRUE(refused.has_value());
+  EXPECT_EQ(refused->as_commandRejected_or_null()->reason, "room unavailable or already in a room");
+
+  // The reap clears alice's fossil; resumed dave keeps his seat, so the
+  // old room survives him.
   auto cleared = AwaitSnapshot(
       *store_,
       [&](const HubStore::Snapshot& snapshot) {
-        return snapshot.rooms.size() == 1 && snapshot.rooms[0] == shared_room;
+        for (const auto& member : snapshot.members) {
+          if (member.player_id == alice->player_id) return false;
+        }
+        return true;
       },
       std::chrono::seconds(6));
-  ASSERT_EQ(cleared.rooms.size(), 1u);
+  std::set<std::string> remaining;
+  for (const auto& member : cleared.members) remaining.insert(member.player_id);
+  ASSERT_FALSE(remaining.contains(alice->player_id)) << "the boot deadline never reaped";
+  ASSERT_TRUE(remaining.contains(dave->player_id));
 
-  // The share-link visit: alice's resume finds no fossil membership,
-  // and the join that #260 saw rejected goes through.
+  // The share-link visit on the hub's timeline: alice's resume finds no
+  // fossil membership, and the join that #260 saw rejected goes through.
   auto alice_back = OpenSeatVia(*instance->client, alice->resume_token);
   ASSERT_TRUE(alice_back.has_value());
   auto ready = ReceiveCase(alice_back->stream, "sessionReady");
   ASSERT_TRUE(ready.has_value());
   EXPECT_FALSE(ready->as_sessionReady_or_null()->roomId.has_value());
-  moonbase::golf::JoinRoom join;
-  join.roomId = shared_room;
-  ASSERT_TRUE(alice_back->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(alice_back->stream.Send(GolfCommands::FromJoinroom(join_shared)).ok());
   auto joined = ReceiveCase(alice_back->stream, "roomState");
   ASSERT_TRUE(joined.has_value());
   EXPECT_EQ(joined->as_roomState_or_null()->roomId, shared_room);
@@ -1138,8 +1176,17 @@ TEST_F(GolfHubStreamFixture, BootGraceNeverClaimsASeatRestoredConnected) {
                           /*grace=*/std::chrono::seconds(1));
   ASSERT_NE(instance, nullptr);
   // She parks inside the sibling's boot window; this generation's
-  // registry arms her grace (60s here — far past the test).
+  // registry arms her grace (60s here — far past the test). Await the
+  // row flip before watching for the reap: a drain that read her row
+  // still connected would spare her for the wrong reason and mask a
+  // deleted restore filter.
   alice->stream.Close();
+  AwaitSnapshot(*store_, [&](const HubStore::Snapshot& snapshot) {
+    for (const auto& member : snapshot.members) {
+      if (member.player_id == alice->player_id) return !member.connected;
+    }
+    return false;
+  });
 
   // bob's reap is the deadline's proof; alice must outlive it.
   auto reaped = AwaitSnapshot(
@@ -1224,9 +1271,99 @@ TEST_F(GolfHubStreamFixture, BootGraceCedesASeatObservedConnectedMidWindow) {
       std::chrono::seconds(6));
   std::set<std::string> survivors;
   for (const auto& member : reaped.members) survivors.insert(member.player_id);
+  // Hard canary: AwaitSnapshot hands back its last look on timeout, so
+  // a reaper that never ran would leave carol present and every spare
+  // assertion below vacuously green.
+  ASSERT_FALSE(survivors.contains(carol->player_id)) << "the boot deadline never reaped";
   EXPECT_TRUE(survivors.contains(alice->player_id));
   EXPECT_TRUE(survivors.contains(bob->player_id))
       << "a seat whose row a reconcile observed connected was still reaped by the boot cohort";
+}
+
+// The drain's own row check, pinned in the one shape neither the
+// restore filter nor the cede can reach: bob enters the cohort parked,
+// turns connected by resuming on this generation, and no reconcile ever
+// shows the sibling that pulse — so only the drain-time fresh read
+// stands between him and a wrongful reap. carol is the parked-ghost
+// canary proving the deadline fired.
+TEST_F(GolfHubStreamFixture, BootGraceDrainSparesARowThatTurnedConnectedUnobserved) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  auto carol = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value() && carol.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(carol->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "roomState").has_value());
+  bob->stream.Close();
+  carol->stream.Close();
+  AwaitSnapshot(*store_, [](const HubStore::Snapshot& snapshot) {
+    int disconnected = 0;
+    for (const auto& member : snapshot.members) {
+      if (!member.connected) ++disconnected;
+    }
+    return disconnected == 2;
+  });
+
+  // The sibling boots with bob and carol both parked — both cohort.
+  auto instance =
+      BuildSecondInstance(vault_, store_, chat_store_,
+                          std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"),
+                          /*grace=*/std::chrono::seconds(2));
+  ASSERT_NE(instance, nullptr);
+  // bob resumes on this generation. Deliberately no OnChannelActive on
+  // the sibling: it never observes the connected pulse, so bob stays in
+  // its cohort and only the drain's fresh read can spare him.
+  auto bob_back = OpenSeat(bob->resume_token);
+  ASSERT_TRUE(bob_back.has_value());
+  ASSERT_TRUE(ReceiveCase(bob_back->stream, "sessionReady").has_value());
+
+  auto reaped = AwaitSnapshot(
+      *store_,
+      [&](const HubStore::Snapshot& snapshot) {
+        for (const auto& member : snapshot.members) {
+          if (member.player_id == carol->player_id) return false;
+        }
+        return true;
+      },
+      std::chrono::seconds(6));
+  std::set<std::string> survivors;
+  for (const auto& member : reaped.members) survivors.insert(member.player_id);
+  ASSERT_FALSE(survivors.contains(carol->player_id)) << "the boot deadline never reaped";
+  EXPECT_TRUE(survivors.contains(alice->player_id));
+  EXPECT_TRUE(survivors.contains(bob->player_id))
+      << "the drain reaped a row its own fresh read shows connected";
+}
+
+// The once-guard is behavior, not just a comment: a second restore
+// would stack a fresh cohort behind a reaper that never re-arms —
+// forever-membership again, silently. Refusal must not depend on
+// whether the first restore happened to arm a thread.
+TEST_F(GolfHubStreamFixture, RestoreFromStoreRefusesASecondCall) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_FALSE(CreateRoomFor(*alice).empty());
+  store_->Flush();
+
+  auto instance =
+      BuildSecondInstance(vault_, store_, chat_store_,
+                          std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"));
+  ASSERT_NE(instance, nullptr);
+  const absl::Status again = instance->handler->RestoreFromStore();
+  EXPECT_EQ(again.code(), absl::StatusCode::kFailedPrecondition) << again;
+
+  // The fixture's own hub restored an empty store — no thread armed —
+  // and must refuse a second call all the same.
+  const absl::Status empty_again = handler_->RestoreFromStore();
+  EXPECT_EQ(empty_again.code(), absl::StatusCode::kFailedPrecondition) << empty_again;
 }
 
 TEST_F(GolfHubStreamFixture, JoinHistoryIsCappedAtTheRetentionLimit) {

--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -9,10 +9,12 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <set>
 #include <string>
+#include <thread>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -202,16 +204,34 @@ class NotAMemberChatStore final : public ChatStore {
   std::shared_ptr<ChatStore> delegate_;
 };
 
+// Distinct id space for the second instance (the hub_store_race_test /
+// pg suite pattern): two SequentialIdGenerators would both mint
+// "player-1", and a fresh seat on the second instance would then hold
+// the first instance's player id — a seat conflict for that player's
+// own resume.
+class RemoteIdGenerator final : public IdGenerator {
+ public:
+  std::string PlayerId() override { return "remote-player-" + std::to_string(++players_); }
+  std::string RoomId() override { return "remote-room-" + std::to_string(++rooms_); }
+  std::string GameCode() override { return "RGAME" + std::to_string(++games_); }
+
+ private:
+  int players_ = 0;
+  int rooms_ = 0;
+  int games_ = 0;
+};
+
 std::unique_ptr<SecondInstance> BuildSecondInstance(
     std::shared_ptr<TicketVault> vault, std::shared_ptr<HubStore> store,
     std::shared_ptr<ChatStore> chat_store,
     std::shared_ptr<futility::otel::MetricsRecorder> metrics =
-        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test")) {
+        std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"),
+    std::chrono::seconds grace = std::chrono::seconds(60)) {
   auto instance = std::make_unique<SecondInstance>();
-  instance->handler = std::make_shared<HubHandler>(
-      std::move(vault), std::make_shared<cards::NoShuffleDealer>(),
-      std::make_shared<SequentialIdGenerator>(), std::chrono::seconds(60), std::move(metrics),
-      std::move(store), std::move(chat_store), UnlimitedRateLimits());
+  instance->handler =
+      std::make_shared<HubHandler>(std::move(vault), std::make_shared<cards::NoShuffleDealer>(),
+                                   std::make_shared<RemoteIdGenerator>(), grace, std::move(metrics),
+                                   std::move(store), std::move(chat_store), UnlimitedRateLimits());
   EXPECT_TRUE(instance->handler->RestoreFromStore().ok());
   instance->server = std::make_unique<moonbase::golf::GolfHubServer>(instance->handler);
 
@@ -947,6 +967,140 @@ TEST_F(GolfHubStreamFixture, BootCatchUpProjectsNothingWhenRowsNeverMoved) {
   auto leftover = resumed->stream.Receive(std::chrono::milliseconds(50));
   EXPECT_TRUE(!leftover.ok() || !leftover->has_value())
       << "boot catch-up projected a frame though no row moved";
+}
+
+// The boot reaper works on wall time and rows, not frames, so its tests
+// watch the store converge. Returns the last snapshot either way; the
+// caller's assertions name what never arrived.
+HubStore::Snapshot AwaitSnapshot(HubStore& store,
+                                 const std::function<bool(const HubStore::Snapshot&)>& predicate,
+                                 std::chrono::milliseconds budget = std::chrono::seconds(5)) {
+  const auto deadline = std::chrono::steady_clock::now() + budget;
+  while (true) {
+    auto snapshot = store.LoadSnapshot();
+    if (snapshot.ok() && predicate(*snapshot)) return *std::move(snapshot);
+    if (std::chrono::steady_clock::now() >= deadline) {
+      return snapshot.ok() ? *std::move(snapshot) : HubStore::Snapshot{};
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  }
+}
+
+// The boot cohort (#1295): a restart converts a parked member's grace
+// into forever-membership, because the registry that owned their timer
+// died with the process. The successor's one boot deadline reaps what
+// no session reclaims — under the same row check as session expiry, so
+// each spare mode gets a seat here: bob's row says connected (a live
+// seat "elsewhere" — this generation), and carol resumes on the new
+// instance before the deadline. Only alice, parked with her row at
+// disconnected and never coming back, is the ghost.
+TEST_F(GolfHubStreamFixture, BootGraceReapsParkedGhostAndSparesLiveSeats) {
+  auto alice = OpenSeat();
+  auto bob = OpenSeat();
+  auto carol = OpenSeat();
+  ASSERT_TRUE(alice.has_value() && bob.has_value() && carol.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "sessionReady").has_value());
+  const std::string room_id = CreateRoomFor(*alice);
+  ASSERT_FALSE(room_id.empty());
+  moonbase::golf::JoinRoom join;
+  join.roomId = room_id;
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "roomState").has_value());
+  ASSERT_TRUE(carol->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  ASSERT_TRUE(ReceiveCase(carol->stream, "roomState").has_value());
+
+  // alice and carol park; their clean closes write disconnected through.
+  alice->stream.Close();
+  carol->stream.Close();
+  auto parked = AwaitSnapshot(*store_, [](const HubStore::Snapshot& snapshot) {
+    int disconnected = 0;
+    for (const auto& member : snapshot.members) {
+      if (!member.connected) ++disconnected;
+    }
+    return disconnected == 2;
+  });
+  ASSERT_EQ(parked.members.size(), 3u);
+
+  // The "crash": a successor boots over the same rows while this
+  // generation stays parked, saying no goodbyes. Two seconds of boot
+  // grace — enough headroom for carol's loopback resume, short enough
+  // for a test.
+  auto instance =
+      BuildSecondInstance(vault_, store_, chat_store_,
+                          std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"),
+                          /*grace=*/std::chrono::seconds(2));
+  ASSERT_NE(instance, nullptr);
+  auto carol_back = OpenSeatVia(*instance->client, carol->resume_token);
+  ASSERT_TRUE(carol_back.has_value());
+  EXPECT_EQ(carol_back->player_id, carol->player_id);
+  ASSERT_TRUE(ReceiveCase(carol_back->stream, "sessionReady").has_value());
+
+  auto reaped = AwaitSnapshot(
+      *store_, [](const HubStore::Snapshot& snapshot) { return snapshot.members.size() == 2; },
+      std::chrono::seconds(6));
+  ASSERT_EQ(reaped.members.size(), 2u);
+  std::set<std::string> survivors;
+  for (const auto& member : reaped.members) survivors.insert(member.player_id);
+  EXPECT_TRUE(survivors.contains(bob->player_id)) << "connected row was reaped";
+  EXPECT_TRUE(survivors.contains(carol->player_id)) << "resumed seat was reaped";
+}
+
+// The muchq.github.io#260 symptom, hub half: a visitor parked in one
+// room follows a share link into another, and the stale membership the
+// old process's death fossilized must not answer "room unavailable or
+// already in a room" forever. Once the boot grace clears it, the resume
+// carries no room and the join lands.
+TEST_F(GolfHubStreamFixture, ShareLinkJoinSucceedsOnceBootGraceClearsStaleMembership) {
+  auto alice = OpenSeat();
+  ASSERT_TRUE(alice.has_value());
+  ASSERT_TRUE(ReceiveCase(alice->stream, "sessionReady").has_value());
+  const std::string old_room = CreateRoomFor(*alice);
+  ASSERT_FALSE(old_room.empty());
+  alice->stream.Close();
+  AwaitSnapshot(*store_, [](const HubStore::Snapshot& snapshot) {
+    return snapshot.members.size() == 1 && !snapshot.members[0].connected;
+  });
+
+  auto instance =
+      BuildSecondInstance(vault_, store_, chat_store_,
+                          std::make_shared<futility::otel::MetricsRecorder>("golf_hub_test"),
+                          /*grace=*/std::chrono::seconds(1));
+  ASSERT_NE(instance, nullptr);
+  // The share link's room, created on the new instance while the old
+  // membership ages out.
+  auto bob = OpenSeatVia(*instance->client);
+  ASSERT_TRUE(bob.has_value());
+  ASSERT_TRUE(ReceiveCase(bob->stream, "sessionReady").has_value());
+  ASSERT_TRUE(bob->stream.Send(GolfCommands::FromCreateroom(moonbase::golf::CreateRoom{})).ok());
+  auto created = ReceiveCase(bob->stream, "roomState");
+  ASSERT_TRUE(created.has_value());
+  const std::string shared_room = created->as_roomState_or_null()->roomId;
+
+  // The reap deletes alice's membership, and with it her empty room.
+  auto cleared = AwaitSnapshot(
+      *store_,
+      [&](const HubStore::Snapshot& snapshot) {
+        return snapshot.rooms.size() == 1 && snapshot.rooms[0] == shared_room;
+      },
+      std::chrono::seconds(6));
+  ASSERT_EQ(cleared.rooms.size(), 1u);
+
+  // The share-link visit: alice's resume finds no fossil membership,
+  // and the join that #260 saw rejected goes through.
+  auto alice_back = OpenSeatVia(*instance->client, alice->resume_token);
+  ASSERT_TRUE(alice_back.has_value());
+  auto ready = ReceiveCase(alice_back->stream, "sessionReady");
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_FALSE(ready->as_sessionReady_or_null()->roomId.has_value());
+  moonbase::golf::JoinRoom join;
+  join.roomId = shared_room;
+  ASSERT_TRUE(alice_back->stream.Send(GolfCommands::FromJoinroom(join)).ok());
+  auto joined = ReceiveCase(alice_back->stream, "roomState");
+  ASSERT_TRUE(joined.has_value());
+  EXPECT_EQ(joined->as_roomState_or_null()->roomId, shared_room);
+  EXPECT_EQ(joined->as_roomState_or_null()->players.size(), 2u);
 }
 
 TEST_F(GolfHubStreamFixture, JoinHistoryIsCappedAtTheRetentionLimit) {

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -163,6 +163,7 @@ HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards
                           return WithMember(room_id, player_id, action);
                         })),
       limits_(limits),
+      grace_period_(grace_period),
       instance_id_(InstanceId()),
       registry_([this, grace_period] {
         Registry::Options options;
@@ -171,6 +172,15 @@ HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards
         options.on_expired = [this](const std::string& id) { OnExpired(id); };
         return options;
       }()) {}
+
+HubHandler::~HubHandler() {
+  {
+    const std::lock_guard<std::mutex> lock(reaper_mu_);
+    reaper_stop_ = true;
+  }
+  reaper_cv_.notify_all();
+  if (boot_reaper_.joinable()) boot_reaper_.join();
+}
 
 absl::Status HubHandler::RestoreFromStore() {
   auto snapshot = store_->LoadSnapshot();
@@ -193,6 +203,7 @@ absl::Status HubHandler::RestoreFromStore() {
     member.total_score = row.total_score;
     rooms_[row.room_id].members.emplace(row.player_id, member);
     player_room_[row.player_id] = row.room_id;
+    restored_pending_.insert(row.player_id);
   }
   for (HubStore::GameRow& row : snapshot->games) {
     if (row.state.has_value() && row.state->isOver()) {
@@ -214,7 +225,34 @@ absl::Status HubHandler::RestoreFromStore() {
   for (const auto& [room_id, room] : rooms_) SeedChatCursorLocked(room_id);
   LOG(INFO) << "hub restored " << snapshot->rooms.size() << " rooms, " << snapshot->members.size()
             << " members, " << snapshot->games.size() << " games";
+  // The old process's registry took every parked member's grace timer
+  // with it; this cohort deadline is their replacement (#1295). Zero
+  // grace keeps it disabled, matching the registry's own contract.
+  if (!restored_pending_.empty() && grace_period_ > std::chrono::seconds(0) &&
+      !boot_reaper_.joinable()) {
+    boot_reaper_ = std::thread([this] { BootReaperMain(); });
+  }
   return absl::OkStatus();
+}
+
+void HubHandler::BootReaperMain() {
+  {
+    std::unique_lock<std::mutex> lock(reaper_mu_);
+    reaper_cv_.wait_for(lock, grace_period_, [this] { return reaper_stop_; });
+    if (reaper_stop_) return;
+  }
+  std::vector<std::string> pending;
+  {
+    const std::lock_guard<std::mutex> lock(mu_);
+    pending.assign(restored_pending_.begin(), restored_pending_.end());
+    restored_pending_.clear();
+  }
+  for (const std::string& player_id : pending) {
+    // A resume that races this drain is safe either way: its admission
+    // already staged connected=true, and the reap's fresh read flushes
+    // before it looks, so the row spares the seat.
+    if (ReapUnlessResumedElsewhere(player_id)) Count("restored_seats_reaped");
+  }
 }
 
 void HubHandler::SeedChatCursorLocked(const std::string& room_id) {
@@ -597,6 +635,9 @@ smithy::eventstream::StreamTask HubHandler::Play(moonbase::golf::PlayInput input
   SetConnected(player_id, true);
   {
     const std::lock_guard<std::mutex> lock(mu_);
+    // A reclaimed seat leaves the boot cohort: its lifecycle belongs to
+    // the registry's own grace from here on (#1295).
+    restored_pending_.erase(player_id);
     const auto room_it = player_room_.find(player_id);
     if (room_it != player_room_.end()) room = room_it->second;
     // A resumed seat mid-game gets its current view back immediately.
@@ -1413,13 +1454,22 @@ void HubHandler::OnExpired(const std::string& player_id) {
   // Grace ran out (ADR-0020): the seat is gone; free the room and game
   // slots and tell whoever remains. Runs on the registry's expiry thread.
   Count("stream_seats_expired");
+  ReapUnlessResumedElsewhere(player_id);
+}
+
+bool HubHandler::ReapUnlessResumedElsewhere(const std::string& player_id) {
   Outbox outbox;
   Writes writes;
+  bool reaped = false;
   {
     const std::lock_guard<std::mutex> lock(mu_);
     // Cross-instance grace (#1194 step 3): the player may have resumed
     // on another instance while parked here. One fresh read decides —
-    // a member row back at connected belongs to its new instance.
+    // a member row back at connected belongs to its new instance. The
+    // boot reaper leans on the same check from the other side: a row
+    // still at connected after a whole boot grace may be a sibling's
+    // live seat, so it stays (#1295 records the orphaned-row residue
+    // this leaves — only that seat's owner could have known better).
     bool resumed_elsewhere = false;
     if (const auto room_it = player_room_.find(player_id); room_it != player_room_.end()) {
       RefreshRoomLocked(room_it->second, outbox);
@@ -1431,9 +1481,11 @@ void HubHandler::OnExpired(const std::string& player_id) {
     if (!resumed_elsewhere) {
       LeaveEverywhere(player_id, outbox, writes);
       EnqueueWritesLocked(writes);
+      reaped = true;
     }
   }
   Deliver(outbox);
+  return reaped;
 }
 
 void HubHandler::Deliver(Outbox& outbox) {

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -183,6 +183,12 @@ HubHandler::~HubHandler() {
 }
 
 absl::Status HubHandler::RestoreFromStore() {
+  // Once, before serving. A second restore would stack a new cohort
+  // behind a reaper that never re-arms — forever-membership again, the
+  // exact silent shape #1295 closed — so refuse it loudly instead.
+  if (boot_reaper_.joinable()) {
+    return absl::FailedPreconditionError("RestoreFromStore already ran");
+  }
   auto snapshot = store_->LoadSnapshot();
   if (!snapshot.ok()) return snapshot.status();
   const std::lock_guard<std::mutex> lock(mu_);
@@ -203,7 +209,12 @@ absl::Status HubHandler::RestoreFromStore() {
     member.total_score = row.total_score;
     rooms_[row.room_id].members.emplace(row.player_id, member);
     player_room_[row.player_id] = row.room_id;
-    restored_pending_.insert(row.player_id);
+    // Only parked rows enter the boot cohort. A row restored connected
+    // is either a sibling's live seat — whose registry owns its grace,
+    // and whose later park must run that full grace, not the remainder
+    // of ours — or a connected-at-crash ghost the drain's row check
+    // would spare anyway (#1295 records that residue).
+    if (!row.connected) restored_pending_.insert(row.player_id);
   }
   for (HubStore::GameRow& row : snapshot->games) {
     if (row.state.has_value() && row.state->isOver()) {
@@ -228,8 +239,7 @@ absl::Status HubHandler::RestoreFromStore() {
   // The old process's registry took every parked member's grace timer
   // with it; this cohort deadline is their replacement (#1295). Zero
   // grace keeps it disabled, matching the registry's own contract.
-  if (!restored_pending_.empty() && grace_period_ > std::chrono::seconds(0) &&
-      !boot_reaper_.joinable()) {
+  if (!restored_pending_.empty() && grace_period_ > std::chrono::seconds(0)) {
     boot_reaper_ = std::thread([this] { BootReaperMain(); });
   }
   return absl::OkStatus();
@@ -248,9 +258,17 @@ void HubHandler::BootReaperMain() {
     restored_pending_.clear();
   }
   for (const std::string& player_id : pending) {
-    // A resume that races this drain is safe either way: its admission
-    // already staged connected=true, and the reap's fresh read flushes
-    // before it looks, so the row spares the seat.
+    // Re-check stop between reaps: each one is a store round trip, and
+    // a destructor landing mid-drain should wait out one, not all.
+    {
+      const std::lock_guard<std::mutex> lock(reaper_mu_);
+      if (reaper_stop_) return;
+    }
+    // A resume that races this drain lands coherently in either order:
+    // if its SetConnected write is in before the reap's flushed read,
+    // the row spares the seat; if the reap wins mu_ first, the seat is
+    // reaped and the resume admits room-less — the same outcome as
+    // resuming a moment after the deadline.
     if (ReapUnlessResumedElsewhere(player_id)) Count("restored_seats_reaped");
   }
 }
@@ -461,6 +479,13 @@ bool HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
     member.total_score = row.total_score;
     members.emplace(row.player_id, member);
     player_room_[row.player_id] = room_id;
+    // A row observed connected is a seat some session owns, and that
+    // session's registry owns its grace from here on. Ceding the boot
+    // cohort's claim is the remote mirror of Play's local erase: a
+    // member who resumed on a sibling during our boot window — and may
+    // park again before our deadline — gets their full grace from the
+    // sibling's registry, not the remainder of ours (#1295).
+    if (row.connected) restored_pending_.erase(row.player_id);
   }
   if (members.size() != room.members.size()) {
     changed = true;

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -186,7 +186,7 @@ absl::Status HubHandler::RestoreFromStore() {
   // Once, before serving. A second restore would stack a new cohort
   // behind a reaper that never re-arms — forever-membership again, the
   // exact silent shape #1295 closed — so refuse it loudly instead.
-  if (boot_reaper_.joinable()) {
+  if (restored_) {
     return absl::FailedPreconditionError("RestoreFromStore already ran");
   }
   auto snapshot = store_->LoadSnapshot();
@@ -242,6 +242,7 @@ absl::Status HubHandler::RestoreFromStore() {
   if (!restored_pending_.empty() && grace_period_ > std::chrono::seconds(0)) {
     boot_reaper_ = std::thread([this] { BootReaperMain(); });
   }
+  restored_ = true;
   return absl::OkStatus();
 }
 
@@ -484,7 +485,11 @@ bool HubHandler::ReconcileRoomLocked(const std::string& room_id, const HubStore:
     // cohort's claim is the remote mirror of Play's local erase: a
     // member who resumed on a sibling during our boot window — and may
     // park again before our deadline — gets their full grace from the
-    // sibling's registry, not the remainder of ours (#1295).
+    // sibling's registry, not the remainder of ours (#1295). This is a
+    // sample, not a subscription: a resume-and-repark whose connected
+    // pulse no wake ever showed us stays in the cohort and reaps at our
+    // deadline — closing that for real needs row-level presence
+    // ownership, the same schema gap #1295's residue note records.
     if (row.connected) restored_pending_.erase(row.player_id);
   }
   if (members.size() != room.members.size()) {

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -2,12 +2,14 @@
 #define DOMAINS_GAMES_APIS_GOLF_HUB_HUB_HANDLER_H
 
 #include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -41,7 +43,9 @@ namespace golf_hub {
 /// game layer on the reshaped libs/cards/golf engine. One SessionRegistry
 /// keyed by playerId carries all fan-out (async delivery — no writer
 /// threads); rooms are a mutex'd map, membership marked disconnected
-/// during ADR-0020 grace and reaped by on_expired.
+/// during ADR-0020 grace and reaped by on_expired — with one boot-time
+/// grace for restored members no session ever reclaims (#1295), since
+/// the registry that died with the old process took their timers.
 ///
 /// Redaction discipline: every game broadcast goes through the
 /// per-recipient Broadcast(ids, make) form with views built by ViewLocked
@@ -93,6 +97,9 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
                       std::shared_ptr<futility::otel::MetricsRecorder> metrics = nullptr,
                       std::shared_ptr<HubStore> store = nullptr,
                       std::shared_ptr<ChatStore> chat_store = nullptr, RateLimits limits = {});
+
+  /// Joins the boot reaper before the members it walks are torn down.
+  ~HubHandler() override;
 
   /// Runs `action` while mu_ holds (room_id, player_id) to be a current
   /// member, or returns false without running it. Membership cannot
@@ -283,6 +290,19 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   void BroadcastRoom(const std::string& room_id);
   void Reject(const std::string& player_id, std::string reason);
   void OnExpired(const std::string& player_id);
+  /// The reap decision both expiry paths share: one fresh read of the
+  /// member's room, then LeaveEverywhere unless the row says connected —
+  /// a row back at connected belongs to a live session somewhere (their
+  /// new instance, or a sibling that held them all along) and must not
+  /// be reaped from here. Returns whether the member was reaped.
+  bool ReapUnlessResumedElsewhere(const std::string& player_id);
+  /// Waits out one grace period from boot, then reaps every restored
+  /// member no session reclaimed (#1295): the registry can only arm
+  /// grace for seats it admitted, so without this a restart converts a
+  /// parked member's five-minute grace into forever-membership — and a
+  /// stale membership is what turns a share-link join into "room
+  /// unavailable or already in a room" (muchq.github.io#260).
+  void BootReaperMain();
   void Deliver(Outbox& outbox);
   /// Hands staged ops to the store's writer queue. Callers hold mu_ (see
   /// Writes above). Asynchronous — clients may be told before the row
@@ -363,6 +383,9 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   const std::shared_ptr<HubStore> store_;
   const std::shared_ptr<ChatStore> chat_store_;
   const RateLimits limits_;
+  /// ADR-0020 reconnect grace, shared by the registry's per-seat timers
+  /// and the boot reaper's one cohort deadline. Zero disables both.
+  const std::chrono::seconds grace_period_;
   /// Rides every commit and rider as the notify payload, so an instance
   /// can tell its own wake-ups from the ones that carry news.
   const std::string instance_id_;
@@ -385,8 +408,20 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
 
   std::unordered_map<std::string, std::string> player_room_;
   std::unordered_map<std::string, std::string> player_game_;
+
+  /// The boot cohort (#1295): members RestoreFromStore rebuilt, minus
+  /// everyone a session reclaimed since. Guarded by mu_; drained once by
+  /// the boot reaper at boot + grace_period_. The stop flag has its own
+  /// mutex so the destructor never contends with a reap in progress.
+  std::unordered_set<std::string> restored_pending_;
+  std::mutex reaper_mu_;
+  std::condition_variable reaper_cv_;
+  bool reaper_stop_ = false;
+  std::thread boot_reaper_;
+
   // Declared last: destroyed first, joining registry threads before the
-  // maps its on_expired callback touches go away.
+  // maps its on_expired callback touches go away. (The boot reaper is
+  // joined earlier still, explicitly, in ~HubHandler.)
   Registry registry_;
 };
 

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -414,6 +414,10 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// the boot reaper at boot + grace_period_. The stop flag has its own
   /// mutex so the destructor never contends with a reap in progress.
   std::unordered_set<std::string> restored_pending_;
+  /// RestoreFromStore ran to completion — the real once-guard, since a
+  /// restore that found nothing (or zero grace) arms no thread and a
+  /// joinable() check would wave the second call through.
+  bool restored_ = false;
   std::mutex reaper_mu_;
   std::condition_variable reaper_cv_;
   bool reaper_stop_ = false;

--- a/domains/games/apis/golf_hub/hub_store_race_test.cc
+++ b/domains/games/apis/golf_hub/hub_store_race_test.cc
@@ -97,18 +97,6 @@ class GatedHubStore final : public HubStore {
   std::atomic<int> delete_game_count_ = 0;
 };
 
-class RemoteIdGenerator final : public IdGenerator {
- public:
-  std::string PlayerId() override { return "remote-player-" + std::to_string(++players_); }
-  std::string RoomId() override { return "remote-room-" + std::to_string(++rooms_); }
-  std::string GameCode() override { return "RGAME" + std::to_string(++games_); }
-
- private:
-  int players_ = 0;
-  int rooms_ = 0;
-  int games_ = 0;
-};
-
 class HubStoreRaceFixture : public GolfHubStreamFixture {
  protected:
   struct Instance {

--- a/domains/games/apis/golf_hub/id_generator.h
+++ b/domains/games/apis/golf_hub/id_generator.h
@@ -49,6 +49,23 @@ class SequentialIdGenerator final : public IdGenerator {
   int games_ = 0;
 };
 
+/// SequentialIdGenerator's twin for a test's second hub instance: a
+/// distinct id space (remote-player-1, remote-room-1, RGAME1), because
+/// two SequentialIdGenerators would both mint "player-1" and a fresh
+/// seat on the second instance would then hold the first instance's
+/// player id — a seat conflict for that player's own resume.
+class RemoteIdGenerator final : public IdGenerator {
+ public:
+  std::string PlayerId() override { return "remote-player-" + std::to_string(++players_); }
+  std::string RoomId() override { return "remote-room-" + std::to_string(++rooms_); }
+  std::string GameCode() override { return "RGAME" + std::to_string(++games_); }
+
+ private:
+  int players_ = 0;
+  int rooms_ = 0;
+  int games_ = 0;
+};
+
 }  // namespace golf_hub
 
 #endif

--- a/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/pg_hub_e2e_test.cc
@@ -83,21 +83,6 @@ std::optional<moonbase::golf::GameView> AwaitGameView(
   return std::nullopt;
 }
 
-// Distinct id space for the second instance: two SequentialIdGenerators
-// would both mint "player-1", and the shared database would treat the
-// two seats as one person.
-class RemoteIdGenerator final : public IdGenerator {
- public:
-  std::string PlayerId() override { return "remote-player-" + std::to_string(++players_); }
-  std::string RoomId() override { return "remote-room-" + std::to_string(++rooms_); }
-  std::string GameCode() override { return "RGAME" + std::to_string(++games_); }
-
- private:
-  int players_ = 0;
-  int rooms_ = 0;
-  int games_ = 0;
-};
-
 class PgGolfHubFixture : public GolfHubStreamFixture {
  protected:
   void SetUp() override {

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -261,6 +261,10 @@ var serviceRegistry = map[string]serviceEntry{
 			counter("Sessions", "refused", "", `stream_admissions_refused_total`),
 			counter("Sessions", "disconnects", "", `stream_disconnects_total`),
 			counter("Sessions", "seats_expired", "", `stream_seats_expired_total`),
+			// Boot-cohort reaps (#1295): fires unattended at boot+grace, so
+			// this series is the only evidence the reaper runs at all — a
+			// broken one is indistinguishable from a hub with no ghosts.
+			counter("Sessions", "restored_reaped", "", `restored_seats_reaped_total`),
 			counter("Activity", "commands", "", `stream_commands_total`),
 			counter("Activity", "events", "", `stream_events_total`),
 			counter("Activity", "rejections", "", `stream_rejections_total`),

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -350,19 +350,19 @@ func TestMetricsHandler_GetServiceMetrics_MapsEveryFieldDistinctly(t *testing.T)
 	assert.Equal(t, "Sessions", response.Custom[0].Title)
 	assert.Equal(t, "Activity", response.Custom[1].Title)
 	assert.Equal(t, "Chat", response.Custom[2].Title)
-	assert.Len(t, response.Custom[0].Metrics, 6)
+	assert.Len(t, response.Custom[0].Metrics, 7)
 	assert.Len(t, response.Custom[1].Metrics, 4)
 	require.Len(t, response.Custom[2].Metrics, 5)
 
 	// A gauge: one form, so no toggle offered.
 	assert.Equal(t, CustomMetricValue{Label: "active", Value: 200.0, Unit: "sessions"},
 		response.Custom[0].Metrics[0])
-	assert.Equal(t, CustomMetricValue{Label: "commands", Value: 206.0, Toggleable: true},
+	assert.Equal(t, CustomMetricValue{Label: "commands", Value: 207.0, Toggleable: true},
 		response.Custom[1].Metrics[0])
-	assert.Equal(t, CustomMetricValue{Label: "rejections", Value: 208.0, Toggleable: true},
+	assert.Equal(t, CustomMetricValue{Label: "rejections", Value: 209.0, Toggleable: true},
 		response.Custom[1].Metrics[2])
-	// Chat starts at CustomScalars index 10, so its first value is 200+10.
-	assert.Equal(t, CustomMetricValue{Label: "messages", Value: 210.0, Toggleable: true},
+	// Chat starts at CustomScalars index 11, so its first value is 200+11.
+	assert.Equal(t, CustomMetricValue{Label: "messages", Value: 211.0, Toggleable: true},
 		response.Custom[2].Metrics[0])
 	// The omitted query's descriptor survives with a zero value.
 	last := response.Custom[2].Metrics[4]
@@ -1013,7 +1013,7 @@ func TestMetricsHandler_GetServiceMetrics_RateViewSelectsTheRateForm(t *testing.
 	// answers "" and "rows".
 	assert.Equal(t, "/s", byLabel["commands"].Unit)
 	assert.Equal(t, "rows/s", byLabel["delivered_rows"].Unit)
-	assert.Equal(t, 306.0, byLabel["commands"].Value)
+	assert.Equal(t, 307.0, byLabel["commands"].Value)
 
 	// The fixed-form tiles are untouched by the view: a gauge has no rate, and
 	// the windowed mean is already a ratio of two rates.


### PR DESCRIPTION
## Summary

The hub half of muchq.github.io#260 (frontend half: muchq.github.io#266). The registry's ADR-0020 grace only covers seats it admitted, so a restart converted every parked member's five-minute grace into forever-membership: the successor restored them from rows, and nothing ever reaped them. That fossil membership is what answered share-link joins with `"room unavailable or already in a room"` until the visitor's old room emptied by other means.

## Fix

`RestoreFromStore` records a boot cohort and arms one deadline of the same `grace_period`; whatever no session reclaims by then reaps through the same fresh-row check as session expiry (`OnExpired` → `ReapUnlessResumedElsewhere`, factored). Timing only ever favors the player: park at T, deploy at D, reap at boot+5min ≥ T+5min.

The cohort's contract: **a seat whose row reads connected belongs to whatever session owns that row.** It never enters the cohort at restore, and is ceded when any reconcile observes the row connected. The cede is a sample, not a subscription (a pulse no wake shows this instance still early-reaps in a fleet) — owned in a comment and tracked with the rest of the presence-ownership residue in #1299. The drain re-checks stop between reaps so `~HubHandler` waits out one store round trip, not the cohort; `RestoreFromStore` refuses a second call via a real `restored_` flag (not `joinable()`, which a thread-less first restore would fool). The reaper reports through `restored_seats_reaped` (prom_proxy Sessions tile beside `seats_expired` — it fires unattended at boot+grace, so the series is the only evidence it runs at all).

**Deliberately not covered** (recorded on #1295 and tracked in #1299): hard-crash ghosts whose rows still read connected are spared — indistinguishable from a sibling's live seat without row-level presence ownership. Orderly restarts (deploys — the #260 case) write the goodbyes and are fully covered.

## Tests

All memory-suite — no pg gate, so they run on every CI pass. Each guard has its own pin; each reap test carries a parked-ghost canary hard-asserted gone, so a reaper that never fires cannot pass vacuously:

| Test | Pins |
|---|---|
| `BootGraceReapsParkedGhostAndSparesLiveSeats` | happy-path smoke of the whole flow (explicitly not a unique pin of any one guard) |
| `ShareLinkJoinSucceedsOnceBootGraceClearsStaleMembership` | both #260 timelines: mid-window resume + bare join still gets the exact refusal (the frontend half's territory), and the post-reap join lands |
| `BootGraceNeverClaimsASeatRestoredConnected` | restore-time cohort filter (awaits the parked row before watching the reap) |
| `BootGraceCedesASeatObservedConnectedMidWindow` | reconcile-time cede |
| `BootGraceDrainSparesARowThatTurnedConnectedUnobserved` | the drain's fresh-read row check — the one shape neither filter nor cede can reach |
| `RestoreFromStoreRefusesASecondCall` | the once-guard, including the thread-less first restore |

`BuildSecondInstance` uses the shared `RemoteIdGenerator` (now one class in `id_generator.h` beside `SequentialIdGenerator`; the altitude pass caught this PR introducing its fourth byte-identical copy) — a fresh seat on the second instance used to mint the first instance's `player-1` and refuse that player's own resume as a seat conflict.

| Check | Result |
|---|---|
| `hub_e2e_test` (11.9s, `size=small`), incl. `--runs_per_test=15` | PASSED |
| Full golf_hub + pg suites vs postgres 16 | 16/16 PASSED |
| `scripts/mutation-check`: filter unconditional, cede deleted, drain row check forced, once-guard disabled | all 4 killed |
| clang-format | clean |

Review history: the panel round (concurrency + semantics lenses; the test-quality agent was stopped mid-run after its in-tree mutation runs collided with live edits — its checks were re-run from the main loop) surfaced the fleet early-reap, fixed from both ends. The follow-up cursor review's should-fixes are all in, and the altitude pass (#1298's fourth lens) confirmed the level — its two survivors (the invisible reaper metric, the fourth `RemoteIdGenerator`) landed in `5c90e37`, with the clock seam filed as #1300. The working-agreement process edit moved to #1298 per "One item, one PR".

Fixes #1295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUrPZEoRVcJ6qUe794xhvD