### PR TITLE
metrics: give counters a zero baseline, and count bursty work over a day

### DIFF
--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -88,6 +88,19 @@ public class IndexWorker {
   static final String RUN_DURATION = "index_run_duration_micros";
 
   /**
+   * The label values the counters above can carry, so each series can be declared at startup and
+   * export a zero baseline. Bounded sets only: {@link #MOTIF_OCCURRENCES} is labelled by motif and
+   * left to appear on first use, since its baseline would be one series per motif for a tile that
+   * only ever reads their sum.
+   */
+  static final List<String> RUN_OUTCOMES =
+      List.of("completed", "failed", "interrupted", "lease_lost");
+
+  static final List<String> MONTH_RESULTS = List.of("indexed", "degraded", "cached", "empty");
+
+  static final List<String> ARCHIVE_FETCH_RESULTS = List.of("ok", "no_archive", "error");
+
+  /**
    * Bounds for {@link #RUN_DURATION}, in microseconds, spanning a millisecond to the {@link
    * RetentionPolicy#MAX_RUN} ceiling.
    *
@@ -365,6 +378,38 @@ public class IndexWorker {
               t.setDaemon(true);
               return t;
             });
+    declareMetrics();
+  }
+
+  /**
+   * Every series this worker can report, declared at construction so each exports as 0 from process
+   * start rather than springing into existence carrying its first run's numbers.
+   *
+   * <p>Declared here rather than at the top of {@link #process}, which is where the distribution
+   * bounds used to be: a baseline is only useful if it is exported <em>before</em> the increment it
+   * is a baseline for, and a run that starts and finishes between two export ticks would declare
+   * and increment inside the same interval, leaving the first run as invisible as it was. The
+   * worker bean is eager, so construction happens at startup and the baseline is minutes old before
+   * any request arrives. See {@link CustomMetrics#defineCounter}.
+   *
+   * <p>The label values are spelled out because the emit sites spell them out; {@code
+   * IndexWorkerMetricsTest} pins that the two sets agree, so an outcome added at an emit site
+   * without a declaration here fails rather than quietly losing its first occurrence.
+   */
+  private void declareMetrics() {
+    metrics.defineDistribution(RUN_DURATION, RUN_DURATION_BOUNDS);
+    metrics.defineDistribution(GAMES_PER_MONTH, GAMES_PER_MONTH_BOUNDS);
+
+    metrics.defineCounter(GAMES_INDEXED);
+    for (String outcome : RUN_OUTCOMES) {
+      metrics.defineCounter(RUNS, Map.of("outcome", outcome));
+    }
+    for (String result : MONTH_RESULTS) {
+      metrics.defineCounter(MONTHS, Map.of("result", result));
+    }
+    for (String result : ARCHIVE_FETCH_RESULTS) {
+      metrics.defineCounter(ARCHIVE_FETCHES, Map.of("result", result));
+    }
   }
 
   public void process(IndexMessage message) {
@@ -413,8 +458,6 @@ public class IndexWorker {
     // that jumps its clock by six hours to trip the ceiling would otherwise report a six-hour run.
     long runStartNanos = System.nanoTime();
     String outcome = "failed";
-    metrics.defineDistribution(RUN_DURATION, RUN_DURATION_BOUNDS);
-    metrics.defineDistribution(GAMES_PER_MONTH, GAMES_PER_MONTH_BOUNDS);
     try {
       progress(message.requestId(), 0);
 

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -393,8 +393,8 @@ public class IndexWorker {
    * any request arrives. See {@link CustomMetrics#defineCounter}.
    *
    * <p>The label values are spelled out because the emit sites spell them out; {@code
-   * IndexWorkerMetricsTest} pins that the two sets agree, so an outcome added at an emit site
-   * without a declaration here fails rather than quietly losing its first occurrence.
+   * IndexWorkerTest} pins that the two sets agree, so an outcome added at an emit site without a
+   * declaration here fails rather than quietly losing its first occurrence.
    */
   private void declareMetrics() {
     metrics.defineDistribution(RUN_DURATION, RUN_DURATION_BOUNDS);

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -1066,6 +1066,66 @@ public class IndexWorkerTest {
         metrics);
   }
 
+  /**
+   * The zero baseline (#1313). Constructing the worker must put every bounded series on the wire at
+   * 0, before any run — otherwise the series is born carrying its first run's numbers and
+   * increase() shows nothing for that run, forever. That is what hid a thousand-game overnight run
+   * behind a panel of zeros: the counter read 1092 and every dashboard read 0.
+   */
+  @Test
+  public void constructionDeclaresEveryBoundedSeriesAtZero() {
+    meteredWorker();
+
+    assertThat(counter(IndexWorker.GAMES_INDEXED, Map.of())).isZero();
+    for (String outcome : IndexWorker.RUN_OUTCOMES) {
+      assertThat(counter(IndexWorker.RUNS, Map.of("outcome", outcome)))
+          .as("run outcome %s", outcome)
+          .isZero();
+    }
+    for (String result : IndexWorker.MONTH_RESULTS) {
+      assertThat(counter(IndexWorker.MONTHS, Map.of("result", result)))
+          .as("month result %s", result)
+          .isZero();
+    }
+    for (String result : IndexWorker.ARCHIVE_FETCH_RESULTS) {
+      assertThat(counter(IndexWorker.ARCHIVE_FETCHES, Map.of("result", result)))
+          .as("archive fetch result %s", result)
+          .isZero();
+    }
+    // Presence, not just a zero read: counter() sums an empty stream to 0, so the assertions
+    // above pass just as happily against a worker that declared nothing at all.
+    assertThat(metrics.counterSnapshot()).isNotEmpty();
+  }
+
+  /**
+   * The declarations and the emit sites have to agree, or a declared-but-never-emitted series is a
+   * permanently flat line and an emitted-but-never-declared one loses its first event. A run emits
+   * only series this list already knows about.
+   */
+  @Test
+  public void aRunEmitsNoSeriesThatConstructionDidNotDeclare() {
+    IndexWorker metered = meteredWorker();
+    java.util.Set<String> declared =
+        metrics.counterSnapshot().stream()
+            .map(sn -> sn.name() + sn.labels())
+            .collect(java.util.stream.Collectors.toSet());
+
+    stubChessClient.setResponse(
+        java.time.YearMonth.of(2024, 1),
+        List.of(playedGame("https://chess.com/g/baseline", SCHOLARS_MATE_PGN, "blitz")));
+    metered.process(new IndexMessage(REQUEST_ID, PLAYER, PLATFORM, "2024-01", "2024-01", false));
+
+    assertThat(
+            metrics.counterSnapshot().stream()
+                .map(sn -> sn.name() + sn.labels())
+                .filter(key -> !declared.contains(key))
+                // motif_occurrences is labelled per motif and deliberately left undeclared.
+                .filter(key -> !key.startsWith(IndexWorker.MOTIF_OCCURRENCES))
+                .toList())
+        .as("every counter a run touches must have had a zero baseline waiting for it")
+        .isEmpty();
+  }
+
   private long counter(String name, Map<String, String> labels) {
     return metrics.counterSnapshot().stream()
         .filter(s -> s.name().equals(name) && s.labels().equals(labels))

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -80,6 +80,21 @@ func probesTile(service string) customScalarDef {
 // at the dashboard after the fact still sees it.
 const alarmWindow = "24h"
 
+// The window for counters over work that arrives in bursts rather than as a
+// steady stream: indexing runs, and the months and archive fetches inside
+// them. All of it is triggered by a person asking for a player, so between
+// asks the true rate is zero and a 5m window reads zero — which is the honest
+// answer to "how busy is it right now?" and the wrong answer to the question
+// anyone actually opens this panel with, "did the thing I ran work?".
+//
+// #1313: a thousand-game run at 05:09 left a panel of zeros by breakfast,
+// with nothing to distinguish it from a service that had never indexed
+// anything. Same length as alarmWindow, for the same reason — the interesting
+// events are sparse — but named apart because these are volumes, not alarms,
+// and a future change to how long a failure stays on screen should not
+// silently retune how far back the counts reach.
+const burstWindow = "24h"
+
 // ValidView reports whether a client-supplied view is one this package builds
 // queries for. Callers must check before passing the value on: a view string
 // never reaches PromQL, but an unrecognised one would silently fall through to
@@ -382,10 +397,13 @@ var serviceRegistry = map[string]serviceEntry{
 			// routes there. The deploy config test and one_d4's
 			// HealthProbeRouteLabelTest pin the two ways a zero here can lie.
 			probesTile("one_d4"),
-			counter("Indexing", "games_indexed", "games", `games_indexed_total{service_name="one_d4"}`),
-			counter("Indexing", "runs_completed", "", `index_runs_total{service_name="one_d4",outcome="completed"}`),
-			// The three outcomes below are alarms rather than volumes, so they
-			// count over a day. A failed run an hour ago is still the thing an
+			counterOver("Indexing", "games_indexed", "games",
+				`games_indexed_total{service_name="one_d4"}`, burstWindow),
+			counterOver("Indexing", "runs_completed", "",
+				`index_runs_total{service_name="one_d4",outcome="completed"}`, burstWindow),
+			// The three outcomes below are alarms rather than volumes. They
+			// share burstWindow's length by coincidence of both being sparse,
+			// not by meaning: a failed run an hour ago is still the thing an
 			// operator opened this page to find.
 			counterOver("Indexing", "runs_failed", "",
 				`index_runs_total{service_name="one_d4",outcome="failed"}`, alarmWindow),
@@ -409,10 +427,14 @@ var serviceRegistry = map[string]serviceEntry{
 				`sum(rate(index_run_duration_micros_sum{service_name="one_d4",outcome="completed"}[1h]))/sum(rate(index_run_duration_micros_count{service_name="one_d4",outcome="completed"}[1h]))/1000000`),
 			scalar("Indexing", "avg_games_per_month_1h", "games",
 				`sum(rate(index_games_per_month_sum{service_name="one_d4"}[1h]))/sum(rate(index_games_per_month_count{service_name="one_d4"}[1h]))`),
-			counter("Indexing", "empty_months", "", `index_months_total{service_name="one_d4",result="empty"}`),
-			counter("Indexing", "cached_months", "", `index_months_total{service_name="one_d4",result="cached"}`),
-			counter("Indexing", "archive_fetches", "", `chess_com_archive_fetches_total{service_name="one_d4"}`),
-			counter("Motifs", "occurrences", "", `motif_occurrences_total{service_name="one_d4"}`),
+			counterOver("Indexing", "empty_months", "",
+				`index_months_total{service_name="one_d4",result="empty"}`, burstWindow),
+			counterOver("Indexing", "cached_months", "",
+				`index_months_total{service_name="one_d4",result="cached"}`, burstWindow),
+			counterOver("Indexing", "archive_fetches", "",
+				`chess_com_archive_fetches_total{service_name="one_d4"}`, burstWindow),
+			counterOver("Motifs", "occurrences", "",
+				`motif_occurrences_total{service_name="one_d4"}`, burstWindow),
 			// No motifs-per-game tile. The two counters are recorded on opposite sides of
 			// the durability boundary — motifs per game inside the drain loop, games only
 			// after the month's flush and period write succeed — so an interrupted or

--- a/domains/platform/apis/prom_proxy/registry.go
+++ b/domains/platform/apis/prom_proxy/registry.go
@@ -87,7 +87,7 @@ const alarmWindow = "24h"
 // answer to "how busy is it right now?" and the wrong answer to the question
 // anyone actually opens this panel with, "did the thing I ran work?".
 //
-// #1313: a thousand-game run at 05:09 left a panel of zeros by breakfast,
+// #1323: a thousand-game run at 05:09 left a panel of zeros by breakfast,
 // with nothing to distinguish it from a service that had never indexed
 // anything. Same length as alarmWindow, for the same reason — the interesting
 // events are sparse — but named apart because these are volumes, not alarms,

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -1342,23 +1342,43 @@ func TestMetricsHandler_GetServiceMetrics_JsonKeysAreStable(t *testing.T) {
 
 // Indexing is triggered by a person asking for a player, so between asks the
 // true rate is zero. Read through the 5m window every serving tile uses, a
-// thousand-game run is invisible by breakfast — which is what #1313 reported:
+// thousand-game run is invisible by breakfast — which is what #1323 reported:
 // an Indexing panel of zeros over a night's work, indistinguishable from a
-// service that had never indexed anything. These tiles count over a day
+// service that had never indexed anything. These tiles count over burstWindow
 // instead, so "did the thing I ran work?" has an answer for as long as the
 // question is likely to be asked.
-func TestRegistry_OneD4IndexingVolumesCountOverADay(t *testing.T) {
-	entry, ok := serviceRegistry["one_d4"]
-	if !ok {
-		t.Fatal("one_d4 missing from the registry")
-	}
+//
+// Only the volume tiles. The three run-outcome alarms in the same group are
+// owned by TestRegistry_AlarmCountersCountOverALongWindow and measured against
+// alarmWindow — asserting them here against a literal would re-couple the two
+// constants that were deliberately named apart, so retuning how long a failure
+// stays on screen would fail a test about volumes.
+func TestRegistry_OneD4IndexingVolumesCountOverABurstWindow(t *testing.T) {
+	// The constant itself first, for the reason the alarm test gives: every
+	// check below compares against burstWindow, so shrinking it would leave
+	// them all comparing against the shrunken value and still passing.
+	//
+	// A floor of twelve hours, because the reported gap is the point: the run
+	// finished overnight and the panel was read the next morning. Anything
+	// shorter differs from the default and still answers zero to the question
+	// this window exists to answer.
+	window, err := time.ParseDuration(burstWindow)
+	require.NoError(t, err, "burstWindow is not a duration Go can parse: %q", burstWindow)
+	require.GreaterOrEqual(t, window, 12*time.Hour,
+		"burstWindow is %s — too short to still be non-zero when someone reads the "+
+			"dashboard the morning after a run", burstWindow)
 
-	// Every Indexing and Motifs counter, not a sample of them: a tile left on
-	// the 5m default is exactly the flat zero this test exists to prevent.
-	wantDay := map[string]bool{
-		"games_indexed": true, "runs_completed": true, "runs_failed": true,
-		"runs_interrupted": true, "runs_lease_lost": true, "empty_months": true,
-		"cached_months": true, "archive_fetches": true, "occurrences": true,
+	entry, ok := serviceRegistry["one_d4"]
+	require.True(t, ok, "one_d4 missing from the registry")
+
+	// Every volume counter, not a sample: a tile left on the 5m default is
+	// exactly the flat zero this test exists to prevent.
+	wantBurst := map[string]bool{
+		"games_indexed": true, "empty_months": true, "cached_months": true,
+		"archive_fetches": true, "occurrences": true, "runs_completed": true,
+	}
+	alarms := map[string]bool{
+		"runs_failed": true, "runs_interrupted": true, "runs_lease_lost": true,
 	}
 	seen := map[string]bool{}
 	for _, def := range entry.CustomScalars {
@@ -1368,16 +1388,20 @@ func TestRegistry_OneD4IndexingVolumesCountOverADay(t *testing.T) {
 		if def.Counter == "" {
 			continue // the windowed averages are scalars, with their own 1h range
 		}
+		if alarms[def.Label] {
+			continue // owned by the alarm test, against alarmWindow
+		}
 		seen[def.Label] = true
-		if !wantDay[def.Label] {
+		if !wantBurst[def.Label] {
 			t.Errorf("unexpected indexing counter %q: add it to this test with a window decision", def.Label)
 			continue
 		}
-		if got := def.window(); got != "24h" {
-			t.Errorf("%s counts over %s; episodic work needs a day to stay visible", def.Label, got)
+		if got := def.window(); got != burstWindow {
+			t.Errorf("%s counts over %s; episodic work needs burstWindow (%s) to stay visible",
+				def.Label, got, burstWindow)
 		}
 	}
-	for label := range wantDay {
+	for label := range wantBurst {
 		if !seen[label] {
 			t.Errorf("expected an indexing counter %q; did it move groups or get dropped?", label)
 		}

--- a/domains/platform/apis/prom_proxy/service_handlers_test.go
+++ b/domains/platform/apis/prom_proxy/service_handlers_test.go
@@ -1339,3 +1339,47 @@ func TestMetricsHandler_GetServiceMetrics_JsonKeysAreStable(t *testing.T) {
 	assert.False(t, present,
 		"a fixed-form tile must omit the key entirely, not send false: %v", gauge)
 }
+
+// Indexing is triggered by a person asking for a player, so between asks the
+// true rate is zero. Read through the 5m window every serving tile uses, a
+// thousand-game run is invisible by breakfast — which is what #1313 reported:
+// an Indexing panel of zeros over a night's work, indistinguishable from a
+// service that had never indexed anything. These tiles count over a day
+// instead, so "did the thing I ran work?" has an answer for as long as the
+// question is likely to be asked.
+func TestRegistry_OneD4IndexingVolumesCountOverADay(t *testing.T) {
+	entry, ok := serviceRegistry["one_d4"]
+	if !ok {
+		t.Fatal("one_d4 missing from the registry")
+	}
+
+	// Every Indexing and Motifs counter, not a sample of them: a tile left on
+	// the 5m default is exactly the flat zero this test exists to prevent.
+	wantDay := map[string]bool{
+		"games_indexed": true, "runs_completed": true, "runs_failed": true,
+		"runs_interrupted": true, "runs_lease_lost": true, "empty_months": true,
+		"cached_months": true, "archive_fetches": true, "occurrences": true,
+	}
+	seen := map[string]bool{}
+	for _, def := range entry.CustomScalars {
+		if def.Group != "Indexing" && def.Group != "Motifs" {
+			continue
+		}
+		if def.Counter == "" {
+			continue // the windowed averages are scalars, with their own 1h range
+		}
+		seen[def.Label] = true
+		if !wantDay[def.Label] {
+			t.Errorf("unexpected indexing counter %q: add it to this test with a window decision", def.Label)
+			continue
+		}
+		if got := def.window(); got != "24h" {
+			t.Errorf("%s counts over %s; episodic work needs a day to stay visible", def.Label, got)
+		}
+	}
+	for label := range wantDay {
+		if !seen[label] {
+			t.Errorf("expected an indexing counter %q; did it move groups or get dropped?", label)
+		}
+	}
+}

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -89,6 +89,39 @@ public final class CustomMetrics {
   }
 
   /**
+   * Declares a counter series ahead of its first event, so it exports as 0 from process start.
+   *
+   * <p>Without this a counter springs into existence already carrying the value of the first event
+   * it counted, and that first event is then invisible forever. {@code increase()} and {@code
+   * rate()} measure the change <em>between</em> samples, so they need an earlier sample to measure
+   * from; a series whose very first sample is 75 shows no increase at all, and every later sample
+   * is flat until something else happens. The counter is not wrong — {@code games_indexed_total}
+   * really does read 75 — but every dashboard built on it reads zero, which is worse than a missing
+   * tile because it looks like an answer.
+   *
+   * <p>That is not a corner case: it is what every process does after every deploy, so the first
+   * run of anything is uncounted until a second one follows it. It cost a real investigation on
+   * one_d4, where an overnight indexing run of a thousand games left an Indexing panel of zeros
+   * (https://github.com/muchq/MoonBase/issues/1313).
+   *
+   * <p>Declare the label sets whose values are known up front — outcomes, results, states. An
+   * unbounded label (a username, a URL) has no series to declare, and declaring one per possible
+   * value is how a metric becomes a cardinality problem; leave those to appear on first use and
+   * accept that their first event is the baseline.
+   *
+   * <p>Idempotent, and never resets a counter that has already counted something: a repeat call for
+   * the same series leaves the existing total alone.
+   */
+  public void defineCounter(String name, Map<String, String> labels) {
+    counters.computeIfAbsent(series(name, labels), s -> new LongAdder());
+  }
+
+  /** Declares an unlabelled counter series. See {@link #defineCounter(String, Map)}. */
+  public void defineCounter(String name) {
+    defineCounter(name, Map.of());
+  }
+
+  /**
    * Declares the bucket bounds for a distribution, ahead of the first observation.
    *
    * <p>The default is {@link #DEFAULT_BOUNDS}, which tops out at 10000 and is a guess about no

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -102,7 +102,7 @@ public final class CustomMetrics {
    * <p>That is not a corner case: it is what every process does after every deploy, so the first
    * run of anything is uncounted until a second one follows it. It cost a real investigation on
    * one_d4, where an overnight indexing run of a thousand games left an Indexing panel of zeros
-   * (https://github.com/muchq/MoonBase/issues/1313).
+   * (https://github.com/muchq/MoonBase/issues/1323).
    *
    * <p>Declare the label sets whose values are known up front — outcomes, results, states. An
    * unbounded label (a username, a URL) has no series to declare, and declaring one per possible

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
@@ -359,4 +359,60 @@ public class CustomMetricsTest {
     assertThat(metrics.counterSnapshot().get(0).value()).isEqualTo((long) threads * perThread);
     assertThat(metrics.distributionSnapshot().get(0).count()).isEqualTo((long) threads * perThread);
   }
+
+  /**
+   * The zero baseline, and the failure it exists to prevent: a counter whose first exported sample
+   * already carries its first event's value shows no increase for that event, ever. increase() and
+   * rate() measure between samples, so the event that created the series has nothing to be measured
+   * against. Declaring the series up front gives it something.
+   */
+  @Test
+  public void aDeclaredCounterExportsAtZeroBeforeAnythingHappens() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.defineCounter("games_indexed");
+    metrics.defineCounter("index_runs", Map.of("outcome", "completed"));
+
+    assertThat(metrics.isEmpty())
+        .as("a declared series must be exported, or there is no baseline to increase from")
+        .isFalse();
+    assertThat(metrics.counterSnapshot())
+        .extracting(CustomMetrics.CounterSnapshot::name, CustomMetrics.CounterSnapshot::value)
+        .containsExactlyInAnyOrder(
+            org.assertj.core.groups.Tuple.tuple("games_indexed", 0L),
+            org.assertj.core.groups.Tuple.tuple("index_runs", 0L));
+  }
+
+  /** The declared series is the same series the event lands on, not a second one beside it. */
+  @Test
+  public void aDeclaredCounterCountsNormallyOnceEventsArrive() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.defineCounter("games_indexed");
+    metrics.add("games_indexed", 75, Map.of());
+
+    assertThat(metrics.counterSnapshot()).hasSize(1);
+    assertThat(metrics.counterSnapshot().get(0).value()).isEqualTo(75L);
+  }
+
+  /**
+   * Declaration runs at construction and events arrive later, but nothing stops a caller declaring
+   * again — a re-declared counter must not lose what it has already counted.
+   */
+  @Test
+  public void redeclaringACounterDoesNotResetIt() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.increment("index_runs", Map.of("outcome", "completed"));
+    metrics.defineCounter("index_runs", Map.of("outcome", "completed"));
+
+    assertThat(metrics.counterSnapshot().get(0).value()).isEqualTo(1L);
+  }
+
+  /** Label sets are distinct series, so declaring one leaves the others to appear on first use. */
+  @Test
+  public void declaringOneLabelSetDoesNotDeclareItsSiblings() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.defineCounter("index_runs", Map.of("outcome", "completed"));
+
+    assertThat(metrics.counterSnapshot()).hasSize(1);
+    assertThat(metrics.counterSnapshot().get(0).labels()).containsEntry("outcome", "completed");
+  }
 }


### PR DESCRIPTION
## The report

> `muchq.com/metrics/one_d4` doesn't show 1d4 indexing metrics, but I indexed a bunch of games last night.

True, and worse than stale: the Indexing panel read **zero**, indistinguishable from a service that had never indexed anything.

## What I found

The emit path is fine. I confirmed that by triggering a real index run and watching `games_indexed` go 0 → 15.8 within 20 seconds — instrumentation, export, collector, Prometheus and dashboard all work. Two separate causes conspired instead, both general rather than one_d4's. Tracked as **#1323**.

**1. A counter's first event is invisible, permanently.**

A `CustomMetrics` counter only exists once something increments it, so the series is *born already carrying* the value of the first event it counted. `increase()` and `rate()` measure the change *between* samples — with no earlier sample to measure from, that first event shows no increase at all, and every sample after it is flat until something else happens. The counter isn't wrong (`games_indexed_total` really did read 1092); every dashboard built on it is.

That's not a corner case: it's what every process does after every deploy, so on every rail **the first run of anything has been uncounted**.

Dated from the deployed data rather than inferred — the reported run finished at **05:09:27**, and the `games_indexed` series first appears at **05:14**. Across seven days the only nonzero point on that metric is the run I triggered while investigating, visible precisely because the series already existed by then.

**2. The tiles count over five minutes.**

Right for serving traffic, wrong for work a person triggers: between asks the true rate is zero, so a 5m window answers "how busy is it right now?" when the question is "did the thing I ran work?".

## The fix

- **`CustomMetrics.defineCounter`** — declares a series so it exports as `0` from process start; the counter equivalent of the existing `defineDistribution`. Idempotent, and never resets a counter that has already counted.
- **`IndexWorker` declares its bounded series at construction**, not at the top of `process()` where the distribution bounds used to sit. A baseline only helps if it's exported *before* the increment it's a baseline for, and a run that starts and finishes between two export ticks would declare and increment inside the same interval — leaving the first run as invisible as it was. The worker bean is eager, so the baseline is minutes old before any request arrives.
- **Unbounded labels are left alone.** `motif_occurrences` is labelled per motif; declaring one series per possible value is how a metric becomes a cardinality problem, and the tile only reads their sum.
- **A `burstWindow` of 24h** for the indexing and motif volume tiles, joining the failure counters that already counted over a day. Named apart from `alarmWindow` deliberately: these are volumes, not alarms, and retuning how long a failure stays on screen shouldn't silently change how far back the counts reach.

**Scope note — the tiles were blind, not the charts.** The Trends `tsCounter` panels are unchanged (rate still over 5m, count still over the chart's step), and a 24h Trends range already showed an overnight run as a step-sized `increase` bump. What this fixes is the scalar tiles, which is what the report was about.

## Tests

- yodel: a declared counter exports at zero and makes the registry non-empty; counts normally once events arrive; survives re-declaration without losing its total; declaring one label set doesn't declare its siblings.
- one_d4: construction declares every bounded series at zero (asserting presence too, since summing an empty stream also yields 0 — the assertion would otherwise pass against a worker that declared nothing); and **a run emits no series construction didn't declare**, so an outcome added at an emit site without a declaration fails rather than quietly losing its first occurrence.
- prom_proxy: every Indexing/Motifs *volume* counter counts over `burstWindow`, checked exhaustively rather than by sample, with the constant itself pinned against a 12-hour floor. The run-outcome alarms are deliberately left to `TestRegistry_AlarmCountersCountOverALongWindow`, so the two constants stay independent — verified by mutation in both directions: shrinking `alarmWindow` survives the volumes test but is still killed by the suite.

**Mutations killed**: dropping `declareMetrics()`, dropping just the run-outcome declarations, making `defineCounter` a no-op, returning a tile to the 5m default, and shrinking each window constant.

## Verification

72/72 across `one_d4`, plus yodel and prom_proxy suites; `scripts/format-java` and gofmt clean.

## Note

Diagnosis required one real index request against production (`drawlya`, 2025-11, 15 games) — the service's own public operation, cleared by the 7-day retention sweep. It's the run visible in the 12:59 data point above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg