### PR TITLE
one_d4: bound read-query execution with a statement timeout

### DIFF
--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -580,6 +580,7 @@ java_test_suite(
     srcs = [
         "src/test/java/com/muchq/games/one_d4/db/PostgresAggregateCompatTest.java",
         "src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java",
+        "src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java",
     ],
     env_inherit = ["PG_TEST_DB_URL"],
     # One shared scratch database: concurrent DB tests drop each other's schemas.

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -698,7 +698,9 @@ java_test_suite(
 
 java_test_suite(
     name = "http_integration_tests",
-    size = "small",
+    # medium (300s), not small: FirstPageWarmupTest boots an embedded server per method plus a
+    # polling warm-up wait, which sits too close to small's 60s ceiling on a loaded CI machine.
+    size = "medium",
     srcs = [
         "src/test/java/com/muchq/games/one_d4/api/AggregateResponseWireTest.java",
         "src/test/java/com/muchq/games/one_d4/api/ContentTypeHandlingTest.java",

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -78,6 +78,7 @@ java_library(
         "src/main/java/com/muchq/games/one_d4/db/IndexingRequestStore.java",
         "src/main/java/com/muchq/games/one_d4/db/Migration.java",
         "src/main/java/com/muchq/games/one_d4/db/RetentionPolicy.java",
+        "src/main/java/com/muchq/games/one_d4/db/StatementTimeouts.java",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -502,10 +503,12 @@ java_test_suite(
     size = "small",
     srcs = [
         "src/test/java/com/muchq/games/one_d4/db/ConcurrentFlushTest.java",
+        "src/test/java/com/muchq/games/one_d4/db/DataSourceFactoryTest.java",
         "src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java",
         "src/test/java/com/muchq/games/one_d4/db/IndexedPeriodDaoTest.java",
         "src/test/java/com/muchq/games/one_d4/db/IndexingRequestDaoTest.java",
         "src/test/java/com/muchq/games/one_d4/db/MigrationTest.java",
+        "src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java",
         "src/test/java/com/muchq/games/one_d4/db/TableDispatchTest.java",
     ],
     deps = [

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -141,8 +141,13 @@ line) instead of using an environment variable. The app resolves config in this 
 
 For Neon, the URL looks like:
 ```
-jdbc:postgresql://ep-xxx.us-east-2.aws.neon.tech/dbname?user=xxx&password=xxx&sslmode=require
+jdbc:postgresql://ep-xxx.us-east-2.aws.neon.tech/dbname?user=xxx&password=xxx&sslmode=require&socketTimeout=30
 ```
+
+Include `socketTimeout` (seconds) on any remote Postgres URL. The application bounds read-query
+*execution* with a 10s JDBC statement timeout, but that cancellation travels over the network — on
+a dead network only a driver-level socket timeout gets the connection back. Without it, a TCP
+black hole can still hang a query indefinitely.
 
 The server starts on **port 8080**. Then index a player and query:
 

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -141,13 +141,15 @@ line) instead of using an environment variable. The app resolves config in this 
 
 For Neon, the URL looks like:
 ```
-jdbc:postgresql://ep-xxx.us-east-2.aws.neon.tech/dbname?user=xxx&password=xxx&sslmode=require&socketTimeout=30
+jdbc:postgresql://ep-xxx.us-east-2.aws.neon.tech/dbname?user=xxx&password=xxx&sslmode=require
 ```
 
-Include `socketTimeout` (seconds) on any remote Postgres URL. The application bounds read-query
-*execution* with a 10s JDBC statement timeout, but that cancellation travels over the network — on
-a dead network only a driver-level socket timeout gets the connection back. Without it, a TCP
-black hole can still hang a query indefinitely.
+Postgres URLs get a default `socketTimeout=150` (seconds) from `DataSourceFactory` unless the URL
+already carries one. The application bounds query *execution* with JDBC statement timeouts, but
+that cancellation travels over the network — on a dead network only a driver-level socket timeout
+gets the connection back. If you override it in the URL, keep it above the retention sweep's 120s
+statement bound: a long DELETE sends nothing over the socket until it finishes, and a smaller
+value would sever a healthy connection mid-sweep.
 
 The server starts on **port 8080**. Then index a player and query:
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/FirstPageWarmer.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/FirstPageWarmer.java
@@ -31,7 +31,7 @@ public class FirstPageWarmer {
   // fixedDelay must stay at half FirstPageCache.MAX_AGE or less (pinned by
   // FirstPageWarmerTest), or the cache expires between refreshes and every first load falls
   // through to the database again. fixedDelay measures from the previous run's completion, and
-  // a tick runs two database reads, each bounded by GameFeatureDao.READ_QUERY_TIMEOUT_SECONDS —
+  // a tick runs two database reads, each bounded by StatementTimeouts.SERVING_READ_SECONDS —
   // so the true worst-case period is 30s plus twice that bound, which must also stay under
   // MAX_AGE (pinned by FirstPageWarmerTest too). refreshNow() keeps the last good snapshot and
   // logs on failure, so a failed tick never cancels the schedule; the read timeout is what

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/FirstPageWarmer.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/FirstPageWarmer.java
@@ -30,11 +30,12 @@ public class FirstPageWarmer {
 
   // fixedDelay must stay at half FirstPageCache.MAX_AGE or less (pinned by
   // FirstPageWarmerTest), or the cache expires between refreshes and every first load falls
-  // through to the database again. fixedDelay measures from the previous run's completion, so
-  // the true period is 30s plus query time; the 2x headroom in MAX_AGE absorbs that.
-  // refreshNow() keeps the last good snapshot and logs on failure, so a failed tick never
-  // cancels the schedule. A query that hangs (rather than throws) does block future ticks —
-  // the cache's load-on-miss bounds the damage to serving live until a restart.
+  // through to the database again. fixedDelay measures from the previous run's completion, and
+  // a tick runs two database reads, each bounded by GameFeatureDao.READ_QUERY_TIMEOUT_SECONDS —
+  // so the true worst-case period is 30s plus twice that bound, which must also stay under
+  // MAX_AGE (pinned by FirstPageWarmerTest too). refreshNow() keeps the last good snapshot and
+  // logs on failure, so a failed tick never cancels the schedule; the read timeout is what
+  // guarantees a tick cannot hang the schedule either.
   @Scheduled(fixedDelay = "30s", initialDelay = "1s")
   public void refresh() {
     cache.refreshNow();

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/QueryExecutor.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/api/QueryExecutor.java
@@ -16,8 +16,8 @@ import java.util.Map;
 
 /**
  * The query pipeline (parse, compile, run, attach occurrences), shared by {@link QueryController}
- * and {@link FirstPageWarmer} so the warmed response is built by exactly the code a live request
- * would run.
+ * and {@link FirstPageCache}'s loader so the warmed snapshot is built by exactly the code a live
+ * request would run.
  */
 @Singleton
 public class QueryExecutor {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/DataSourceFactory.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/DataSourceFactory.java
@@ -55,7 +55,11 @@ public class DataSourceFactory {
    * operator's explicit choice in {@code /etc/one_d4/db_config} is never overridden.
    */
   static OptionalInt defaultSocketTimeout(String jdbcUrl) {
-    if (!jdbcUrl.startsWith("jdbc:postgresql:") || jdbcUrl.contains("socketTimeout=")) {
+    // Matched at a parameter boundary so the substring appearing inside another parameter's
+    // value cannot silently suppress the default.
+    if (!jdbcUrl.startsWith("jdbc:postgresql:")
+        || jdbcUrl.contains("?socketTimeout=")
+        || jdbcUrl.contains("&socketTimeout=")) {
       return OptionalInt.empty();
     }
     return OptionalInt.of(PG_SOCKET_TIMEOUT_SECONDS);

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/DataSourceFactory.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/DataSourceFactory.java
@@ -2,9 +2,25 @@ package com.muchq.games.one_d4.db;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import java.util.OptionalInt;
 import javax.sql.DataSource;
 
 public class DataSourceFactory {
+
+  /**
+   * Default driver-level socket timeout for Postgres, in seconds. The statement timeouts in {@link
+   * StatementTimeouts} cancel server-side execution, but that cancellation travels over the network
+   * — on a TCP black hole only a socket timeout gets the connection back, and pgjdbc's default is
+   * to wait forever.
+   *
+   * <p>Must exceed the longest legitimately <em>silent</em> statement, which is the retention sweep
+   * ({@link StatementTimeouts#RETENTION_SWEEP_SECONDS}): a long-running DELETE sends nothing until
+   * it finishes, so a smaller socket timeout would sever a healthy connection mid-sweep before the
+   * server-side bound fires. DataSourceFactoryTest pins that ordering. This is a default, not a
+   * mandate — a {@code socketTimeout} already present in the JDBC URL wins.
+   */
+  static final int PG_SOCKET_TIMEOUT_SECONDS = 150;
+
   private DataSourceFactory() {
     throw new RuntimeException();
   }
@@ -17,6 +33,21 @@ public class DataSourceFactory {
     config.setKeepaliveTime(60_000);
     config.setConnectionTestQuery("SELECT 1");
     config.setConnectionTimeout(10_000);
+    defaultSocketTimeout(jdbcUrl)
+        .ifPresent(
+            seconds -> config.addDataSourceProperty("socketTimeout", String.valueOf(seconds)));
     return new HikariDataSource(config);
+  }
+
+  /**
+   * The socket-timeout default to apply for this URL, if any. Postgres only — H2 rejects unknown
+   * connection properties outright — and only when the URL does not already carry one, so an
+   * operator's explicit choice in {@code /etc/one_d4/db_config} is never overridden.
+   */
+  static OptionalInt defaultSocketTimeout(String jdbcUrl) {
+    if (!jdbcUrl.startsWith("jdbc:postgresql:") || jdbcUrl.contains("socketTimeout=")) {
+      return OptionalInt.empty();
+    }
+    return OptionalInt.of(PG_SOCKET_TIMEOUT_SECONDS);
   }
 }

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/DataSourceFactory.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/DataSourceFactory.java
@@ -26,6 +26,16 @@ public class DataSourceFactory {
   }
 
   public static DataSource create(String jdbcUrl) {
+    return new HikariDataSource(hikariConfig(jdbcUrl));
+  }
+
+  /**
+   * Package-private so DataSourceFactoryTest can assert what {@link #create} actually wires —
+   * probing the built config rather than {@link #defaultSocketTimeout} alone, which would stay
+   * green if create() stopped applying it — without starting a pool against a database that isn't
+   * there.
+   */
+  static HikariConfig hikariConfig(String jdbcUrl) {
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(jdbcUrl);
     config.setMaximumPoolSize(5);
@@ -36,7 +46,7 @@ public class DataSourceFactory {
     defaultSocketTimeout(jdbcUrl)
         .ifPresent(
             seconds -> config.addDataSourceProperty("socketTimeout", String.valueOf(seconds)));
-    return new HikariDataSource(config);
+    return config;
   }
 
   /**

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
@@ -29,6 +29,29 @@ import org.slf4j.LoggerFactory;
 public class GameFeatureDao implements GameFeatureStore {
   private static final Logger LOG = LoggerFactory.getLogger(GameFeatureDao.class);
 
+  /**
+   * Execution bound on the read path (query, aggregate, aggregateTotals, queryOccurrences).
+   * HikariCP's connectionTimeout bounds pool <em>checkout</em> only — nothing bounded execution, so
+   * a query wedged on a lock wait ran forever. That is worst for FirstPageWarmer: its
+   * {@code @Scheduled(fixedDelay)} never re-schedules while a run is in flight, so one hung query
+   * silently stopped all future refreshes until a restart, while holding a thread of the small
+   * shared scheduled pool.
+   *
+   * <p>Ten seconds is far above any legitimate read here (LIMIT-bounded pages over a table with
+   * 7-day retention, now index-served) and well under the warmer's 30s tick, so a wedged tick fails
+   * — loudly, into the warmer's catch-and-log — before the next tick is due. Write paths are
+   * deliberately not bounded by this: the index worker has its own lease ceiling and interrupt
+   * machinery, and cutting a flush short creates recovery work a read never has.
+   *
+   * <p>JDBC's queryTimeout cancels server-side execution (lock waits, slow plans). A true network
+   * black hole additionally needs a driver-level socket timeout, which lives in the JDBC URL (e.g.
+   * {@code &socketTimeout=30} for Postgres) — deployment config, not code.
+   *
+   * <p>On H2 the timeout is session-scoped rather than statement-scoped, so every read clears it
+   * again on the way out; see {@link #clearSessionQueryTimeout}.
+   */
+  static final int READ_QUERY_TIMEOUT_SECONDS = 10;
+
   private static final String H2_INSERT =
       """
       MERGE INTO game_features (
@@ -112,9 +135,22 @@ public class GameFeatureDao implements GameFeatureStore {
   private final Jdbi jdbi;
   private final boolean useH2;
   private final Clock clock;
+  private final int readQueryTimeoutSeconds;
 
   public GameFeatureDao(Jdbi jdbi, boolean useH2) {
-    this(jdbi, useH2, Clock.systemUTC());
+    this(jdbi, useH2, Clock.systemUTC(), READ_QUERY_TIMEOUT_SECONDS);
+  }
+
+  /**
+   * @param readQueryTimeoutSeconds injected so a test can bound a deliberately slow query in about
+   *     a second instead of ten — the behavioral test for the timeout is the point of the seam.
+   *     Production always uses {@link #READ_QUERY_TIMEOUT_SECONDS}.
+   */
+  GameFeatureDao(Jdbi jdbi, boolean useH2, Clock clock, int readQueryTimeoutSeconds) {
+    this.jdbi = jdbi;
+    this.useH2 = useH2;
+    this.clock = clock;
+    this.readQueryTimeoutSeconds = readQueryTimeoutSeconds;
   }
 
   /**
@@ -123,9 +159,7 @@ public class GameFeatureDao implements GameFeatureStore {
    *     come from one source; see {@link #deleteOlderThan}.
    */
   public GameFeatureDao(Jdbi jdbi, boolean useH2, Clock clock) {
-    this.jdbi = jdbi;
-    this.useH2 = useH2;
-    this.clock = clock;
+    this(jdbi, useH2, clock, READ_QUERY_TIMEOUT_SECONDS);
   }
 
   /**
@@ -396,6 +430,27 @@ public class GameFeatureDao implements GameFeatureStore {
     }
   }
 
+  /**
+   * H2 scopes {@code Statement.setQueryTimeout} to the connection's session — {@code JdbcStatement}
+   * delegates straight to {@code JdbcConnection.setQueryTimeout} — and HikariCP does not reset it
+   * on checkin, so without this a single read would leave its timeout on the pooled connection for
+   * every later statement, including writes this class deliberately leaves unbounded. Postgres
+   * scopes the timeout to the statement, so there is nothing to clean up there.
+   *
+   * <p>Reset through the JDBC API rather than {@code SET QUERY_TIMEOUT 0}: H2 also caches the value
+   * client-side in the connection, and raw SQL resets only the server session, leaving the cached
+   * value to keep answering {@code getQueryTimeout} — and to keep applying — for later statements.
+   */
+  private void clearSessionQueryTimeout(Handle h) {
+    if (useH2) {
+      try (var stmt = h.getConnection().createStatement()) {
+        stmt.setQueryTimeout(0);
+      } catch (SQLException e) {
+        throw new RuntimeException("Failed to clear H2 session query timeout", e);
+      }
+    }
+  }
+
   @Override
   public List<GameFeature> query(Object compiledQuery, int limit, int offset) {
     if (!(compiledQuery instanceof CompiledQuery cq)) {
@@ -405,14 +460,18 @@ public class GameFeatureDao implements GameFeatureStore {
     String sql = cq.selectSql() + " LIMIT ? OFFSET ?";
     return jdbi.withHandle(
         h -> {
-          var query = h.createQuery(sql);
-          int idx = 0;
-          for (Object param : cq.parameters()) {
-            query.bind(idx++, param);
+          try {
+            var query = h.createQuery(sql).setQueryTimeout(readQueryTimeoutSeconds);
+            int idx = 0;
+            for (Object param : cq.parameters()) {
+              query.bind(idx++, param);
+            }
+            query.bind(idx++, limit);
+            query.bind(idx, offset);
+            return query.map(GAME_FEATURE_MAPPER).list();
+          } finally {
+            clearSessionQueryTimeout(h);
           }
-          query.bind(idx++, limit);
-          query.bind(idx, offset);
-          return query.map(GAME_FEATURE_MAPPER).list();
         });
   }
 
@@ -425,22 +484,26 @@ public class GameFeatureDao implements GameFeatureStore {
     String sql = cq.selectSql() + " LIMIT ?";
     return jdbi.withHandle(
         h -> {
-          var query = h.createQuery(sql);
-          int idx = 0;
-          for (Object param : cq.parameters()) {
-            query.bind(idx++, param);
+          try {
+            var query = h.createQuery(sql).setQueryTimeout(readQueryTimeoutSeconds);
+            int idx = 0;
+            for (Object param : cq.parameters()) {
+              query.bind(idx++, param);
+            }
+            query.bind(idx, limit);
+            return query
+                .map(
+                    (rs, ctx) -> {
+                      Map<String, Object> group = new LinkedHashMap<>();
+                      for (String column : groupColumns) {
+                        group.put(column, rs.getObject(column));
+                      }
+                      return new AggregateRow(group, rs.getLong("group_count"));
+                    })
+                .list();
+          } finally {
+            clearSessionQueryTimeout(h);
           }
-          query.bind(idx, limit);
-          return query
-              .map(
-                  (rs, ctx) -> {
-                    Map<String, Object> group = new LinkedHashMap<>();
-                    for (String column : groupColumns) {
-                      group.put(column, rs.getObject(column));
-                    }
-                    return new AggregateRow(group, rs.getLong("group_count"));
-                  })
-              .list();
         });
   }
 
@@ -452,16 +515,20 @@ public class GameFeatureDao implements GameFeatureStore {
     }
     return jdbi.withHandle(
         h -> {
-          var query = h.createQuery(cq.selectSql());
-          int idx = 0;
-          for (Object param : cq.parameters()) {
-            query.bind(idx++, param);
+          try {
+            var query = h.createQuery(cq.selectSql()).setQueryTimeout(readQueryTimeoutSeconds);
+            int idx = 0;
+            for (Object param : cq.parameters()) {
+              query.bind(idx++, param);
+            }
+            return query
+                .map(
+                    (rs, ctx) ->
+                        new AggregateTotals(rs.getLong("total_games"), rs.getLong("total_groups")))
+                .one();
+          } finally {
+            clearSessionQueryTimeout(h);
           }
-          return query
-              .map(
-                  (rs, ctx) ->
-                      new AggregateTotals(rs.getLong("total_games"), rs.getLong("total_groups")))
-              .one();
         });
   }
 
@@ -473,36 +540,42 @@ public class GameFeatureDao implements GameFeatureStore {
     Map<String, Map<String, List<OccurrenceRow>>> result =
         jdbi.withHandle(
             h -> {
-              var rows =
-                  h.createQuery(QUERY_OCCURRENCES)
-                      .bindList("urls", gameUrls)
-                      .map(
-                          (rs, ctx) -> {
-                            String gameUrl = rs.getString("game_url");
-                            // Store motif key as lowercase to match ChessQL motif naming convention
-                            String motif = rs.getString("motif").toLowerCase();
-                            return new OccurrenceRow(
-                                gameUrl,
-                                motif,
-                                rs.getInt("move_number"),
-                                rs.getString("side"),
-                                rs.getString("description"),
-                                rs.getString("moved_piece"),
-                                rs.getString("attacker"),
-                                rs.getString("target"),
-                                rs.getBoolean("is_discovered"),
-                                rs.getBoolean("is_mate"),
-                                rs.getString("pin_type"));
-                          })
-                      .list();
-              Map<String, Map<String, List<OccurrenceRow>>> grouped = new LinkedHashMap<>();
-              for (OccurrenceRow row : rows) {
-                grouped
-                    .computeIfAbsent(row.gameUrl(), k -> new LinkedHashMap<>())
-                    .computeIfAbsent(row.motif(), k -> new ArrayList<>())
-                    .add(row);
+              try {
+                var rows =
+                    h.createQuery(QUERY_OCCURRENCES)
+                        .setQueryTimeout(readQueryTimeoutSeconds)
+                        .bindList("urls", gameUrls)
+                        .map(
+                            (rs, ctx) -> {
+                              String gameUrl = rs.getString("game_url");
+                              // Store motif key as lowercase to match ChessQL motif naming
+                              // convention
+                              String motif = rs.getString("motif").toLowerCase();
+                              return new OccurrenceRow(
+                                  gameUrl,
+                                  motif,
+                                  rs.getInt("move_number"),
+                                  rs.getString("side"),
+                                  rs.getString("description"),
+                                  rs.getString("moved_piece"),
+                                  rs.getString("attacker"),
+                                  rs.getString("target"),
+                                  rs.getBoolean("is_discovered"),
+                                  rs.getBoolean("is_mate"),
+                                  rs.getString("pin_type"));
+                            })
+                        .list();
+                Map<String, Map<String, List<OccurrenceRow>>> grouped = new LinkedHashMap<>();
+                for (OccurrenceRow row : rows) {
+                  grouped
+                      .computeIfAbsent(row.gameUrl(), k -> new LinkedHashMap<>())
+                      .computeIfAbsent(row.motif(), k -> new ArrayList<>())
+                      .add(row);
+                }
+                return grouped;
+              } finally {
+                clearSessionQueryTimeout(h);
               }
-              return grouped;
             });
 
     // Post-process: derive all ATTACK-based motifs, then remove ATTACK (internal primitive).

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
@@ -30,27 +30,36 @@ public class GameFeatureDao implements GameFeatureStore {
   private static final Logger LOG = LoggerFactory.getLogger(GameFeatureDao.class);
 
   /**
-   * Execution bound on the read path (query, aggregate, aggregateTotals, queryOccurrences).
-   * HikariCP's connectionTimeout bounds pool <em>checkout</em> only — nothing bounded execution, so
-   * a query wedged on a lock wait ran forever. That is worst for FirstPageWarmer: its
+   * Execution bound on the serving read paths — everything that goes through {@link
+   * #withReadHandle}: query, aggregate, aggregateTotals, queryOccurrences. HikariCP's
+   * connectionTimeout bounds pool <em>checkout</em> only — nothing bounded execution, so a query
+   * wedged on a lock wait ran forever. That is worst for FirstPageWarmer: its
    * {@code @Scheduled(fixedDelay)} never re-schedules while a run is in flight, so one hung query
    * silently stopped all future refreshes until a restart, while holding a thread of the small
    * shared scheduled pool.
    *
    * <p>Ten seconds is far above any legitimate read here (LIMIT-bounded pages over a table with
-   * 7-day retention, now index-served) and well under the warmer's 30s tick, so a wedged tick fails
-   * — loudly, into the warmer's catch-and-log — before the next tick is due. Write paths are
-   * deliberately not bounded by this: the index worker has its own lease ceiling and interrupt
-   * machinery, and cutting a flush short creates recovery work a read never has.
+   * 7-day retention, now index-served). The binding constraint is FirstPageCache.MAX_AGE (60s), not
+   * the warmer's 30s tick — fixedDelay measures from completion, so ticks cannot overlap at any
+   * timeout — and a warmer tick runs <em>two</em> bounded reads (query, then queryOccurrences), so
+   * its worst successful case is 2x this value plus the 30s delay, which must stay under MAX_AGE or
+   * the snapshot expires between refreshes. FirstPageWarmerTest pins that arithmetic. A wedged tick
+   * fails loudly, into the warmer's catch-and-log, well before the next tick is due.
+   *
+   * <p>Write paths are deliberately not bounded by this: the index worker has its own lease ceiling
+   * and interrupt machinery, and cutting a flush short creates recovery work a read never has.
+   * {@link #fetchForReanalysis} is also excluded on purpose — it is the read half of the admin
+   * reanalysis batch loop, paging the whole table to feed a write path, not a serving read.
    *
    * <p>JDBC's queryTimeout cancels server-side execution (lock waits, slow plans). A true network
    * black hole additionally needs a driver-level socket timeout, which lives in the JDBC URL (e.g.
-   * {@code &socketTimeout=30} for Postgres) — deployment config, not code.
+   * {@code &socketTimeout=30} for Postgres) — deployment config, not code; the one_d4 README's
+   * database-URL section carries the guidance.
    *
    * <p>On H2 the timeout is session-scoped rather than statement-scoped, so every read clears it
    * again on the way out; see {@link #clearSessionQueryTimeout}.
    */
-  static final int READ_QUERY_TIMEOUT_SECONDS = 10;
+  public static final int READ_QUERY_TIMEOUT_SECONDS = 10;
 
   private static final String H2_INSERT =
       """
@@ -446,9 +455,33 @@ public class GameFeatureDao implements GameFeatureStore {
       try (var stmt = h.getConnection().createStatement()) {
         stmt.setQueryTimeout(0);
       } catch (SQLException e) {
-        throw new RuntimeException("Failed to clear H2 session query timeout", e);
+        // Log-and-swallow: this runs in a finally, where a throw would replace the read's real
+        // exception — including the timeout this bound exists to surface — and could fail an
+        // otherwise-successful read. A connection too broken to accept the reset is one HikariCP
+        // evicts, so the leak this guards against cannot outlive it.
+        LOG.warn("Failed to clear H2 session query timeout", e);
       }
     }
+  }
+
+  /**
+   * The single entry point for serving reads: every statement opened by {@code body} carries {@link
+   * #READ_QUERY_TIMEOUT_SECONDS} (set once on the handle's statement config), and the H2 session is
+   * cleared on the way out. The bound being part of the entry point — rather than a call each read
+   * must remember — is what makes "serving reads are bounded" structural: a new read either goes
+   * through here and is bounded, or visibly doesn't.
+   */
+  private <T> T withReadHandle(org.jdbi.v3.core.HandleCallback<T, RuntimeException> body) {
+    return jdbi.withHandle(
+        h -> {
+          h.getConfig(org.jdbi.v3.core.statement.SqlStatements.class)
+              .setQueryTimeout(readQueryTimeoutSeconds);
+          try {
+            return body.withHandle(h);
+          } finally {
+            clearSessionQueryTimeout(h);
+          }
+        });
   }
 
   @Override
@@ -458,20 +491,16 @@ public class GameFeatureDao implements GameFeatureStore {
           "Expected CompiledQuery, got: " + compiledQuery.getClass());
     }
     String sql = cq.selectSql() + " LIMIT ? OFFSET ?";
-    return jdbi.withHandle(
+    return withReadHandle(
         h -> {
-          try {
-            var query = h.createQuery(sql).setQueryTimeout(readQueryTimeoutSeconds);
-            int idx = 0;
-            for (Object param : cq.parameters()) {
-              query.bind(idx++, param);
-            }
-            query.bind(idx++, limit);
-            query.bind(idx, offset);
-            return query.map(GAME_FEATURE_MAPPER).list();
-          } finally {
-            clearSessionQueryTimeout(h);
+          var query = h.createQuery(sql);
+          int idx = 0;
+          for (Object param : cq.parameters()) {
+            query.bind(idx++, param);
           }
+          query.bind(idx++, limit);
+          query.bind(idx, offset);
+          return query.map(GAME_FEATURE_MAPPER).list();
         });
   }
 
@@ -482,28 +511,24 @@ public class GameFeatureDao implements GameFeatureStore {
           "Expected CompiledQuery, got: " + compiledQuery.getClass());
     }
     String sql = cq.selectSql() + " LIMIT ?";
-    return jdbi.withHandle(
+    return withReadHandle(
         h -> {
-          try {
-            var query = h.createQuery(sql).setQueryTimeout(readQueryTimeoutSeconds);
-            int idx = 0;
-            for (Object param : cq.parameters()) {
-              query.bind(idx++, param);
-            }
-            query.bind(idx, limit);
-            return query
-                .map(
-                    (rs, ctx) -> {
-                      Map<String, Object> group = new LinkedHashMap<>();
-                      for (String column : groupColumns) {
-                        group.put(column, rs.getObject(column));
-                      }
-                      return new AggregateRow(group, rs.getLong("group_count"));
-                    })
-                .list();
-          } finally {
-            clearSessionQueryTimeout(h);
+          var query = h.createQuery(sql);
+          int idx = 0;
+          for (Object param : cq.parameters()) {
+            query.bind(idx++, param);
           }
+          query.bind(idx, limit);
+          return query
+              .map(
+                  (rs, ctx) -> {
+                    Map<String, Object> group = new LinkedHashMap<>();
+                    for (String column : groupColumns) {
+                      group.put(column, rs.getObject(column));
+                    }
+                    return new AggregateRow(group, rs.getLong("group_count"));
+                  })
+              .list();
         });
   }
 
@@ -513,22 +538,18 @@ public class GameFeatureDao implements GameFeatureStore {
       throw new IllegalArgumentException(
           "Expected CompiledQuery, got: " + compiledQuery.getClass());
     }
-    return jdbi.withHandle(
+    return withReadHandle(
         h -> {
-          try {
-            var query = h.createQuery(cq.selectSql()).setQueryTimeout(readQueryTimeoutSeconds);
-            int idx = 0;
-            for (Object param : cq.parameters()) {
-              query.bind(idx++, param);
-            }
-            return query
-                .map(
-                    (rs, ctx) ->
-                        new AggregateTotals(rs.getLong("total_games"), rs.getLong("total_groups")))
-                .one();
-          } finally {
-            clearSessionQueryTimeout(h);
+          var query = h.createQuery(cq.selectSql());
+          int idx = 0;
+          for (Object param : cq.parameters()) {
+            query.bind(idx++, param);
           }
+          return query
+              .map(
+                  (rs, ctx) ->
+                      new AggregateTotals(rs.getLong("total_games"), rs.getLong("total_groups")))
+              .one();
         });
   }
 
@@ -538,44 +559,39 @@ public class GameFeatureDao implements GameFeatureStore {
     // Fetch all rows including ATTACK (needed for derivation) but excluding stale materialized
     // rows for motifs now derived at response time. ATTACK itself is removed in post-processing.
     Map<String, Map<String, List<OccurrenceRow>>> result =
-        jdbi.withHandle(
+        withReadHandle(
             h -> {
-              try {
-                var rows =
-                    h.createQuery(QUERY_OCCURRENCES)
-                        .setQueryTimeout(readQueryTimeoutSeconds)
-                        .bindList("urls", gameUrls)
-                        .map(
-                            (rs, ctx) -> {
-                              String gameUrl = rs.getString("game_url");
-                              // Store motif key as lowercase to match ChessQL motif naming
-                              // convention
-                              String motif = rs.getString("motif").toLowerCase();
-                              return new OccurrenceRow(
-                                  gameUrl,
-                                  motif,
-                                  rs.getInt("move_number"),
-                                  rs.getString("side"),
-                                  rs.getString("description"),
-                                  rs.getString("moved_piece"),
-                                  rs.getString("attacker"),
-                                  rs.getString("target"),
-                                  rs.getBoolean("is_discovered"),
-                                  rs.getBoolean("is_mate"),
-                                  rs.getString("pin_type"));
-                            })
-                        .list();
-                Map<String, Map<String, List<OccurrenceRow>>> grouped = new LinkedHashMap<>();
-                for (OccurrenceRow row : rows) {
-                  grouped
-                      .computeIfAbsent(row.gameUrl(), k -> new LinkedHashMap<>())
-                      .computeIfAbsent(row.motif(), k -> new ArrayList<>())
-                      .add(row);
-                }
-                return grouped;
-              } finally {
-                clearSessionQueryTimeout(h);
+              var rows =
+                  h.createQuery(QUERY_OCCURRENCES)
+                      .bindList("urls", gameUrls)
+                      .map(
+                          (rs, ctx) -> {
+                            String gameUrl = rs.getString("game_url");
+                            // Store motif key as lowercase to match ChessQL motif naming
+                            // convention
+                            String motif = rs.getString("motif").toLowerCase();
+                            return new OccurrenceRow(
+                                gameUrl,
+                                motif,
+                                rs.getInt("move_number"),
+                                rs.getString("side"),
+                                rs.getString("description"),
+                                rs.getString("moved_piece"),
+                                rs.getString("attacker"),
+                                rs.getString("target"),
+                                rs.getBoolean("is_discovered"),
+                                rs.getBoolean("is_mate"),
+                                rs.getString("pin_type"));
+                          })
+                      .list();
+              Map<String, Map<String, List<OccurrenceRow>>> grouped = new LinkedHashMap<>();
+              for (OccurrenceRow row : rows) {
+                grouped
+                    .computeIfAbsent(row.gameUrl(), k -> new LinkedHashMap<>())
+                    .computeIfAbsent(row.motif(), k -> new ArrayList<>())
+                    .add(row);
               }
+              return grouped;
             });
 
     // Post-process: derive all ATTACK-based motifs, then remove ATTACK (internal primitive).

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
@@ -112,22 +112,9 @@ public class GameFeatureDao implements GameFeatureStore {
   private final Jdbi jdbi;
   private final boolean useH2;
   private final Clock clock;
-  private final int readQueryTimeoutSeconds;
 
   public GameFeatureDao(Jdbi jdbi, boolean useH2) {
-    this(jdbi, useH2, Clock.systemUTC(), StatementTimeouts.SERVING_READ_SECONDS);
-  }
-
-  /**
-   * @param readQueryTimeoutSeconds injected so a test can bound a deliberately slow query in about
-   *     a second instead of ten — the behavioral test for the timeout is the point of the seam.
-   *     Production always uses {@link StatementTimeouts#SERVING_READ_SECONDS}.
-   */
-  GameFeatureDao(Jdbi jdbi, boolean useH2, Clock clock, int readQueryTimeoutSeconds) {
-    this.jdbi = jdbi;
-    this.useH2 = useH2;
-    this.clock = clock;
-    this.readQueryTimeoutSeconds = readQueryTimeoutSeconds;
+    this(jdbi, useH2, Clock.systemUTC());
   }
 
   /**
@@ -136,7 +123,9 @@ public class GameFeatureDao implements GameFeatureStore {
    *     come from one source; see {@link #deleteOlderThan}.
    */
   public GameFeatureDao(Jdbi jdbi, boolean useH2, Clock clock) {
-    this(jdbi, useH2, clock, StatementTimeouts.SERVING_READ_SECONDS);
+    this.jdbi = jdbi;
+    this.useH2 = useH2;
+    this.clock = clock;
   }
 
   /**
@@ -419,7 +408,8 @@ public class GameFeatureDao implements GameFeatureStore {
    * reanalysis batch loop, paging the whole table to feed a write path, not a serving read.
    */
   private <T> T withReadHandle(org.jdbi.v3.core.HandleCallback<T, RuntimeException> body) {
-    return StatementTimeouts.withStatementTimeout(jdbi, readQueryTimeoutSeconds, body);
+    return StatementTimeouts.withStatementTimeout(
+        jdbi, StatementTimeouts.SERVING_READ_SECONDS, body);
   }
 
   @Override

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/GameFeatureDao.java
@@ -29,38 +29,6 @@ import org.slf4j.LoggerFactory;
 public class GameFeatureDao implements GameFeatureStore {
   private static final Logger LOG = LoggerFactory.getLogger(GameFeatureDao.class);
 
-  /**
-   * Execution bound on the serving read paths — everything that goes through {@link
-   * #withReadHandle}: query, aggregate, aggregateTotals, queryOccurrences. HikariCP's
-   * connectionTimeout bounds pool <em>checkout</em> only — nothing bounded execution, so a query
-   * wedged on a lock wait ran forever. That is worst for FirstPageWarmer: its
-   * {@code @Scheduled(fixedDelay)} never re-schedules while a run is in flight, so one hung query
-   * silently stopped all future refreshes until a restart, while holding a thread of the small
-   * shared scheduled pool.
-   *
-   * <p>Ten seconds is far above any legitimate read here (LIMIT-bounded pages over a table with
-   * 7-day retention, now index-served). The binding constraint is FirstPageCache.MAX_AGE (60s), not
-   * the warmer's 30s tick — fixedDelay measures from completion, so ticks cannot overlap at any
-   * timeout — and a warmer tick runs <em>two</em> bounded reads (query, then queryOccurrences), so
-   * its worst successful case is 2x this value plus the 30s delay, which must stay under MAX_AGE or
-   * the snapshot expires between refreshes. FirstPageWarmerTest pins that arithmetic. A wedged tick
-   * fails loudly, into the warmer's catch-and-log, well before the next tick is due.
-   *
-   * <p>Write paths are deliberately not bounded by this: the index worker has its own lease ceiling
-   * and interrupt machinery, and cutting a flush short creates recovery work a read never has.
-   * {@link #fetchForReanalysis} is also excluded on purpose — it is the read half of the admin
-   * reanalysis batch loop, paging the whole table to feed a write path, not a serving read.
-   *
-   * <p>JDBC's queryTimeout cancels server-side execution (lock waits, slow plans). A true network
-   * black hole additionally needs a driver-level socket timeout, which lives in the JDBC URL (e.g.
-   * {@code &socketTimeout=30} for Postgres) — deployment config, not code; the one_d4 README's
-   * database-URL section carries the guidance.
-   *
-   * <p>On H2 the timeout is session-scoped rather than statement-scoped, so every read clears it
-   * again on the way out; see {@link #clearSessionQueryTimeout}.
-   */
-  public static final int READ_QUERY_TIMEOUT_SECONDS = 10;
-
   private static final String H2_INSERT =
       """
       MERGE INTO game_features (
@@ -147,13 +115,13 @@ public class GameFeatureDao implements GameFeatureStore {
   private final int readQueryTimeoutSeconds;
 
   public GameFeatureDao(Jdbi jdbi, boolean useH2) {
-    this(jdbi, useH2, Clock.systemUTC(), READ_QUERY_TIMEOUT_SECONDS);
+    this(jdbi, useH2, Clock.systemUTC(), StatementTimeouts.SERVING_READ_SECONDS);
   }
 
   /**
    * @param readQueryTimeoutSeconds injected so a test can bound a deliberately slow query in about
    *     a second instead of ten — the behavioral test for the timeout is the point of the seam.
-   *     Production always uses {@link #READ_QUERY_TIMEOUT_SECONDS}.
+   *     Production always uses {@link StatementTimeouts#SERVING_READ_SECONDS}.
    */
   GameFeatureDao(Jdbi jdbi, boolean useH2, Clock clock, int readQueryTimeoutSeconds) {
     this.jdbi = jdbi;
@@ -168,7 +136,7 @@ public class GameFeatureDao implements GameFeatureStore {
    *     come from one source; see {@link #deleteOlderThan}.
    */
   public GameFeatureDao(Jdbi jdbi, boolean useH2, Clock clock) {
-    this(jdbi, useH2, clock, READ_QUERY_TIMEOUT_SECONDS);
+    this(jdbi, useH2, clock, StatementTimeouts.SERVING_READ_SECONDS);
   }
 
   /**
@@ -254,7 +222,12 @@ public class GameFeatureDao implements GameFeatureStore {
    */
   @Override
   public int deleteOlderThan(Instant threshold) {
-    return jdbi.withHandle(
+    // Bounded at the sweep timeout, not the read one: RetentionWorker shares the warmer's
+    // scheduled pool with no lease or interrupt machinery, and this cascade delete is the
+    // statement most likely to sit behind a lock. Idempotent, so a truncated pass loses nothing.
+    return StatementTimeouts.withStatementTimeout(
+        jdbi,
+        StatementTimeouts.RETENTION_SWEEP_SECONDS,
         h -> {
           int deleted =
               h.createUpdate("DELETE FROM game_features WHERE indexed_at < ?")
@@ -440,48 +413,13 @@ public class GameFeatureDao implements GameFeatureStore {
   }
 
   /**
-   * H2 scopes {@code Statement.setQueryTimeout} to the connection's session — {@code JdbcStatement}
-   * delegates straight to {@code JdbcConnection.setQueryTimeout} — and HikariCP does not reset it
-   * on checkin, so without this a single read would leave its timeout on the pooled connection for
-   * every later statement, including writes this class deliberately leaves unbounded. Postgres
-   * scopes the timeout to the statement, so there is nothing to clean up there.
-   *
-   * <p>Reset through the JDBC API rather than {@code SET QUERY_TIMEOUT 0}: H2 also caches the value
-   * client-side in the connection, and raw SQL resets only the server session, leaving the cached
-   * value to keep answering {@code getQueryTimeout} — and to keep applying — for later statements.
-   */
-  private void clearSessionQueryTimeout(Handle h) {
-    if (useH2) {
-      try (var stmt = h.getConnection().createStatement()) {
-        stmt.setQueryTimeout(0);
-      } catch (SQLException e) {
-        // Log-and-swallow: this runs in a finally, where a throw would replace the read's real
-        // exception — including the timeout this bound exists to surface — and could fail an
-        // otherwise-successful read. A connection too broken to accept the reset is one HikariCP
-        // evicts, so the leak this guards against cannot outlive it.
-        LOG.warn("Failed to clear H2 session query timeout", e);
-      }
-    }
-  }
-
-  /**
-   * The single entry point for serving reads: every statement opened by {@code body} carries {@link
-   * #READ_QUERY_TIMEOUT_SECONDS} (set once on the handle's statement config), and the H2 session is
-   * cleared on the way out. The bound being part of the entry point — rather than a call each read
-   * must remember — is what makes "serving reads are bounded" structural: a new read either goes
-   * through here and is bounded, or visibly doesn't.
+   * The serving reads' bounded entry point — see {@link StatementTimeouts#withStatementTimeout} for
+   * the mechanism and {@link StatementTimeouts#SERVING_READ_SECONDS} for the policy. {@link
+   * #fetchForReanalysis} deliberately does not go through here: it is the read half of the admin
+   * reanalysis batch loop, paging the whole table to feed a write path, not a serving read.
    */
   private <T> T withReadHandle(org.jdbi.v3.core.HandleCallback<T, RuntimeException> body) {
-    return jdbi.withHandle(
-        h -> {
-          h.getConfig(org.jdbi.v3.core.statement.SqlStatements.class)
-              .setQueryTimeout(readQueryTimeoutSeconds);
-          try {
-            return body.withHandle(h);
-          } finally {
-            clearSessionQueryTimeout(h);
-          }
-        });
+    return StatementTimeouts.withStatementTimeout(jdbi, readQueryTimeoutSeconds, body);
   }
 
   @Override

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexedPeriodDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexedPeriodDao.java
@@ -118,7 +118,10 @@ public class IndexedPeriodDao implements IndexedPeriodStore {
 
   @Override
   public int deleteOlderThan(Instant threshold) {
-    return jdbi.withHandle(
+    // Bounded at the sweep timeout: idempotent hourly cleanup, re-run in an hour if truncated.
+    return StatementTimeouts.withStatementTimeout(
+        jdbi,
+        StatementTimeouts.RETENTION_SWEEP_SECONDS,
         h -> {
           int deleted =
               h.createUpdate(DELETE_OLDER_THAN).bind(0, Timestamp.from(threshold)).execute();

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexedPeriodDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexedPeriodDao.java
@@ -108,7 +108,10 @@ public class IndexedPeriodDao implements IndexedPeriodStore {
   @Override
   public List<IndexedPeriod> findPeriodsForPlayers(Collection<String> players) {
     if (players.isEmpty()) return List.of();
-    return jdbi.withHandle(
+    // Bounded like every serving read: this feeds the data-availability block of GET /v1/index.
+    return StatementTimeouts.withStatementTimeout(
+        jdbi,
+        StatementTimeouts.SERVING_READ_SECONDS,
         h ->
             h.createQuery(FIND_FOR_PLAYERS)
                 .bindList("players", List.copyOf(players))

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -434,7 +434,10 @@ public class IndexingRequestDao implements IndexingRequestStore {
 
   @Override
   public List<IndexingRequest> listRecent(int limit) {
-    return jdbi.withHandle(
+    // Bounded like every serving read: this backs GET /v1/index on a request thread.
+    return StatementTimeouts.withStatementTimeout(
+        jdbi,
+        StatementTimeouts.SERVING_READ_SECONDS,
         h ->
             h.createQuery("SELECT * FROM indexing_requests ORDER BY created_at DESC LIMIT ?")
                 .bind(0, limit)

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -335,7 +335,12 @@ public class IndexingRequestDao implements IndexingRequestStore {
 
   private int reclaim(String keyOrNull, Duration staleAfter, Instant now) {
     String keyClause = keyOrNull == null ? "" : "  AND dedupe_key = :key\n";
-    return jdbi.inTransaction(
+    // Bounded at the sweep timeout: this runs on the retention tick's shared scheduled pool with
+    // no lease or interrupt machinery, and settling is idempotent — a truncated pass re-runs in
+    // an hour (or on the next submit of the same tuple).
+    return StatementTimeouts.inTransactionWithTimeout(
+        jdbi,
+        StatementTimeouts.RETENTION_SWEEP_SECONDS,
         h -> {
           // Order matters twice, for two different reasons, and neither is the one that looks
           // obvious. A row at the attempt limit cannot match RELEASE_SQL at all — that statement

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/IndexingRequestDao.java
@@ -570,8 +570,14 @@ public class IndexingRequestDao implements IndexingRequestStore {
     // H2 has none; the conditional UPDATE claim already performs is what makes this safe without
     // it, since at most one racer's WHERE can match a given row. Losing costs a retry against the
     // next candidate, not correctness.
+    //
+    // Bounded: this scan runs every few seconds on the poller's single dedicated thread, whose
+    // loop never returns while a statement is in flight — unbounded, one wedged scan stopped the
+    // instance claiming any work until a restart, with nothing local to recover it.
     List<UUID> candidates =
-        jdbi.withHandle(
+        StatementTimeouts.withStatementTimeout(
+            jdbi,
+            StatementTimeouts.SERVING_READ_SECONDS,
             h ->
                 h.createQuery(
                         """
@@ -719,7 +725,10 @@ public class IndexingRequestDao implements IndexingRequestStore {
 
   @Override
   public int deleteOlderThan(Instant threshold) {
-    return jdbi.withHandle(
+    // Bounded at the sweep timeout: idempotent hourly cleanup, re-run in an hour if truncated.
+    return StatementTimeouts.withStatementTimeout(
+        jdbi,
+        StatementTimeouts.RETENTION_SWEEP_SECONDS,
         h -> {
           int deleted =
               h.createUpdate(

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/StatementTimeouts.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/StatementTimeouts.java
@@ -39,12 +39,14 @@ public final class StatementTimeouts {
   public static final int SERVING_READ_SECONDS = 10;
 
   /**
-   * The bound for the hourly retention sweep's deletes. Sized for a sweep, not a page: the
-   * steady-state delete covers roughly one hour of aged-out rows, and even a post-outage backlog of
-   * days clears in well under this. The sweep is idempotent and re-runs in an hour, so a truncated
-   * pass loses nothing — unlike the index worker's flushes, which have their own lease and
-   * interrupt machinery and stay unbounded (GameFeatureDao.fetchForReanalysis likewise, as the read
-   * half of the admin reanalysis batch loop).
+   * The bound for the hourly retention tick's statements — the reclaim transaction and the three
+   * deletes. Sized for a sweep, not a page: the steady-state delete covers roughly one hour of
+   * aged-out rows, and even a post-outage backlog of days clears in well under this. Per statement,
+   * not per tick — a tick where everything wedges can take up to four windows (~8 minutes) before
+   * the hourly schedule re-arms, still bounded. The sweep is idempotent and re-runs in an hour, so
+   * a truncated pass loses nothing — unlike the index worker's flushes, which have their own lease
+   * and interrupt machinery and stay unbounded (GameFeatureDao.fetchForReanalysis likewise, as the
+   * read half of the admin reanalysis batch loop).
    *
    * <p>Must stay under {@link DataSourceFactory}'s default Postgres socketTimeout, or the driver
    * would sever the connection under a legitimately long sweep before the server-side cancel fires.
@@ -64,6 +66,25 @@ public final class StatementTimeouts {
   public static <T> T withStatementTimeout(
       Jdbi jdbi, int timeoutSeconds, HandleCallback<T, RuntimeException> body) {
     return jdbi.withHandle(
+        h -> {
+          h.getConfig(SqlStatements.class).setQueryTimeout(timeoutSeconds);
+          try {
+            return body.withHandle(h);
+          } finally {
+            clearSessionQueryTimeout(h);
+          }
+        });
+  }
+
+  /**
+   * {@link #withStatementTimeout}'s transactional sibling, for bounded work that must stay one
+   * transaction — the retention tick's reclaim, whose three UPDATEs settle abandoned requests as a
+   * unit. Same bound-and-clear contract; the session clear runs inside the transaction, which is
+   * safe because session settings are not transactional on either engine.
+   */
+  public static <T> T inTransactionWithTimeout(
+      Jdbi jdbi, int timeoutSeconds, HandleCallback<T, RuntimeException> body) {
+    return jdbi.inTransaction(
         h -> {
           h.getConfig(SqlStatements.class).setQueryTimeout(timeoutSeconds);
           try {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/StatementTimeouts.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/StatementTimeouts.java
@@ -1,0 +1,101 @@
+package com.muchq.games.one_d4.db;
+
+import java.sql.SQLException;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.SqlStatements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Execution bounds for the statements run by unattended loops, and the one entry point that applies
+ * them. HikariCP's connectionTimeout bounds pool <em>checkout</em> only — nothing bounded
+ * execution, so a statement wedged on a lock wait ran forever, and the loops that never re-enter
+ * while a run is in flight (the first-page warmer's {@code @Scheduled(fixedDelay)}, the dispatch
+ * poller's single thread, the hourly retention sweep) stayed wedged until a restart.
+ *
+ * <p>JDBC's queryTimeout cancels server-side execution (lock waits, slow plans). A true network
+ * black hole additionally needs a driver-level socket timeout, which {@link DataSourceFactory}
+ * defaults for Postgres URLs — see the constant there for how the two relate.
+ */
+public final class StatementTimeouts {
+  private static final Logger LOG = LoggerFactory.getLogger(StatementTimeouts.class);
+
+  /**
+   * The bound for serving reads (GameFeatureDao's query/aggregate/occurrence paths) and the
+   * dispatch poller's candidate scan. Ten seconds is far above any legitimate run of these —
+   * LIMIT-bounded pages and an 8-row poll over tables with 7-day retention.
+   *
+   * <p>For the first-page warmer, the binding constraint is FirstPageCache.MAX_AGE (60s), not the
+   * warmer's 30s tick — fixedDelay measures from completion, so ticks cannot overlap at any timeout
+   * — and a warmer tick runs <em>two</em> bounded reads (query, then queryOccurrences), so its
+   * worst successful case is 2x this value plus the 30s delay, which must stay under MAX_AGE or the
+   * snapshot expires between refreshes. FirstPageWarmerTest pins that arithmetic. For the dispatch
+   * poller (IndexingRequestDao.claimNext, every ≤5s on a single dedicated thread), a bounded
+   * failure delays the next poll; an unbounded one used to stop the instance claiming work until a
+   * restart.
+   */
+  public static final int SERVING_READ_SECONDS = 10;
+
+  /**
+   * The bound for the hourly retention sweep's deletes. Sized for a sweep, not a page: the
+   * steady-state delete covers roughly one hour of aged-out rows, and even a post-outage backlog of
+   * days clears in well under this. The sweep is idempotent and re-runs in an hour, so a truncated
+   * pass loses nothing — unlike the index worker's flushes, which have their own lease and
+   * interrupt machinery and stay unbounded (GameFeatureDao.fetchForReanalysis likewise, as the read
+   * half of the admin reanalysis batch loop).
+   *
+   * <p>Must stay under {@link DataSourceFactory}'s default Postgres socketTimeout, or the driver
+   * would sever the connection under a legitimately long sweep before the server-side cancel fires.
+   * DataSourceFactoryTest pins that ordering.
+   */
+  public static final int RETENTION_SWEEP_SECONDS = 120;
+
+  private StatementTimeouts() {}
+
+  /**
+   * Runs {@code body} with every statement it opens carrying {@code timeoutSeconds}, set once on
+   * the handle's statement config, and the session cleared on the way out. The bound being part of
+   * the entry point — rather than a call each statement must remember — is what makes "this path is
+   * bounded" structural: a new statement either goes through here and is bounded, or visibly
+   * doesn't.
+   */
+  public static <T> T withStatementTimeout(
+      Jdbi jdbi, int timeoutSeconds, HandleCallback<T, RuntimeException> body) {
+    return jdbi.withHandle(
+        h -> {
+          h.getConfig(SqlStatements.class).setQueryTimeout(timeoutSeconds);
+          try {
+            return body.withHandle(h);
+          } finally {
+            clearSessionQueryTimeout(h);
+          }
+        });
+  }
+
+  /**
+   * H2 scopes {@code Statement.setQueryTimeout} to the connection's session — {@code JdbcStatement}
+   * delegates straight to {@code JdbcConnection.setQueryTimeout} — and HikariCP does not reset it
+   * on checkin, so without this a single bounded statement would leave its timeout on the pooled
+   * connection for every later statement, including the writes this class deliberately leaves
+   * unbounded. Postgres scopes the timeout to the statement, so there the reset is a pure
+   * client-side no-op (creating and closing a never-executed statement touches no network) — which
+   * is why it runs unconditionally rather than carrying dialect knowledge.
+   *
+   * <p>Reset through the JDBC API rather than {@code SET QUERY_TIMEOUT 0}: H2 also caches the value
+   * client-side in the connection, and raw SQL resets only the server session, leaving the cached
+   * value to keep answering {@code getQueryTimeout} — and to keep applying — for later statements.
+   */
+  private static void clearSessionQueryTimeout(Handle h) {
+    try (var stmt = h.getConnection().createStatement()) {
+      stmt.setQueryTimeout(0);
+    } catch (SQLException e) {
+      // Log-and-swallow: this runs in a finally, where a throw would replace the statement's real
+      // exception — including the timeout this bound exists to surface — and could fail an
+      // otherwise-successful call. A connection too broken to accept the reset is one HikariCP
+      // evicts, so the leak this guards against cannot outlive it.
+      LOG.warn("Failed to clear session query timeout", e);
+    }
+  }
+}

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/StatementTimeouts.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/StatementTimeouts.java
@@ -9,44 +9,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Execution bounds for the statements run by unattended loops, and the one entry point that applies
- * them. HikariCP's connectionTimeout bounds pool <em>checkout</em> only — nothing bounded
- * execution, so a statement wedged on a lock wait ran forever, and the loops that never re-enter
- * while a run is in flight (the first-page warmer's {@code @Scheduled(fixedDelay)}, the dispatch
- * poller's single thread, the hourly retention sweep) stayed wedged until a restart.
+ * Execution bounds for the statements run by unattended loops and serving reads, and the entry
+ * points that apply them. HikariCP's connectionTimeout bounds pool <em>checkout</em> only — nothing
+ * bounded execution, so a statement wedged on a lock wait ran forever, and the loops that never
+ * re-enter while a run is in flight (the first-page warmer's {@code @Scheduled(fixedDelay)}, the
+ * dispatch poller's single thread, the hourly retention sweep) stayed wedged until a restart.
  *
  * <p>JDBC's queryTimeout cancels server-side execution (lock waits, slow plans). A true network
  * black hole additionally needs a driver-level socket timeout, which {@link DataSourceFactory}
  * defaults for Postgres URLs — see the constant there for how the two relate.
+ *
+ * <p>Statements that do not go through these entry points carry no statement timeout, on purpose —
+ * the index worker's writes have their own lease ceiling and interrupt machinery, and the admin
+ * reanalysis read pages the whole table. The rationale lives at each excluded call site, and the
+ * exclusions are pinned by tests. Note "unbounded" here means by statement timeout: on Postgres the
+ * driver socket timeout still caps any statement <em>silent</em> for longer than its value, by
+ * connection teardown rather than clean cancellation.
  */
 public final class StatementTimeouts {
   private static final Logger LOG = LoggerFactory.getLogger(StatementTimeouts.class);
 
   /**
-   * The bound for serving reads (GameFeatureDao's query/aggregate/occurrence paths) and the
-   * dispatch poller's candidate scan. Ten seconds is far above any legitimate run of these —
-   * LIMIT-bounded pages and an 8-row poll over tables with 7-day retention.
-   *
-   * <p>For the first-page warmer, the binding constraint is FirstPageCache.MAX_AGE (60s), not the
-   * warmer's 30s tick — fixedDelay measures from completion, so ticks cannot overlap at any timeout
-   * — and a warmer tick runs <em>two</em> bounded reads (query, then queryOccurrences), so its
-   * worst successful case is 2x this value plus the 30s delay, which must stay under MAX_AGE or the
-   * snapshot expires between refreshes. FirstPageWarmerTest pins that arithmetic. For the dispatch
-   * poller (IndexingRequestDao.claimNext, every ≤5s on a single dedicated thread), a bounded
-   * failure delays the next poll; an unbounded one used to stop the instance claiming work until a
-   * restart.
+   * The bound for serving reads and the dispatch poller's candidate scan. Ten seconds is far above
+   * any legitimate run of these — LIMIT-bounded pages and an 8-row poll over tables with 7-day
+   * retention. The value's relationships are pinned where they bind: FirstPageWarmerTest pins that
+   * a warmer tick (two bounded reads plus the 30s delay) refreshes before FirstPageCache.MAX_AGE
+   * expires the snapshot, and StatementTimeoutsTest pins the value itself.
    */
   public static final int SERVING_READ_SECONDS = 10;
 
   /**
-   * The bound for the hourly retention tick's statements — the reclaim transaction and the three
-   * deletes. Sized for a sweep, not a page: the steady-state delete covers roughly one hour of
-   * aged-out rows, and even a post-outage backlog of days clears in well under this. Per statement,
-   * not per tick — a tick where everything wedges can take up to four windows (~8 minutes) before
-   * the hourly schedule re-arms, still bounded. The sweep is idempotent and re-runs in an hour, so
-   * a truncated pass loses nothing — unlike the index worker's flushes, which have their own lease
-   * and interrupt machinery and stay unbounded (GameFeatureDao.fetchForReanalysis likewise, as the
-   * read half of the admin reanalysis batch loop).
+   * The bound for the hourly retention tick's statements — the reclaim transaction's three settles
+   * and the three deletes. Sized for a sweep, not a page: the steady-state pass covers roughly one
+   * hour of aged-out rows, and even a post-outage backlog clears in well under this. Per statement,
+   * not per tick: a tick where every statement wedges is bounded at six windows (~12 minutes),
+   * still far inside the hourly schedule. The deletes are idempotent, so a truncated delete pass
+   * loses nothing; a truncated reclaim rolls back as a unit — which is why it runs in {@link
+   * #inTransactionWithTimeout} — and re-runs next tick.
    *
    * <p>Must stay under {@link DataSourceFactory}'s default Postgres socketTimeout, or the driver
    * would sever the connection under a legitimately long sweep before the server-side cancel fires.
@@ -65,15 +64,7 @@ public final class StatementTimeouts {
    */
   public static <T> T withStatementTimeout(
       Jdbi jdbi, int timeoutSeconds, HandleCallback<T, RuntimeException> body) {
-    return jdbi.withHandle(
-        h -> {
-          h.getConfig(SqlStatements.class).setQueryTimeout(timeoutSeconds);
-          try {
-            return body.withHandle(h);
-          } finally {
-            clearSessionQueryTimeout(h);
-          }
-        });
+    return jdbi.withHandle(bounded(timeoutSeconds, body));
   }
 
   /**
@@ -84,15 +75,19 @@ public final class StatementTimeouts {
    */
   public static <T> T inTransactionWithTimeout(
       Jdbi jdbi, int timeoutSeconds, HandleCallback<T, RuntimeException> body) {
-    return jdbi.inTransaction(
-        h -> {
-          h.getConfig(SqlStatements.class).setQueryTimeout(timeoutSeconds);
-          try {
-            return body.withHandle(h);
-          } finally {
-            clearSessionQueryTimeout(h);
-          }
-        });
+    return jdbi.inTransaction(bounded(timeoutSeconds, body));
+  }
+
+  private static <T> HandleCallback<T, RuntimeException> bounded(
+      int timeoutSeconds, HandleCallback<T, RuntimeException> body) {
+    return h -> {
+      h.getConfig(SqlStatements.class).setQueryTimeout(timeoutSeconds);
+      try {
+        return body.withHandle(h);
+      } finally {
+        clearSessionQueryTimeout(h);
+      }
+    };
   }
 
   /**

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -206,6 +206,7 @@ misses share a single query — so serving the live result also re-warms the cac
 | Bad ChessQL syntax | 400         | `ParseException` (body includes `position`) |
 | Unknown field      | 400         | `IllegalArgumentException`           |
 | Unknown motif      | 400         | `IllegalArgumentException`           |
+| Query exceeds the 10s read timeout | 500 | Statement cancelled server-side; previously such a request never returned |
 
 ---
 
@@ -293,6 +294,7 @@ it first via `POST /v1/index`.
 | Conflicting bucket widths for one field           | 400         |
 | Perspective field in groupBy without `player`     | 400         |
 | Perspective field in the filter without `player`  | 400         |
+| Query exceeds the 10s read timeout (per statement; aggregate runs two) | 500 |
 
 ---
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -294,7 +294,7 @@ it first via `POST /v1/index`.
 | Conflicting bucket widths for one field           | 400         |
 | Perspective field in groupBy without `player`     | 400         |
 | Perspective field in the filter without `player`  | 400         |
-| Query exceeds the 10s read timeout (per statement; aggregate runs two) | 500 |
+| Query exceeds the 10s read timeout (per statement; an aggregate that truncates runs a second totals statement) | 500 |
 
 ---
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
@@ -335,7 +335,10 @@ Already addressed:
 Additional hardening:
 - Max query string length (4KB)
 - Max AST depth (20 levels) to prevent stack overflow on deeply nested queries
-- Query timeout at the DB level (`SET statement_timeout = '5s'`)
+- ~~Query timeout at the DB level (`SET statement_timeout = '5s'`)~~ **Done**, as a 10s JDBC
+  statement timeout on GameFeatureDao's serving reads rather than a session-level setting — a
+  session `statement_timeout` would also bound writes, which keep their own recovery machinery.
+  A driver `socketTimeout` for network black holes remains deployment config (see README).
 
 ### Estimated Changes
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
@@ -335,10 +335,12 @@ Already addressed:
 Additional hardening:
 - Max query string length (4KB)
 - Max AST depth (20 levels) to prevent stack overflow on deeply nested queries
-- ~~Query timeout at the DB level (`SET statement_timeout = '5s'`)~~ **Done**, as a 10s JDBC
-  statement timeout on GameFeatureDao's serving reads rather than a session-level setting — a
-  session `statement_timeout` would also bound writes, which keep their own recovery machinery.
-  A driver `socketTimeout` for network black holes remains deployment config (see README).
+- ~~Query timeout at the DB level (`SET statement_timeout = '5s'`)~~ **Done**, as JDBC statement
+  timeouts (`StatementTimeouts`: 10s serving reads and the dispatch poll, 120s retention sweep)
+  rather than a session-level setting — a session `statement_timeout` would also bound writes,
+  which keep their own recovery machinery. A driver `socketTimeout` for network black holes is
+  defaulted in `DataSourceFactory` for Postgres URLs; an explicit URL value overrides it (see
+  README).
 
 ### Estimated Changes
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmerTest.java
@@ -103,8 +103,12 @@ public class FirstPageWarmerTest {
             .getAnnotation(io.micronaut.scheduling.annotation.Scheduled.class);
 
     assertThat(scheduled).as("refresh() is no longer scheduled").isNotNull();
-    assertThat(scheduled.fixedDelay()).matches("\\d+s");
-    long delaySeconds = Long.parseLong(scheduled.fixedDelay().replace("s", ""));
+    // fixedDelay, not fixedRate: fixedRate ticks can overlap, which would invalidate the budget
+    // arithmetic below (it assumes a tick completes before the next delay starts).
+    assertThat(scheduled.fixedRate())
+        .as("the warmer must not use an overlapping schedule")
+        .isEmpty();
+    long delaySeconds = parseSeconds(scheduled.fixedDelay());
     // The comment on the annotation states this invariant; this is what enforces it. If the
     // delay exceeds half MAX_AGE, the snapshot expires between refreshes and every first load
     // falls through to the database again.
@@ -118,6 +122,20 @@ public class FirstPageWarmerTest {
     assertThat(delaySeconds + worstTickSeconds)
         .as("a worst-case tick plus the delay must refresh before MAX_AGE expires the snapshot")
         .isLessThan(FirstPageCache.MAX_AGE.toSeconds());
+  }
+
+  /** Tolerant of the spellings Micronaut accepts, so the pin is on the budget, not the format. */
+  private static long parseSeconds(String duration) {
+    var matcher = java.util.regex.Pattern.compile("(\\d+)(m?s|m|h)").matcher(duration.strip());
+    assertThat(matcher.matches()).as("unrecognized @Scheduled duration: %s", duration).isTrue();
+    long value = Long.parseLong(matcher.group(1));
+    return switch (matcher.group(2)) {
+      case "ms" -> value / 1000;
+      case "s" -> value;
+      case "m" -> value * 60;
+      case "h" -> value * 3600;
+      default -> throw new IllegalStateException(duration);
+    };
   }
 
   private static GameFeature gameFeature(String gameUrl) {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.muchq.games.chessql.compiler.SqlCompiler;
 import com.muchq.games.one_d4.api.dto.GameFeature;
+import com.muchq.games.one_d4.db.GameFeatureDao;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -108,6 +109,15 @@ public class FirstPageWarmerTest {
     // delay exceeds half MAX_AGE, the snapshot expires between refreshes and every first load
     // falls through to the database again.
     assertThat(delaySeconds * 2).isLessThanOrEqualTo(FirstPageCache.MAX_AGE.toSeconds());
+
+    // The full tick budget: fixedDelay measures from completion, and a tick runs two reads each
+    // bounded by the DAO's read timeout — so a worst-case-but-successful tick must still land a
+    // fresh snapshot before the previous one expires. This is the arithmetic that makes the read
+    // timeout's value safe, pinned here rather than reasoned about in javadoc.
+    long worstTickSeconds = 2 * GameFeatureDao.READ_QUERY_TIMEOUT_SECONDS;
+    assertThat(delaySeconds + worstTickSeconds)
+        .as("a worst-case tick plus the delay must refresh before MAX_AGE expires the snapshot")
+        .isLessThan(FirstPageCache.MAX_AGE.toSeconds());
   }
 
   private static GameFeature gameFeature(String gameUrl) {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmerTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.muchq.games.chessql.compiler.SqlCompiler;
 import com.muchq.games.one_d4.api.dto.GameFeature;
-import com.muchq.games.one_d4.db.GameFeatureDao;
+import com.muchq.games.one_d4.db.StatementTimeouts;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -114,7 +114,7 @@ public class FirstPageWarmerTest {
     // bounded by the DAO's read timeout — so a worst-case-but-successful tick must still land a
     // fresh snapshot before the previous one expires. This is the arithmetic that makes the read
     // timeout's value safe, pinned here rather than reasoned about in javadoc.
-    long worstTickSeconds = 2 * GameFeatureDao.READ_QUERY_TIMEOUT_SECONDS;
+    long worstTickSeconds = 2 * StatementTimeouts.SERVING_READ_SECONDS;
     assertThat(delaySeconds + worstTickSeconds)
         .as("a worst-case tick plus the delay must refresh before MAX_AGE expires the snapshot")
         .isLessThan(FirstPageCache.MAX_AGE.toSeconds());

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmupTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/FirstPageWarmupTest.java
@@ -91,8 +91,13 @@ public class FirstPageWarmupTest {
         .contains("\"count\":0")
         .doesNotContain("after-warm");
 
+    // DEFAULT_LIMIT + 1, derived rather than literal: a hardcoded 26 would silently become a
+    // cache HIT if the default ever changed to 26, failing this control with a misleading message.
     HttpResponse<String> live =
-        postQuery("{\"query\":\"num.moves >= 0\",\"limit\":26,\"offset\":0}");
+        postQuery(
+            "{\"query\":\"num.moves >= 0\",\"limit\":"
+                + (FirstPageCache.DEFAULT_LIMIT + 1)
+                + ",\"offset\":0}");
     assertThat(live.statusCode()).isEqualTo(200);
     assertThat(live.body())
         .as("control: any other page size goes to the database and sees the insert")

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/QueryControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/QueryControllerTest.java
@@ -227,6 +227,25 @@ public class QueryControllerTest {
     assertThat(store.queryCount()).isEqualTo(1);
   }
 
+  /**
+   * A failing read — which since the statement timeouts includes a query cancelled at the bound —
+   * must surface as an error, never as an empty or partial page. Nothing else prevents a future
+   * "resilience" change from catching the failure and returning an empty result: users would see a
+   * silently empty page, operators no error, and no test would break. Pinned on both paths: the
+   * live one and the cache's cold-miss loader.
+   */
+  @Test
+  public void query_readFailureSurfacesAsAnErrorNotAnEmptyPage() {
+    store.failQueriesWith(new RuntimeException("statement cancelled at the read timeout"));
+
+    assertThatThrownBy(() -> controller.query(new QueryRequest("white_elo >= 2000", 25, 0, null)))
+        .as("live path")
+        .hasMessageContaining("statement cancelled");
+    assertThatThrownBy(() -> controller.query(defaultRequest()))
+        .as("cold-cache loader path")
+        .hasMessageContaining("statement cancelled");
+  }
+
   @Test
   public void query_blankQuery_throws() {
     assertThatThrownBy(() -> controller.query(new QueryRequest("  ", 10, 0)))

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/DataSourceFactoryTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/DataSourceFactoryTest.java
@@ -39,6 +39,22 @@ public class DataSourceFactoryTest {
                 "jdbc:postgresql://host:5432/db?user=u&socketTimeout=30"))
         .as("an operator's explicit choice in the URL must never be overridden")
         .isEmpty();
+    assertThat(
+            DataSourceFactory.defaultSocketTimeout(
+                "jdbc:postgresql://host:5432/db?socketTimeout=30"))
+        .as("first query parameter position counts too")
+        .isEmpty();
+  }
+
+  @Test
+  public void theSubstringInsideAnotherParametersValueDoesNotSuppressTheDefault() {
+    // The "already set?" check must match at a parameter boundary. A bare substring search
+    // would read this ApplicationName value as the operator choosing a socket timeout and
+    // silently ship the connection without one.
+    assertThat(
+            DataSourceFactory.defaultSocketTimeout(
+                "jdbc:postgresql://host:5432/db?user=u&ApplicationName=why_socketTimeout=is_here"))
+        .hasValue(150);
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/DataSourceFactoryTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/DataSourceFactoryTest.java
@@ -1,0 +1,41 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class DataSourceFactoryTest {
+
+  @Test
+  public void postgresUrlWithoutSocketTimeoutGetsTheDefault() {
+    assertThat(DataSourceFactory.defaultSocketTimeout("jdbc:postgresql://host:5432/db?user=u"))
+        .hasValue(150);
+  }
+
+  @Test
+  public void explicitSocketTimeoutInTheUrlWins() {
+    assertThat(
+            DataSourceFactory.defaultSocketTimeout(
+                "jdbc:postgresql://host:5432/db?user=u&socketTimeout=30"))
+        .as("an operator's explicit choice in the URL must never be overridden")
+        .isEmpty();
+  }
+
+  @Test
+  public void h2UrlsGetNoSocketTimeout() {
+    // H2 rejects unknown connection properties outright, so the default must be Postgres-only.
+    assertThat(DataSourceFactory.defaultSocketTimeout("jdbc:h2:mem:x;DB_CLOSE_DELAY=-1")).isEmpty();
+  }
+
+  /**
+   * A long-running DELETE sends nothing over the socket until it finishes, so the driver-level
+   * socket timeout must exceed the retention sweep's statement bound — otherwise a healthy
+   * connection is severed mid-sweep before the server-side cancel fires. This is the ordering the
+   * two constants' javadocs promise each other.
+   */
+  @Test
+  public void socketTimeoutExceedsTheLongestSilentStatementBound() {
+    assertThat(DataSourceFactory.PG_SOCKET_TIMEOUT_SECONDS)
+        .isGreaterThan(StatementTimeouts.RETENTION_SWEEP_SECONDS);
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/DataSourceFactoryTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/DataSourceFactoryTest.java
@@ -12,6 +12,26 @@ public class DataSourceFactoryTest {
         .hasValue(150);
   }
 
+  /**
+   * Through the config create() actually builds, not just the policy function — deleting the
+   * addDataSourceProperty wiring must fail here, not stay green behind a correct-but-unapplied
+   * policy.
+   */
+  @Test
+  public void createWiresTheDefaultIntoTheDriverProperties() {
+    assertThat(
+            DataSourceFactory.hikariConfig("jdbc:postgresql://host:5432/db?user=u")
+                .getDataSourceProperties()
+                .getProperty("socketTimeout"))
+        .isEqualTo("150");
+    assertThat(
+            DataSourceFactory.hikariConfig("jdbc:h2:mem:x;DB_CLOSE_DELAY=-1")
+                .getDataSourceProperties()
+                .getProperty("socketTimeout"))
+        .as("H2 must get no driver property it would reject")
+        .isNull();
+  }
+
   @Test
   public void explicitSocketTimeoutInTheUrlWins() {
     assertThat(

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
@@ -1,6 +1,7 @@
 package com.muchq.games.one_d4.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.muchq.games.chessql.compiler.CompiledQuery;
 import com.muchq.games.chessql.compiler.SqlCompiler;
@@ -12,6 +13,7 @@ import com.muchq.games.one_d4.api.dto.OccurrenceRow;
 import com.muchq.games.one_d4.db.GameFeatureStore.GameForReanalysis;
 import com.muchq.games.one_d4.engine.model.GameFeatures;
 import com.muchq.games.one_d4.engine.model.Motif;
+import java.sql.SQLException;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -19,6 +21,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jdbi.v3.core.statement.SqlLogger;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -102,13 +108,23 @@ public class GameFeatureDaoTest {
             List.of());
 
     long start = System.nanoTime();
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> boundedDao.query(slow, 500, 0))
+    assertThatThrownBy(() -> boundedDao.query(slow, 500, 0))
         .as("a query outrunning the timeout must be cancelled, not awaited")
-        .isInstanceOf(Exception.class);
+        .isInstanceOf(UnableToExecuteStatementException.class);
     long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
     assertThat(elapsedMillis)
         .as("cancellation must arrive well before the ~8s the full query needs")
-        .isLessThan(7_000);
+        .isLessThan(5_000);
+
+    // The error path must clear the H2 session too: this is the leak that matters in production
+    // — a timed-out read returning its pooled connection with the timeout still set. Without the
+    // reset running in a finally (rather than at the end of the try), this probe reads 1.
+    try (var conn = testDb.dataSource().getConnection();
+        var probe = conn.createStatement()) {
+      assertThat(probe.getQueryTimeout())
+          .as("a timed-out read must not leave its timeout on the pooled connection")
+          .isEqualTo(0);
+    }
 
     // Positive twin: the same query shape under a negligible per-row sleep completes normally,
     // proving the alias and the crafted CompiledQuery work and the failure above is the timeout.
@@ -135,21 +151,20 @@ public class GameFeatureDaoTest {
    */
   @Test
   public void allFourReadPathsCarryTheProductionTimeout() {
-    java.util.concurrent.atomic.AtomicInteger lastTimeout =
-        new java.util.concurrent.atomic.AtomicInteger(-1);
+    AtomicInteger lastTimeout = new AtomicInteger(-1);
     testDb
         .jdbi()
         .setSqlLogger(
-            new org.jdbi.v3.core.statement.SqlLogger() {
+            new SqlLogger() {
               @Override
-              public void logBeforeExecution(org.jdbi.v3.core.statement.StatementContext ctx) {
+              public void logBeforeExecution(StatementContext ctx) {
                 try {
                   // Batch statements log with a null statement here; only reads are probed.
                   var statement = ctx.getStatement();
                   if (statement != null) {
                     lastTimeout.set(statement.getQueryTimeout());
                   }
-                } catch (java.sql.SQLException e) {
+                } catch (SQLException e) {
                   throw new RuntimeException(e);
                 }
               }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
@@ -1,7 +1,6 @@
 package com.muchq.games.one_d4.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.muchq.games.chessql.compiler.CompiledQuery;
 import com.muchq.games.chessql.compiler.SqlCompiler;
@@ -14,7 +13,6 @@ import com.muchq.games.one_d4.db.GameFeatureStore.GameForReanalysis;
 import com.muchq.games.one_d4.engine.model.GameFeatures;
 import com.muchq.games.one_d4.engine.model.Motif;
 import java.sql.SQLException;
-import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -24,7 +22,6 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jdbi.v3.core.statement.SqlLogger;
 import org.jdbi.v3.core.statement.StatementContext;
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,82 +69,19 @@ public class GameFeatureDaoTest {
     assertThat(dao.query(allGames, 10, 0)).isEmpty();
   }
 
-  /** H2 alias target for the slow-query tests: sleeps per evaluated row. Must be public static. */
-  public static int nap(int millis) throws InterruptedException {
-    Thread.sleep(millis);
-    return 0;
-  }
-
   /**
-   * The read-path timeout must cancel a query that is actually running, not merely be set. 400 rows
-   * sleeping 20ms each is a ~8s query; a 1s timeout has to kill it partway. H2 enforces the timeout
-   * cooperatively and only checks every so many processed rows, which is why the fixture needs
-   * hundreds of rows rather than a handful — with too few rows the check never runs and the query
-   * completes as if unbounded. The positive twin below shares the fixture (same alias, same query
-   * shape), so a broken alias cannot masquerade as the timeout firing.
-   */
-  @Test
-  public void query_slowExecutionIsCancelledByTheReadTimeout() throws Exception {
-    try (var conn = testDb.dataSource().getConnection();
-        var stmt = conn.createStatement()) {
-      stmt.execute(
-          "CREATE ALIAS IF NOT EXISTS NAP FOR"
-              + " \"com.muchq.games.one_d4.db.GameFeatureDaoTest.nap\"");
-    }
-    List<GameFeature> games = new ArrayList<>();
-    for (int i = 0; i < 400; i++) {
-      games.add(createGame("https://chess.com/game/slow-" + i));
-    }
-    dao.insertBatch(games);
-
-    GameFeatureDao boundedDao = new GameFeatureDao(testDb.jdbi(), true, Clock.systemUTC(), 1);
-    CompiledQuery slow =
-        new CompiledQuery(
-            "SELECT g.* FROM game_features g WHERE NAP(20) = 0"
-                + " ORDER BY g.played_at DESC, g.game_url ASC",
-            List.of());
-
-    long start = System.nanoTime();
-    assertThatThrownBy(() -> boundedDao.query(slow, 500, 0))
-        .as("a query outrunning the timeout must be cancelled, not awaited")
-        .isInstanceOf(UnableToExecuteStatementException.class);
-    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
-    assertThat(elapsedMillis)
-        .as("cancellation must arrive well before the ~8s the full query needs")
-        .isLessThan(5_000);
-
-    // The error path must clear the H2 session too: this is the leak that matters in production
-    // — a timed-out read returning its pooled connection with the timeout still set. Without the
-    // reset running in a finally (rather than at the end of the try), this probe reads 1.
-    try (var conn = testDb.dataSource().getConnection();
-        var probe = conn.createStatement()) {
-      assertThat(probe.getQueryTimeout())
-          .as("a timed-out read must not leave its timeout on the pooled connection")
-          .isEqualTo(0);
-    }
-
-    // Positive twin: the same query shape under a negligible per-row sleep completes normally,
-    // proving the alias and the crafted CompiledQuery work and the failure above is the timeout.
-    CompiledQuery fast =
-        new CompiledQuery(
-            "SELECT g.* FROM game_features g WHERE NAP(0) = 0"
-                + " ORDER BY g.played_at DESC, g.game_url ASC",
-            List.of());
-    assertThat(boundedDao.query(fast, 500, 0)).hasSize(400);
-  }
-
-  /**
-   * The production constructors must apply the 10-second timeout to all four read statements —
-   * observed on the real JDBC statements via Jdbi's logger, per "test through the same objects
-   * production uses". Asserted against the literal 10 rather than the constant, so mutating the
-   * constant cannot mutate the expectation with it. Any read path losing its timeout regresses to
-   * unbounded execution silently; this is what notices.
+   * All four read paths must route through the bounded entry point — observed on the real JDBC
+   * statements via Jdbi's logger, per "test through the same objects production uses". Wiring is
+   * asserted against the constant (0 from a path that lost its bound never equals it); the
+   * constant's value itself is pinned once, in StatementTimeoutsTest, so a bound change costs one
+   * edit rather than a scavenger hunt. Behavioral cancellation at a short bound lives on the
+   * mechanism in StatementTimeoutsTest too.
    *
    * <p>The final probe pins the H2 session cleanup: H2 scopes setQueryTimeout to the pooled
-   * connection's session, so without the DAO's reset a read's timeout would leak into every later
-   * statement on that connection — including writes, which are deliberately unbounded. It also
-   * keeps the per-path probes honest: with a leaked session value, a read path that forgot its own
-   * setQueryTimeout would inherit an earlier read's and still probe as 10.
+   * connection's session, so without the entry point's reset a read's timeout would leak into every
+   * later statement on that connection — including writes, which are deliberately left without a
+   * statement bound. It also keeps the per-path probes honest: with a leaked session value, a read
+   * path that lost its own bound would inherit an earlier read's and still probe as bounded.
    */
   @Test
   public void allFourReadPathsCarryTheProductionTimeout() {
@@ -174,11 +108,13 @@ public class GameFeatureDaoTest {
 
     lastTimeout.set(-1);
     prodDao.query(new SqlCompiler().compile(Parser.parse("white_elo >= 1000")), 10, 0);
-    assertThat(lastTimeout.get()).as("query()").isEqualTo(10);
+    assertThat(lastTimeout.get()).as("query()").isEqualTo(StatementTimeouts.SERVING_READ_SECONDS);
 
     lastTimeout.set(-1);
     prodDao.queryOccurrences(List.of("https://chess.com/game/timeout-probe"));
-    assertThat(lastTimeout.get()).as("queryOccurrences()").isEqualTo(10);
+    assertThat(lastTimeout.get())
+        .as("queryOccurrences()")
+        .isEqualTo(StatementTimeouts.SERVING_READ_SECONDS);
 
     lastTimeout.set(-1);
     prodDao.aggregate(
@@ -188,13 +124,17 @@ public class GameFeatureDaoTest {
             List.of()),
         List.of("opening_family"),
         10);
-    assertThat(lastTimeout.get()).as("aggregate()").isEqualTo(10);
+    assertThat(lastTimeout.get())
+        .as("aggregate()")
+        .isEqualTo(StatementTimeouts.SERVING_READ_SECONDS);
 
     lastTimeout.set(-1);
     prodDao.aggregateTotals(
         new CompiledQuery(
             "SELECT COUNT(*) AS total_games, 1 AS total_groups FROM game_features", List.of()));
-    assertThat(lastTimeout.get()).as("aggregateTotals()").isEqualTo(10);
+    assertThat(lastTimeout.get())
+        .as("aggregateTotals()")
+        .isEqualTo(StatementTimeouts.SERVING_READ_SECONDS);
 
     // An unrelated statement on the same (pooled) session must NOT inherit the read timeout.
     lastTimeout.set(-1);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/GameFeatureDaoTest.java
@@ -12,6 +12,7 @@ import com.muchq.games.one_d4.api.dto.OccurrenceRow;
 import com.muchq.games.one_d4.db.GameFeatureStore.GameForReanalysis;
 import com.muchq.games.one_d4.engine.model.GameFeatures;
 import com.muchq.games.one_d4.engine.model.Motif;
+import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -63,6 +64,129 @@ public class GameFeatureDaoTest {
     dao.insertBatch(List.of());
     CompiledQuery allGames = new SqlCompiler().compile(Parser.parse("white_elo >= 1000"));
     assertThat(dao.query(allGames, 10, 0)).isEmpty();
+  }
+
+  /** H2 alias target for the slow-query tests: sleeps per evaluated row. Must be public static. */
+  public static int nap(int millis) throws InterruptedException {
+    Thread.sleep(millis);
+    return 0;
+  }
+
+  /**
+   * The read-path timeout must cancel a query that is actually running, not merely be set. 400 rows
+   * sleeping 20ms each is a ~8s query; a 1s timeout has to kill it partway. H2 enforces the timeout
+   * cooperatively and only checks every so many processed rows, which is why the fixture needs
+   * hundreds of rows rather than a handful — with too few rows the check never runs and the query
+   * completes as if unbounded. The positive twin below shares the fixture (same alias, same query
+   * shape), so a broken alias cannot masquerade as the timeout firing.
+   */
+  @Test
+  public void query_slowExecutionIsCancelledByTheReadTimeout() throws Exception {
+    try (var conn = testDb.dataSource().getConnection();
+        var stmt = conn.createStatement()) {
+      stmt.execute(
+          "CREATE ALIAS IF NOT EXISTS NAP FOR"
+              + " \"com.muchq.games.one_d4.db.GameFeatureDaoTest.nap\"");
+    }
+    List<GameFeature> games = new ArrayList<>();
+    for (int i = 0; i < 400; i++) {
+      games.add(createGame("https://chess.com/game/slow-" + i));
+    }
+    dao.insertBatch(games);
+
+    GameFeatureDao boundedDao = new GameFeatureDao(testDb.jdbi(), true, Clock.systemUTC(), 1);
+    CompiledQuery slow =
+        new CompiledQuery(
+            "SELECT g.* FROM game_features g WHERE NAP(20) = 0"
+                + " ORDER BY g.played_at DESC, g.game_url ASC",
+            List.of());
+
+    long start = System.nanoTime();
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> boundedDao.query(slow, 500, 0))
+        .as("a query outrunning the timeout must be cancelled, not awaited")
+        .isInstanceOf(Exception.class);
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+    assertThat(elapsedMillis)
+        .as("cancellation must arrive well before the ~8s the full query needs")
+        .isLessThan(7_000);
+
+    // Positive twin: the same query shape under a negligible per-row sleep completes normally,
+    // proving the alias and the crafted CompiledQuery work and the failure above is the timeout.
+    CompiledQuery fast =
+        new CompiledQuery(
+            "SELECT g.* FROM game_features g WHERE NAP(0) = 0"
+                + " ORDER BY g.played_at DESC, g.game_url ASC",
+            List.of());
+    assertThat(boundedDao.query(fast, 500, 0)).hasSize(400);
+  }
+
+  /**
+   * The production constructors must apply the 10-second timeout to all four read statements —
+   * observed on the real JDBC statements via Jdbi's logger, per "test through the same objects
+   * production uses". Asserted against the literal 10 rather than the constant, so mutating the
+   * constant cannot mutate the expectation with it. Any read path losing its timeout regresses to
+   * unbounded execution silently; this is what notices.
+   *
+   * <p>The final probe pins the H2 session cleanup: H2 scopes setQueryTimeout to the pooled
+   * connection's session, so without the DAO's reset a read's timeout would leak into every later
+   * statement on that connection — including writes, which are deliberately unbounded. It also
+   * keeps the per-path probes honest: with a leaked session value, a read path that forgot its own
+   * setQueryTimeout would inherit an earlier read's and still probe as 10.
+   */
+  @Test
+  public void allFourReadPathsCarryTheProductionTimeout() {
+    java.util.concurrent.atomic.AtomicInteger lastTimeout =
+        new java.util.concurrent.atomic.AtomicInteger(-1);
+    testDb
+        .jdbi()
+        .setSqlLogger(
+            new org.jdbi.v3.core.statement.SqlLogger() {
+              @Override
+              public void logBeforeExecution(org.jdbi.v3.core.statement.StatementContext ctx) {
+                try {
+                  // Batch statements log with a null statement here; only reads are probed.
+                  var statement = ctx.getStatement();
+                  if (statement != null) {
+                    lastTimeout.set(statement.getQueryTimeout());
+                  }
+                } catch (java.sql.SQLException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            });
+    GameFeatureDao prodDao = new GameFeatureDao(testDb.jdbi(), true);
+    dao.insertBatch(List.of(createGame("https://chess.com/game/timeout-probe")));
+
+    lastTimeout.set(-1);
+    prodDao.query(new SqlCompiler().compile(Parser.parse("white_elo >= 1000")), 10, 0);
+    assertThat(lastTimeout.get()).as("query()").isEqualTo(10);
+
+    lastTimeout.set(-1);
+    prodDao.queryOccurrences(List.of("https://chess.com/game/timeout-probe"));
+    assertThat(lastTimeout.get()).as("queryOccurrences()").isEqualTo(10);
+
+    lastTimeout.set(-1);
+    prodDao.aggregate(
+        new CompiledQuery(
+            "SELECT opening_family, COUNT(*) AS group_count FROM game_features"
+                + " GROUP BY opening_family",
+            List.of()),
+        List.of("opening_family"),
+        10);
+    assertThat(lastTimeout.get()).as("aggregate()").isEqualTo(10);
+
+    lastTimeout.set(-1);
+    prodDao.aggregateTotals(
+        new CompiledQuery(
+            "SELECT COUNT(*) AS total_games, 1 AS total_groups FROM game_features", List.of()));
+    assertThat(lastTimeout.get()).as("aggregateTotals()").isEqualTo(10);
+
+    // An unrelated statement on the same (pooled) session must NOT inherit the read timeout.
+    lastTimeout.set(-1);
+    testDb.jdbi().withHandle(h -> h.createQuery("SELECT 1").mapTo(Integer.class).one());
+    assertThat(lastTimeout.get())
+        .as("the read timeout must not leak to later statements on the session")
+        .isEqualTo(0);
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
@@ -163,6 +163,21 @@ public class PostgresReadTimeoutTest {
     }
   }
 
+  /**
+   * The socket-timeout default, proven through the real driver rather than the built config: {@code
+   * setUp}'s pool came from {@code DataSourceFactory.create} on a URL without {@code
+   * socketTimeout}, and pgjdbc surfaces the applied value as {@code Connection.getNetworkTimeout}
+   * (milliseconds, backed by the socket's SO_TIMEOUT).
+   */
+  @Test
+  public void createAppliesTheSocketTimeoutDefaultToRealConnections() throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      assertThat(conn.getNetworkTimeout())
+          .as("the 150s default must reach the actual socket")
+          .isEqualTo(150_000);
+    }
+  }
+
   private void insertOneGame(String gameUrl) {
     GameFeatureDao dao = new GameFeatureDao(Jdbi.create(dataSource), false);
     dao.insertBatch(

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
@@ -4,20 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import com.muchq.games.chessql.compiler.CompiledQuery;
-import com.muchq.games.one_d4.api.dto.GameFeature;
 import java.io.Closeable;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.Statement;
-import java.time.Clock;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import javax.sql.DataSource;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -26,49 +20,33 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * The read-path query timeout, on the deployment dialect. H2's cooperative enforcement is covered
- * in {@link GameFeatureDaoTest}; Postgres enforces it differently — pgjdbc runs a cancel timer that
- * interrupts the server out-of-band — and Postgres is also the dialect where the DAO's H2-only
- * session cleanup must correctly do nothing: pgjdbc scopes the timeout to the statement, which this
- * suite pins rather than asserts in prose.
+ * The statement-timeout mechanism on the deployment dialect. H2's cooperative enforcement is
+ * covered in {@link StatementTimeoutsTest}; Postgres enforces the bound differently — pgjdbc runs a
+ * cancel timer that interrupts the server out-of-band — and Postgres is also the dialect where the
+ * session cleanup must be a harmless no-op: pgjdbc scopes the timeout to the statement, which this
+ * suite pins behaviorally rather than asserting in prose. (The cleanup runs unconditionally on both
+ * dialects; on Postgres it is pure client-side bookkeeping.)
  *
  * <p>Runs against the real postgres that CI's build-and-test job provides via {@code
- * PG_TEST_DB_URL}; skips when that is unset. Uses a dedicated schema so it cannot collide with the
- * other suites sharing that scratch database.
+ * PG_TEST_DB_URL}; skips when that is unset. Runs no migrations and touches no tables — everything
+ * here is expressible with {@code pg_sleep} and session probes.
  */
 public class PostgresReadTimeoutTest {
 
   private static final String DB_URL_ENV = "PG_TEST_DB_URL";
-  private static final String SCHEMA = "one_d4_pg_read_timeout_test";
 
   private DataSource dataSource;
-  private UUID requestId;
+  private Jdbi jdbi;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     String rawUrl = System.getenv(DB_URL_ENV);
     assumeTrue(
         rawUrl != null && !rawUrl.isBlank(),
         DB_URL_ENV + " is not set; skipping the real-postgres read-timeout suite");
 
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
-        Statement stmt = conn.createStatement()) {
-      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
-      stmt.execute("CREATE SCHEMA " + SCHEMA);
-    }
-
-    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl, SCHEMA));
-    new Migration(dataSource, false).run();
-
-    requestId = UUID.randomUUID();
-    try (Connection conn = dataSource.getConnection();
-        var stmt =
-            conn.prepareStatement(
-                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
-                    + " status) VALUES (?, 'p', 'CHESS_COM', '2026-06', '2026-07', 'COMPLETED')")) {
-      stmt.setObject(1, requestId);
-      stmt.executeUpdate();
-    }
+    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl));
+    jdbi = Jdbi.create(dataSource);
   }
 
   @AfterEach
@@ -76,75 +54,50 @@ public class PostgresReadTimeoutTest {
     if (dataSource instanceof Closeable closeable) {
       closeable.close();
     }
-    String rawUrl = System.getenv(DB_URL_ENV);
-    if (rawUrl == null || rawUrl.isBlank()) {
-      return;
-    }
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
-        Statement stmt = conn.createStatement()) {
-      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
-    }
   }
 
   /**
-   * pgjdbc must cancel a running query at the timeout — server-side, out-of-band, mid-sleep. The
-   * positive twin shares the fixture (same query shape, zero sleep), so a broken query cannot
-   * masquerade as the timeout firing.
+   * pgjdbc must cancel a running statement at the bound — server-side, out-of-band, mid-sleep. The
+   * positive twin shares the query shape with zero sleep, so a broken query cannot masquerade as
+   * the bound firing.
    */
   @Test
-  public void slowQueryIsCancelledAtTheTimeoutOnPostgres() {
-    GameFeatureDao bounded = new GameFeatureDao(Jdbi.create(dataSource), false, Clock.systemUTC());
-    GameFeatureDao oneSecond =
-        new GameFeatureDao(Jdbi.create(dataSource), false, Clock.systemUTC(), 1);
-    insertOneGame("https://chess.com/game/pg-slow");
-
-    // pg_sleep is volatile, so it runs per candidate row; void casts to the empty string.
-    CompiledQuery slow =
-        new CompiledQuery(
-            "SELECT g.* FROM game_features g WHERE pg_sleep(5)::text = ''"
-                + " ORDER BY g.played_at DESC, g.game_url ASC",
-            List.of());
-
+  public void slowExecutionIsCancelledAtTheBoundOnPostgres() {
     long start = System.nanoTime();
-    assertThatThrownBy(() -> oneSecond.query(slow, 10, 0))
-        .as("a query outrunning the timeout must be cancelled, not awaited")
+    assertThatThrownBy(
+            () ->
+                StatementTimeouts.withStatementTimeout(
+                    jdbi,
+                    1,
+                    h -> h.createQuery("SELECT pg_sleep(5)::text").mapTo(String.class).one()))
+        .as("a statement outrunning the bound must be cancelled, not awaited")
         .isInstanceOf(UnableToExecuteStatementException.class);
     long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
     assertThat(elapsedMillis)
-        .as("cancellation must arrive near the 1s timeout, not after the 5s sleep")
+        .as("cancellation must arrive near the 1s bound, not after the 5s sleep")
         .isLessThan(4_000);
 
-    CompiledQuery fast =
-        new CompiledQuery(
-            "SELECT g.* FROM game_features g WHERE pg_sleep(0)::text = ''"
-                + " ORDER BY g.played_at DESC, g.game_url ASC",
-            List.of());
-    assertThat(bounded.query(fast, 10, 0)).hasSize(1);
+    String result =
+        StatementTimeouts.withStatementTimeout(
+            jdbi, 1, h -> h.createQuery("SELECT pg_sleep(0)::text").mapTo(String.class).one());
+    assertThat(result).isEqualTo("");
   }
 
   /**
-   * The claim behind gating the session cleanup on H2 only: on Postgres a read's timeout must not
-   * bound later statements on the same pooled connection, even though the DAO does nothing to clear
-   * it there.
+   * On Postgres a bounded statement's timeout must not bound later statements on the same pooled
+   * connection, even though the cleanup does nothing driver-visible there.
    *
    * <p>Pinned behaviorally, not by reading a client-side field: a fresh {@code PgStatement}'s
    * {@code getQueryTimeout()} is 0 by construction, so asserting it proves nothing. Instead, after
-   * a 1s-bounded read, an <em>unbounded</em> 2s {@code pg_sleep} on the same pool must complete —
-   * any leak, through the client timer or a server-side {@code statement_timeout}, would cancel it
-   * at 1s. The {@code SHOW statement_timeout} probe additionally pins that pgjdbc's mechanism is
-   * the client cancel timer and left no server-side session setting behind.
+   * a 1s-bounded statement, an <em>unbounded</em> 2s {@code pg_sleep} on the same pool must
+   * complete — any leak, through the client timer or a server-side {@code statement_timeout}, would
+   * cancel it at 1s. The {@code SHOW statement_timeout} probe additionally pins that pgjdbc's
+   * mechanism is the client cancel timer and left no server-side session setting behind.
    */
   @Test
-  public void readTimeoutDoesNotLeakAcrossStatementsOnPostgres() throws Exception {
-    GameFeatureDao oneSecond =
-        new GameFeatureDao(Jdbi.create(dataSource), false, Clock.systemUTC(), 1);
-    insertOneGame("https://chess.com/game/pg-leak-probe");
-
-    oneSecond.query(
-        new CompiledQuery(
-            "SELECT g.* FROM game_features g ORDER BY g.played_at DESC, g.game_url ASC", List.of()),
-        10,
-        0);
+  public void boundDoesNotLeakAcrossStatementsOnPostgres() throws Exception {
+    StatementTimeouts.withStatementTimeout(
+        jdbi, 1, h -> h.createQuery("SELECT 1").mapTo(Integer.class).one());
 
     // The pool is small and access is sequential, so this draws the connection the read used.
     try (Connection conn = dataSource.getConnection();
@@ -152,56 +105,30 @@ public class PostgresReadTimeoutTest {
       try (var rs = stmt.executeQuery("SHOW statement_timeout")) {
         assertThat(rs.next()).isTrue();
         assertThat(rs.getString(1))
-            .as("the read bound must not become a server-side session setting")
+            .as("the bound must not become a server-side session setting")
             .isEqualTo("0");
       }
       try (var rs = stmt.executeQuery("SELECT pg_sleep(2)")) {
         assertThat(rs.next())
-            .as("an unbounded statement after a bounded read must run to completion")
+            .as("an unbounded statement after a bounded one must run to completion")
             .isTrue();
       }
     }
   }
 
   /**
-   * The socket-timeout default, proven through the real driver rather than the built config: {@code
-   * setUp}'s pool came from {@code DataSourceFactory.create} on a URL without {@code
-   * socketTimeout}, and pgjdbc surfaces the applied value as {@code Connection.getNetworkTimeout}
-   * (milliseconds, backed by the socket's SO_TIMEOUT).
+   * The socket-timeout default, proven through the real driver rather than the built config: this
+   * suite's pool came from {@code DataSourceFactory.create} on a URL without {@code socketTimeout},
+   * and pgjdbc surfaces the applied value as {@code Connection.getNetworkTimeout} (milliseconds,
+   * backed by the socket's SO_TIMEOUT).
    */
   @Test
   public void createAppliesTheSocketTimeoutDefaultToRealConnections() throws Exception {
     try (Connection conn = dataSource.getConnection()) {
       assertThat(conn.getNetworkTimeout())
-          .as("the 150s default must reach the actual socket")
-          .isEqualTo(150_000);
+          .as("the default must reach the actual socket")
+          .isEqualTo(DataSourceFactory.PG_SOCKET_TIMEOUT_SECONDS * 1000);
     }
-  }
-
-  private void insertOneGame(String gameUrl) {
-    GameFeatureDao dao = new GameFeatureDao(Jdbi.create(dataSource), false);
-    dao.insertBatch(
-        List.of(
-            new GameFeature(
-                UUID.randomUUID(),
-                requestId,
-                gameUrl,
-                "CHESS_COM",
-                "white",
-                "black",
-                2000,
-                1900,
-                null,
-                "GM",
-                "blitz",
-                "B90",
-                "Sicilian Defense Najdorf Variation",
-                "Sicilian Defense",
-                "1-0",
-                Instant.now(),
-                30,
-                Instant.now(),
-                "pgn")));
   }
 
   /**
@@ -209,7 +136,7 @@ public class PostgresReadTimeoutTest {
    * pgjdbc URL, same as the other PG-gated suites. pgjdbc does not accept credentials in the
    * authority, so they move to query params.
    */
-  private static String jdbcUrl(String rawUrl, String schema) {
+  private static String jdbcUrl(String rawUrl) {
     URI uri = URI.create(rawUrl);
     List<String> params = new ArrayList<>();
     String userInfo = uri.getUserInfo();
@@ -221,17 +148,13 @@ public class PostgresReadTimeoutTest {
         params.add("password=" + encode(userInfo.substring(colon + 1)));
       }
     }
-    if (schema != null) {
-      params.add("currentSchema=" + encode(schema));
-    }
     int port = uri.getPort() < 0 ? 5432 : uri.getPort();
     return "jdbc:postgresql://"
         + uri.getHost()
         + ":"
         + port
         + uri.getPath()
-        + "?"
-        + String.join("&", params);
+        + (params.isEmpty() ? "" : "?" + String.join("&", params));
   }
 
   private static String encode(String value) {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.muchq.games.chessql.compiler.CompiledQuery;
+import com.muchq.games.one_d4.api.dto.GameFeature;
 import java.io.Closeable;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -14,10 +15,12 @@ import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.sql.DataSource;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -105,7 +108,7 @@ public class PostgresReadTimeoutTest {
     long start = System.nanoTime();
     assertThatThrownBy(() -> oneSecond.query(slow, 10, 0))
         .as("a query outrunning the timeout must be cancelled, not awaited")
-        .isInstanceOf(Exception.class);
+        .isInstanceOf(UnableToExecuteStatementException.class);
     long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
     assertThat(elapsedMillis)
         .as("cancellation must arrive near the 1s timeout, not after the 5s sleep")
@@ -120,16 +123,24 @@ public class PostgresReadTimeoutTest {
   }
 
   /**
-   * The claim behind gating the session cleanup on H2 only: pgjdbc scopes setQueryTimeout to the
-   * statement, so a read's timeout must not be visible to a later statement on the same pooled
-   * connection even though the DAO does nothing to clear it there.
+   * The claim behind gating the session cleanup on H2 only: on Postgres a read's timeout must not
+   * bound later statements on the same pooled connection, even though the DAO does nothing to clear
+   * it there.
+   *
+   * <p>Pinned behaviorally, not by reading a client-side field: a fresh {@code PgStatement}'s
+   * {@code getQueryTimeout()} is 0 by construction, so asserting it proves nothing. Instead, after
+   * a 1s-bounded read, an <em>unbounded</em> 2s {@code pg_sleep} on the same pool must complete —
+   * any leak, through the client timer or a server-side {@code statement_timeout}, would cancel it
+   * at 1s. The {@code SHOW statement_timeout} probe additionally pins that pgjdbc's mechanism is
+   * the client cancel timer and left no server-side session setting behind.
    */
   @Test
   public void readTimeoutDoesNotLeakAcrossStatementsOnPostgres() throws Exception {
-    GameFeatureDao dao = new GameFeatureDao(Jdbi.create(dataSource), false);
+    GameFeatureDao oneSecond =
+        new GameFeatureDao(Jdbi.create(dataSource), false, Clock.systemUTC(), 1);
     insertOneGame("https://chess.com/game/pg-leak-probe");
 
-    dao.query(
+    oneSecond.query(
         new CompiledQuery(
             "SELECT g.* FROM game_features g ORDER BY g.played_at DESC, g.game_url ASC", List.of()),
         10,
@@ -138,9 +149,17 @@ public class PostgresReadTimeoutTest {
     // The pool is small and access is sequential, so this draws the connection the read used.
     try (Connection conn = dataSource.getConnection();
         Statement stmt = conn.createStatement()) {
-      assertThat(stmt.getQueryTimeout())
-          .as("a fresh statement must not inherit the read timeout")
-          .isEqualTo(0);
+      try (var rs = stmt.executeQuery("SHOW statement_timeout")) {
+        assertThat(rs.next()).isTrue();
+        assertThat(rs.getString(1))
+            .as("the read bound must not become a server-side session setting")
+            .isEqualTo("0");
+      }
+      try (var rs = stmt.executeQuery("SELECT pg_sleep(2)")) {
+        assertThat(rs.next())
+            .as("an unbounded statement after a bounded read must run to completion")
+            .isTrue();
+      }
     }
   }
 
@@ -148,7 +167,7 @@ public class PostgresReadTimeoutTest {
     GameFeatureDao dao = new GameFeatureDao(Jdbi.create(dataSource), false);
     dao.insertBatch(
         List.of(
-            new com.muchq.games.one_d4.api.dto.GameFeature(
+            new GameFeature(
                 UUID.randomUUID(),
                 requestId,
                 gameUrl,
@@ -177,7 +196,7 @@ public class PostgresReadTimeoutTest {
    */
   private static String jdbcUrl(String rawUrl, String schema) {
     URI uri = URI.create(rawUrl);
-    java.util.List<String> params = new java.util.ArrayList<>();
+    List<String> params = new ArrayList<>();
     String userInfo = uri.getUserInfo();
     if (userInfo != null) {
       int colon = userInfo.indexOf(':');

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
@@ -1,0 +1,206 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.muchq.games.chessql.compiler.CompiledQuery;
+import java.io.Closeable;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The read-path query timeout, on the deployment dialect. H2's cooperative enforcement is covered
+ * in {@link GameFeatureDaoTest}; Postgres enforces it differently — pgjdbc runs a cancel timer that
+ * interrupts the server out-of-band — and Postgres is also the dialect where the DAO's H2-only
+ * session cleanup must correctly do nothing: pgjdbc scopes the timeout to the statement, which this
+ * suite pins rather than asserts in prose.
+ *
+ * <p>Runs against the real postgres that CI's build-and-test job provides via {@code
+ * PG_TEST_DB_URL}; skips when that is unset. Uses a dedicated schema so it cannot collide with the
+ * other suites sharing that scratch database.
+ */
+public class PostgresReadTimeoutTest {
+
+  private static final String DB_URL_ENV = "PG_TEST_DB_URL";
+  private static final String SCHEMA = "one_d4_pg_read_timeout_test";
+
+  private DataSource dataSource;
+  private UUID requestId;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    String rawUrl = System.getenv(DB_URL_ENV);
+    assumeTrue(
+        rawUrl != null && !rawUrl.isBlank(),
+        DB_URL_ENV + " is not set; skipping the real-postgres read-timeout suite");
+
+    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+      stmt.execute("CREATE SCHEMA " + SCHEMA);
+    }
+
+    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl, SCHEMA));
+    new Migration(dataSource, false).run();
+
+    requestId = UUID.randomUUID();
+    try (Connection conn = dataSource.getConnection();
+        var stmt =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " status) VALUES (?, 'p', 'CHESS_COM', '2026-06', '2026-07', 'COMPLETED')")) {
+      stmt.setObject(1, requestId);
+      stmt.executeUpdate();
+    }
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (dataSource instanceof Closeable closeable) {
+      closeable.close();
+    }
+    String rawUrl = System.getenv(DB_URL_ENV);
+    if (rawUrl == null || rawUrl.isBlank()) {
+      return;
+    }
+    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+    }
+  }
+
+  /**
+   * pgjdbc must cancel a running query at the timeout — server-side, out-of-band, mid-sleep. The
+   * positive twin shares the fixture (same query shape, zero sleep), so a broken query cannot
+   * masquerade as the timeout firing.
+   */
+  @Test
+  public void slowQueryIsCancelledAtTheTimeoutOnPostgres() {
+    GameFeatureDao bounded = new GameFeatureDao(Jdbi.create(dataSource), false, Clock.systemUTC());
+    GameFeatureDao oneSecond =
+        new GameFeatureDao(Jdbi.create(dataSource), false, Clock.systemUTC(), 1);
+    insertOneGame("https://chess.com/game/pg-slow");
+
+    // pg_sleep is volatile, so it runs per candidate row; void casts to the empty string.
+    CompiledQuery slow =
+        new CompiledQuery(
+            "SELECT g.* FROM game_features g WHERE pg_sleep(5)::text = ''"
+                + " ORDER BY g.played_at DESC, g.game_url ASC",
+            List.of());
+
+    long start = System.nanoTime();
+    assertThatThrownBy(() -> oneSecond.query(slow, 10, 0))
+        .as("a query outrunning the timeout must be cancelled, not awaited")
+        .isInstanceOf(Exception.class);
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+    assertThat(elapsedMillis)
+        .as("cancellation must arrive near the 1s timeout, not after the 5s sleep")
+        .isLessThan(4_000);
+
+    CompiledQuery fast =
+        new CompiledQuery(
+            "SELECT g.* FROM game_features g WHERE pg_sleep(0)::text = ''"
+                + " ORDER BY g.played_at DESC, g.game_url ASC",
+            List.of());
+    assertThat(bounded.query(fast, 10, 0)).hasSize(1);
+  }
+
+  /**
+   * The claim behind gating the session cleanup on H2 only: pgjdbc scopes setQueryTimeout to the
+   * statement, so a read's timeout must not be visible to a later statement on the same pooled
+   * connection even though the DAO does nothing to clear it there.
+   */
+  @Test
+  public void readTimeoutDoesNotLeakAcrossStatementsOnPostgres() throws Exception {
+    GameFeatureDao dao = new GameFeatureDao(Jdbi.create(dataSource), false);
+    insertOneGame("https://chess.com/game/pg-leak-probe");
+
+    dao.query(
+        new CompiledQuery(
+            "SELECT g.* FROM game_features g ORDER BY g.played_at DESC, g.game_url ASC", List.of()),
+        10,
+        0);
+
+    // The pool is small and access is sequential, so this draws the connection the read used.
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      assertThat(stmt.getQueryTimeout())
+          .as("a fresh statement must not inherit the read timeout")
+          .isEqualTo(0);
+    }
+  }
+
+  private void insertOneGame(String gameUrl) {
+    GameFeatureDao dao = new GameFeatureDao(Jdbi.create(dataSource), false);
+    dao.insertBatch(
+        List.of(
+            new com.muchq.games.one_d4.api.dto.GameFeature(
+                UUID.randomUUID(),
+                requestId,
+                gameUrl,
+                "CHESS_COM",
+                "white",
+                "black",
+                2000,
+                1900,
+                null,
+                "GM",
+                "blitz",
+                "B90",
+                "Sicilian Defense Najdorf Variation",
+                "Sicilian Defense",
+                "1-0",
+                Instant.now(),
+                30,
+                Instant.now(),
+                "pgn")));
+  }
+
+  /**
+   * Converts the libpq-style URL CI exports ({@code postgresql://user:pass@host:port/db}) into a
+   * pgjdbc URL, same as the other PG-gated suites. pgjdbc does not accept credentials in the
+   * authority, so they move to query params.
+   */
+  private static String jdbcUrl(String rawUrl, String schema) {
+    URI uri = URI.create(rawUrl);
+    java.util.List<String> params = new java.util.ArrayList<>();
+    String userInfo = uri.getUserInfo();
+    if (userInfo != null) {
+      int colon = userInfo.indexOf(':');
+      String user = colon < 0 ? userInfo : userInfo.substring(0, colon);
+      params.add("user=" + encode(user));
+      if (colon >= 0) {
+        params.add("password=" + encode(userInfo.substring(colon + 1)));
+      }
+    }
+    if (schema != null) {
+      params.add("currentSchema=" + encode(schema));
+    }
+    int port = uri.getPort() < 0 ? 5432 : uri.getPort();
+    return "jdbc:postgresql://"
+        + uri.getHost()
+        + ":"
+        + port
+        + uri.getPath()
+        + "?"
+        + String.join("&", params);
+  }
+
+  private static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
@@ -1,6 +1,7 @@
 package com.muchq.games.one_d4.db;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.SQLException;
 import java.time.Duration;
@@ -9,14 +10,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jdbi.v3.core.statement.SqlLogger;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * The bounds on the other unattended loops — the dispatch poller's candidate scan and the hourly
- * retention sweep's deletes — observed on the real JDBC statements via Jdbi's logger, the same way
- * GameFeatureDaoTest pins the serving reads. Asserted against literals rather than the constants,
- * so mutating a constant cannot mutate the expectation with it.
+ * The timeout mechanism itself, plus the wiring of the unattended loops and status reads onto it —
+ * observed on the real JDBC statements via Jdbi's logger. Wiring assertions reference the constants
+ * (0 from a path that lost its bound never equals them); the constants' values are pinned exactly
+ * once, in {@link #theBoundsAreThePolicyValues}, so changing a bound costs one edit plus whatever
+ * pinned arithmetic genuinely breaks.
  */
 public class StatementTimeoutsTest {
 
@@ -47,8 +50,27 @@ public class StatementTimeoutsTest {
             });
   }
 
+  /**
+   * The one home of each bound's value, with its rationale — every wiring assertion elsewhere
+   * references the constant. Mutating a constant fails exactly here; losing a bound at a call site
+   * fails the wiring probe for that site.
+   */
   @Test
-  public void claimNextsCandidateScanIsBoundedAndItsClaimUpdatesAreNot() {
+  public void theBoundsAreThePolicyValues() {
+    assertThat(StatementTimeouts.SERVING_READ_SECONDS)
+        .as(
+            "far above any LIMIT-bounded read or 8-row poll; FirstPageWarmerTest pins its"
+                + " relationship to the warmer tick budget")
+        .isEqualTo(10);
+    assertThat(StatementTimeouts.RETENTION_SWEEP_SECONDS)
+        .as(
+            "sized for a sweep, not a page; DataSourceFactoryTest pins that the Postgres socket"
+                + " timeout exceeds it")
+        .isEqualTo(120);
+  }
+
+  @Test
+  public void claimNextsCandidateScanIsBounded() {
     IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi());
     dao.createOrAdopt(
         "poller",
@@ -63,17 +85,27 @@ public class StatementTimeoutsTest {
     timeouts.clear();
     var claimed = dao.claimNext("owner-1", Duration.ofMinutes(5), Instant.now());
 
-    // The claim must succeed, or the "statements after the scan" half below is vacuously true.
+    // The claim must succeed so the probe list demonstrably covers a full poll, not a no-op.
     assertThat(claimed).as("the seeded request must be claimable").isPresent();
-    assertThat(timeouts.size())
-        .as("a successful claim runs the scan plus at least the claim UPDATE")
-        .isGreaterThan(1);
+    assertThat(timeouts).as("claimNext ran no statements?").isNotEmpty();
     assertThat(timeouts.get(0))
         .as("the candidate scan — the poller's wedge point — must carry the serving-read bound")
-        .isEqualTo(10);
-    assertThat(timeouts.subList(1, timeouts.size()))
-        .as("the claim UPDATE and status reads that follow stay unbounded")
-        .allMatch(t -> t == 0);
+        .isEqualTo(StatementTimeouts.SERVING_READ_SECONDS);
+  }
+
+  @Test
+  public void statusPathServingReadsAreBounded() {
+    timeouts.clear();
+    new IndexingRequestDao(testDb.jdbi()).listRecent(50);
+    assertThat(timeouts)
+        .as("listRecent — GET /v1/index's list read")
+        .containsExactly(StatementTimeouts.SERVING_READ_SECONDS);
+
+    timeouts.clear();
+    new IndexedPeriodDao(testDb.jdbi(), true).findPeriodsForPlayers(List.of("hikaru"));
+    assertThat(timeouts)
+        .as("findPeriodsForPlayers — GET /v1/index's data-availability read")
+        .containsExactly(StatementTimeouts.SERVING_READ_SECONDS);
   }
 
   @Test
@@ -85,31 +117,121 @@ public class StatementTimeoutsTest {
     assertThat(timeouts).as("reclaim ran no statements?").isNotEmpty();
     assertThat(timeouts)
         .as("every settle statement in the reclaim transaction carries the sweep bound")
-        .allMatch(t -> t == 120);
-    // The "inside its transaction" half: reclaim must use the transactional variant, or the three
-    // settle statements stop being a unit. The non-transactional variant compiles in its place,
-    // which is exactly why this is a probe rather than prose.
+        .allMatch(t -> t == StatementTimeouts.RETENTION_SWEEP_SECONDS);
+    // The "inside its transaction" half: reclaim's three settles have order-dependent predicates
+    // (releasing stamps updated_at, which hides the staleness the retire arm looks for), so they
+    // must stay one unit. The non-transactional variant compiles in its place, which is exactly
+    // why this is a probe rather than prose.
     assertThat(autoCommits)
         .as("reclaim's statements run inside one transaction")
         .allMatch(ac -> !ac);
   }
 
   @Test
-  public void theSweepDeletesAreSingleStatementsOutsideAnyTransaction() {
+  public void allThreeRetentionDeletesCarryTheSweepBound() {
+    Instant threshold = Instant.parse("2026-01-01T00:00:00Z");
+
     timeouts.clear();
-    autoCommits.clear();
+    new GameFeatureDao(testDb.jdbi(), true).deleteOlderThan(threshold);
+    assertThat(timeouts)
+        .as("game_features delete")
+        .contains(StatementTimeouts.RETENTION_SWEEP_SECONDS);
+
+    timeouts.clear();
+    new IndexingRequestDao(testDb.jdbi()).deleteOlderThan(threshold);
+    assertThat(timeouts)
+        .as("indexing_requests delete")
+        .contains(StatementTimeouts.RETENTION_SWEEP_SECONDS);
+
+    timeouts.clear();
+    new IndexedPeriodDao(testDb.jdbi(), true).deleteOlderThan(threshold);
+    assertThat(timeouts)
+        .as("indexed_periods delete")
+        .contains(StatementTimeouts.RETENTION_SWEEP_SECONDS);
+  }
+
+  @Test
+  public void aBoundedSweepLeavesNoTimeoutOnTheSession() throws Exception {
     new GameFeatureDao(testDb.jdbi(), true).deleteOlderThan(Instant.parse("2026-01-01T00:00:00Z"));
 
-    // Each delete is one self-committing statement — unlike reclaim there is no multi-statement
-    // unit to keep atomic, and holding a transaction open across the cascade would only lengthen
-    // lock hold times. Pinned so the two shapes stay deliberate rather than accidental.
-    assertThat(autoCommits).as("the delete ran no statements?").isNotEmpty();
-    assertThat(autoCommits).allMatch(ac -> ac);
+    try (var conn = testDb.dataSource().getConnection();
+        var probe = conn.createStatement()) {
+      assertThat(probe.getQueryTimeout())
+          .as("the sweep bound must not leak to later statements on the pooled connection")
+          .isEqualTo(0);
+    }
   }
 
   // ---------------------------------------------------------------------------------------------
   // The mechanism itself, tested directly rather than through a DAO.
   // ---------------------------------------------------------------------------------------------
+
+  /** H2 alias target for the slow-query tests: sleeps per evaluated row. Must be public static. */
+  public static int nap(int millis) throws InterruptedException {
+    Thread.sleep(millis);
+    return 0;
+  }
+
+  /**
+   * The bound must cancel a statement that is actually running, not merely be set. 400 rows
+   * sleeping 20ms each is a ~8s query; a 1s bound has to kill it partway. H2 enforces the timeout
+   * cooperatively and only checks every so many processed rows, which is why the fixture needs
+   * hundreds of rows — with too few the check never runs and the query completes as if unbounded.
+   * The positive twin shares the fixture (same alias, same query shape), so a broken alias cannot
+   * masquerade as the bound firing. Postgres-side cancellation is covered by
+   * PostgresReadTimeoutTest.
+   */
+  @Test
+  public void slowExecutionIsCancelledAtTheBound() throws Exception {
+    try (var conn = testDb.dataSource().getConnection();
+        var stmt = conn.createStatement()) {
+      stmt.execute(
+          "CREATE ALIAS IF NOT EXISTS NAP FOR"
+              + " \"com.muchq.games.one_d4.db.StatementTimeoutsTest.nap\"");
+      for (int i = 0; i < 400; i++) {
+        stmt.execute(
+            "INSERT INTO indexed_periods (player, platform, year_month, fetched_at, is_complete,"
+                + " games_count) VALUES ('slow-"
+                + i
+                + "', 'CHESS_COM', '2026-01', now(), true, 0)");
+      }
+    }
+
+    String slowSql = "SELECT player FROM indexed_periods WHERE NAP(20) = 0";
+    long start = System.nanoTime();
+    assertThatThrownBy(
+            () ->
+                StatementTimeouts.withStatementTimeout(
+                    testDb.jdbi(), 1, h -> h.createQuery(slowSql).mapTo(String.class).list()))
+        .as("a statement outrunning the bound must be cancelled, not awaited")
+        .isInstanceOf(UnableToExecuteStatementException.class);
+    long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+    assertThat(elapsedMillis)
+        .as("cancellation must arrive well before the ~8s the full query needs")
+        .isLessThan(5_000);
+
+    // The error path must clear the H2 session too: this is the leak that matters in production
+    // — a timed-out statement returning its pooled connection with the bound still set. Without
+    // the reset running in a finally (rather than at the end of the try), this probe reads 1.
+    try (var conn = testDb.dataSource().getConnection();
+        var probe = conn.createStatement()) {
+      assertThat(probe.getQueryTimeout())
+          .as("a cancelled statement must not leave its bound on the pooled connection")
+          .isEqualTo(0);
+    }
+
+    // Positive twin: the same query shape under a negligible per-row sleep completes normally,
+    // proving the alias and the query work and the failure above is the bound.
+    List<String> rows =
+        StatementTimeouts.withStatementTimeout(
+            testDb.jdbi(),
+            1,
+            h ->
+                h.createQuery("SELECT player FROM indexed_periods WHERE NAP(0) = 0")
+                    .mapTo(String.class)
+                    .list());
+    assertThat(rows).hasSize(400);
+  }
 
   @Test
   public void withStatementTimeout_appliesTheGivenBoundAndReturnsTheBodysValue() {
@@ -126,7 +248,7 @@ public class StatementTimeoutsTest {
   @Test
   public void withStatementTimeout_propagatesTheBodysExceptionAndStillClearsTheSession()
       throws Exception {
-    org.assertj.core.api.Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 StatementTimeouts.withStatementTimeout(
                     testDb.jdbi(),
@@ -194,7 +316,7 @@ public class StatementTimeoutsTest {
 
     // Error path: the body's exception survives a failed cleanup — not the cleanup's.
     failCreateStatement.set(false);
-    org.assertj.core.api.Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 StatementTimeouts.withStatementTimeout(
                     faultyJdbi,
@@ -210,7 +332,7 @@ public class StatementTimeoutsTest {
   @Test
   public void inTransactionWithTimeout_isBoundedAndActuallyTransactional() {
     timeouts.clear();
-    org.assertj.core.api.Assertions.assertThatThrownBy(
+    assertThatThrownBy(
             () ->
                 StatementTimeouts.inTransactionWithTimeout(
                     testDb.jdbi(),
@@ -234,7 +356,7 @@ public class StatementTimeoutsTest {
             .withHandle(
                 h ->
                     h.createQuery(
-                            "SELECT COUNT(*) FROM indexing_requests WHERE player =" + " 'rollback'")
+                            "SELECT COUNT(*) FROM indexing_requests WHERE player = 'rollback'")
                         .mapTo(Integer.class)
                         .one());
     assertThat(survivors)
@@ -251,34 +373,5 @@ public class StatementTimeoutsTest {
     // The exclusion GameFeatureDao's javadoc states, pinned: the admin batch read pages the whole
     // table to feed a write path and must not silently gain the serving bound.
     assertThat(timeouts).allMatch(t -> t == 0);
-  }
-
-  @Test
-  public void allThreeRetentionDeletesCarryTheSweepBound() {
-    Instant threshold = Instant.parse("2026-01-01T00:00:00Z");
-
-    timeouts.clear();
-    new GameFeatureDao(testDb.jdbi(), true).deleteOlderThan(threshold);
-    assertThat(timeouts).as("game_features delete").contains(120);
-
-    timeouts.clear();
-    new IndexingRequestDao(testDb.jdbi()).deleteOlderThan(threshold);
-    assertThat(timeouts).as("indexing_requests delete").contains(120);
-
-    timeouts.clear();
-    new IndexedPeriodDao(testDb.jdbi(), true).deleteOlderThan(threshold);
-    assertThat(timeouts).as("indexed_periods delete").contains(120);
-  }
-
-  @Test
-  public void aBoundedSweepLeavesNoTimeoutOnTheSession() throws Exception {
-    new GameFeatureDao(testDb.jdbi(), true).deleteOlderThan(Instant.parse("2026-01-01T00:00:00Z"));
-
-    try (var conn = testDb.dataSource().getConnection();
-        var probe = conn.createStatement()) {
-      assertThat(probe.getQueryTimeout())
-          .as("the sweep bound must not leak to later statements on the pooled connection")
-          .isEqualTo(0);
-    }
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
@@ -59,15 +59,41 @@ public class StatementTimeoutsTest {
         Instant.now());
 
     timeouts.clear();
-    dao.claimNext("owner-1", Duration.ofMinutes(5), Instant.now());
+    var claimed = dao.claimNext("owner-1", Duration.ofMinutes(5), Instant.now());
 
-    assertThat(timeouts).as("claimNext ran no statements?").isNotEmpty();
+    // The claim must succeed, or the "statements after the scan" half below is vacuously true.
+    assertThat(claimed).as("the seeded request must be claimable").isPresent();
+    assertThat(timeouts.size())
+        .as("a successful claim runs the scan plus at least the claim UPDATE")
+        .isGreaterThan(1);
     assertThat(timeouts.get(0))
         .as("the candidate scan — the poller's wedge point — must carry the serving-read bound")
         .isEqualTo(10);
     assertThat(timeouts.subList(1, timeouts.size()))
         .as("the claim UPDATE and status reads that follow stay unbounded")
         .allMatch(t -> t == 0);
+  }
+
+  @Test
+  public void reclaimStaleCarriesTheSweepBoundInsideItsTransaction() {
+    timeouts.clear();
+    new IndexingRequestDao(testDb.jdbi()).reclaimStale(Duration.ofHours(1), Instant.now());
+
+    assertThat(timeouts).as("reclaim ran no statements?").isNotEmpty();
+    assertThat(timeouts)
+        .as("every settle statement in the reclaim transaction carries the sweep bound")
+        .allMatch(t -> t == 120);
+  }
+
+  @Test
+  public void fetchForReanalysisStaysDeliberatelyUnbounded() {
+    timeouts.clear();
+    new GameFeatureDao(testDb.jdbi(), true).fetchForReanalysis(10, 0);
+
+    assertThat(timeouts).as("fetchForReanalysis ran no statements?").isNotEmpty();
+    // The exclusion GameFeatureDao's javadoc states, pinned: the admin batch read pages the whole
+    // table to feed a write path and must not silently gain the serving bound.
+    assertThat(timeouts).allMatch(t -> t == 0);
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
@@ -91,6 +91,13 @@ public class StatementTimeoutsTest {
     assertThat(timeouts.get(0))
         .as("the candidate scan — the poller's wedge point — must carry the serving-read bound")
         .isEqualTo(StatementTimeouts.SERVING_READ_SECONDS);
+    // The exclusion is as deliberate as the bound: the claim UPDATEs that follow the scan stay
+    // unbounded, so wrapping all of claimNext in the serving bound must fail here. Non-empty
+    // because a successful claim necessarily ran at least the claiming UPDATE.
+    assertThat(timeouts.subList(1, timeouts.size()))
+        .as("the claim UPDATEs after the scan stay deliberately unbounded")
+        .isNotEmpty()
+        .allMatch(t -> t == 0);
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
@@ -1,0 +1,101 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.jdbi.v3.core.statement.SqlLogger;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The bounds on the other unattended loops — the dispatch poller's candidate scan and the hourly
+ * retention sweep's deletes — observed on the real JDBC statements via Jdbi's logger, the same way
+ * GameFeatureDaoTest pins the serving reads. Asserted against literals rather than the constants,
+ * so mutating a constant cannot mutate the expectation with it.
+ */
+public class StatementTimeoutsTest {
+
+  private TestDb testDb;
+  private final List<Integer> timeouts = new ArrayList<>();
+
+  @BeforeEach
+  public void setUp() {
+    testDb = TestDb.create("statementtimeouts");
+    testDb
+        .jdbi()
+        .setSqlLogger(
+            new SqlLogger() {
+              @Override
+              public void logBeforeExecution(StatementContext ctx) {
+                try {
+                  // Batch statements log with a null statement; only plain statements are probed.
+                  var statement = ctx.getStatement();
+                  if (statement != null) {
+                    timeouts.add(statement.getQueryTimeout());
+                  }
+                } catch (SQLException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            });
+  }
+
+  @Test
+  public void claimNextsCandidateScanIsBoundedAndItsClaimUpdatesAreNot() {
+    IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi());
+    dao.createOrAdopt(
+        "poller",
+        "CHESS_COM",
+        "2026-01",
+        "2026-01",
+        false,
+        false,
+        Duration.ofMinutes(5),
+        Instant.now());
+
+    timeouts.clear();
+    dao.claimNext("owner-1", Duration.ofMinutes(5), Instant.now());
+
+    assertThat(timeouts).as("claimNext ran no statements?").isNotEmpty();
+    assertThat(timeouts.get(0))
+        .as("the candidate scan — the poller's wedge point — must carry the serving-read bound")
+        .isEqualTo(10);
+    assertThat(timeouts.subList(1, timeouts.size()))
+        .as("the claim UPDATE and status reads that follow stay unbounded")
+        .allMatch(t -> t == 0);
+  }
+
+  @Test
+  public void allThreeRetentionDeletesCarryTheSweepBound() {
+    Instant threshold = Instant.parse("2026-01-01T00:00:00Z");
+
+    timeouts.clear();
+    new GameFeatureDao(testDb.jdbi(), true).deleteOlderThan(threshold);
+    assertThat(timeouts).as("game_features delete").contains(120);
+
+    timeouts.clear();
+    new IndexingRequestDao(testDb.jdbi()).deleteOlderThan(threshold);
+    assertThat(timeouts).as("indexing_requests delete").contains(120);
+
+    timeouts.clear();
+    new IndexedPeriodDao(testDb.jdbi(), true).deleteOlderThan(threshold);
+    assertThat(timeouts).as("indexed_periods delete").contains(120);
+  }
+
+  @Test
+  public void aBoundedSweepLeavesNoTimeoutOnTheSession() throws Exception {
+    new GameFeatureDao(testDb.jdbi(), true).deleteOlderThan(Instant.parse("2026-01-01T00:00:00Z"));
+
+    try (var conn = testDb.dataSource().getConnection();
+        var probe = conn.createStatement()) {
+      assertThat(probe.getQueryTimeout())
+          .as("the sweep bound must not leak to later statements on the pooled connection")
+          .isEqualTo(0);
+    }
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/StatementTimeoutsTest.java
@@ -22,6 +22,7 @@ public class StatementTimeoutsTest {
 
   private TestDb testDb;
   private final List<Integer> timeouts = new ArrayList<>();
+  private final List<Boolean> autoCommits = new ArrayList<>();
 
   @BeforeEach
   public void setUp() {
@@ -37,6 +38,7 @@ public class StatementTimeoutsTest {
                   var statement = ctx.getStatement();
                   if (statement != null) {
                     timeouts.add(statement.getQueryTimeout());
+                    autoCommits.add(statement.getConnection().getAutoCommit());
                   }
                 } catch (SQLException e) {
                   throw new RuntimeException(e);
@@ -77,12 +79,167 @@ public class StatementTimeoutsTest {
   @Test
   public void reclaimStaleCarriesTheSweepBoundInsideItsTransaction() {
     timeouts.clear();
+    autoCommits.clear();
     new IndexingRequestDao(testDb.jdbi()).reclaimStale(Duration.ofHours(1), Instant.now());
 
     assertThat(timeouts).as("reclaim ran no statements?").isNotEmpty();
     assertThat(timeouts)
         .as("every settle statement in the reclaim transaction carries the sweep bound")
         .allMatch(t -> t == 120);
+    // The "inside its transaction" half: reclaim must use the transactional variant, or the three
+    // settle statements stop being a unit. The non-transactional variant compiles in its place,
+    // which is exactly why this is a probe rather than prose.
+    assertThat(autoCommits)
+        .as("reclaim's statements run inside one transaction")
+        .allMatch(ac -> !ac);
+  }
+
+  @Test
+  public void theSweepDeletesAreSingleStatementsOutsideAnyTransaction() {
+    timeouts.clear();
+    autoCommits.clear();
+    new GameFeatureDao(testDb.jdbi(), true).deleteOlderThan(Instant.parse("2026-01-01T00:00:00Z"));
+
+    // Each delete is one self-committing statement — unlike reclaim there is no multi-statement
+    // unit to keep atomic, and holding a transaction open across the cascade would only lengthen
+    // lock hold times. Pinned so the two shapes stay deliberate rather than accidental.
+    assertThat(autoCommits).as("the delete ran no statements?").isNotEmpty();
+    assertThat(autoCommits).allMatch(ac -> ac);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // The mechanism itself, tested directly rather than through a DAO.
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void withStatementTimeout_appliesTheGivenBoundAndReturnsTheBodysValue() {
+    timeouts.clear();
+    int result =
+        StatementTimeouts.withStatementTimeout(
+            testDb.jdbi(), 7, h -> h.createQuery("SELECT 42").mapTo(Integer.class).one());
+
+    assertThat(result).isEqualTo(42);
+    // 7, not one of the production constants: the entry point must carry whatever it is given.
+    assertThat(timeouts).containsExactly(7);
+  }
+
+  @Test
+  public void withStatementTimeout_propagatesTheBodysExceptionAndStillClearsTheSession()
+      throws Exception {
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () ->
+                StatementTimeouts.withStatementTimeout(
+                    testDb.jdbi(),
+                    7,
+                    h -> {
+                      throw new IllegalStateException("body failure");
+                    }))
+        .as("the body's own exception must come through untouched")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("body failure");
+
+    try (var conn = testDb.dataSource().getConnection();
+        var probe = conn.createStatement()) {
+      assertThat(probe.getQueryTimeout())
+          .as("a failing body must still not leak its bound onto the pooled connection")
+          .isEqualTo(0);
+    }
+  }
+
+  /**
+   * The log-and-swallow contract of the session cleanup, under an injected cleanup failure: a
+   * proxied connection whose plain {@code createStatement()} — the cleanup's only entry — starts
+   * failing after the body has run. The body's statements go through {@code prepareStatement}, so
+   * only the cleanup is hit. This is the panel finding (a finally-throw replacing the real outcome)
+   * pinned by a test rather than fixed on trust.
+   */
+  @Test
+  public void aFailingCleanupNeverReplacesTheBodysOutcome() {
+    java.util.concurrent.atomic.AtomicBoolean failCreateStatement =
+        new java.util.concurrent.atomic.AtomicBoolean(false);
+    org.jdbi.v3.core.Jdbi faultyJdbi =
+        org.jdbi.v3.core.Jdbi.create(
+            () -> {
+              java.sql.Connection real = testDb.dataSource().getConnection();
+              return (java.sql.Connection)
+                  java.lang.reflect.Proxy.newProxyInstance(
+                      getClass().getClassLoader(),
+                      new Class<?>[] {java.sql.Connection.class},
+                      (proxy, method, args) -> {
+                        if (method.getName().equals("createStatement")
+                            && (args == null || args.length == 0)
+                            && failCreateStatement.get()) {
+                          throw new SQLException("injected cleanup failure");
+                        }
+                        try {
+                          return method.invoke(real, args);
+                        } catch (java.lang.reflect.InvocationTargetException e) {
+                          throw e.getCause();
+                        }
+                      });
+            });
+
+    // Success path: the body's result survives a failed cleanup.
+    failCreateStatement.set(false);
+    int result =
+        StatementTimeouts.withStatementTimeout(
+            faultyJdbi,
+            7,
+            h -> {
+              int r = h.createQuery("SELECT 42").mapTo(Integer.class).one();
+              failCreateStatement.set(true);
+              return r;
+            });
+    assertThat(result).as("a successful body must not be failed by its cleanup").isEqualTo(42);
+
+    // Error path: the body's exception survives a failed cleanup — not the cleanup's.
+    failCreateStatement.set(false);
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () ->
+                StatementTimeouts.withStatementTimeout(
+                    faultyJdbi,
+                    7,
+                    h -> {
+                      failCreateStatement.set(true);
+                      throw new IllegalStateException("the real failure");
+                    }))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("the real failure");
+  }
+
+  @Test
+  public void inTransactionWithTimeout_isBoundedAndActuallyTransactional() {
+    timeouts.clear();
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () ->
+                StatementTimeouts.inTransactionWithTimeout(
+                    testDb.jdbi(),
+                    7,
+                    h -> {
+                      assertThat(h.isInTransaction()).isTrue();
+                      h.createUpdate(
+                              "INSERT INTO indexing_requests (id, player, platform, start_month,"
+                                  + " end_month) VALUES (:id, 'rollback', 'CHESS_COM', '2026-01',"
+                                  + " '2026-01')")
+                          .bind("id", java.util.UUID.randomUUID())
+                          .execute();
+                      throw new IllegalStateException("roll me back");
+                    }))
+        .hasMessage("roll me back");
+
+    assertThat(timeouts).contains(7);
+    Integer survivors =
+        testDb
+            .jdbi()
+            .withHandle(
+                h ->
+                    h.createQuery(
+                            "SELECT COUNT(*) FROM indexing_requests WHERE player =" + " 'rollback'")
+                        .mapTo(Integer.class)
+                        .one());
+    assertThat(survivors)
+        .as("a failing body must roll its writes back — the transactional half of the contract")
+        .isEqualTo(0);
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/TestDb.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/TestDb.java
@@ -15,8 +15,9 @@ public final class TestDb {
   }
 
   public static TestDb create(String name) {
-    String jdbcUrl =
-        "jdbc:h2:mem:" + name + "_" + System.currentTimeMillis() + ";DB_CLOSE_DELAY=-1";
+    // nanoTime, not currentTimeMillis: two tests starting in the same millisecond would silently
+    // share a database.
+    String jdbcUrl = "jdbc:h2:mem:" + name + "_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
     DataSource dataSource = DataSourceFactory.create(jdbcUrl);
     new Migration(dataSource, true).run();
     return new TestDb(dataSource, Jdbi.create(dataSource));

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycleTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerLifecycleTest.java
@@ -231,6 +231,150 @@ public class IndexWorkerLifecycleTest {
         NOW);
   }
 
+  /**
+   * The statement timeouts turned a wedged poll from a hang into a throw, which only helps if the
+   * loop survives the throw — pollLoop's catch-and-backoff is the designed recovery path, and
+   * nothing else pins it. The first claimNext fails the way a timed-out candidate scan now does;
+   * the loop must back off and claim the work on a later poll rather than dying with the exception.
+   */
+  @Test
+  @Timeout(30)
+  public void pollLoopSurvivesAClaimFailureAndClaimsOnALaterPoll() throws Exception {
+    UUID id = submit("resilient", false).request().id();
+
+    FeatureExtractor extractor =
+        new FeatureExtractor(new PgnParser(), new GameReplayer(), List.of(new CheckDetector()));
+    IndexWorker worker =
+        new IndexWorker(
+            new RecordingClient(),
+            extractor,
+            dao,
+            new NoOpGameFeatureStore(),
+            new NoOpPeriodStore(),
+            extraction,
+            CLOCK,
+            Duration.ofHours(1));
+    ThrowingFirstClaimStore store = new ThrowingFirstClaimStore(dao);
+    IndexWorkerLifecycle lifecycle =
+        new IndexWorkerLifecycle(new InMemoryIndexQueue(), worker, store, CLOCK);
+    lifecycle.onApplicationEvent(null);
+    try {
+      // The recovery poll arrives after ERROR_BACKOFF (5s); poll well past it.
+      long deadline = System.nanoTime() + Duration.ofSeconds(25).toNanos();
+      while (System.nanoTime() < deadline
+          && !"COMPLETED".equals(dao.findById(id).orElseThrow().status())) {
+        Thread.sleep(100);
+      }
+    } finally {
+      lifecycle.stop();
+    }
+
+    assertThat(store.claimNextCalls.get())
+        .as("the loop polled again after the failure — the control that the throw happened")
+        .isGreaterThan(1);
+    assertThat(dao.findById(id).orElseThrow().status()).isEqualTo("COMPLETED");
+  }
+
+  /** Delegates everything to the real DAO except the first claimNext, which fails. */
+  private static final class ThrowingFirstClaimStore implements IndexingRequestStore {
+    private final IndexingRequestStore delegate;
+    final java.util.concurrent.atomic.AtomicInteger claimNextCalls =
+        new java.util.concurrent.atomic.AtomicInteger();
+
+    ThrowingFirstClaimStore(IndexingRequestStore delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Optional<IndexingRequest> claimNext(String ownerId, Duration lease, Instant now) {
+      if (claimNextCalls.incrementAndGet() == 1) {
+        throw new IllegalStateException("candidate scan cancelled at the statement timeout");
+      }
+      return delegate.claimNext(ownerId, lease, now);
+    }
+
+    @Override
+    public Claim createOrAdopt(
+        String player,
+        String platform,
+        String startMonth,
+        String endMonth,
+        boolean excludeBullet,
+        boolean skipCache,
+        Duration lease,
+        Instant now) {
+      return delegate.createOrAdopt(
+          player, platform, startMonth, endMonth, excludeBullet, skipCache, lease, now);
+    }
+
+    @Override
+    public Optional<IndexingRequest> findById(UUID id) {
+      return delegate.findById(id);
+    }
+
+    @Override
+    public Optional<IndexingRequest> findExistingRequest(
+        String player, String platform, String startMonth, String endMonth, boolean excludeBullet) {
+      return delegate.findExistingRequest(player, platform, startMonth, endMonth, excludeBullet);
+    }
+
+    @Override
+    public List<IndexingRequest> listRecent(int limit) {
+      return delegate.listRecent(limit);
+    }
+
+    @Override
+    public void updateStatus(UUID id, String status, String errorMessage, int gamesIndexed) {
+      delegate.updateStatus(id, status, errorMessage, gamesIndexed);
+    }
+
+    @Override
+    public int reclaimStale(Duration staleAfter, Instant now) {
+      return delegate.reclaimStale(staleAfter, now);
+    }
+
+    @Override
+    public boolean claim(UUID id, String ownerId, Duration lease, Instant now) {
+      return delegate.claim(id, ownerId, lease, now);
+    }
+
+    @Override
+    public boolean renewLease(UUID id, String ownerId, Duration lease, Instant now) {
+      return delegate.renewLease(id, ownerId, lease, now);
+    }
+
+    @Override
+    public boolean handBack(UUID id, String ownerId, Instant now) {
+      return delegate.handBack(id, ownerId, now);
+    }
+
+    @Override
+    public boolean releaseOwned(UUID id, String ownerId, Instant now) {
+      return delegate.releaseOwned(id, ownerId, now);
+    }
+
+    @Override
+    public boolean holdsLease(UUID id, String ownerId, Instant now) {
+      return delegate.holdsLease(id, ownerId, now);
+    }
+
+    @Override
+    public boolean updateStatusOwned(
+        UUID id,
+        String ownerId,
+        String status,
+        String errorMessage,
+        int gamesIndexed,
+        Instant now) {
+      return delegate.updateStatusOwned(id, ownerId, status, errorMessage, gamesIndexed, now);
+    }
+
+    @Override
+    public int deleteOlderThan(Instant threshold) {
+      return delegate.deleteOlderThan(threshold);
+    }
+  }
+
   private IndexWorkerLifecycle lifecycleFor(ChessClient client, IndexQueue queue) {
     return lifecycleFor(client, queue, new NoOpPeriodStore());
   }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RetentionWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RetentionWorkerTest.java
@@ -49,6 +49,36 @@ public class RetentionWorkerTest {
     }
   }
 
+  /**
+   * The statement timeouts turned a wedged sweep from a hang into a throw, which only helps if the
+   * schedule survives the throw: an exception escaping a {@code @Scheduled(fixedDelay)} task
+   * cancels all future ticks permanently, so runRetention's catch-everything is the designed
+   * recovery path — pinned here against stores that fail the way a timed-out statement now does
+   * (every call throws; the datasource underneath is closed).
+   */
+  @Test
+  public void runRetention_survivesStoreFailuresWithoutPropagating() throws Exception {
+    TestDb broken = TestDb.create("retention_broken");
+    RetentionWorker brokenWorker =
+        new RetentionWorker(
+            new GameFeatureDao(broken.jdbi(), true),
+            new IndexedPeriodDao(broken.jdbi(), true),
+            new IndexingRequestDao(broken.jdbi()));
+    ((java.io.Closeable) broken.dataSource()).close();
+
+    org.assertj.core.api.Assertions.assertThatCode(brokenWorker::runRetention)
+        .as("a failing sweep must not escape and cancel the schedule")
+        .doesNotThrowAnyException();
+
+    // The control: the same worker method against healthy stores still does its work, so the
+    // no-throw above is swallow-and-recover, not a sweep that never ran.
+    GameFeature old = createGame("https://chess.com/control-old");
+    dao.insertBatch(List.of(old));
+    updateIndexedAt("https://chess.com/control-old", Instant.now().minus(8, ChronoUnit.DAYS));
+    worker.runRetention();
+    assertThat(countGames()).isEqualTo(0);
+  }
+
   @Test
   public void runRetention_deletesOldGames() {
     // Insert a fresh game and an old game

--- a/domains/games/apps/1d4_web/src/__tests__/GamesView.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/GamesView.test.tsx
@@ -92,16 +92,6 @@ describe('GamesView', () => {
     );
   });
 
-  it('fetches with correct limit and offset on initial load', async () => {
-    render(<GamesView />, { wrapper: makeWrapper() });
-    await waitFor(() => screen.getByText('_prior'));
-
-    // Initial load: page 0, pageSize 25 → offset 0, limit 25
-    expect(api.query).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 25, offset: 0 })
-    );
-  });
-
   it('sends the exact request the backend first-page cache is keyed on', async () => {
     render(<GamesView />, { wrapper: makeWrapper() });
     await waitFor(() => screen.getByText('_prior'));


### PR DESCRIPTION
## What

Items 6–9 of #1313. Nothing bounded query *execution* — HikariCP's `connectionTimeout` bounds pool checkout only — so a statement wedged on a lock wait ran forever, and every unattended loop that can't re-enter while a run is in flight stayed wedged until a restart: the first-page warmer's `@Scheduled` slot, the dispatch poller's single claiming thread, and the hourly retention sweep.

- **`StatementTimeouts`** — the one entry point (`withStatementTimeout`, plus `inTransactionWithTimeout` sharing the same bounded core) that applies a bound via the handle's statement config and clears the session on the way out. Bounds are structural, not a call each statement must remember; a mutation routing a read around the entry point is killed.
- **Serving reads: 10s** (`query`, `aggregate`, `aggregateTotals`, `queryOccurrences` via `withReadHandle`, and the `GET /v1/index` status reads `listRecent` + `findPeriodsForPlayers`). The binding constraint is `FirstPageCache.MAX_AGE` (60s) — a warmer tick runs **two** bounded reads, and `fixedDelay + 2×timeout < MAX_AGE` is pinned by a test.
- **Dispatch poller: 10s** on `claimNext`'s candidate scan — it runs every few seconds on a single dedicated thread whose loop never returns while a statement is in flight; unbounded, one wedged scan stopped the instance claiming any work. The claim UPDATEs that follow stay unbounded (pinned).
- **Retention sweep: 120s** on all three `deleteOlderThan`s and the stale-request reclaim transaction — `RetentionWorker` shares the warmer's scheduled pool with no lease or interrupt machinery, and a truncated idempotent sweep re-runs in an hour, so the "writes stay unbounded" rationale (which holds for the index worker's flushes and `fetchForReanalysis`) never reached it.
- **`socketTimeout=150` default for Postgres URLs** in `DataSourceFactory` — in code, versioned and tested, rather than an instruction against unversioned per-host config. Statement cancellation travels over the network; on a TCP black hole only a socket timeout gets the connection back. The value must exceed the sweep bound (a long DELETE is silent on the socket until it finishes) — pinned — and an explicit URL value always wins; H2 URLs are excluded (H2 rejects unknown connection properties).
- **H2 session-leak containment**: H2 scopes `setQueryTimeout` to the connection's session (verified in driver bytecode) and Hikari doesn't reset it on checkin, so without cleanup a bound would leak to every later statement on the pooled connection — including the deliberately unbounded writes. The entry point clears the session in a `finally`, through the JDBC API (raw `SET QUERY_TIMEOUT 0` leaves H2's client cache stale), logging rather than throwing so cleanup failure can't mask the timeout it exists to surface. On Postgres the clear is a pure client-side no-op, so it runs unconditionally and the helper carries no dialect knowledge. The leak was surfaced by mutation checking — probes were passing by inheriting an earlier read's leaked session value.

## Holistic altitude pass (final commit)

A three-lens review over the whole two-PR arc (#1312 + this) closed the gaps it found:

- **Two behaviors were argued in prose but unpinned — both now tested and mutation-verified**: the dispatch poller surviving a `claimNext` failure and claiming on a later poll (`IndexWorkerLifecycleTest`), and a failing/cancelled read surfacing as an error rather than a silently empty page, on both the live path and the cache's cold-miss loader (`QueryControllerTest`). The retention sweep's survive-store-failure contract got the same treatment (`RetentionWorkerTest`).
- **`GET /v1/index` reads were the last unbounded serving path** — `listRecent` and `findPeriodsForPlayers` now carry the 10s bound, pinned in `StatementTimeoutsTest` (removing either bound is a killed mutation).
- **Consolidation**: `StatementTimeouts` is the single home of the policy (vestigial `GameFeatureDao` timeout field/constructor removed); all mechanism tests live in `StatementTimeoutsTest` with the literals 10/120 in exactly one place; `PostgresReadTimeoutTest` reduced to pure `pg_sleep` mechanism (no migrations or tables); a stale javadoc, a subsumed frontend test, and a vacuous sweep-autocommit assertion removed; `GamesView.test.tsx` now reads the cross-language first-page fixture directly.

Posture findings that belong to future work (username-search indexes, `indexed_at` index for the sweep, serve-stale-on-error cache, bounded-loop outcome metrics, the 150s socket cliff on reanalysis) are filed on #1313 as items 10–13 and re-scopes of 2/4/5.

## Tests

- **H2 behavioral cancellation** (`StatementTimeoutsTest`): per-row sleeping UDF over 400 rows (H2 checks the timeout cooperatively every N rows) killed near a 1s injected timeout, with an error-path probe asserting the timed-out read left no timeout on the pooled connection, and a fast positive twin.
- **Real-Postgres suite** (`PostgresReadTimeoutTest`, new, in `pg_db_tests`): `pg_sleep` cancelled at the timeout, a behavioral no-leak probe — after a 1s-bounded read, an unbounded 2s `pg_sleep` must complete, and `SHOW statement_timeout` pins no server-side session setting was left — and the socket-timeout default pinned via `Connection.getNetworkTimeout` on a real connection. Env-gated on `PG_TEST_DB_URL` (CI supplies `postgres:18`); **also run locally against a real PostgreSQL 16** — see Verification.
- **`StatementTimeoutsTest`** (new): probes the poller scan (10, and the claim UPDATEs at 0), the status-path reads, the reclaim transaction, and all three sweep deletes (120) on the real JDBC statements via `SqlLogger`, plus session-leak probes on the success and error paths. `DataSourceFactoryTest` (new) pins the socket-timeout policy: default applied, explicit URL wins, H2 excluded, value exceeds the sweep bound.
- Probe assertions use literals so mutating a constant can't mutate the expectation; timing-sensitive tests re-run at `--runs_per_test=15`.

## Review panel

Ran the 4-lens read-only panel on the initial commit. Correctness: one finding (finally-throw replacing the primary exception) — fixed. Resources: no defects; confirmed from bytecode that Hikari never plants its own session timeout on H2 and pgjdbc uses one shared JVM-wide cancel timer. Tests/docs: found an escaped mutation (reset moved from `finally` to `try` survived) — now killed by the error-path probe, verified by applying the mutation and watching it fail; found the original PG leak probe was vacuous — replaced with the behavioral probe. Altitude: right mechanism (it attacked `connectionInitSql`, URL `options`, and HTTP-layer bounds; each failed on merits), but the boundary was class-shaped rather than risk-shaped — its three boundary findings are the poller/sweep/socket work now included in this PR. The closing three-lens holistic pass is summarized above.

Mutation checks: all killed — per-path timeout removal, constant drift (both values), session-reset removal, reads bypassing the entry point, the escaped finally-placement mutation, poller-bound removal, socket-timeout policy inversions, (against real Postgres) removing the bound from `withStatementTimeout`, and from the altitude pass: poll-loop catch removal, retention catch removal, read-failure swallowed into an empty page, and status-path bound removal on both DAOs.

## Verification

- `bazel test //domains/games/apis/one_d4/...` — 60/60 pass, **including `pg_db_tests` against a real local PostgreSQL 16.13** (`PG_TEST_DB_URL` exported): zero skips, `PostgresReadTimeoutTest` stable over `--runs_per_test=15` (real cancellations). CI additionally runs the same suites against `postgres:18`.
- `1d4_web`: 119 vitest tests pass, `tsc --noEmit` clean.
- `scripts/format-java` + buildifier run
- Built via the sandbox git-override workaround for proxy-blocked archives; no lockfile churn committed.

Docs updated in the same PR: README (socketTimeout default and override rule), API.md (deterministic 500 on a query exceeding the read timeout), ROADMAP (`SET statement_timeout` item marked done in this form and why not that one), and the warmer's now-false "a hung query blocks future ticks" comment corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg