### PR TITLE
one_d4 + 1d4.net: refuse unscoped player aggregates, correct the storage docs, add a /mcp page (#1313 items 14–15, #1321)

### DIFF
--- a/domains/games/apis/mcpserver/BUILD.bazel
+++ b/domains/games/apis/mcpserver/BUILD.bazel
@@ -146,6 +146,13 @@ java_binary(
 
 linux_oci_java(bin_name = "mcpserver")
 
+java_library(
+    name = "mcp_tools_fixture",
+    testonly = True,
+    resource_strip_prefix = "domains/games/apis/mcpserver/src/test/resources",
+    resources = ["src/test/resources/mcp_tools.json"],
+)
+
 java_test_suite(
     name = "tools_tests",
     size = "small",
@@ -156,9 +163,12 @@ java_test_suite(
         "src/test/java/com/muchq/games/mcpserver/tools/ChessComStatsToolTest.java",
         "src/test/java/com/muchq/games/mcpserver/tools/IndexerFacadeAggregateTest.java",
         "src/test/java/com/muchq/games/mcpserver/tools/IndexerToolsTest.java",
+        "src/test/java/com/muchq/games/mcpserver/tools/McpToolRegistryContractTest.java",
         "src/test/java/com/muchq/games/mcpserver/tools/ServerTimeToolTest.java",
     ],
     deps = [
+        ":mcp_tools_fixture",
+        ":module",
         ":tools",
         "//domains/games/apis/one_d4:db",
         "//domains/games/apis/one_d4:dto",

--- a/domains/games/apis/mcpserver/README.md
+++ b/domains/games/apis/mcpserver/README.md
@@ -254,6 +254,14 @@ The indexer engine, database, and worker are embedded in this process (Option A 
 `one_d4/.../docs/MCP_INTEGRATION.md`). By default the index lives in in-memory H2; set
 `INDEXER_DB_URL` to point at a durable database.
 
+**The deployed MCP server takes that default.** `INDEXER_DB_URL` is the only source `McpModule`
+reads — there is no `/etc/…/db_config` fallback like `one_d4`'s — and the Compose service sets no
+such variable, so its index is in-memory H2, scoped to the process: empty at boot, discarded on
+restart, and entirely separate from the `one_d4` service's PostgreSQL corpus. Indexing tools work
+here, but each container starts from nothing and re-indexes on demand. Pointing this at the shared
+database is a deliberate deployment change (it would write to the production corpus), not a
+missing setting to paste in.
+
 - `index_chess_games` — index a player's games. Required: `username`, `platform`
   (`chess.com`), `start_month`/`end_month` (YYYY-MM). Optional: `exclude_bullet`, and
   `skip_cache` to refetch already-indexed months (refreshing stored rows, e.g. backfilling

--- a/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/tools/AggregateGamesTool.java
+++ b/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/tools/AggregateGamesTool.java
@@ -32,8 +32,10 @@ public class AggregateGamesTool implements McpTool {
   public String getDescription() {
     return "Count indexed games grouped by one or more fields, filtered by a ChessQL query"
         + " (index first with index_chess_games). This answers questions like 'most popular"
-        + " openings' in one call: query 'white.username = \"hikaru\" AND time.class ="
-        + " \"blitz\"' with group_by [\"opening_family\"]. The filter may scope time with date"
+        + " openings' in one call: for one player's openings, query 'white.username ="
+        + " \"hikaru\" OR black.username = \"hikaru\"' with group_by [\"opening_family\"] —"
+        + " both sides, or you count only the games they had white. The filter may scope time"
+        + " with date"
         + " comparisons ('date >= \"2026-07-01\"') or 'month = \"2026-07\"'; date and month"
         + " filter the indexed corpus only, so a period that was never indexed comes back with"
         + " zero groups rather than an error — indistinguishable from 'played no games then'"
@@ -67,7 +69,11 @@ public class AggregateGamesTool implements McpTool {
             "description",
             "chess.com username that perspective fields (me.*, opponent.*, outcome) are resolved"
                 + " against; required when the filter uses them, and when group_by uses any"
-                + " perspective field"));
+                + " perspective field. It does NOT by itself restrict the aggregate to that"
+                + " player: to count only their games, either use a perspective field (in the"
+                + " filter or group_by) or filter explicitly with 'white.username = \"NAME\" OR"
+                + " black.username = \"NAME\"'. Naming a player without either is rejected"
+                + " rather than silently aggregating every indexed game"));
     properties.put(
         "group_by",
         Map.of(

--- a/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/tools/AggregateGamesTool.java
+++ b/domains/games/apis/mcpserver/src/main/java/com/muchq/games/mcpserver/tools/AggregateGamesTool.java
@@ -72,8 +72,12 @@ public class AggregateGamesTool implements McpTool {
                 + " perspective field. It does NOT by itself restrict the aggregate to that"
                 + " player: to count only their games, either use a perspective field (in the"
                 + " filter or group_by) or filter explicitly with 'white.username = \"NAME\" OR"
-                + " black.username = \"NAME\"'. Naming a player without either is rejected"
-                + " rather than silently aggregating every indexed game"));
+                + " black.username = \"NAME\"' — the same NAME on both sides, matching this"
+                + " player. Naming a player without either is rejected rather than silently"
+                + " counting other people's games. The filter must be one that cannot match"
+                + " another player's game, so a negation ('NOT white.username = ...'), a '!='"
+                + " comparison, an OR whose other branch is unrestricted, or an IN list naming"
+                + " anyone else does not qualify"));
     properties.put(
         "group_by",
         Map.of(

--- a/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/tools/IndexerFacadeAggregateTest.java
+++ b/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/tools/IndexerFacadeAggregateTest.java
@@ -1,6 +1,7 @@
 package com.muchq.games.mcpserver.tools;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.muchq.games.chessql.compiler.SqlCompiler;
 import com.muchq.games.one_d4.api.dto.AggregateRow;
@@ -65,14 +66,45 @@ public class IndexerFacadeAggregateTest {
     assertThat(result.totalGroups()).isZero();
   }
 
+  /**
+   * The MCP path is where the unscoped-player aggregate does the most damage (#1313 item 14): an
+   * assistant asked for "hikaru's most common openings" naturally sends {@code player: hikaru} with
+   * a plain filter, and a corpus-wide answer under that heading is indistinguishable from a correct
+   * one. This facade never touches {@code AggregateController}, so the endpoint's own rejection
+   * test would not cover it — the rule lives in the compiler for exactly that reason, and this pins
+   * that the facade inherits it rather than answering.
+   */
+  @Test
+  public void aggregate_playerThatWouldNotScopeTheResultIsRefusedBeforeAnyQuery() {
+    store.rows = TWO_GROUPS;
+
+    assertThatThrownBy(
+            () -> facade.aggregate("num.moves >= 0", List.of("opening_family"), "hikaru", 20))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("would not scope this aggregate");
+    assertThat(store.aggregateCalls).as("no wrong answer is computed").isZero();
+
+    // The scoped form the message points at still answers.
+    IndexerFacade.AggregateResult scoped =
+        facade.aggregate(
+            "white.username = \"hikaru\" OR black.username = \"hikaru\"",
+            List.of("opening_family"),
+            "hikaru",
+            20);
+    assertThat(scoped.groups()).isEqualTo(TWO_GROUPS);
+    assertThat(store.aggregateCalls).isEqualTo(1);
+  }
+
   private static final class CountingStore implements GameFeatureStore {
     List<AggregateRow> rows = List.of();
     AggregateTotals totals = new AggregateTotals(0, 0);
     int totalsCalls;
+    int aggregateCalls;
 
     @Override
     public List<AggregateRow> aggregate(
         Object compiledQuery, List<String> groupColumns, int limit) {
+      aggregateCalls++;
       return rows.size() > limit ? rows.subList(0, limit) : rows;
     }
 

--- a/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/tools/McpToolRegistryContractTest.java
+++ b/domains/games/apis/mcpserver/src/test/java/com/muchq/games/mcpserver/tools/McpToolRegistryContractTest.java
@@ -1,0 +1,68 @@
+package com.muchq.games.mcpserver.tools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.muchq.games.mcpserver.McpModule;
+import com.muchq.platform.json.JsonUtils;
+import java.io.InputStream;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The tool roster is a published contract, not an internal detail: 1d4.net's {@code /mcp} page
+ * documents it, and that page cannot fetch {@code tools/list} at runtime — {@code mcp.1d4.net}
+ * sends no CORS headers, so a browser call from 1d4.net is blocked. A hand-maintained table on the
+ * site would therefore rot silently the first time a tool is added or renamed.
+ *
+ * <p>{@code mcp_tools.json} closes that loop from both ends. This test fails when the registry
+ * stops matching the file, and {@code McpView.test.tsx} in 1d4_web fails when the page's table
+ * stops matching the same file — so a tool change breaks the build here first, and again on the
+ * frontend until the page is updated.
+ *
+ * <p>Names only, deliberately. Descriptions and input schemas are prose the tools own and reword
+ * freely; pinning them here would turn every wording improvement into a two-repo-directory edit for
+ * no reader's benefit. What the page promises, and what a change to it must be deliberate about, is
+ * which tools exist.
+ */
+public class McpToolRegistryContractTest {
+
+  @Test
+  public void theRegistryAdvertisesExactlyTheToolsTheSiteDocuments() throws Exception {
+    List<String> documented = documentedToolNames();
+    List<String> registered =
+        new ToolRegistry(allTools()).getTools().stream().map(t -> t.name()).sorted().toList();
+
+    assertThat(registered)
+        .as(
+            "mcp_tools.json is the contract between this registry and 1d4.net's /mcp page;"
+                + " update it (and the page's table) alongside the tool")
+        .isEqualTo(documented);
+  }
+
+  private static List<String> documentedToolNames() throws Exception {
+    try (InputStream in =
+        McpToolRegistryContractTest.class.getClassLoader().getResourceAsStream("mcp_tools.json")) {
+      assertThat(in).as("mcp_tools.json must be on the test classpath").isNotNull();
+      JsonNode root = JsonUtils.mapper().readTree(in);
+      List<String> names = new ArrayList<>();
+      root.get("tools").forEach(n -> names.add(n.asText()));
+      return names.stream().sorted().toList();
+    }
+  }
+
+  /**
+   * The server's own tool list, from the factory the running server uses — not a copy of it. A
+   * second hand-written list here would be one more place to forget, which is the failure this
+   * whole file exists to prevent.
+   *
+   * <p>Collaborators are null because the factory only hands them to constructors that store them;
+   * nothing is called. A tool that reached into a collaborator while being constructed would fail
+   * here, and should — registry construction runs at startup, before anything is ready.
+   */
+  private static List<McpTool> allTools() {
+    return new McpModule().mcpTools(Clock.systemUTC(), null, null, null);
+  }
+}

--- a/domains/games/apis/mcpserver/src/test/resources/mcp_tools.json
+++ b/domains/games/apis/mcpserver/src/test/resources/mcp_tools.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "The tool roster mcp.1d4.net advertises, and the contract between the server and the site's /mcp page. McpToolRegistryContractTest asserts this matches ToolRegistry exactly; 1d4_web's McpView.test.tsx asserts the page's table matches this file. Adding, removing or renaming a tool therefore fails on the Java side until this list is updated, and fails on the frontend side until the page is. Sorted by name.",
+  "tools": [
+    "aggregate_chess_games",
+    "analyze_position",
+    "chess_com_games",
+    "chess_com_player",
+    "chess_com_players",
+    "chess_com_stats",
+    "index_chess_games",
+    "index_status",
+    "query_chess_games",
+    "server_time"
+  ]
+}

--- a/domains/games/apis/one_d4/README.md
+++ b/domains/games/apis/one_d4/README.md
@@ -379,24 +379,30 @@ Returns `{"gamesReanalyzed": N}`.
 
 ## Inspecting the database (deployed)
 
-On the deployed machine the indexer uses H2 file storage at `/data/indexer` inside the container (Compose volume `one_d4_data`).
+On the deployed machine the indexer runs against **PostgreSQL** — the `one_d4_postgres` service
+(image `postgres:18`, Compose volume `one_d4_pgdata`), reached via the JDBC URL in
+`/etc/one_d4/db_config` (mounted into the container; see the resolution order above). H2 is the
+local-dev default only.
 
 ### Via the API (no direct DB access)
 
 - **Index requests:** `GET http://localhost:8088/v1/index/{id}` — returns `id`, `status`, `gamesIndexed`, `errorMessage` and a `data` block for that request. `GET http://localhost:8088/v1/index` lists the 50 most recent, newest first, so you do not need the UUID to look around.
 - **Query games:** `POST http://localhost:8088/v1/query` with a ChessQL query (e.g. `white_username = "drawlya"` or `black_username = "drawlya"`) and check the `playedAt` field in the results to see what date ranges are indexed.
 
-### Direct H2 access (copy DB out)
+### Direct database access
 
-1. Find the container: `docker ps | grep one_d4` (Compose names it like `*_one_d4_*`).
-2. Copy the H2 files from the container (e.g. replace `CONTAINER` with the actual name):
+1. Find the database container: `docker ps | grep one_d4_postgres`.
+2. Open a shell against it (credentials come from the deploy environment; the JDBC URL in
+   `/etc/one_d4/db_config` carries the same user and database):
    ```bash
-   docker cp CONTAINER:/data ./one_d4_data_backup
+   docker exec -it CONTAINER psql -U one_d4 -d one_d4
    ```
-   The DB file is `./one_d4_data_backup/indexer.mv.db`. Copying while the app is running is usually safe for a read-only snapshot; for a fully consistent copy you can stop the container first.
-3. On a machine with [H2](https://www.h2database.com/) installed, open the copy:
-   - **H2 Console (jar):** `java -jar h2*.jar` → JDBC URL `jdbc:h2:file:/path/to/one_d4_data_backup/indexer`, user `sa`, password blank.
-   - Or use any SQL client that supports H2 (e.g. DBeaver).
+3. Or dump a snapshot to inspect elsewhere:
+   ```bash
+   docker exec CONTAINER pg_dump -U one_d4 one_d4 > one_d4_backup.sql
+   ```
+   `pg_dump` takes a consistent snapshot without stopping the service, so there is no need to
+   pause the indexer first.
 
 Main tables:
 - `indexing_requests` — id, player, platform, start_month, end_month, status, games_indexed, …

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -220,7 +220,7 @@ matching row and group client-side.
 
 ```json
 {
-  "query": "white.username = \"hikaru\" AND time.class = \"blitz\"",
+  "query": "(white.username = \"hikaru\" OR black.username = \"hikaru\") AND time.class = \"blitz\"",
   "groupBy": ["opening_family"],
   "orderBy": "count",
   "limit": 20

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -238,16 +238,26 @@ matching row and group client-side.
 `player` resolves perspective fields; it is not a filter. Games are restricted to that player
 only through the participation guard, which is added when a perspective field is actually in play
 (in the filter or in `groupBy`). An aggregate that names a `player`, uses no perspective field,
-and does not filter on a username is therefore rejected with **400** rather than answered: the
-response would count every indexed game while reading as that player's, and — unlike
-`/v1/query`, whose rows show the usernames — nothing in an aggregate response would reveal it.
-To count one player's games either use a perspective field, or filter explicitly:
+and whose filter cannot by itself exclude other players' games is therefore rejected with **400**
+rather than answered: the response would count games that are not that player's while reading as
+theirs, and — unlike `/v1/query`, whose rows show the usernames — nothing in an aggregate
+response would reveal it. To count one player's games either use a perspective field, or filter
+explicitly:
 
 ```json
 { "query": "white.username = \"hikaru\" OR black.username = \"hikaru\"", "groupBy": ["opening_family"] }
 ```
 
-(Both sides, or the aggregate counts only the games they had White.) Omitting `player` entirely
+(Both sides, or the aggregate counts only the games they had White.)
+
+"Cannot admit another player's games" is checked, not assumed, so mentioning a username is not
+enough on its own. `AND` qualifies if any one conjunct does; an `OR` qualifies only if *every*
+branch does; `NOT` never does; only `=` pins a value (`!=` and the ordering operators do not);
+an `IN` list qualifies only when every alternative is the player; and the name must be the
+`player` named on the request, compared case-insensitively. So `white.username != "hikaru"`,
+`NOT white.username = "hikaru"`, `white.username = "hikaru" OR time.class = "blitz"`, and
+`black.username IN ["hikaru", "magnus"]` are all rejected — each still admits games that are not
+hikaru's. Omitting `player` entirely
 is unaffected — a corpus-wide aggregate is a legitimate question.
 
 Group-by fields validate against the same column whitelist as ChessQL comparisons. With
@@ -309,6 +319,7 @@ it first via `POST /v1/index`.
 | Conflicting bucket widths for one field           | 400         |
 | Perspective field in groupBy without `player`     | 400         |
 | Perspective field in the filter without `player`  | 400         |
+| `player` set, but neither a perspective field nor a filter that excludes other players' games | 400 |
 | Query exceeds the 10s read timeout (per statement; an aggregate that truncates runs a second totals statement) | 500 |
 
 ---

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/API.md
@@ -233,7 +233,22 @@ matching row and group client-side.
 | groupBy | string[] | yes      | —       | 5    | Fields to group by (dotted or underscore form; physical columns, plus the perspective fields when `player` is set — the rating fields as width-bucketed terms like `"opponent.elo(200)"`) |
 | orderBy | string   | no       | "count" | —    | Only "count" is supported (descending)            |
 | limit   | int      | no       | 50      | 1000 | Max groups to return                              |
-| player  | string   | no       | —       | —    | Username that perspective fields in the filter and groupBy are resolved against |
+| player  | string   | no       | —       | —    | Username that perspective fields in the filter and groupBy are resolved against. It does **not** by itself scope the aggregate — see below |
+
+`player` resolves perspective fields; it is not a filter. Games are restricted to that player
+only through the participation guard, which is added when a perspective field is actually in play
+(in the filter or in `groupBy`). An aggregate that names a `player`, uses no perspective field,
+and does not filter on a username is therefore rejected with **400** rather than answered: the
+response would count every indexed game while reading as that player's, and — unlike
+`/v1/query`, whose rows show the usernames — nothing in an aggregate response would reveal it.
+To count one player's games either use a perspective field, or filter explicitly:
+
+```json
+{ "query": "white.username = \"hikaru\" OR black.username = \"hikaru\"", "groupBy": ["opening_family"] }
+```
+
+(Both sides, or the aggregate counts only the games they had White.) Omitting `player` entirely
+is unaffected — a corpus-wide aggregate is a legitimate question.
 
 Group-by fields validate against the same column whitelist as ChessQL comparisons. With
 `player`, the perspective fields are also groupable (response keys use their underscore forms):

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
@@ -138,6 +138,13 @@ outcome = "win" AND opponent.title = "GM" AND time.class = "blitz"
 with `player: "hikaru"`. Perspective fields compile to `CASE` expressions over the `white_*` /
 `black_*` columns plus a participation guard.
 
+The guard exists to repair those `CASE` expressions — they read "not white" as "black" — so it is
+added only when a perspective field is used. `player` on its own is **not** a filter: a query
+that names a player but uses no perspective field is compiled without any player predicate, and
+matches every indexed game. On `/v1/query` that is visible in the first row's usernames, and it
+stays permitted; on `/v1/aggregate` no column would reveal it, so that combination is rejected
+(400) unless the filter names a username itself — see API.md.
+
 The categorical perspective fields may also be used in `groupBy` on `/v1/aggregate` (and the
 `aggregate_chess_games` tool) when `player` is supplied: `me.color`, `me.title`,
 `opponent.username`, `opponent.title`, and `outcome`. This is what makes both-colors

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/CHESSQL.md
@@ -143,7 +143,7 @@ added only when a perspective field is used. `player` on its own is **not** a fi
 that names a player but uses no perspective field is compiled without any player predicate, and
 matches every indexed game. On `/v1/query` that is visible in the first row's usernames, and it
 stays permitted; on `/v1/aggregate` no column would reveal it, so that combination is rejected
-(400) unless the filter names a username itself — see API.md.
+(400) unless the filter itself restricts the games to that player — see API.md.
 
 The categorical perspective fields may also be used in `groupBy` on `/v1/aggregate` (and the
 `aggregate_chess_games` tool) when `player` is supplied: `me.color`, `me.title`,

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/docs/ROADMAP.md
@@ -135,7 +135,12 @@ Allow forcing a full re-fetch and re-index for periods that would otherwise be s
 
 ### Disk cap
 
-Avoid filling disk when using file-based storage (e.g. H2 file in Docker with `one_d4_data` volume). Neither H2 nor the current Compose config impose a size limit; the volume can grow until the host runs out of space.
+**Largely overtaken by the move to PostgreSQL (#1194).** This item was written when the
+deployment ran H2 file storage on a `one_d4_data` volume, which no longer exists: the indexer
+depends on the `one_d4_postgres` service and its `one_d4_pgdata` volume, and retention (7 days of
+games, see README) bounds growth in a way the original H2 setup did not. What is left of the
+concern is host-level: nothing caps `one_d4_pgdata`, so the notes below apply to that volume,
+minus the app-level H2 file measurement.
 
 **App-level cap (optional):**
 
@@ -148,9 +153,9 @@ Avoid filling disk when using file-based storage (e.g. H2 file in Docker with `o
 **Deployment / volume:**
 
 - Document that production deployments should put the indexer data volume on a quota-backed filesystem or use a volume driver that supports a size limit where available.
-- Compose does not support a max size on named volumes directly; document recommended host-level limits or quota setup for `one_d4_data`.
+- Compose does not support a max size on named volumes directly; document recommended host-level limits or quota setup for `one_d4_pgdata`.
 
-**Note:** Once the indexer uses PostgreSQL (e.g. Neon) instead of H2 file storage, this is less of a concern: the database runs in a managed service with its own storage limits and scaling; the app no longer owns the data directory on disk.
+**Note:** the app no longer owns a data directory on disk — Postgres does. A managed service (e.g. Neon) would push storage limits and scaling onto the provider entirely; on the current self-hosted `postgres:18` container, a host-level quota on `one_d4_pgdata` is what remains to do.
 
 ### Fanout by player+year_month
 

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AggregateControllerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/api/AggregateControllerTest.java
@@ -243,6 +243,48 @@ public class AggregateControllerTest {
     assertThat(store.lastCompiled).isNull();
   }
 
+  /**
+   * The unscoped-player aggregate is refused before it reaches the store (#1313 item 14). The
+   * request that matters is the natural one — "hikaru's most common openings" — which named a
+   * player, used no perspective field, and counted the whole corpus under a heading that read as
+   * hikaru's. Pinned here, at the endpoint, because that is where a caller meets it; the compiler
+   * owns the rule so the MCP facade (which never touches this controller) is covered too.
+   */
+  @Test
+  public void aggregate_playerThatWouldNotScopeTheResultIsRejectedBeforeStoreCall() {
+    assertThatThrownBy(
+            () ->
+                controller.aggregate(
+                    new AggregateRequest(
+                        "num.moves >= 0", List.of("opening_family"), "count", 20, "hikaru")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("would not scope this aggregate");
+    assertThat(store.lastCompiled)
+        .as("a wrong answer must not be computed, let alone returned")
+        .isNull();
+  }
+
+  /** The same request, scoped the two ways the rejection message offers, reaches the store. */
+  @Test
+  public void aggregate_scopedPlayerRequestsStillReachTheStore() {
+    store.rows = List.of(new AggregateRow(Map.of("opening_family", "Sicilian Defense"), 3));
+    store.totals = new GameFeatureStore.AggregateTotals(3, 1);
+
+    controller.aggregate(
+        new AggregateRequest(
+            "white.username = \"hikaru\" OR black.username = \"hikaru\"",
+            List.of("opening_family"),
+            "count",
+            20,
+            "hikaru"));
+    assertThat(store.lastCompiled).as("explicit username filter").isNotNull();
+
+    store.lastCompiled = null;
+    controller.aggregate(
+        new AggregateRequest("num.moves >= 0", List.of("me.color"), "count", 20, "hikaru"));
+    assertThat(store.lastCompiled).as("perspective field in groupBy").isNotNull();
+  }
+
   @Test
   public void aggregate_invalidRequestRejectedBeforeStoreCall() {
     assertThatThrownBy(

--- a/domains/games/apps/1d4_web/README.md
+++ b/domains/games/apps/1d4_web/README.md
@@ -7,6 +7,7 @@ React + TypeScript frontend for the [one_d4](https://github.com/muchq/MoonBase/t
 - **Games** — Browse indexed games with sortable columns (player, ELO, time class, ECO, result, motifs), motif badges with occurrence tooltips, and click-through to chess.com. Pagination.
 - **Index** — Enqueue index requests (username, platform, start/end month). Auto-polls `GET /v1/index` while any request is pending/processing.
 - **Query** — ChessQL query input with syntax help and example chips; results table and limit selector.
+- **MCP** — Documentation for the MCP server at `mcp.1d4.net`: the tool roster, the index-before-you-query ordering, how to connect, and a worked example. Static documentation, not an interactive client — `mcp.1d4.net` sends no CORS headers, so the browser cannot call it from here.
 
 ## Develop locally
 
@@ -59,3 +60,4 @@ This tars `dist/` for CI artifact storage.
 
 - Requires the one_d4 API deployed at `api.1d4.net`.
 - API CORS must allow origin `https://1d4.net`.
+- The `/mcp` page documents `mcp.1d4.net` but never calls it, so that server needs nothing from this app. Its tool list is checked in at `src/mcpTools.ts` and pinned against the server's registry from both sides — see `src/__tests__/McpView.test.tsx` and mcpserver's `McpToolRegistryContractTest`.

--- a/domains/games/apps/1d4_web/src/App.tsx
+++ b/domains/games/apps/1d4_web/src/App.tsx
@@ -3,6 +3,7 @@ import Header from './components/Header';
 import GamesView from './views/GamesView';
 import IndexView from './views/IndexView';
 import QueryView from './views/QueryView';
+import McpView from './views/McpView';
 
 export default function App() {
   return (
@@ -14,6 +15,7 @@ export default function App() {
           <Route path="/games" element={<GamesView />} />
           <Route path="/index" element={<IndexView />} />
           <Route path="/query" element={<QueryView />} />
+          <Route path="/mcp" element={<McpView />} />
           <Route path="*" element={<Navigate to="/games" replace />} />
         </Routes>
       </main>

--- a/domains/games/apps/1d4_web/src/__tests__/McpView.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/McpView.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import App from '../App';
+import McpView from '../views/McpView';
+import { MCP_TOOLS } from '../mcpTools';
+
+// The tool roster the server actually advertises. McpToolRegistryContractTest (Java) pins the
+// registry to this same file, so a tool added, removed or renamed on the server fails there
+// first, and fails here until the page's table catches up. The page cannot ask the server
+// directly — mcp.1d4.net sends no CORS headers — which is exactly why this loop exists.
+// Resolved from the package root (vitest's cwd), because import.meta.url is not a file: URL
+// under the jsdom transform.
+const ADVERTISED_TOOLS: { tools: string[] } = JSON.parse(
+  readFileSync(
+    resolve(process.cwd(), '../../apis/mcpserver/src/test/resources/mcp_tools.json'),
+    'utf-8'
+  )
+);
+
+afterEach(cleanup);
+
+describe('McpView', () => {
+  it('documents exactly the tools the server advertises', () => {
+    const documented = MCP_TOOLS.map((t) => t.name).sort();
+    expect(documented).toEqual([...ADVERTISED_TOOLS.tools].sort());
+  });
+
+  it('renders a row per tool, each with a description', () => {
+    render(
+      <MemoryRouter>
+        <McpView />
+      </MemoryRouter>
+    );
+
+    // Scoped to the table: several tool names also appear in the prose above it.
+    const table = within(screen.getByRole('table'));
+    for (const tool of MCP_TOOLS) {
+      const row = table.getByText(tool.name).closest('tr');
+      expect(row).not.toBeNull();
+      // The name alone is not documentation: the row must also carry the summary.
+      expect(within(row as HTMLElement).getByText(tool.summary)).toBeTruthy();
+    }
+  });
+
+  /**
+   * The index-first ordering is the single thing a newcomer gets wrong, so it is not allowed to
+   * quietly vanish from the page.
+   */
+  it('tells the reader to index before querying', () => {
+    render(
+      <MemoryRouter>
+        <McpView />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /index first/i })).toBeTruthy();
+    expect(screen.getByText(/only see games that have been indexed/i)).toBeTruthy();
+  });
+
+  /**
+   * The transport caveat is the reason a reader's standard MCP client will not connect, and it is
+   * the kind of awkward sentence that gets tidied away. Pinned so removing it is deliberate.
+   */
+  it('states the endpoint and that it is not a standard MCP transport', () => {
+    render(
+      <MemoryRouter>
+        <McpView />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText(/mcp\.1d4\.net/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/no SSE/i)).toBeTruthy();
+    expect(screen.getByText(/Mcp-Session-Id/)).toBeTruthy();
+  });
+
+  it('is reachable at /mcp and marks its nav link active', () => {
+    render(
+      <MemoryRouter initialEntries={['/mcp']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /MCP server/i })).toBeTruthy();
+    const link = screen.getByRole('link', { name: 'MCP' });
+    expect(link.className).toContain('active');
+  });
+});

--- a/domains/games/apps/1d4_web/src/__tests__/McpView.test.tsx
+++ b/domains/games/apps/1d4_web/src/__tests__/McpView.test.tsx
@@ -17,9 +17,12 @@ import { MCP_TOOLS } from '../mcpTools';
 // under the jsdom transform.
 const ADVERTISED_TOOLS: { tools: string[] } = JSON.parse(
   readFileSync(
-    resolve(process.cwd(), '../../apis/mcpserver/src/test/resources/mcp_tools.json'),
-    'utf-8'
-  )
+    resolve(
+      process.cwd(),
+      '../../apis/mcpserver/src/test/resources/mcp_tools.json',
+    ),
+    'utf-8',
+  ),
 );
 
 afterEach(cleanup);
@@ -34,7 +37,7 @@ describe('McpView', () => {
     render(
       <MemoryRouter>
         <McpView />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     // Scoped to the table: several tool names also appear in the prose above it.
@@ -55,11 +58,13 @@ describe('McpView', () => {
     render(
       <MemoryRouter>
         <McpView />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByRole('heading', { name: /index first/i })).toBeTruthy();
-    expect(screen.getByText(/only see games that have been indexed/i)).toBeTruthy();
+    expect(
+      screen.getByText(/only see games that have been indexed/i),
+    ).toBeTruthy();
   });
 
   /**
@@ -70,7 +75,7 @@ describe('McpView', () => {
     render(
       <MemoryRouter>
         <McpView />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getAllByText(/mcp\.1d4\.net/).length).toBeGreaterThan(0);
@@ -78,11 +83,53 @@ describe('McpView', () => {
     expect(screen.getByText(/Mcp-Session-Id/)).toBeTruthy();
   });
 
+  /**
+   * The MCP server indexes into its own in-memory database — empty at boot, discarded on restart,
+   * and not the corpus behind Games/api.1d4.net. A page that sits in the same nav and talks about
+   * indexing invites exactly the wrong conclusion, so the fact is pinned rather than left to
+   * whoever edits the copy next.
+   */
+  it('says its index is separate from the site corpus and does not survive restarts', () => {
+    render(
+      <MemoryRouter>
+        <McpView />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /its index is its own/i }),
+    ).toBeTruthy();
+    expect(screen.getByText(/in-memory database/i)).toBeTruthy();
+    expect(
+      screen.getByText(/discarded when the process restarts/i),
+    ).toBeTruthy();
+  });
+
+  /**
+   * index_chess_games is synchronous for a single month (IndexerFacade goes through
+   * submitHybrid) and queued for a range. The page's worked example is one month, so copy that
+   * says "poll until it completes" would be telling readers to poll something already finished.
+   */
+  it('describes single-month indexing as synchronous and ranges as polled', () => {
+    render(
+      <MemoryRouter>
+        <McpView />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText(/single month is indexed while you wait/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/multi-month range is queued/i)).toBeTruthy();
+    // And the worked example, which is a single month, must not send the reader off to poll.
+    expect(screen.getByText(/nothing to poll/i)).toBeTruthy();
+  });
+
   it('is reachable at /mcp and marks its nav link active', () => {
     render(
       <MemoryRouter initialEntries={['/mcp']}>
         <App />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByRole('heading', { name: /MCP server/i })).toBeTruthy();

--- a/domains/games/apps/1d4_web/src/components/Header.tsx
+++ b/domains/games/apps/1d4_web/src/components/Header.tsx
@@ -26,6 +26,12 @@ export default function Header() {
         >
           Query
         </NavLink>
+        <NavLink
+          to="/mcp"
+          className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}
+        >
+          MCP
+        </NavLink>
       </nav>
     </header>
   );

--- a/domains/games/apps/1d4_web/src/index.css
+++ b/domains/games/apps/1d4_web/src/index.css
@@ -719,3 +719,66 @@ tr.selected td {
   padding: 1.5rem 0;
   text-align: center;
 }
+
+/* MCP page */
+.code-block {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.875rem 1rem;
+  overflow-x: auto;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.code-block code {
+  font-family: var(--font-mono);
+  color: var(--text);
+  white-space: pre;
+}
+
+.mcp-steps,
+.mcp-examples {
+  margin: 0.5rem 0 1rem;
+  padding-left: 1.25rem;
+  line-height: 1.7;
+}
+
+.mcp-steps code,
+.mcp-examples code,
+.panel-note code,
+.mcp-view p code {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.mcp-tools-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mcp-tools-table th,
+.mcp-tools-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.mcp-tools-table th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.mcp-needs-index {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}

--- a/domains/games/apps/1d4_web/src/mcpTools.ts
+++ b/domains/games/apps/1d4_web/src/mcpTools.ts
@@ -18,16 +18,17 @@ export const MCP_TOOLS: McpToolDoc[] = [
   {
     name: 'index_chess_games',
     summary:
-      "Index a player's games for a month range. Asynchronous — returns a request id to poll.",
+      "Index a player's games. A single month runs while you wait; a multi-month range returns a request id to poll.",
   },
   {
     name: 'index_status',
     summary:
-      'Poll an indexing request: status, how many games have landed, and any error message.',
+      'Poll a multi-month indexing request: status, how many games have landed, and any error message.',
   },
   {
     name: 'query_chess_games',
-    summary: 'Search indexed games with ChessQL, including motif and sequence predicates.',
+    summary:
+      'Search indexed games with ChessQL, including motif and sequence predicates.',
     needsIndex: true,
   },
   {
@@ -60,6 +61,7 @@ export const MCP_TOOLS: McpToolDoc[] = [
   },
   {
     name: 'server_time',
-    summary: 'Current UTC time, for grounding relative dates like "last month".',
+    summary:
+      'Current UTC time, for grounding relative dates like "last month".',
   },
 ];

--- a/domains/games/apps/1d4_web/src/mcpTools.ts
+++ b/domains/games/apps/1d4_web/src/mcpTools.ts
@@ -1,0 +1,65 @@
+/**
+ * The tools mcp.1d4.net advertises, as documented on /mcp.
+ *
+ * The page cannot ask the server for this list: mcp.1d4.net sends no CORS headers, so a
+ * tools/list call from a browser on 1d4.net is blocked. So the roster is checked in — and pinned
+ * from both ends, because a hand-maintained table would otherwise rot the first time a tool is
+ * added or renamed. `McpToolRegistryContractTest` (Java) asserts the server's registry matches
+ * mcp_tools.json, and `McpView.test.tsx` asserts the names below match that same file.
+ */
+export type McpToolDoc = {
+  name: string;
+  summary: string;
+  /** True when the tool reads indexed games, i.e. it needs index_chess_games to have run. */
+  needsIndex?: boolean;
+};
+
+export const MCP_TOOLS: McpToolDoc[] = [
+  {
+    name: 'index_chess_games',
+    summary:
+      "Index a player's games for a month range. Asynchronous — returns a request id to poll.",
+  },
+  {
+    name: 'index_status',
+    summary:
+      'Poll an indexing request: status, how many games have landed, and any error message.',
+  },
+  {
+    name: 'query_chess_games',
+    summary: 'Search indexed games with ChessQL, including motif and sequence predicates.',
+    needsIndex: true,
+  },
+  {
+    name: 'aggregate_chess_games',
+    summary:
+      'Grouped counts over indexed games — "most popular openings" in one call instead of paging every row.',
+    needsIndex: true,
+  },
+  {
+    name: 'analyze_position',
+    summary:
+      'Detect motifs in a single PGN. The one indexer tool that needs no indexing first.',
+  },
+  {
+    name: 'chess_com_games',
+    summary:
+      "A player's chess.com games for one month, filterable by time class, colour, rated and opponent.",
+  },
+  {
+    name: 'chess_com_player',
+    summary: "A player's chess.com profile, including their title.",
+  },
+  {
+    name: 'chess_com_players',
+    summary: 'Batch profile lookup, up to 50 usernames per call.',
+  },
+  {
+    name: 'chess_com_stats',
+    summary: "A player's chess.com rating stats per time class.",
+  },
+  {
+    name: 'server_time',
+    summary: 'Current UTC time, for grounding relative dates like "last month".',
+  },
+];

--- a/domains/games/apps/1d4_web/src/views/McpView.tsx
+++ b/domains/games/apps/1d4_web/src/views/McpView.tsx
@@ -20,9 +20,10 @@ export default function McpView() {
       <section className="panel">
         <h2>MCP server</h2>
         <p>
-          1d4 exposes its chess indexer and chess.com lookups as {MCP_TOOLS.length} tools over the
-          Model Context Protocol, so an assistant can index a player, search the games with
-          ChessQL, and aggregate them without a human in the loop.
+          1d4 exposes its chess indexer and chess.com lookups as{' '}
+          {MCP_TOOLS.length} tools over the Model Context Protocol, so an
+          assistant can index a player, search the games with ChessQL, and
+          aggregate them without a human in the loop.
         </p>
         <p className="panel-note">
           Endpoint: <code>{ENDPOINT}</code> — no account, no API key.
@@ -30,52 +31,76 @@ export default function McpView() {
       </section>
 
       <section className="panel">
+        <h2>Its index is its own</h2>
+        <p>
+          What you index through these tools is <strong>not</strong> what
+          1d4.net shows. The MCP server carries its own indexer with an
+          in-memory database: it starts empty, it is discarded when the process
+          restarts, and it is separate from the corpus behind the{' '}
+          <Link to="/games">Games</Link> page and <code>api.1d4.net</code>.
+        </p>
+        <p className="panel-note">
+          So a player you index here is searchable here, by you, until the next
+          restart — and does not appear on the site. Index through the{' '}
+          <Link to="/index">Index</Link> page instead if the corpus is what you
+          are filling.
+        </p>
+      </section>
+
+      <section className="panel">
         <h2>Connecting</h2>
         <p>
-          The endpoint speaks <strong>JSON-RPC 2.0 over a single HTTP POST</strong>. Each request
-          is self-contained: send a method, get a JSON response.
+          The endpoint speaks{' '}
+          <strong>JSON-RPC 2.0 over a single HTTP POST</strong>. Each request is
+          self-contained: send a method, get a JSON response.
         </p>
         <pre className="code-block">
           <code>{LIST_TOOLS_CURL}</code>
         </pre>
         <p>
           That is the whole protocol surface — which is also the caveat. It is{' '}
-          <strong>not</strong> one of MCP&rsquo;s standard remote transports: there is no SSE
-          stream, no <code>Mcp-Session-Id</code>, and <code>notifications/initialized</code> is not
-          implemented. Clients that speak stdio, HTTP+SSE or Streamable HTTP will not connect
-          without a small bridge that turns their transport into these plain POSTs. If you are
-          driving it from your own code, the <code>curl</code> above is the entire contract.
+          <strong>not</strong> one of MCP&rsquo;s standard remote transports:
+          there is no SSE stream, no <code>Mcp-Session-Id</code>, and{' '}
+          <code>notifications/initialized</code> is not implemented. Clients
+          that speak stdio, HTTP+SSE or Streamable HTTP will not connect without
+          a small bridge that turns their transport into these plain POSTs. If
+          you are driving it from your own code, the <code>curl</code> above is
+          the entire contract.
         </p>
         <p className="panel-note">
-          <code>initialize</code>, <code>tools/list</code> and <code>tools/call</code> are the
-          three methods implemented. Calls are unauthenticated today; the server supports a bearer
-          token, but the deployment sets none.
+          <code>initialize</code>, <code>tools/list</code> and{' '}
+          <code>tools/call</code> are the three methods implemented. Calls are
+          unauthenticated today; the server supports a bearer token, but the
+          deployment sets none.
         </p>
       </section>
 
       <section className="panel">
         <h2>Index first</h2>
         <p>
-          The searching tools only see games that have been indexed. Nothing is indexed
-          speculatively, so the order matters:
+          The searching tools only see games that have been indexed. Nothing is
+          indexed speculatively, so the order matters:
         </p>
         <ol className="mcp-steps">
           <li>
-            <code>index_chess_games</code> — asks for a player and a month range. Returns a request
-            id immediately; the work happens in the background.
+            <code>index_chess_games</code> — asks for a player and a month
+            range. A <strong>single month is indexed while you wait</strong> and
+            comes back completed; a multi-month range is queued and comes back
+            with a request id.
           </li>
           <li>
-            <code>index_status</code> — poll that id until it reports completed. A month already
-            indexed is skipped, so re-running is cheap.
+            <code>index_status</code> — for a queued range, poll that id until
+            it reports completed. A month already indexed is skipped, so
+            re-running is cheap.
           </li>
           <li>
-            <code>query_chess_games</code> / <code>aggregate_chess_games</code> — now they have
-            something to read.
+            <code>query_chess_games</code> / <code>aggregate_chess_games</code>{' '}
+            — now they have something to read.
           </li>
         </ol>
         <p className="panel-note">
-          <code>analyze_position</code> is the exception: hand it a PGN and it detects motifs in
-          that one game, with no indexing at all.
+          <code>analyze_position</code> is the exception: hand it a PGN and it
+          detects motifs in that one game, with no indexing at all.
         </p>
       </section>
 
@@ -95,7 +120,10 @@ export default function McpView() {
                   <td className="nowrap">
                     <code>{tool.name}</code>
                     {tool.needsIndex && (
-                      <span className="mcp-needs-index" title="Reads indexed games">
+                      <span
+                        className="mcp-needs-index"
+                        title="Reads indexed games"
+                      >
                         indexed
                       </span>
                     )}
@@ -107,8 +135,9 @@ export default function McpView() {
           </table>
         </div>
         <p className="panel-note">
-          Each tool advertises its own JSON input schema through <code>tools/list</code>; the
-          descriptions there are what an assistant actually reads.
+          Each tool advertises its own JSON input schema through{' '}
+          <code>tools/list</code>; the descriptions there are what an assistant
+          actually reads.
         </p>
       </section>
 
@@ -119,37 +148,43 @@ export default function McpView() {
           <code>{CALL_TOOL_CURL}</code>
         </pre>
         <p>
-          Poll <code>index_status</code> with the returned id until it is completed, then query the
-          indexed games:
+          That is one month, so it returns completed — nothing to poll. (Ask for
+          a range and you get a request id instead, which is what{' '}
+          <code>index_status</code> is for.) Then query what it indexed:
         </p>
         <ul className="mcp-examples">
           <li>
             <code>query_chess_games</code> with{' '}
             <code>
-              {'(white.username = "hikaru" OR black.username = "hikaru") AND motif(fork)'}
+              {
+                '(white.username = "hikaru" OR black.username = "hikaru") AND motif(fork)'
+              }
             </code>{' '}
             — their games containing a fork.
           </li>
           <li>
             <code>aggregate_chess_games</code> with the same filter and{' '}
-            <code>group_by: ["opening_family"]</code> — the openings they played, by count.
+            <code>group_by: ["opening_family"]</code> — the openings they
+            played, by count.
           </li>
         </ul>
         <p className="panel-note">
-          Both sides of the OR, or you only count the games they had White. Naming a{' '}
-          <code>player</code> instead is for perspective fields (<code>me.color</code>,{' '}
-          <code>outcome</code>, <code>opponent.elo</code>); on its own it does not restrict an
-          aggregate to that player, and an aggregate that would not be scoped is refused rather
-          than silently counting everyone.
+          Both sides of the OR, or you only count the games they had White.
+          Naming a <code>player</code> instead is for perspective fields (
+          <code>me.color</code>, <code>outcome</code>, <code>opponent.elo</code>
+          ); on its own it does not restrict an aggregate to that player, and an
+          aggregate that would not be scoped is refused rather than silently
+          counting everyone.
         </p>
       </section>
 
       <section className="panel">
         <h2>ChessQL</h2>
         <p>
-          <code>query_chess_games</code> and the filter half of <code>aggregate_chess_games</code>{' '}
-          take ChessQL — the same language the <Link to="/query">Query</Link> page uses, where the
-          field and motif reference lives.
+          <code>query_chess_games</code> and the filter half of{' '}
+          <code>aggregate_chess_games</code> take ChessQL — the same language
+          the <Link to="/query">Query</Link> page uses, where the field and
+          motif reference lives.
         </p>
       </section>
     </div>

--- a/domains/games/apps/1d4_web/src/views/McpView.tsx
+++ b/domains/games/apps/1d4_web/src/views/McpView.tsx
@@ -1,0 +1,157 @@
+import { Link } from 'react-router';
+import { MCP_TOOLS } from '../mcpTools';
+
+const ENDPOINT = 'https://mcp.1d4.net/mcp';
+
+const LIST_TOOLS_CURL = `curl -s ${ENDPOINT} \\
+  -H 'Content-Type: application/json' \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'`;
+
+const CALL_TOOL_CURL = `curl -s ${ENDPOINT} \\
+  -H 'Content-Type: application/json' \\
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call",
+       "params":{"name":"index_chess_games",
+                 "arguments":{"username":"hikaru","platform":"chess.com",
+                              "start_month":"2026-06","end_month":"2026-06"}}}'`;
+
+export default function McpView() {
+  return (
+    <div className="mcp-view">
+      <section className="panel">
+        <h2>MCP server</h2>
+        <p>
+          1d4 exposes its chess indexer and chess.com lookups as {MCP_TOOLS.length} tools over the
+          Model Context Protocol, so an assistant can index a player, search the games with
+          ChessQL, and aggregate them without a human in the loop.
+        </p>
+        <p className="panel-note">
+          Endpoint: <code>{ENDPOINT}</code> — no account, no API key.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2>Connecting</h2>
+        <p>
+          The endpoint speaks <strong>JSON-RPC 2.0 over a single HTTP POST</strong>. Each request
+          is self-contained: send a method, get a JSON response.
+        </p>
+        <pre className="code-block">
+          <code>{LIST_TOOLS_CURL}</code>
+        </pre>
+        <p>
+          That is the whole protocol surface — which is also the caveat. It is{' '}
+          <strong>not</strong> one of MCP&rsquo;s standard remote transports: there is no SSE
+          stream, no <code>Mcp-Session-Id</code>, and <code>notifications/initialized</code> is not
+          implemented. Clients that speak stdio, HTTP+SSE or Streamable HTTP will not connect
+          without a small bridge that turns their transport into these plain POSTs. If you are
+          driving it from your own code, the <code>curl</code> above is the entire contract.
+        </p>
+        <p className="panel-note">
+          <code>initialize</code>, <code>tools/list</code> and <code>tools/call</code> are the
+          three methods implemented. Calls are unauthenticated today; the server supports a bearer
+          token, but the deployment sets none.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2>Index first</h2>
+        <p>
+          The searching tools only see games that have been indexed. Nothing is indexed
+          speculatively, so the order matters:
+        </p>
+        <ol className="mcp-steps">
+          <li>
+            <code>index_chess_games</code> — asks for a player and a month range. Returns a request
+            id immediately; the work happens in the background.
+          </li>
+          <li>
+            <code>index_status</code> — poll that id until it reports completed. A month already
+            indexed is skipped, so re-running is cheap.
+          </li>
+          <li>
+            <code>query_chess_games</code> / <code>aggregate_chess_games</code> — now they have
+            something to read.
+          </li>
+        </ol>
+        <p className="panel-note">
+          <code>analyze_position</code> is the exception: hand it a PGN and it detects motifs in
+          that one game, with no indexing at all.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2>Tools</h2>
+        <div className="table-wrap">
+          <table className="mcp-tools-table">
+            <thead>
+              <tr>
+                <th>Tool</th>
+                <th>What it does</th>
+              </tr>
+            </thead>
+            <tbody>
+              {MCP_TOOLS.map((tool) => (
+                <tr key={tool.name}>
+                  <td className="nowrap">
+                    <code>{tool.name}</code>
+                    {tool.needsIndex && (
+                      <span className="mcp-needs-index" title="Reads indexed games">
+                        indexed
+                      </span>
+                    )}
+                  </td>
+                  <td>{tool.summary}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="panel-note">
+          Each tool advertises its own JSON input schema through <code>tools/list</code>; the
+          descriptions there are what an assistant actually reads.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2>A worked example</h2>
+        <p>Index one month, then ask two questions about it.</p>
+        <pre className="code-block">
+          <code>{CALL_TOOL_CURL}</code>
+        </pre>
+        <p>
+          Poll <code>index_status</code> with the returned id until it is completed, then query the
+          indexed games:
+        </p>
+        <ul className="mcp-examples">
+          <li>
+            <code>query_chess_games</code> with{' '}
+            <code>
+              {'(white.username = "hikaru" OR black.username = "hikaru") AND motif(fork)'}
+            </code>{' '}
+            — their games containing a fork.
+          </li>
+          <li>
+            <code>aggregate_chess_games</code> with the same filter and{' '}
+            <code>group_by: ["opening_family"]</code> — the openings they played, by count.
+          </li>
+        </ul>
+        <p className="panel-note">
+          Both sides of the OR, or you only count the games they had White. Naming a{' '}
+          <code>player</code> instead is for perspective fields (<code>me.color</code>,{' '}
+          <code>outcome</code>, <code>opponent.elo</code>); on its own it does not restrict an
+          aggregate to that player, and an aggregate that would not be scoped is refused rather
+          than silently counting everyone.
+        </p>
+      </section>
+
+      <section className="panel">
+        <h2>ChessQL</h2>
+        <p>
+          <code>query_chess_games</code> and the filter half of <code>aggregate_chess_games</code>{' '}
+          take ChessQL — the same language the <Link to="/query">Query</Link> page uses, where the
+          field and motif reference lives.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/domains/games/libs/chessql/src/main/java/com/muchq/games/chessql/compiler/SqlCompiler.java
+++ b/domains/games/libs/chessql/src/main/java/com/muchq/games/chessql/compiler/SqlCompiler.java
@@ -522,12 +522,15 @@ public class SqlCompiler implements QueryCompiler<CompiledQuery> {
    * aggregate entry points reject the combination instead of answering the wrong question
    * convincingly.
    *
-   * <p>An explicit username filter counts as scoping, since the caller has said what they meant in
-   * the query itself; the named player is then merely redundant.
+   * <p>A filter that pins a username column to the named player counts as scoping — the caller said
+   * what they meant in the query itself, and the named player is then merely redundant. That is a
+   * narrower test than "a username is mentioned somewhere", deliberately: {@code NOT white.username
+   * = "magnus"} names a username while saying nothing about the player, and answering it would
+   * reproduce exactly the failure this method exists to prevent.
    */
   private void requireTheAggregateScopesToItsPlayer(ParsedQuery pq, Perspective perspective) {
     // Perspective normalizes a blank player to null, so the null check covers both.
-    if (perspective.player == null || perspective.used || filtersOnUsername(pq.expr())) {
+    if (perspective.player == null || perspective.used || scopesToPlayer(pq.expr(), perspective)) {
       return;
     }
     throw new IllegalArgumentException(
@@ -535,23 +538,44 @@ public class SqlCompiler implements QueryCompiler<CompiledQuery> {
             + perspective.player
             + "\" would not scope this aggregate: no perspective field ("
             + PERSPECTIVE_FIELDS.keySet().stream().sorted().collect(Collectors.joining(", "))
-            + ") appears in the filter or groupBy, and the filter names no username, so the"
-            + " result would cover every indexed game rather than that player's. Group by or"
+            + ") appears in the filter or groupBy, and the filter does not restrict a username"
+            + " to that player, so the result would cover games that are not theirs. Group by or"
             + " filter on a perspective field, or filter explicitly:"
-            + " white.username = \"NAME\" OR black.username = \"NAME\".");
+            + " white.username = \"NAME\" OR black.username = \"NAME\" (the same NAME).");
   }
 
-  /** Whether the filter itself constrains a username column, on either side. */
-  private boolean filtersOnUsername(Expr expr) {
+  /**
+   * Whether this filter cannot match a game the named player did not play.
+   *
+   * <p>Read as "does every row this expression admits belong to the player?", which is why the
+   * cases are not symmetric. A conjunction scopes if <em>any</em> conjunct does, since AND only
+   * narrows. A disjunction scopes only if <em>every</em> branch does, since one unscoped branch
+   * admits the whole corpus. Negation never scopes: the complement of "is the player" is everyone
+   * else. Only equality pins a value — {@code !=} and the ordering operators widen — and an {@code
+   * IN} list scopes only when every alternative is the player, since a list naming anyone else
+   * admits their games too.
+   */
+  private boolean scopesToPlayer(Expr expr, Perspective perspective) {
     return switch (expr) {
-      case OrExpr or -> or.operands().stream().anyMatch(this::filtersOnUsername);
-      case AndExpr and -> and.operands().stream().anyMatch(this::filtersOnUsername);
-      case NotExpr not -> filtersOnUsername(not.operand());
-      case ComparisonExpr cmp -> isUsernameField(cmp.field());
-      case InExpr in -> isUsernameField(in.field());
+      case OrExpr or -> or.operands().stream().allMatch(e -> scopesToPlayer(e, perspective));
+      case AndExpr and -> and.operands().stream().anyMatch(e -> scopesToPlayer(e, perspective));
+      case NotExpr ignored -> false;
+      case ComparisonExpr cmp ->
+          "=".equals(cmp.operator())
+              && isUsernameField(cmp.field())
+              && isThePlayer(cmp.value(), perspective);
+      case InExpr in ->
+          isUsernameField(in.field())
+              && !in.values().isEmpty()
+              && in.values().stream().allMatch(v -> isThePlayer(v, perspective));
       case MotifExpr ignored -> false;
       case SequenceExpr ignored -> false;
     };
+  }
+
+  /** Compared case-insensitively, since the compiled username predicates case-fold both sides. */
+  private static boolean isThePlayer(Object value, Perspective perspective) {
+    return value instanceof String name && name.equalsIgnoreCase(perspective.player);
   }
 
   private boolean isUsernameField(String field) {

--- a/domains/games/libs/chessql/src/main/java/com/muchq/games/chessql/compiler/SqlCompiler.java
+++ b/domains/games/libs/chessql/src/main/java/com/muchq/games/chessql/compiler/SqlCompiler.java
@@ -320,6 +320,7 @@ public class SqlCompiler implements QueryCompiler<CompiledQuery> {
     List<Object> whereParams = new ArrayList<>();
     String whereClause = compileExpr(pq.expr(), whereParams, perspective);
     whereClause = guardParticipation(whereClause, whereParams, perspective);
+    requireTheAggregateScopesToItsPlayer(pq, perspective);
 
     // GROUP BY references the term keys: the column itself for physical fields, the SELECT alias
     // for perspective fields. Repeating the CASE expression instead would not be portable —
@@ -371,6 +372,7 @@ public class SqlCompiler implements QueryCompiler<CompiledQuery> {
       groupExprs.add(groupTermExpr(term, perspective, groupParams));
     }
     whereClause = guardParticipation(whereClause, whereParams, perspective);
+    requireTheAggregateScopesToItsPlayer(pq, perspective);
 
     String sql =
         "SELECT COUNT(*) AS total_groups, COALESCE(SUM(group_count), 0) AS total_games FROM ("
@@ -506,6 +508,61 @@ public class SqlCompiler implements QueryCompiler<CompiledQuery> {
         + " bucket by "
         + DEFAULT_ELO_BUCKET_WIDTH
         + "; opponent.elo(200) groups ratings into [2000, 2200), [2200, 2400), ...";
+  }
+
+  /**
+   * Aggregates must not name a player they never scope to.
+   *
+   * <p>A player only narrows a query through the participation guard, and the guard only fires when
+   * a perspective field is in play (it exists to repair the CASE expressions, not to filter). On
+   * the select path that is harmless: the rows carry usernames, so a caller who expected one
+   * player's games sees strangers immediately. An aggregate has no such tell — {@code player:
+   * hikaru, query: num.moves >= 0, group by opening_family} returns the whole corpus's openings
+   * under a heading that reads as hikaru's, and nothing in the response reveals it. So the
+   * aggregate entry points reject the combination instead of answering the wrong question
+   * convincingly.
+   *
+   * <p>An explicit username filter counts as scoping, since the caller has said what they meant in
+   * the query itself; the named player is then merely redundant.
+   */
+  private void requireTheAggregateScopesToItsPlayer(ParsedQuery pq, Perspective perspective) {
+    // Perspective normalizes a blank player to null, so the null check covers both.
+    if (perspective.player == null || perspective.used || filtersOnUsername(pq.expr())) {
+      return;
+    }
+    throw new IllegalArgumentException(
+        "player \""
+            + perspective.player
+            + "\" would not scope this aggregate: no perspective field ("
+            + PERSPECTIVE_FIELDS.keySet().stream().sorted().collect(Collectors.joining(", "))
+            + ") appears in the filter or groupBy, and the filter names no username, so the"
+            + " result would cover every indexed game rather than that player's. Group by or"
+            + " filter on a perspective field, or filter explicitly:"
+            + " white.username = \"NAME\" OR black.username = \"NAME\".");
+  }
+
+  /** Whether the filter itself constrains a username column, on either side. */
+  private boolean filtersOnUsername(Expr expr) {
+    return switch (expr) {
+      case OrExpr or -> or.operands().stream().anyMatch(this::filtersOnUsername);
+      case AndExpr and -> and.operands().stream().anyMatch(this::filtersOnUsername);
+      case NotExpr not -> filtersOnUsername(not.operand());
+      case ComparisonExpr cmp -> isUsernameField(cmp.field());
+      case InExpr in -> isUsernameField(in.field());
+      case MotifExpr ignored -> false;
+      case SequenceExpr ignored -> false;
+    };
+  }
+
+  private boolean isUsernameField(String field) {
+    try {
+      String column = resolveColumn(field);
+      return column.equals("white_username") || column.equals("black_username");
+    } catch (IllegalArgumentException unknownOrPerspective) {
+      // Perspective spellings and genuinely unknown fields both land here. The first is already
+      // covered by perspective.used; the second is compileExpr's error to report, not ours.
+      return false;
+    }
   }
 
   /**

--- a/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
+++ b/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
@@ -1,6 +1,7 @@
 package com.muchq.games.chessql.compiler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.muchq.games.chessql.ast.OrderByClause;
@@ -925,24 +926,110 @@ public class SqlCompilerTest {
 
   /**
    * The guard exists to repair perspective resolution (the CASEs read "not white" as "black"), not
-   * to scope results — so a player with no perspective field in play adds no predicate at all.
-   * Pinned in both directions because the aggregate half is a genuine footgun: {@code
-   * player=hikaru, group by opening_family} over a plain filter aggregates the whole corpus, and
-   * unlike the select path nothing in the output reveals it. Whoever changes this semantics (e.g.
-   * to always-scope) is changing a documented contract, and this is the test that makes them say
-   * so.
+   * to scope results — so on the select path a player with no perspective field in play adds no
+   * predicate at all. That stays: the rows carry usernames, so a caller who expected one player's
+   * games sees strangers in the very first result.
    */
   @Test
-  public void testPlayerWithoutPerspectiveFieldAddsNoParticipationGuard() {
+  public void testPlayerWithoutPerspectiveFieldAddsNoParticipationGuardOnSelect() {
     CompiledQuery select = compiler.compile(Parser.parse("num.moves >= 0"), "hikaru");
     assertThat(select.selectSql()).doesNotContain("LOWER(white_username)");
     assertThat(select.parameters()).isEqualTo(List.of(0));
+  }
 
-    CompiledQuery aggregate =
+  /**
+   * The aggregate half of the same semantics was a footgun rather than a contract, so it is now
+   * refused (#1313 item 14). {@code player=hikaru, group by opening_family} over a plain filter
+   * aggregated the whole corpus under a heading that read as hikaru's, and — unlike the select path
+   * — no column in the response revealed it. Both aggregate entry points reject it, because the
+   * truncation path runs the totals query and the MCP facade calls the compiler directly rather
+   * than through the controller.
+   */
+  @Test
+  public void testAggregateRefusesAPlayerItWouldNotScopeTo() {
+    assertThatThrownBy(
+            () ->
+                compiler.compileAggregate(
+                    Parser.parse("num.moves >= 0"), List.of("opening_family"), "hikaru"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("would not scope this aggregate")
+        .hasMessageContaining("hikaru")
+        .hasMessageContaining("white.username");
+
+    assertThatThrownBy(
+            () ->
+                compiler.compileAggregateTotals(
+                    Parser.parse("num.moves >= 0"), List.of("opening_family"), "hikaru"))
+        .as("the totals query runs on the truncation path and must refuse the same request")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("would not scope this aggregate");
+  }
+
+  /**
+   * The three ways an aggregate legitimately names a player — a perspective field in the filter, a
+   * perspective field in the groupBy, or an explicit username filter that scopes it without any
+   * perspective field at all. Each must still compile; a refusal that swallowed these would push
+   * callers back to hand-written unions.
+   */
+  @Test
+  public void testAggregateAcceptsEveryFormThatActuallyScopes() {
+    assertThat(
+            compiler
+                .compileAggregate(Parser.parse("outcome = \"win\""), List.of("eco"), "hikaru")
+                .selectSql())
+        .as("perspective field in the filter")
+        .contains(PARTICIPATION_GUARD);
+
+    assertThat(
+            compiler
+                .compileAggregate(Parser.parse("num.moves >= 0"), List.of("me.color"), "hikaru")
+                .selectSql())
+        .as("perspective field in the groupBy")
+        .contains(PARTICIPATION_GUARD);
+
+    CompiledQuery explicit =
         compiler.compileAggregate(
-            Parser.parse("num.moves >= 0"), List.of("opening_family"), "hikaru");
-    assertThat(aggregate.selectSql()).doesNotContain("LOWER(white_username)");
-    assertThat(aggregate.parameters()).isEqualTo(List.of(0));
+            Parser.parse("white.username = \"hikaru\" OR black.username = \"hikaru\""),
+            List.of("opening_family"),
+            "hikaru");
+    // The filter compiles to text identical to the guard — the same coincidence the username
+    // indexes rely on — so the params are what distinguish them: two values from the filter, and
+    // no third and fourth from a guard that never fired.
+    assertThat(explicit.selectSql())
+        .as("an explicit username filter scopes it; the named player is merely redundant")
+        .contains(PARTICIPATION_GUARD);
+    assertThat(explicit.parameters())
+        .as("the filter's own two binds, with no guard params layered on top")
+        .isEqualTo(List.of("hikaru", "hikaru"));
+
+    assertThat(
+            compiler
+                .compileAggregate(Parser.parse("num.moves >= 0"), List.of("opening_family"), null)
+                .selectSql())
+        .as("and naming no player at all is a corpus-wide aggregate, which is a real question")
+        .doesNotContain("LOWER(white_username)");
+  }
+
+  /**
+   * The username filter may sit anywhere in the tree, including under a NOT or an IN — the refusal
+   * asks whether the filter constrains a username at all, not whether it does so in one shape.
+   */
+  @Test
+  public void testAggregateAcceptsAUsernameFilterAnywhereInTheTree() {
+    assertThatCode(
+            () ->
+                compiler.compileAggregate(
+                    Parser.parse("time.class = \"blitz\" AND NOT white.username = \"magnus\""),
+                    List.of("eco"),
+                    "hikaru"))
+        .doesNotThrowAnyException();
+    assertThatCode(
+            () ->
+                compiler.compileAggregate(
+                    Parser.parse("black.username IN [\"hikaru\", \"magnus\"]"),
+                    List.of("eco"),
+                    "hikaru"))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
+++ b/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
@@ -1011,24 +1011,57 @@ public class SqlCompilerTest {
   }
 
   /**
-   * The username filter may sit anywhere in the tree, including under a NOT or an IN — the refusal
-   * asks whether the filter constrains a username at all, not whether it does so in one shape.
+   * The question is not "is a username mentioned?" but "can this filter match a game the player did
+   * not play?" — so shapes that name a username while still admitting strangers are refused. Each
+   * would otherwise reproduce the exact failure the refusal exists to prevent: a corpus-wide (or
+   * someone-else-wide) count under the named player's heading.
    */
   @Test
-  public void testAggregateAcceptsAUsernameFilterAnywhereInTheTree() {
-    assertThatCode(
-            () ->
-                compiler.compileAggregate(
-                    Parser.parse("time.class = \"blitz\" AND NOT white.username = \"magnus\""),
-                    List.of("eco"),
-                    "hikaru"))
-        .doesNotThrowAnyException();
-    assertThatCode(
-            () ->
-                compiler.compileAggregate(
-                    Parser.parse("black.username IN [\"hikaru\", \"magnus\"]"),
-                    List.of("eco"),
-                    "hikaru"))
+  public void testAggregateRefusesUsernameFiltersThatStillAdmitOtherPlayersGames() {
+    // The complement of "is magnus" is everyone else — hikaru included, but hardly alone.
+    assertUnscoped("time.class = \"blitz\" AND NOT white.username = \"magnus\"");
+    // Negation of the player's own name is the case that matters: it names hikaru and admits
+    // precisely the games that are not his. A rule that recursed through NOT would accept it.
+    assertUnscoped("NOT white.username = \"hikaru\"");
+    assertUnscoped("NOT (white.username = \"hikaru\" OR black.username = \"hikaru\")");
+    // One unscoped branch of an OR admits the whole corpus, whatever the other branch says.
+    assertUnscoped("white.username = \"hikaru\" OR time.class = \"blitz\"");
+    // Only equality pins a value — "not hikaru" names him and excludes him.
+    assertUnscoped("white.username != \"hikaru\"");
+    assertUnscoped("white.username != \"magnus\"");
+    // A list naming anyone else admits their games too.
+    assertUnscoped("black.username IN [\"hikaru\", \"magnus\"]");
+    // And a filter pinning a username to somebody who is not the named player scopes to them, not
+    // to the player the response will be read as being about.
+    assertUnscoped("white.username = \"magnus\" OR black.username = \"magnus\"");
+  }
+
+  /** The shapes that genuinely cannot match another player's game still compile. */
+  @Test
+  public void testAggregateAcceptsUsernameFiltersThatCannotAdmitOtherPlayersGames() {
+    // AND only narrows, so one scoping conjunct suffices, at any depth.
+    assertScoped("time.class = \"blitz\" AND white.username = \"hikaru\"");
+    assertScoped(
+        "(white.username = \"hikaru\" OR black.username = \"hikaru\") AND time.class = \"blitz\"");
+    // Every branch of the OR pins the same player.
+    assertScoped("white.username = \"hikaru\" OR black.username = \"hikaru\"");
+    // Case-folded, matching the case-folding the compiled predicate itself does.
+    assertScoped("white.username = \"HIKARU\" OR black.username = \"Hikaru\"");
+    // A single-alternative IN is an equality in list clothing.
+    assertScoped("black.username IN [\"hikaru\"]");
+  }
+
+  private void assertUnscoped(String query) {
+    assertThatThrownBy(
+            () -> compiler.compileAggregate(Parser.parse(query), List.of("eco"), "hikaru"))
+        .as(query)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("would not scope this aggregate");
+  }
+
+  private void assertScoped(String query) {
+    assertThatCode(() -> compiler.compileAggregate(Parser.parse(query), List.of("eco"), "hikaru"))
+        .as(query)
         .doesNotThrowAnyException();
   }
 

--- a/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
+++ b/domains/games/libs/chessql/src/test/java/com/muchq/games/chessql/compiler/SqlCompilerTest.java
@@ -992,12 +992,10 @@ public class SqlCompilerTest {
             Parser.parse("white.username = \"hikaru\" OR black.username = \"hikaru\""),
             List.of("opening_family"),
             "hikaru");
-    // The filter compiles to text identical to the guard — the same coincidence the username
-    // indexes rely on — so the params are what distinguish them: two values from the filter, and
-    // no third and fourth from a guard that never fired.
-    assertThat(explicit.selectSql())
-        .as("an explicit username filter scopes it; the named player is merely redundant")
-        .contains(PARTICIPATION_GUARD);
+    // No guard fires here — the filter is the caller's own, and it compiles to text identical to
+    // the guard (the same coincidence the username indexes rely on), so asserting on the SQL
+    // string could not tell the two apart. The params can: two from the filter, and no third and
+    // fourth from a guard that never ran.
     assertThat(explicit.parameters())
         .as("the filter's own two binds, with no guard params layered on top")
         .isEqualTo(List.of("hikaru", "hikaru"));


### PR DESCRIPTION
Three issues, all one_d4-adjacent: two backend/doc corrections from #1313 and the new `/mcp` page from #1321.

## #1313 item 14: the unguarded-aggregate footgun

A `player` only narrows a query through the participation guard, and the guard only fires when a perspective field is in play — it exists to repair the `CASE` expressions ("not white" means "black"), not to filter. On `/v1/query` that is harmless: the rows carry usernames, so a caller who expected one player's games sees strangers in the first result. An aggregate has no such tell:

```
player: hikaru, query: 'num.moves >= 0', group_by: ["opening_family"]
```

— the natural MCP call for "hikaru's most common openings" — returned **the whole corpus's** openings under a heading that reads as hikaru's, and nothing in the response revealed it. Now rejected (400).

**Where the rule lives.** In `SqlCompiler`, at both aggregate entry points — not the API validator. `IndexerFacade` (the MCP path, where an assistant phrases the request most naturally) never touches `AggregateController`, and the totals query runs separately on the truncation path. The compiler is the only layer both callers share, and it already knows `perspective.used`, which an API-layer check would re-derive by duplicating the perspective roster.

**What still compiles.** A filter that *cannot match another player's game* counts as scoping. That test is checked, not assumed, which makes the cases deliberately asymmetric: `AND` scopes if any conjunct does, `OR` only if every branch does, `NOT` never does, only `=` pins a value, an `IN` list scopes only when every alternative is the player, and the name must *be* the named player (case-folded). Naming no player is untouched. `/v1/query` keeps its permissive semantics, now stated in CHESSQL.md rather than only pinned in a test.

**Blast radius: empty.** Every existing `compileAggregate(..., player)` call site uses a perspective field; `1d4_web` never calls `/v1/aggregate`.

## #1313 item 15: storage docs

The one_d4 README described the deployed indexer as H2 file storage at `/data/indexer` with copy-the-`.mv.db` instructions. It has run PostgreSQL since #1194 (`one_d4_postgres`, volume `one_d4_pgdata`, URL from `/etc/one_d4/db_config`) — replaced with the `psql`/`pg_dump` path against the user and database Compose actually creates. ROADMAP's disk-cap item justified itself with the `one_d4_data` volume that no longer exists and a "once the indexer uses PostgreSQL" note that has since happened; rewritten as what's left (a host-level quota on `one_d4_pgdata`).

The mcpserver README now records that its in-process indexer really does take the in-memory H2 default — `INDEXER_DB_URL` is the only source `McpModule` reads, and Compose sets none — so its index is per-process and empty at boot. Pointing it at the shared corpus would give MCP indexing tools write access to production data: a deliberate deployment decision, deferred rather than quietly made.

## #1321: the /mcp page

The issue asked that three questions be **settled before writing the page**. Answered by connecting to the deployed endpoint rather than reading the code:

- **Transport.** Plain JSON-RPC 2.0 over a single `POST /mcp`. No SSE stream (`GET /mcp` answers 200 with an empty body), no `Mcp-Session-Id`, and `notifications/initialized` is unimplemented — it answers `-32601`, to a notification that per JSON-RPC should draw no response at all. **No standard MCP client transport connects as deployed.** The page says so plainly instead of shipping a config that would not work; the `curl` recipe it gives is verified against the live server.
- **Auth.** An unauthenticated `tools/list` returns 200 with results, so the deployment runs open. README and Compose agree — no mismatch to discover on a public page.
- **CORS.** No `access-control-*` headers on `mcp.1d4.net`, confirming the page must be documentation, not an interactive client.

The page covers the roster, the index-first ordering (the one thing a newcomer gets wrong), the connection caveat, a worked example, and a pointer to `/query` for ChessQL. Route and nav link follow the existing three exactly; `wrangler.toml` already handles SPA deep links and `1d4_web` has no Bazel targets, so neither needed work.

**The table cannot rot silently** — the issue's own "interesting test". `mcp_tools.json` is the contract: `McpToolRegistryContractTest` asserts the server's registry matches it, built from `McpModule`'s own factory rather than a copy of the list, and `McpView.test.tsx` asserts the page matches the same file. Verified by adding a phantom tool and watching both ends fail.

## Tests

- **Aggregate refusal** at three levels, each pinning that no query ran: compiler (`SqlCompilerTest` — a table of five refused shapes, each with the reason it admits strangers), endpoint (`AggregateControllerTest`), MCP facade (`IndexerFacadeAggregateTest` — the path the endpoint test cannot reach). **Six mutations, six kills**: dropping the check, `NOT` recursing, the `=` check, the value check, `OR`→`anyMatch`, `AND`→`allMatch`, `IN`→`anyMatch`.
- **/mcp page**: roster matches the server contract, every row carries a summary, the index-first ordering and the transport caveat are present, and the route renders with its nav link active.

## Review panel

Two read-only lenses on the aggregate work, each self-refuting; both found real defects, both applied.

- **Correctness** found the original predicate weaker than the guarantee — and *pinned that way*: `NOT white.username = "magnus"` compiled and returned every blitz game magnus didn't play as White, under hikaru's heading, with a test asserting it was fine.
- Mutation testing then caught a second-order problem the (passing) new tests hid: every negative case used *magnus*, so the value check alone rejected them and the `NOT`/`!=` logic was unpinned. The killing cases name the player himself.
- **Altitude/tests** confirmed the compiler is the right layer, confirmed throwing over warning-or-auto-scoping, and found the tightening had shipped without its doc sweep — three places still described the loose rule, API.md's 400 table was missing the condition, ROADMAP had the stale volume, and one test label asserted the opposite of what it observed. All fixed.

## Verification

76/76 Java tests across `chessql`, `one_d4`, `mcpserver`; 124/124 frontend tests, `tsc` clean, Vite build clean. `scripts/format-java` + buildifier run; no lockfile churn.

## Deferred, noted rather than half-done

A standalone ChessQL route for `/query` and `/mcp` to share (#1321 suggests it; independently scoped), and the transport gap itself — worth its own issue now that it's established rather than suspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg