### PR TITLE
one_d4: fix the submission-count race in RequestLivenessTest

### DIFF
--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/RequestLivenessTest.java
@@ -567,7 +567,11 @@ public class RequestLivenessTest {
     IndexingRequestDao dao = new IndexingRequestDao(testDb.jdbi(), clock);
     UUID requestId = claim(dao).request().id();
 
-    CountDownLatch insideLookup = new CountDownLatch(1);
+    // One count per distinct username in the fixture game ("White" and "Black"). Awaiting a
+    // single lookup raced the pool against the submit loop: the first lookup can be running —
+    // and tripping the latch — before the second is submitted, so the capture below read a
+    // count that was still moving. Awaiting both means the title phase has finished submitting.
+    CountDownLatch insideLookup = new CountDownLatch(2);
     WedgedProfileChessClient client = new WedgedProfileChessClient(insideLookup);
     CountingExecutor pool = new CountingExecutor(2);
     try {
@@ -591,10 +595,11 @@ public class RequestLivenessTest {
                 worker.process(message(requestId));
               });
       assertThat(insideLookup.await(15, TimeUnit.SECONDS))
-          .as("a profile lookup should be parked on the pool")
+          .as("both profile lookups should be parked on the pool")
           .isTrue();
-      // resolveTitles submits every lookup before it drains any of them, so by the time one is
-      // running the title phase has finished submitting and this number has stopped moving.
+      // Stable, not racing: every lookup the title phase will ever submit is now wedged on the
+      // pool, so nothing can move this number again except the extraction submissions the
+      // checkpoint under test exists to prevent.
       int submittedForTitles = pool.submissions();
 
       runThread.get().interrupt();


### PR DESCRIPTION
## What

Fixes the `RequestLivenessTest` failure on main's CI ([run 31115318440](https://github.com/muchq/MoonBase/actions/runs/31115318440/job/92663226735)): `anInterruptedRunDoesNotSubmitTheMonthItWasResolvingTitlesFor` — expected 1 submission, saw 2.

It's a pre-existing race in the test, not a regression from #1314's diff. The fixture game has two distinct usernames ("White" and "Black"), so `resolveTitles` submits two lookups. The latch tripped when the *first* lookup started running on the pool, and the test thread then captured `pool.submissions()` while the worker thread could still be submitting the second lookup. Fast machine: capture reads 2, pass. Loaded CI runner: capture reads 1, final count is 2, fail.

The fix: the latch now counts both lookups, so the capture happens only after everything the title phase will ever submit is wedged on the pool — the count cannot still be moving, and the only thing that could move it afterwards is exactly the extraction submissions the checkpoint under test exists to prevent. Test-only change; production code untouched.

## Verification

- Reproduced CI's failure deterministically: a temporary 200ms delay between the two submits makes the old test fail every time with the exact CI shape (`expected: 1 but was: 2` at the same assertion). The fixed test passes under the same delay.
- Delay removed, full `RequestLivenessTest` suite stable over `--runs_per_test=15` (15/15 pass).
- `scripts/format-java` run; the diff is 9 insertions in one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg)_