### PR TITLE
one_d4: expression indexes for username search + the retention-delete index (#1313 items 10–11)

### DIFF
--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -583,6 +583,7 @@ java_test_suite(
     srcs = [
         "src/test/java/com/muchq/games/one_d4/db/PostgresAggregateCompatTest.java",
         "src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java",
+        "src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java",
         "src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java",
     ],
     env_inherit = ["PG_TEST_DB_URL"],

--- a/domains/games/apis/one_d4/BUILD.bazel
+++ b/domains/games/apis/one_d4/BUILD.bazel
@@ -585,6 +585,7 @@ java_test_suite(
         "src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java",
         "src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java",
         "src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java",
+        "src/test/java/com/muchq/games/one_d4/db/PostgresRetentionIndexTest.java",
     ],
     env_inherit = ["PG_TEST_DB_URL"],
     # One shared scratch database: concurrent DB tests drop each other's schemas.
@@ -596,6 +597,7 @@ java_test_suite(
         ":db",
         ":dto",
         ":model",
+        ":test_db",
         "//domains/games/libs/chessql:compiler",
         "//domains/games/libs/chessql:parser",
         artifact("org.assertj:assertj-core"),
@@ -608,6 +610,7 @@ java_library(
     name = "test_db",
     testonly = True,
     srcs = [
+        "src/test/java/com/muchq/games/one_d4/db/PgTestUrls.java",
         "src/test/java/com/muchq/games/one_d4/db/TestDb.java",
     ],
     visibility = ["//visibility:public"],

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -448,6 +448,17 @@ public class Migration {
         + " ON game_features(black_username)",
   };
 
+  /**
+   * The index behind the retention delete (#1313 item 11). {@code deleteOlderThan} filters {@code
+   * game_features} on {@code indexed_at} hourly; unindexed, every 120s-bounded sweep re-scanned the
+   * table from the start, so a sweep that hit its bound rolled back having made <em>no forward
+   * progress</em> and retried the same scan an hour later — a ratchet that never advances. With the
+   * index the delete walks straight to the expired rows, and a truncated pass leaves fewer of them
+   * for the next one. Dialect-neutral: a plain b-tree on a plain column.
+   */
+  private static final String CREATE_IDX_GAME_FEATURES_INDEXED_AT =
+      "CREATE INDEX IF NOT EXISTS idx_game_features_indexed_at ON game_features(indexed_at)";
+
   private static final String ADD_DEDUPE_KEY_UNIQUE_H2 =
       "ALTER TABLE indexing_requests ADD CONSTRAINT IF NOT EXISTS indexing_requests_dedupe_unique"
           + " UNIQUE (dedupe_key)";
@@ -534,6 +545,7 @@ public class Migration {
           useH2 ? CREATE_IDX_GAME_FEATURES_USERNAMES_H2 : CREATE_IDX_GAME_FEATURES_USERNAMES_PG) {
         stmt.execute(create);
       }
+      stmt.execute(CREATE_IDX_GAME_FEATURES_INDEXED_AT);
 
       // Ownership leases.
       for (String add : ADD_LEASE_COLUMNS) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -402,18 +402,24 @@ public class Migration {
           + " ON game_features(played_at DESC, game_url ASC)";
 
   /**
-   * The indexes behind the player-participation guard (#1313 item 10). Every player-scoped query —
-   * any use of a perspective field — runs SqlCompiler's {@code (LOWER(white_username) = LOWER(?) OR
-   * LOWER(black_username) = LOWER(?))}, case-folded on <em>both</em> sides, so a plain column index
-   * can never serve it on Postgres: these are expression indexes on {@code LOWER(...)}. One per
-   * side rather than a composite, because an OR across two columns is answered by a BitmapOr of two
-   * independent index scans, and a composite serves neither disjunct alone.
+   * The indexes behind username search (#1313 item 10). Two compiler paths emit the same
+   * case-folded predicate shape, {@code LOWER(white_username) = LOWER(?)} OR'd across the sides:
+   * the browse UI's username search compiles {@code white.username = "x" OR black.username = "x"}
+   * through the STRING_COLUMNS equality branch — the highest-traffic consumer — and every
+   * perspective-field query runs the participation guard. Case-folded on <em>both</em> sides, so a
+   * plain column index can never serve either on Postgres: these are expression indexes on {@code
+   * LOWER(...)}. One per side rather than any composite — an OR across two columns is answered by a
+   * BitmapOr of two independent scans, and a BitmapOr's output is unordered, so a composite with
+   * {@code played_at} could not skip the sort either; it would only double index weight on the
+   * hottest-write table.
    *
-   * <p>Without them this predicate was the last user-triggerable full-table scan in the schema —
-   * and with a 5-connection pool, five concurrent player searches held every connection for the
-   * full serving-read bound. {@code PostgresPlayerIndexTest} pins both sides of the contract on the
-   * deployment dialect: the plan actually reaches these indexes for the compiler's exact predicate,
-   * so either side drifting (compiler predicate or index expression) fails a test.
+   * <p>Without them these predicates were the full-table scan on the player-search path — and with
+   * a 5-connection pool, five concurrent player searches held every connection for the full
+   * serving-read bound. (Not the last table walk in the schema: an unscoped {@code /v1/aggregate}
+   * GROUP BY legitimately reads the corpus.) {@code PostgresPlayerIndexTest} pins the contract on
+   * the deployment dialect for both emitting paths: the plan actually reaches these indexes for the
+   * compiler's exact predicates, so either side drifting (a compiler path losing its {@code LOWER},
+   * or an index expression changing) fails a test.
    */
   private static final String[] CREATE_IDX_GAME_FEATURES_USERNAMES_PG = {
     "CREATE INDEX IF NOT EXISTS idx_game_features_white_username"
@@ -423,10 +429,12 @@ public class Migration {
   };
 
   /**
-   * The same indexes for H2, which has no expression indexes; plain column indexes stand in under
-   * the same names. H2 is the test engine rather than the deployment target, so the cost of the
-   * weaker shape is a slower test, never a slower production search — same trade as the claimable
-   * index above.
+   * The same names on H2, which has no expression indexes — and a plain column index cannot serve a
+   * {@code LOWER(...)} predicate there for exactly the reason the Postgres javadoc gives, so on H2
+   * these are pure write cost, not a weaker plan. They are carried anyway so the migration path
+   * stays identical on both engines and the H2 suite can pin their existence. The only H2
+   * deployment is the MCP server's boot-scoped in-memory store, where a handful of rows makes both
+   * the missing plan and the extra writes negligible.
    */
   private static final String[] CREATE_IDX_GAME_FEATURES_USERNAMES_H2 = {
     "CREATE INDEX IF NOT EXISTS idx_game_features_white_username"

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -452,9 +452,11 @@ public class Migration {
    * The index behind the retention delete (#1313 item 11). {@code deleteOlderThan} filters {@code
    * game_features} on {@code indexed_at} hourly; unindexed, every 120s-bounded sweep re-scanned the
    * table from the start, so a sweep that hit its bound rolled back having made <em>no forward
-   * progress</em> and retried the same scan an hour later — a ratchet that never advances. With the
-   * index the delete walks straight to the expired rows, and a truncated pass leaves fewer of them
-   * for the next one. Dialect-neutral: a plain b-tree on a plain column.
+   * progress</em> and retried the same scan an hour later — a ratchet that never advances. The
+   * delete is one statement, so a cancel always rolls the whole pass back; what the index changes
+   * is the cost side, letting the steady-state delete walk straight to the expired rows and
+   * <em>finish</em> inside the bound. (If a backlog ever outgrows the bound anyway, LIMIT-batched
+   * deletes are the next tool.) Dialect-neutral: a plain b-tree on a plain column.
    */
   private static final String CREATE_IDX_GAME_FEATURES_INDEXED_AT =
       "CREATE INDEX IF NOT EXISTS idx_game_features_indexed_at ON game_features(indexed_at)";

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -401,6 +401,40 @@ public class Migration {
       "CREATE INDEX IF NOT EXISTS idx_game_features_played_at"
           + " ON game_features(played_at DESC, game_url ASC)";
 
+  /**
+   * The indexes behind the player-participation guard (#1313 item 10). Every player-scoped query —
+   * any use of a perspective field — runs SqlCompiler's {@code (LOWER(white_username) = LOWER(?) OR
+   * LOWER(black_username) = LOWER(?))}, case-folded on <em>both</em> sides, so a plain column index
+   * can never serve it on Postgres: these are expression indexes on {@code LOWER(...)}. One per
+   * side rather than a composite, because an OR across two columns is answered by a BitmapOr of two
+   * independent index scans, and a composite serves neither disjunct alone.
+   *
+   * <p>Without them this predicate was the last user-triggerable full-table scan in the schema —
+   * and with a 5-connection pool, five concurrent player searches held every connection for the
+   * full serving-read bound. {@code PostgresPlayerIndexTest} pins both sides of the contract on the
+   * deployment dialect: the plan actually reaches these indexes for the compiler's exact predicate,
+   * so either side drifting (compiler predicate or index expression) fails a test.
+   */
+  private static final String[] CREATE_IDX_GAME_FEATURES_USERNAMES_PG = {
+    "CREATE INDEX IF NOT EXISTS idx_game_features_white_username"
+        + " ON game_features(LOWER(white_username))",
+    "CREATE INDEX IF NOT EXISTS idx_game_features_black_username"
+        + " ON game_features(LOWER(black_username))",
+  };
+
+  /**
+   * The same indexes for H2, which has no expression indexes; plain column indexes stand in under
+   * the same names. H2 is the test engine rather than the deployment target, so the cost of the
+   * weaker shape is a slower test, never a slower production search — same trade as the claimable
+   * index above.
+   */
+  private static final String[] CREATE_IDX_GAME_FEATURES_USERNAMES_H2 = {
+    "CREATE INDEX IF NOT EXISTS idx_game_features_white_username"
+        + " ON game_features(white_username)",
+    "CREATE INDEX IF NOT EXISTS idx_game_features_black_username"
+        + " ON game_features(black_username)",
+  };
+
   private static final String ADD_DEDUPE_KEY_UNIQUE_H2 =
       "ALTER TABLE indexing_requests ADD CONSTRAINT IF NOT EXISTS indexing_requests_dedupe_unique"
           + " UNIQUE (dedupe_key)";
@@ -483,6 +517,10 @@ public class Migration {
       stmt.execute(useH2 ? ADD_DEDUPE_KEY_UNIQUE_H2 : ADD_DEDUPE_KEY_UNIQUE_PG);
       stmt.execute(CREATE_IDX_GAME_FEATURES_REQUEST_ID);
       stmt.execute(CREATE_IDX_GAME_FEATURES_PLAYED_AT);
+      for (String create :
+          useH2 ? CREATE_IDX_GAME_FEATURES_USERNAMES_H2 : CREATE_IDX_GAME_FEATURES_USERNAMES_PG) {
+        stmt.execute(create);
+      }
 
       // Ownership leases.
       for (String add : ADD_LEASE_COLUMNS) {

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/db/Migration.java
@@ -420,6 +420,11 @@ public class Migration {
    * the deployment dialect for both emitting paths: the plan actually reaches these indexes for the
    * compiler's exact predicates, so either side drifting (a compiler path losing its {@code LOWER},
    * or an index expression changing) fails a test.
+   *
+   * <p>Ops note, same as every index here: created at boot without {@code CONCURRENTLY}, so the
+   * first deploy onto a populated table holds a SHARE lock for the build and pauses the indexer's
+   * writes; later boots are IF NOT EXISTS no-ops. (CONCURRENTLY + IF NOT EXISTS would be worse — a
+   * failed build leaves an INVALID index behind that IF NOT EXISTS then skips forever.)
    */
   private static final String[] CREATE_IDX_GAME_FEATURES_USERNAMES_PG = {
     "CREATE INDEX IF NOT EXISTS idx_game_features_white_username"

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -178,20 +178,25 @@ public class MigrationTest {
         .as("the browse search predicate these indexes serve, case-folded on both sides")
         .contains("(LOWER(white_username) = LOWER(?) OR LOWER(black_username) = LOWER(?))");
 
-    java.util.Set<String> names = new java.util.HashSet<>();
+    java.util.Map<String, java.util.List<String>> columnsByIndex = new java.util.HashMap<>();
     try (Connection conn = dataSource.getConnection();
         ResultSet indexes =
             conn.getMetaData().getIndexInfo(null, null, "GAME_FEATURES", false, false)) {
       while (indexes.next()) {
         String name = indexes.getString("INDEX_NAME");
         if (name != null) {
-          names.add(name.toLowerCase());
+          columnsByIndex
+              .computeIfAbsent(name.toLowerCase(), k -> new java.util.ArrayList<>())
+              .add(indexes.getString("COLUMN_NAME").toLowerCase());
         }
       }
     }
-    assertThat(names)
-        .as("one index per side: an OR across two columns is served by two indexes, not one")
-        .contains("idx_game_features_white_username", "idx_game_features_black_username");
+    // One index per side — an OR across two columns is served by two indexes, not one — and each
+    // stand-in must sit on its own side's column: a stand-in redirected at the wrong column would
+    // keep the name this test looks for while modeling an index Postgres doesn't have.
+    assertThat(columnsByIndex)
+        .containsEntry("idx_game_features_white_username", java.util.List.of("white_username"))
+        .containsEntry("idx_game_features_black_username", java.util.List.of("black_username"));
   }
 
   @Test

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -18,7 +18,9 @@ public class MigrationTest {
 
   @BeforeEach
   public void setUp() {
-    String jdbcUrl = "jdbc:h2:mem:migration_" + System.currentTimeMillis() + ";DB_CLOSE_DELAY=-1";
+    // nanoTime, not currentTimeMillis: two tests starting in the same millisecond would silently
+    // share a database — the same trap TestDb documents and avoids.
+    String jdbcUrl = "jdbc:h2:mem:migration_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
     dataSource = DataSourceFactory.create(jdbcUrl);
   }
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -143,6 +143,42 @@ public class MigrationTest {
         .containsExactly("PLAYED_AT:D", "GAME_URL:A");
   }
 
+  /**
+   * The username indexes behind the player-participation guard, and the predicate they exist to
+   * serve. On H2 they are plain column indexes (H2 has no expression indexes), so what this pins is
+   * presence and the compiler's side of the contract: the guard must still be the
+   * case-folded-on-both-sides shape the Postgres {@code LOWER(...)} expression indexes mirror. If
+   * the compiler's predicate changes shape, this fails and points at the index definitions; the
+   * plan-level proof on the deployment dialect lives in {@code PostgresPlayerIndexTest}.
+   */
+  @Test
+  public void run_addsTheUsernameIndexesBehindTheParticipationGuard() throws Exception {
+    new Migration(dataSource, true).run();
+
+    String playerScoped =
+        new com.muchq.games.chessql.compiler.SqlCompiler()
+            .compile(com.muchq.games.chessql.parser.Parser.parse("outcome = \"win\""), "hikaru")
+            .selectSql();
+    assertThat(playerScoped)
+        .as("the participation guard these indexes exist to serve, case-folded on both sides")
+        .contains("(LOWER(white_username) = LOWER(?) OR LOWER(black_username) = LOWER(?))");
+
+    java.util.Set<String> names = new java.util.HashSet<>();
+    try (Connection conn = dataSource.getConnection();
+        ResultSet indexes =
+            conn.getMetaData().getIndexInfo(null, null, "GAME_FEATURES", false, false)) {
+      while (indexes.next()) {
+        String name = indexes.getString("INDEX_NAME");
+        if (name != null) {
+          names.add(name.toLowerCase());
+        }
+      }
+    }
+    assertThat(names)
+        .as("one index per side: an OR across two columns is served by two indexes, not one")
+        .contains("idx_game_features_white_username", "idx_game_features_black_username");
+  }
+
   @Test
   public void run_addsTitleAndOpeningColumns() throws Exception {
     Migration migration = new Migration(dataSource, true);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -199,6 +199,30 @@ public class MigrationTest {
         .containsEntry("idx_game_features_black_username", java.util.List.of("black_username"));
   }
 
+  /**
+   * The retention delete's index, pinned to its column: {@code deleteOlderThan} filters {@code
+   * game_features} on {@code indexed_at} hourly, and without this index a sweep truncated at its
+   * 120s bound made no forward progress — same scan, next hour, forever. The plan-level proof on
+   * the deployment dialect lives in {@code PostgresRetentionIndexTest}.
+   */
+  @Test
+  public void run_addsTheIndexedAtRetentionIndex() throws Exception {
+    new Migration(dataSource, true).run();
+
+    java.util.List<String> columns = new java.util.ArrayList<>();
+    try (Connection conn = dataSource.getConnection();
+        ResultSet indexes =
+            conn.getMetaData().getIndexInfo(null, null, "GAME_FEATURES", false, false)) {
+      while (indexes.next()) {
+        String name = indexes.getString("INDEX_NAME");
+        if (name != null && name.equalsIgnoreCase("idx_game_features_indexed_at")) {
+          columns.add(indexes.getString("COLUMN_NAME").toLowerCase());
+        }
+      }
+    }
+    assertThat(columns).containsExactly("indexed_at");
+  }
+
   @Test
   public void run_addsTitleAndOpeningColumns() throws Exception {
     Migration migration = new Migration(dataSource, true);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/MigrationTest.java
@@ -162,7 +162,20 @@ public class MigrationTest {
             .compile(com.muchq.games.chessql.parser.Parser.parse("outcome = \"win\""), "hikaru")
             .selectSql();
     assertThat(playerScoped)
-        .as("the participation guard these indexes exist to serve, case-folded on both sides")
+        .as("the participation guard these indexes serve, case-folded on both sides")
+        .contains("(LOWER(white_username) = LOWER(?) OR LOWER(black_username) = LOWER(?))");
+
+    // The browse UI's username search reaches the same shape through a different compiler branch
+    // (STRING_COLUMNS equality, no player) — the highest-traffic consumer of these indexes.
+    String browseSearch =
+        new com.muchq.games.chessql.compiler.SqlCompiler()
+            .compile(
+                com.muchq.games.chessql.parser.Parser.parse(
+                    "white.username = \"hikaru\" OR black.username = \"hikaru\""),
+                null)
+            .selectSql();
+    assertThat(browseSearch)
+        .as("the browse search predicate these indexes serve, case-folded on both sides")
         .contains("(LOWER(white_username) = LOWER(?) OR LOWER(black_username) = LOWER(?))");
 
     java.util.Set<String> names = new java.util.HashSet<>();

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PgTestUrls.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PgTestUrls.java
@@ -1,0 +1,49 @@
+package com.muchq.games.one_d4.db;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts the libpq-style URL CI exports for the PG-gated suites ({@code
+ * postgresql://user:pass@host:port/db}) into a pgjdbc URL. pgjdbc does not accept credentials in
+ * the authority, so they move to query params; each suite passes its own {@code currentSchema} so
+ * suites sharing the scratch database cannot collide. Extracted here once it had been copied into a
+ * fourth test class.
+ */
+public final class PgTestUrls {
+
+  private PgTestUrls() {}
+
+  /** pgjdbc URL for the given libpq URL, scoped to {@code schema} when non-null. */
+  public static String jdbcUrl(String rawUrl, String schema) {
+    // One suite's copy tolerated an already-jdbc-prefixed value; keep that tolerance.
+    URI uri = URI.create(rawUrl.startsWith("jdbc:") ? rawUrl.substring("jdbc:".length()) : rawUrl);
+    List<String> params = new ArrayList<>();
+    String userInfo = uri.getUserInfo();
+    if (userInfo != null) {
+      int colon = userInfo.indexOf(':');
+      String user = colon < 0 ? userInfo : userInfo.substring(0, colon);
+      params.add("user=" + encode(user));
+      if (colon >= 0) {
+        params.add("password=" + encode(userInfo.substring(colon + 1)));
+      }
+    }
+    if (schema != null) {
+      params.add("currentSchema=" + encode(schema));
+    }
+    int port = uri.getPort() < 0 ? 5432 : uri.getPort();
+    return "jdbc:postgresql://"
+        + uri.getHost()
+        + ":"
+        + port
+        + uri.getPath()
+        + (params.isEmpty() ? "" : "?" + String.join("&", params));
+  }
+
+  private static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresAggregateCompatTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresAggregateCompatTest.java
@@ -9,14 +9,10 @@ import com.muchq.games.chessql.parser.Parser;
 import com.muchq.games.one_d4.api.dto.AggregateRow;
 import com.muchq.games.one_d4.api.dto.GameFeature;
 import java.io.Closeable;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.sql.DataSource;
@@ -64,13 +60,13 @@ public class PostgresAggregateCompatTest {
         DB_URL_ENV + " is not set; skipping the real-postgres compatibility suite");
 
     // A clean schema per run: the same scratch database backs the other DB-gated suites.
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
         Statement stmt = conn.createStatement()) {
       stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
       stmt.execute("CREATE SCHEMA " + SCHEMA);
     }
 
-    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl, SCHEMA));
+    dataSource = DataSourceFactory.create(PgTestUrls.jdbcUrl(rawUrl, SCHEMA));
     new Migration(dataSource, false).run();
     dao = new GameFeatureDao(Jdbi.create(dataSource), false);
 
@@ -94,7 +90,7 @@ public class PostgresAggregateCompatTest {
     if (rawUrl == null || rawUrl.isBlank()) {
       return;
     }
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
         Statement stmt = conn.createStatement()) {
       stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
     }
@@ -572,38 +568,5 @@ public class PostgresAggregateCompatTest {
         30,
         Instant.now(),
         "1. e4 e5 *");
-  }
-
-  /**
-   * Converts the libpq-style URL CI exports ({@code postgresql://user:pass@host:port/db}) into a
-   * pgjdbc URL. pgjdbc does not accept credentials in the authority, so they move to query params.
-   */
-  private static String jdbcUrl(String rawUrl, String schema) {
-    URI uri = URI.create(rawUrl);
-    List<String> params = new ArrayList<>();
-    String userInfo = uri.getUserInfo();
-    if (userInfo != null) {
-      int colon = userInfo.indexOf(':');
-      String user = colon < 0 ? userInfo : userInfo.substring(0, colon);
-      params.add("user=" + encode(user));
-      if (colon >= 0) {
-        params.add("password=" + encode(userInfo.substring(colon + 1)));
-      }
-    }
-    if (schema != null) {
-      params.add("currentSchema=" + encode(schema));
-    }
-    int port = uri.getPort() < 0 ? 5432 : uri.getPort();
-    return "jdbc:postgresql://"
-        + uri.getHost()
-        + ":"
-        + port
-        + uri.getPath()
-        + "?"
-        + String.join("&", params);
-  }
-
-  private static String encode(String value) {
-    return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresConcurrentWriteTest.java
@@ -7,9 +7,6 @@ import com.muchq.games.one_d4.api.dto.GameFeature;
 import com.muchq.games.one_d4.engine.model.GameFeatures;
 import com.muchq.games.one_d4.engine.model.Motif;
 import java.io.Closeable;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
@@ -97,13 +94,13 @@ public class PostgresConcurrentWriteTest {
         rawUrl != null && !rawUrl.isBlank(),
         DB_URL_ENV + " is not set; skipping the real-postgres concurrency suite");
 
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
         Statement stmt = conn.createStatement()) {
       stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
       stmt.execute("CREATE SCHEMA " + SCHEMA);
     }
 
-    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl, SCHEMA));
+    dataSource = DataSourceFactory.create(PgTestUrls.jdbcUrl(rawUrl, SCHEMA));
     new Migration(dataSource, false).run();
     dao = new GameFeatureDao(Jdbi.create(dataSource), false);
     requestId = insertClaimedRequest();
@@ -122,7 +119,7 @@ public class PostgresConcurrentWriteTest {
     if (rawUrl == null || rawUrl.isBlank()) {
       return;
     }
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
         Statement stmt = conn.createStatement()) {
       stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
     }
@@ -380,37 +377,5 @@ public class PostgresConcurrentWriteTest {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-  }
-
-  /**
-   * Same shape as {@link PostgresAggregateCompatTest}: a scratch database, one schema per suite.
-   */
-  private static String jdbcUrl(String rawUrl, String schema) {
-    URI uri = URI.create(rawUrl.startsWith("jdbc:") ? rawUrl.substring("jdbc:".length()) : rawUrl);
-    String userInfo = uri.getUserInfo();
-    StringBuilder sb = new StringBuilder("jdbc:postgresql://");
-    sb.append(uri.getHost());
-    if (uri.getPort() > 0) {
-      sb.append(':').append(uri.getPort());
-    }
-    sb.append(uri.getPath() == null || uri.getPath().isEmpty() ? "/postgres" : uri.getPath());
-    StringBuilder params = new StringBuilder();
-    if (userInfo != null && !userInfo.isEmpty()) {
-      String[] parts = userInfo.split(":", 2);
-      params.append("user=").append(URLEncoder.encode(parts[0], StandardCharsets.UTF_8));
-      if (parts.length > 1) {
-        params.append("&password=").append(URLEncoder.encode(parts[1], StandardCharsets.UTF_8));
-      }
-    }
-    if (schema != null) {
-      if (params.length() > 0) {
-        params.append('&');
-      }
-      params.append("currentSchema=").append(schema);
-    }
-    if (params.length() > 0) {
-      sb.append('?').append(params);
-    }
-    return sb.toString();
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
@@ -29,11 +29,11 @@ import org.junit.jupiter.api.Test;
  * The username expression indexes on the deployment dialect. The participation guard case-folds
  * both sides — {@code LOWER(white_username) = LOWER(?)} — so only an expression index on {@code
  * LOWER(...)} can serve it, and only Postgres has expression indexes; the H2 side of the migration
- * creates plain-column stand-ins that this predicate cannot use. That makes the plan assertion here
- * the only test that can catch either side of the contract drifting: an index losing its {@code
- * LOWER} (back to a plain column) or the compiler's predicate changing shape both leave the H2
- * suite green while production quietly returns to the full-table walk this index exists to remove
- * (#1313 item 10).
+ * creates plain-column stand-ins that this predicate cannot use. The compiled predicate shape is
+ * pinned on H2 too ({@code MigrationTest}), so what is uniquely this suite's job is the
+ * <em>index</em> side of the contract: an index expression drifting from the compiler's predicate —
+ * losing its {@code LOWER}, say — leaves every H2 test green while production quietly returns to
+ * the full-table walk these indexes exist to remove (#1313 item 10).
  *
  * <p>Runs against the real postgres CI provides via {@code PG_TEST_DB_URL}; skips when unset. Uses
  * a dedicated schema like the other PG-gated suites sharing that scratch database.
@@ -110,11 +110,14 @@ public class PostgresPlayerIndexTest {
     String plan = explain(new SqlCompiler().compile(Parser.parse("me.elo >= 0"), "hikaru"));
 
     assertThat(plan)
-        .as("the white side of the OR must be an index scan, not part of a table walk")
+        .as("the white side of the OR must reach its index")
         .contains("idx_game_features_white_username");
     assertThat(plan)
         .as("and the black side its own — one index per disjunct")
         .contains("idx_game_features_black_username");
+    assertThat(plan)
+        .as("and nothing may fall back to walking the table")
+        .doesNotContain("Seq Scan");
   }
 
   /**
@@ -137,6 +140,9 @@ public class PostgresPlayerIndexTest {
         .as("the UI's search predicate must reach the white-side index")
         .contains("idx_game_features_white_username");
     assertThat(plan).as("and the black-side index").contains("idx_game_features_black_username");
+    assertThat(plan)
+        .as("and nothing may fall back to walking the table")
+        .doesNotContain("Seq Scan");
   }
 
   private String explain(CompiledQuery compiled) throws Exception {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
@@ -1,0 +1,217 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.muchq.games.chessql.compiler.CompiledQuery;
+import com.muchq.games.chessql.compiler.SqlCompiler;
+import com.muchq.games.chessql.parser.Parser;
+import com.muchq.games.one_d4.api.dto.GameFeature;
+import java.io.Closeable;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The username expression indexes on the deployment dialect. The participation guard case-folds
+ * both sides — {@code LOWER(white_username) = LOWER(?)} — so only an expression index on {@code
+ * LOWER(...)} can serve it, and only Postgres has expression indexes; the H2 side of the migration
+ * creates plain-column stand-ins that this predicate cannot use. That makes the plan assertion here
+ * the only test that can catch either side of the contract drifting: an index losing its {@code
+ * LOWER} (back to a plain column) or the compiler's predicate changing shape both leave the H2
+ * suite green while production quietly returns to the full-table walk this index exists to remove
+ * (#1313 item 10).
+ *
+ * <p>Runs against the real postgres CI provides via {@code PG_TEST_DB_URL}; skips when unset. Uses
+ * a dedicated schema like the other PG-gated suites sharing that scratch database.
+ */
+public class PostgresPlayerIndexTest {
+
+  private static final String DB_URL_ENV = "PG_TEST_DB_URL";
+  private static final String SCHEMA = "one_d4_pg_player_index_test";
+
+  private DataSource dataSource;
+  private GameFeatureDao dao;
+  private UUID requestId;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    String rawUrl = System.getenv(DB_URL_ENV);
+    assumeTrue(
+        rawUrl != null && !rawUrl.isBlank(),
+        DB_URL_ENV + " is not set; skipping the real-postgres player-index suite");
+
+    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+      stmt.execute("CREATE SCHEMA " + SCHEMA);
+    }
+
+    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl, SCHEMA));
+    new Migration(dataSource, false).run();
+    dao = new GameFeatureDao(Jdbi.create(dataSource), false);
+
+    requestId = UUID.randomUUID();
+    try (Connection conn = dataSource.getConnection();
+        var stmt =
+            conn.prepareStatement(
+                "INSERT INTO indexing_requests (id, player, platform, start_month, end_month,"
+                    + " status) VALUES (?, 'p', 'CHESS_COM', '2026-06', '2026-07', 'COMPLETED')")) {
+      stmt.setObject(1, requestId);
+      stmt.executeUpdate();
+    }
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (dataSource instanceof Closeable closeable) {
+      closeable.close();
+    }
+    String rawUrl = System.getenv(DB_URL_ENV);
+    if (rawUrl == null || rawUrl.isBlank()) {
+      return;
+    }
+    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+    }
+  }
+
+  /**
+   * The plan-level pin: Postgres must answer the compiler's participation guard through both
+   * expression indexes — a BitmapOr of the white-side and black-side scans — rather than a
+   * sequential scan. {@code enable_seqscan = off} removes the planner's row-count judgement from
+   * the test (an empty-ish table would otherwise always seq-scan), leaving exactly the question
+   * this suite exists to answer: <em>can</em> the plan reach these indexes for this predicate? With
+   * a raw-column index, or a predicate whose shape no longer matches the indexed expression, it
+   * cannot — Postgres then seq-scans even at prohibitive cost, and the assertion fails.
+   */
+  @Test
+  public void thePlayerScopedQueryIsServedByBothUsernameIndexesOnPostgres() throws Exception {
+    CompiledQuery compiled = new SqlCompiler().compile(Parser.parse("me.elo >= 0"), "hikaru");
+
+    String plan;
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("SET enable_seqscan = off");
+      StringBuilder sb = new StringBuilder();
+      try (ResultSet rs = stmt.executeQuery("EXPLAIN " + inlineParams(compiled))) {
+        while (rs.next()) {
+          sb.append(rs.getString(1)).append('\n');
+        }
+      } finally {
+        stmt.execute("SET enable_seqscan = on");
+      }
+      plan = sb.toString();
+    }
+
+    assertThat(plan)
+        .as("the white side of the OR must be an index scan, not part of a table walk")
+        .contains("idx_game_features_white_username");
+    assertThat(plan)
+        .as("and the black side its own — one index per disjunct")
+        .contains("idx_game_features_black_username");
+  }
+
+  /**
+   * The behavioral twin: the guard is case-insensitive on both sides, so a player search must find
+   * games where the stored username differs from the queried one only by case, on both colors,
+   * while excluding everyone else — through the real DAO and the real indexes.
+   */
+  @Test
+  public void playerSearchIsCaseInsensitiveOnBothSidesOnPostgres() {
+    dao.insertBatch(
+        List.of(
+            game("pgi-1", "Hikaru", "someone"),
+            game("pgi-2", "other", "HIKARU"),
+            game("pgi-3", "magnus", "fabiano")));
+
+    List<GameFeature> games =
+        dao.query(new SqlCompiler().compile(Parser.parse("me.elo >= 0"), "hikaru"), 10, 0);
+
+    assertThat(games)
+        .extracting(GameFeature::gameUrl)
+        .containsExactlyInAnyOrder("https://chess.com/game/pgi-1", "https://chess.com/game/pgi-2");
+  }
+
+  /** Inlines the compiled query's bind params as SQL literals, for EXPLAIN. */
+  private static String inlineParams(CompiledQuery compiled) {
+    String sql = compiled.selectSql();
+    for (Object param : compiled.parameters()) {
+      String literal =
+          param instanceof Number
+              ? param.toString()
+              : "'" + param.toString().replace("'", "''") + "'";
+      sql = sql.replaceFirst("\\?", java.util.regex.Matcher.quoteReplacement(literal));
+    }
+    return sql;
+  }
+
+  private GameFeature game(String urlSuffix, String white, String black) {
+    return new GameFeature(
+        null,
+        requestId,
+        "https://chess.com/game/" + urlSuffix,
+        "CHESS_COM",
+        white,
+        black,
+        1500,
+        1500,
+        null,
+        null,
+        "blitz",
+        "A00",
+        "Sicilian",
+        "Sicilian",
+        "1-0",
+        Instant.parse("2026-07-02T10:00:00Z"),
+        30,
+        Instant.now(),
+        "1. e4 e5 *");
+  }
+
+  /**
+   * Converts the libpq-style URL CI exports ({@code postgresql://user:pass@host:port/db}) into a
+   * pgjdbc URL, same as the other PG-gated suites.
+   */
+  private static String jdbcUrl(String rawUrl, String schema) {
+    URI uri = URI.create(rawUrl);
+    List<String> params = new ArrayList<>();
+    String userInfo = uri.getUserInfo();
+    if (userInfo != null) {
+      int colon = userInfo.indexOf(':');
+      String user = colon < 0 ? userInfo : userInfo.substring(0, colon);
+      params.add("user=" + encode(user));
+      if (colon >= 0) {
+        params.add("password=" + encode(userInfo.substring(colon + 1)));
+      }
+    }
+    if (schema != null) {
+      params.add("currentSchema=" + encode(schema));
+    }
+    int port = uri.getPort() < 0 ? 5432 : uri.getPort();
+    return "jdbc:postgresql://"
+        + uri.getHost()
+        + ":"
+        + port
+        + uri.getPath()
+        + (params.isEmpty() ? "" : "?" + String.join("&", params));
+  }
+
+  private static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+}

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
@@ -141,7 +141,9 @@ public class PostgresPlayerIndexTest {
   /**
    * The behavioral twin: the guard is case-insensitive on both sides, so a player search must find
    * games where the stored username differs from the queried one only by case, on both colors,
-   * while excluding everyone else — through the real DAO and the real indexes.
+   * while excluding everyone else — through the real DAO on the deployment dialect. (At three
+   * unanalyzed rows the planner seq-scans, so this pins predicate semantics and PG collation
+   * agreement, not index participation — that is the plan test's job.)
    */
   @Test
   public void playerSearchIsCaseInsensitiveOnBothSidesOnPostgres() {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
@@ -8,15 +8,11 @@ import com.muchq.games.chessql.compiler.SqlCompiler;
 import com.muchq.games.chessql.parser.Parser;
 import com.muchq.games.one_d4.api.dto.GameFeature;
 import java.io.Closeable;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.sql.DataSource;
@@ -54,13 +50,13 @@ public class PostgresPlayerIndexTest {
         rawUrl != null && !rawUrl.isBlank(),
         DB_URL_ENV + " is not set; skipping the real-postgres player-index suite");
 
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
         Statement stmt = conn.createStatement()) {
       stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
       stmt.execute("CREATE SCHEMA " + SCHEMA);
     }
 
-    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl, SCHEMA));
+    dataSource = DataSourceFactory.create(PgTestUrls.jdbcUrl(rawUrl, SCHEMA));
     new Migration(dataSource, false).run();
     dao = new GameFeatureDao(Jdbi.create(dataSource), false);
 
@@ -84,7 +80,7 @@ public class PostgresPlayerIndexTest {
     if (rawUrl == null || rawUrl.isBlank()) {
       return;
     }
-    try (Connection conn = DriverManager.getConnection(jdbcUrl(rawUrl, null));
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
         Statement stmt = conn.createStatement()) {
       stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
     }
@@ -245,37 +241,5 @@ public class PostgresPlayerIndexTest {
         30,
         Instant.now(),
         "1. e4 e5 *");
-  }
-
-  /**
-   * Converts the libpq-style URL CI exports ({@code postgresql://user:pass@host:port/db}) into a
-   * pgjdbc URL, same as the other PG-gated suites.
-   */
-  private static String jdbcUrl(String rawUrl, String schema) {
-    URI uri = URI.create(rawUrl);
-    List<String> params = new ArrayList<>();
-    String userInfo = uri.getUserInfo();
-    if (userInfo != null) {
-      int colon = userInfo.indexOf(':');
-      String user = colon < 0 ? userInfo : userInfo.substring(0, colon);
-      params.add("user=" + encode(user));
-      if (colon >= 0) {
-        params.add("password=" + encode(userInfo.substring(colon + 1)));
-      }
-    }
-    if (schema != null) {
-      params.add("currentSchema=" + encode(schema));
-    }
-    int port = uri.getPort() < 0 ? 5432 : uri.getPort();
-    return "jdbc:postgresql://"
-        + uri.getHost()
-        + ":"
-        + port
-        + uri.getPath()
-        + (params.isEmpty() ? "" : "?" + String.join("&", params));
-  }
-
-  private static String encode(String value) {
-    return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
@@ -107,9 +107,39 @@ public class PostgresPlayerIndexTest {
    */
   @Test
   public void thePlayerScopedQueryIsServedByBothUsernameIndexesOnPostgres() throws Exception {
-    CompiledQuery compiled = new SqlCompiler().compile(Parser.parse("me.elo >= 0"), "hikaru");
+    String plan = explain(new SqlCompiler().compile(Parser.parse("me.elo >= 0"), "hikaru"));
 
-    String plan;
+    assertThat(plan)
+        .as("the white side of the OR must be an index scan, not part of a table walk")
+        .contains("idx_game_features_white_username");
+    assertThat(plan)
+        .as("and the black side its own — one index per disjunct")
+        .contains("idx_game_features_black_username");
+  }
+
+  /**
+   * The browse UI's username search — {@code white.username = "x" OR black.username = "x"}, sent by
+   * GamesView with no {@code player} — reaches the same predicate shape through a different
+   * compiler path (the STRING_COLUMNS equality branch, not the participation guard), and it is the
+   * highest-traffic consumer of these indexes. Pinned separately so that path losing its {@code
+   * LOWER} cannot fall off the indexes while every guard-path test stays green.
+   */
+  @Test
+  public void theBrowseUsernameSearchIsServedByBothUsernameIndexesOnPostgres() throws Exception {
+    String plan =
+        explain(
+            new SqlCompiler()
+                .compile(
+                    Parser.parse("white.username = \"hikaru\" OR black.username = \"hikaru\""),
+                    null));
+
+    assertThat(plan)
+        .as("the UI's search predicate must reach the white-side index")
+        .contains("idx_game_features_white_username");
+    assertThat(plan).as("and the black-side index").contains("idx_game_features_black_username");
+  }
+
+  private String explain(CompiledQuery compiled) throws Exception {
     try (Connection conn = dataSource.getConnection();
         Statement stmt = conn.createStatement()) {
       stmt.execute("SET enable_seqscan = off");
@@ -127,15 +157,8 @@ public class PostgresPlayerIndexTest {
           // The connection is already broken; the primary exception is propagating.
         }
       }
-      plan = sb.toString();
+      return sb.toString();
     }
-
-    assertThat(plan)
-        .as("the white side of the OR must be an index scan, not part of a table walk")
-        .contains("idx_game_features_white_username");
-    assertThat(plan)
-        .as("and the black side its own — one index per disjunct")
-        .contains("idx_game_features_black_username");
   }
 
   /**
@@ -157,6 +180,19 @@ public class PostgresPlayerIndexTest {
         dao.query(new SqlCompiler().compile(Parser.parse("me.elo >= 0"), "hikaru"), 10, 0);
 
     assertThat(games)
+        .extracting(GameFeature::gameUrl)
+        .containsExactlyInAnyOrder("https://chess.com/game/pgi-1", "https://chess.com/game/pgi-2");
+
+    // The browse UI's search path must agree: same predicate shape, different compiler branch.
+    List<GameFeature> browsed =
+        dao.query(
+            new SqlCompiler()
+                .compile(
+                    Parser.parse("white.username = \"hikaru\" OR black.username = \"hikaru\""),
+                    null),
+            10,
+            0);
+    assertThat(browsed)
         .extracting(GameFeature::gameUrl)
         .containsExactlyInAnyOrder("https://chess.com/game/pgi-1", "https://chess.com/game/pgi-2");
   }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresPlayerIndexTest.java
@@ -98,6 +98,12 @@ public class PostgresPlayerIndexTest {
    * this suite exists to answer: <em>can</em> the plan reach these indexes for this predicate? With
    * a raw-column index, or a predicate whose shape no longer matches the indexed expression, it
    * cannot — Postgres then seq-scans even at prohibitive cost, and the assertion fails.
+   *
+   * <p>Deliberately the bare SELECT, without the {@code LIMIT ? OFFSET ?} the DAO appends: with a
+   * LIMIT the planner may legitimately prefer walking {@code idx_game_features_played_at} in order
+   * and filtering (cheapest-startup wins for a common player), and which side of that coin it picks
+   * depends on row statistics this fixture cannot meaningfully supply. Reachability is the stable,
+   * load-bearing property; the planner's per-query choice is its own business.
    */
   @Test
   public void thePlayerScopedQueryIsServedByBothUsernameIndexesOnPostgres() throws Exception {
@@ -113,7 +119,13 @@ public class PostgresPlayerIndexTest {
           sb.append(rs.getString(1)).append('\n');
         }
       } finally {
-        stmt.execute("SET enable_seqscan = on");
+        // Best-effort: this pool dies with the test (fresh DataSource per method), and a reset
+        // failure here must not replace the EXPLAIN failure that is the actual signal.
+        try {
+          stmt.execute("SET enable_seqscan = on");
+        } catch (java.sql.SQLException ignored) {
+          // The connection is already broken; the primary exception is propagating.
+        }
       }
       plan = sb.toString();
     }
@@ -147,17 +159,25 @@ public class PostgresPlayerIndexTest {
         .containsExactlyInAnyOrder("https://chess.com/game/pgi-1", "https://chess.com/game/pgi-2");
   }
 
-  /** Inlines the compiled query's bind params as SQL literals, for EXPLAIN. */
+  /**
+   * Inlines the compiled query's bind params as SQL literals, for EXPLAIN. Placeholders are
+   * consumed left to right with a moving cursor rather than repeated replaceFirst from the start,
+   * so a parameter value containing {@code ?} can never be mistaken for the next placeholder.
+   */
   private static String inlineParams(CompiledQuery compiled) {
-    String sql = compiled.selectSql();
+    StringBuilder sql = new StringBuilder(compiled.selectSql());
+    int cursor = 0;
     for (Object param : compiled.parameters()) {
       String literal =
           param instanceof Number
               ? param.toString()
               : "'" + param.toString().replace("'", "''") + "'";
-      sql = sql.replaceFirst("\\?", java.util.regex.Matcher.quoteReplacement(literal));
+      int placeholder = sql.indexOf("?", cursor);
+      assertThat(placeholder).as("a placeholder must exist for every parameter").isNotNegative();
+      sql.replace(placeholder, placeholder + 1, literal);
+      cursor = placeholder + literal.length();
     }
-    return sql;
+    return sql.toString();
   }
 
   private GameFeature game(String urlSuffix, String white, String black) {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresReadTimeoutTest.java
@@ -5,13 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.Closeable;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
 import javax.sql.DataSource;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -45,7 +40,7 @@ public class PostgresReadTimeoutTest {
         rawUrl != null && !rawUrl.isBlank(),
         DB_URL_ENV + " is not set; skipping the real-postgres read-timeout suite");
 
-    dataSource = DataSourceFactory.create(jdbcUrl(rawUrl));
+    dataSource = DataSourceFactory.create(PgTestUrls.jdbcUrl(rawUrl, null));
     jdbi = Jdbi.create(dataSource);
   }
 
@@ -129,35 +124,5 @@ public class PostgresReadTimeoutTest {
           .as("the default must reach the actual socket")
           .isEqualTo(DataSourceFactory.PG_SOCKET_TIMEOUT_SECONDS * 1000);
     }
-  }
-
-  /**
-   * Converts the libpq-style URL CI exports ({@code postgresql://user:pass@host:port/db}) into a
-   * pgjdbc URL, same as the other PG-gated suites. pgjdbc does not accept credentials in the
-   * authority, so they move to query params.
-   */
-  private static String jdbcUrl(String rawUrl) {
-    URI uri = URI.create(rawUrl);
-    List<String> params = new ArrayList<>();
-    String userInfo = uri.getUserInfo();
-    if (userInfo != null) {
-      int colon = userInfo.indexOf(':');
-      String user = colon < 0 ? userInfo : userInfo.substring(0, colon);
-      params.add("user=" + encode(user));
-      if (colon >= 0) {
-        params.add("password=" + encode(userInfo.substring(colon + 1)));
-      }
-    }
-    int port = uri.getPort() < 0 ? 5432 : uri.getPort();
-    return "jdbc:postgresql://"
-        + uri.getHost()
-        + ":"
-        + port
-        + uri.getPath()
-        + (params.isEmpty() ? "" : "?" + String.join("&", params));
-  }
-
-  private static String encode(String value) {
-    return URLEncoder.encode(value, StandardCharsets.UTF_8);
   }
 }

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresRetentionIndexTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/db/PostgresRetentionIndexTest.java
@@ -1,0 +1,101 @@
+package com.muchq.games.one_d4.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.Closeable;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The retention delete's index on the deployment dialect (#1313 item 11). The hourly sweep runs
+ * {@code DELETE FROM game_features WHERE indexed_at < ?} under a 120s statement bound; unindexed, a
+ * sweep that hit the bound rolled back with no forward progress and retried the identical scan an
+ * hour later. What this pins is that the delete's plan can reach {@code
+ * idx_game_features_indexed_at} — same reachability question, and same {@code enable_seqscan = off}
+ * technique, as {@code PostgresPlayerIndexTest}.
+ *
+ * <p>Runs against the real postgres CI provides via {@code PG_TEST_DB_URL}; skips when unset. Uses
+ * a dedicated schema like the other PG-gated suites sharing that scratch database.
+ */
+public class PostgresRetentionIndexTest {
+
+  private static final String DB_URL_ENV = "PG_TEST_DB_URL";
+  private static final String SCHEMA = "one_d4_pg_retention_index_test";
+
+  private DataSource dataSource;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    String rawUrl = System.getenv(DB_URL_ENV);
+    assumeTrue(
+        rawUrl != null && !rawUrl.isBlank(),
+        DB_URL_ENV + " is not set; skipping the real-postgres retention-index suite");
+
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+      stmt.execute("CREATE SCHEMA " + SCHEMA);
+    }
+
+    dataSource = DataSourceFactory.create(PgTestUrls.jdbcUrl(rawUrl, SCHEMA));
+    new Migration(dataSource, false).run();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (dataSource instanceof Closeable closeable) {
+      closeable.close();
+    }
+    String rawUrl = System.getenv(DB_URL_ENV);
+    if (rawUrl == null || rawUrl.isBlank()) {
+      return;
+    }
+    try (Connection conn = DriverManager.getConnection(PgTestUrls.jdbcUrl(rawUrl, null));
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+    }
+  }
+
+  /**
+   * The sweep's exact statement shape, a literal standing in for the bind: the plan must reach the
+   * index rather than walk the table. {@code enable_seqscan = off} asks reachability, not the
+   * planner's row-count judgement, for the same reasons {@code PostgresPlayerIndexTest} gives.
+   */
+  @Test
+  public void theRetentionDeleteIsServedByTheIndexedAtIndexOnPostgres() throws Exception {
+    String plan;
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
+      stmt.execute("SET enable_seqscan = off");
+      StringBuilder sb = new StringBuilder();
+      try (ResultSet rs =
+          stmt.executeQuery(
+              "EXPLAIN DELETE FROM game_features WHERE indexed_at < '2026-01-01T00:00:00'")) {
+        while (rs.next()) {
+          sb.append(rs.getString(1)).append('\n');
+        }
+      } finally {
+        // Best-effort, same as PostgresPlayerIndexTest: the pool dies with the test, and a reset
+        // failure must not replace the EXPLAIN failure that is the actual signal.
+        try {
+          stmt.execute("SET enable_seqscan = on");
+        } catch (java.sql.SQLException ignored) {
+          // The connection is already broken; the primary exception is propagating.
+        }
+      }
+      plan = sb.toString();
+    }
+
+    assertThat(plan)
+        .as("the sweep must walk straight to the expired rows")
+        .contains("idx_game_features_indexed_at");
+    assertThat(plan).as("and never fall back to the table walk").doesNotContain("Seq Scan");
+  }
+}

--- a/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
+++ b/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
@@ -923,6 +923,28 @@ public class SqlCompilerTest {
         .isEqualTo(List.of("hikaru", "hikaru", "hikaru", "hikaru", "loss", "blitz"));
   }
 
+  /**
+   * The guard exists to repair perspective resolution (the CASEs read "not white" as "black"), not
+   * to scope results — so a player with no perspective field in play adds no predicate at all.
+   * Pinned in both directions because the aggregate half is a genuine footgun: {@code
+   * player=hikaru, group by opening_family} over a plain filter aggregates the whole corpus, and
+   * unlike the select path nothing in the output reveals it. Whoever changes this semantics (e.g.
+   * to always-scope) is changing a documented contract, and this is the test that makes them say
+   * so.
+   */
+  @Test
+  public void testPlayerWithoutPerspectiveFieldAddsNoParticipationGuard() {
+    CompiledQuery select = compiler.compile(Parser.parse("num.moves >= 0"), "hikaru");
+    assertThat(select.selectSql()).doesNotContain("LOWER(white_username)");
+    assertThat(select.parameters()).isEqualTo(List.of(0));
+
+    CompiledQuery aggregate =
+        compiler.compileAggregate(
+            Parser.parse("num.moves >= 0"), List.of("opening_family"), "hikaru");
+    assertThat(aggregate.selectSql()).doesNotContain("LOWER(white_username)");
+    assertThat(aggregate.parameters()).isEqualTo(List.of(0));
+  }
+
   @Test
   public void testCompileAggregateGroupByMeColor() {
     CompiledQuery result =


### PR DESCRIPTION
## What

Items 10 **and 11** of #1313 — the two index follow-ups from the holistic altitude pass.

### Item 10: username search (expression indexes)

Two compiler paths emit the same case-folded username predicate, `LOWER(white_username) = LOWER(?)` OR'd across sides: the browse UI's username search (`white.username = "x" OR black.username = "x"` through the STRING_COLUMNS equality branch — the highest-traffic consumer) and the participation guard every perspective-field query runs. No plain column index can serve either — both sides are case-folded — so this was the full-table scan on the player-search path, and with a 5-connection pool, five concurrent player searches held every connection for the full 10s serving-read bound from #1314.

- **Postgres**: two expression indexes, `idx_game_features_white_username ON game_features(LOWER(white_username))` and the black twin. One per side, not a composite: an OR across two columns is answered by a BitmapOr of two independent scans, and a BitmapOr's output is unordered, so a composite with `played_at` couldn't skip the sort either — it would only double index weight on the hottest-write table.
- **H2**: plain-column indexes under the same names — pure write cost there (a plain index can't serve a `LOWER(...)` predicate on H2 either), carried for migration-path parity; the one H2 deployment (the MCP server's boot-scoped in-memory store) makes both costs negligible.

### Item 11: the retention-delete index

`DELETE FROM game_features WHERE indexed_at < ?` runs hourly under the 120s sweep bound from #1314; unindexed, a sweep that hit the bound rolled back having made **no forward progress** and retried the identical table scan an hour later — a ratchet that never advances. The delete is one statement, so a cancel always rolls the whole pass back; what `idx_game_features_indexed_at` (plain b-tree, dialect-neutral) changes is the **cost** side — the steady-state delete walks straight to the expired rows and *finishes* inside the bound. (`LIMIT`-batched deletes remain the next tool if a backlog ever outgrows the bound; deferred.)

## Tests

- **`PostgresPlayerIndexTest`** (new, in `pg_db_tests`): `EXPLAIN` under `enable_seqscan = off` must name both username indexes and contain no Seq Scan — for the guard's compiled query *and* the UI's browse-search query. Reachability, deliberately not planner choice (the javadoc explains why the DAO's `LIMIT`/`OFFSET` suffix is excluded). A behavioral twin pins case-insensitive matching on both colors through the real DAO, on both compiler paths.
- **`PostgresRetentionIndexTest`** (new, in `pg_db_tests`): the sweep's exact DELETE shape must reach `idx_game_features_indexed_at`, same technique.
- **`MigrationTest`**: index presence *and columns* on H2 (a stand-in redirected at the wrong column kept the name the first assertion looked for), plus the compiled predicate shape for both username paths, plus the retention index's column.
- **`SqlCompilerTest`**: a `player` with no perspective field in play adds **no** participation guard, pinned in both directions — documented contract (the guard repairs perspective resolution, it doesn't scope), pinned because the aggregate half is a footgun (item 14 on #1313).

Mutation checks, all killed against real Postgres 16 / H2: white index losing its `LOWER`; black index redirected at the white column; the STRING_COLUMNS compiler branch losing its `LOWER`; the H2 stand-in redirected at the wrong column; the retention index redirected at `played_at`; and the retention index's creation dropped from `run()`.

## Review panel

3-lens read-only panel (correctness, tests, altitude) on item 10, each lens self-refuting; all survivors applied — including the altitude lens's coverage-hole find (the browse path was unpinned) and cursor[bot]'s re-review nits across both rounds (javadoc narrowing, `doesNotContain("Seq Scan")`, H2 column pins, the first-deploy SHARE-lock ops note, and the truncated-pass semantics correction above). Item 11 follows the exact pattern the panel settled for item 10.

Housekeeping from the tests lens: the libpq→pgjdbc URL helper, previously copied into four PG suites (about to be five), now lives once in `PgTestUrls` under `:test_db`; all five suites use it.

## Verification

- Full `//domains/games/apis/one_d4/...` sweep (62/62) + `chessql` compiler suite green, including all five PG-gated suites against a real local PostgreSQL 16 (zero skips). CI additionally runs `postgres:18`.
- `scripts/format-java` + buildifier run; no lockfile churn.

## Follow-ups on #1313

Item 14 (the unguarded-aggregate footgun: `player` + plain filter on `/v1/aggregate` aggregates the whole corpus presented as the player's) and item 15 (stale README H2-storage claim) remain filed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg