### PR TITLE
metrics: sweep the zero baseline across both rails, and cover distributions (#1323)

### DIFF
--- a/domains/games/apis/golf_hub/hub_e2e_test.cc
+++ b/domains/games/apis/golf_hub/hub_e2e_test.cc
@@ -1485,6 +1485,33 @@ TEST_F(GolfHubStreamFixture, ChatMetricsCountOutcomesWithoutIdentifiers) {
 // The unavailable side of the append counter: the store cannot be
 // reached, the sender is told so, and nothing counts as stored or
 // delivered.
+
+// The zero baseline (#1323): a handler must put its unlabelled counters on the
+// wire at 0 when it is built, before any session. Without it each series is
+// born carrying its first event's value and increase() shows nothing for that
+// event, ever — so the first chat message, the first refused admission, the
+// first reaped seat after a deploy are all uncounted.
+//
+// stream_commands and stream_events are deliberately absent: their labels come
+// from a generated union's case names rather than a list the handler could
+// state, and they fire continuously in any live session, which is the case a
+// missing first event costs least.
+TEST_F(GolfHubStreamFixture, BuildingAHandlerDeclaresItsUnlabelledCountersAtZero) {
+  auto capture = MakeCapturingMetricsRecorder();
+  auto instance = BuildSecondInstance(vault_, store_, chat_store_, capture);
+  ASSERT_NE(instance, nullptr);
+
+  for (const char* name :
+       {"chat_appends", "chat_failures", "chat_history_replays", "chat_rows_delivered",
+        "restored_seats_reaped", "stream_admissions_refused", "stream_disconnects",
+        "stream_rate_limited", "stream_rejections", "stream_seats_expired", "stream_sessions"}) {
+    EXPECT_EQ(capture->CounterTotal(name), 0) << name;
+  }
+  // Presence, not just zero reads: CounterTotal sums an empty match to 0, so
+  // every assertion above passes against a handler that declared nothing.
+  EXPECT_GE(capture->Entries().size(), 11U);
+}
+
 TEST_F(GolfHubStreamFixture, AnUnreachableStoreCountsTheAppendAsUnavailable) {
   auto capture = MakeCapturingMetricsRecorder();
   auto instance = BuildSecondInstance(

--- a/domains/games/apis/golf_hub/hub_handler.cc
+++ b/domains/games/apis/golf_hub/hub_handler.cc
@@ -171,7 +171,30 @@ HubHandler::HubHandler(std::shared_ptr<TicketVault> vault, std::shared_ptr<cards
         options.grace_period = grace_period;
         options.on_expired = [this](const std::string& id) { OnExpired(id); };
         return options;
-      }()) {}
+      }()) {
+  DeclareMetrics();
+}
+
+// Every unlabelled counter this handler can report, declared at construction so
+// each exports a zero before it counts anything. Without a baseline the series
+// is born carrying its first event's value, and increase() has nothing earlier
+// to measure it against — so the first chat message, the first refused
+// admission, the first reaped seat after a deploy are all invisible (#1323).
+//
+// The two labelled counters, stream_commands{command} and stream_events{event},
+// are deliberately absent: their labels come from a generated union's case
+// names rather than a list this file could state, and they fire continuously in
+// any live session, which is exactly the case a missing first event costs
+// least.
+void HubHandler::DeclareMetrics() {
+  if (!metrics_) return;
+  for (const char* name :
+       {"chat_appends", "chat_failures", "chat_history_replays", "chat_rows_delivered",
+        "restored_seats_reaped", "stream_admissions_refused", "stream_disconnects",
+        "stream_rate_limited", "stream_rejections", "stream_seats_expired", "stream_sessions"}) {
+    metrics_->DeclareCounter(name);
+  }
+}
 
 HubHandler::~HubHandler() {
   {

--- a/domains/games/apis/golf_hub/hub_handler.h
+++ b/domains/games/apis/golf_hub/hub_handler.h
@@ -235,6 +235,10 @@ class HubHandler final : public moonbase::golf::GolfHubAsyncHandler {
   /// and the command/event flow are counted here. All no-ops when no
   /// recorder is injected.
   void Count(const char* name, const std::map<std::string, std::string>& attributes = {});
+
+  /// Declares the unlabelled counters at construction so each exports a zero
+  /// baseline; see the definition for why the two labelled ones are excluded.
+  void DeclareMetrics();
   void TrackActive(int delta);
   void CountCommand(const moonbase::golf::GolfCommands& command);
   /// Every event leaves through here so stream_events sees each send.

--- a/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
+++ b/domains/games/apis/one_d4/src/main/java/com/muchq/games/one_d4/worker/IndexWorker.java
@@ -399,6 +399,13 @@ public class IndexWorker {
   private void declareMetrics() {
     metrics.defineDistribution(RUN_DURATION, RUN_DURATION_BOUNDS);
     metrics.defineDistribution(GAMES_PER_MONTH, GAMES_PER_MONTH_BOUNDS);
+    // Bounds are per name; the series is per name and labels, so both are declared. Without the
+    // second, avg_run_seconds_1h divides a rate over one sample by a rate over one sample the
+    // first time a run finishes — the same blindness as the counters, one level less obvious.
+    metrics.defineDistributionSeries(GAMES_PER_MONTH);
+    for (String outcome : RUN_OUTCOMES) {
+      metrics.defineDistributionSeries(RUN_DURATION, Map.of("outcome", outcome));
+    }
 
     metrics.defineCounter(GAMES_INDEXED);
     for (String outcome : RUN_OUTCOMES) {

--- a/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
+++ b/domains/games/apis/one_d4/src/test/java/com/muchq/games/one_d4/worker/IndexWorkerTest.java
@@ -1095,6 +1095,19 @@ public class IndexWorkerTest {
     // Presence, not just a zero read: counter() sums an empty stream to 0, so the assertions
     // above pass just as happily against a worker that declared nothing at all.
     assertThat(metrics.counterSnapshot()).isNotEmpty();
+
+    // The distributions too. defineDistribution declares bounds, not a series, so these need
+    // their own declaration or the first run's duration is the value the series is born with —
+    // and avg_run_seconds_1h divides a one-sample rate by a one-sample rate.
+    assertThat(metrics.distributionSnapshot())
+        .extracting(
+            CustomMetrics.DistributionSnapshot::name, CustomMetrics.DistributionSnapshot::labels)
+        .contains(
+            org.assertj.core.groups.Tuple.tuple(IndexWorker.GAMES_PER_MONTH, Map.of()),
+            org.assertj.core.groups.Tuple.tuple(
+                IndexWorker.RUN_DURATION, Map.of("outcome", "completed")));
+    assertThat(distributionCount(IndexWorker.RUN_DURATION, Map.of("outcome", "completed")))
+        .isZero();
   }
 
   /**

--- a/domains/graphics/apis/portrait/tracer_service.h
+++ b/domains/graphics/apis/portrait/tracer_service.h
@@ -35,7 +35,20 @@ class TracerService {
   /// two stay equal. Both members copy the pointer: moving into one of them
   /// would make correctness depend on the order they happen to be declared.
   TracerService(uint16_t _cache_size, std::shared_ptr<futility::otel::MetricsRecorder> metrics)
-      : cache_("trace", _cache_size, metrics), metrics_(metrics) {}
+      : cache_("trace", _cache_size, metrics), metrics_(metrics) {
+    // Declared here rather than left to the first request, so each series
+    // exports a zero before it counts anything and the first render after a
+    // deploy is visible as an increase rather than as the value the series was
+    // born with (#1323). The error labels are spelled out because the emit
+    // sites spell them out; TracerServiceTest pins that the two agree.
+    if (metrics_) {
+      metrics_->DeclareCounter("trace_requests_total");
+      metrics_->DeclareCounter("trace_requests_completed");
+      for (const char* error : {"validation_failed", "out_of_memory", "rendering_failed"}) {
+        metrics_->DeclareCounter("trace_requests_failed", {{"error", error}});
+      }
+    }
+  }
   virtual ~TracerService() = default;
 
   /// Traces a scene and returns the encoded PNG bytes plus dimensions.

--- a/domains/graphics/apis/portrait/tracer_service_test.cc
+++ b/domains/graphics/apis/portrait/tracer_service_test.cc
@@ -449,6 +449,27 @@ TEST_F(TracerServiceTest, ACacheWriteFailureDoesNotDiscardTheRender) {
   EXPECT_EQ(service.attempts, 1);
 }
 
+// The zero baseline (#1323): constructing the service must put every counter
+// on the wire at 0, before any request. Without it the series is born carrying
+// the first render's value and increase() shows nothing for that render, ever
+// — so the first traffic after every deploy is uncounted. The error labels are
+// listed here because the emit sites list them; a label declared under one
+// spelling and emitted under another leaves the real series unbaselined.
+TEST_F(TracerServiceTest, ConstructionDeclaresEveryCounterAtZero) {
+  auto metrics = std::make_shared<futility::otel::CapturingMetricsRecorder>("portrait_test");
+  TracerService service(50, metrics);
+
+  EXPECT_EQ(metrics->CounterTotal("trace_requests_total"), 0);
+  EXPECT_EQ(metrics->CounterTotal("trace_requests_completed"), 0);
+  for (const char* error : {"validation_failed", "out_of_memory", "rendering_failed"}) {
+    EXPECT_EQ(metrics->CounterTotal("trace_requests_failed", {{"error", error}}), 0)
+        << "failure label " << error;
+  }
+  // Presence, not just zero reads: CounterTotal sums an empty match to 0, so
+  // every assertion above passes against a service that declared nothing.
+  EXPECT_EQ(metrics->Entries().size(), 5U);
+}
+
 // The cache lookup copies the stored PNG, so the cheap path allocates too.
 // Before the guard covered the whole body this unwound out of trace(),
 // past the handler, and reached the transport — a different 500 than the one

--- a/domains/platform/libs/futility/otel/BUILD.bazel
+++ b/domains/platform/libs/futility/otel/BUILD.bazel
@@ -97,6 +97,17 @@ cc_test(
 )
 
 cc_test(
+    name = "metrics_declaration_test",
+    size = "small",
+    srcs = ["metrics_declaration_test.cc"],
+    deps = [
+        ":capturing_metrics_recorder",
+        ":metrics",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "http_metrics_test",
     size = "small",
     srcs = ["http_metrics_test.cc"],

--- a/domains/platform/libs/futility/otel/metrics.cc
+++ b/domains/platform/libs/futility/otel/metrics.cc
@@ -60,6 +60,14 @@ void MetricsRecorder::RecordCounter(const std::string& metric_name, int64_t valu
   }
 }
 
+void MetricsRecorder::DeclareCounter(const std::string& metric_name,
+                                     const std::map<std::string, std::string>& attributes) {
+  // Adding zero is what materializes the series: creating the instrument alone
+  // registers no attribute set, so the SDK still has nothing to export until a
+  // measurement arrives. Zero is a measurement.
+  RecordCounter(metric_name, 0, attributes);
+}
+
 void MetricsRecorder::RecordLatency(const std::string& metric_name,
                                     std::chrono::microseconds duration,
                                     const std::map<std::string, std::string>& attributes) {

--- a/domains/platform/libs/futility/otel/metrics.h
+++ b/domains/platform/libs/futility/otel/metrics.h
@@ -79,6 +79,37 @@ class MetricsRecorder {
   virtual void RecordCounter(const std::string& metric_name, int64_t value = 1,
                              const std::map<std::string, std::string>& attributes = {});
 
+  /// @brief Declares a counter series ahead of its first event, so it exports
+  ///        as 0 from process start.
+  ///
+  /// Without this a counter springs into existence already carrying the value
+  /// of the first event it counted: the instrument is created lazily on the
+  /// first RecordCounter, so the series' very first exported sample is that
+  /// event's value. increase() and rate() measure the change *between*
+  /// samples, so with nothing earlier to measure from that first event shows
+  /// no increase at all — forever. The counter is not wrong; every dashboard
+  /// built on it reads zero, which is worse than a missing tile because it
+  /// looks like an answer.
+  ///
+  /// That is what every process does after every deploy, so the first event of
+  /// anything is uncounted until a second one follows it. Diagnosed on the
+  /// Java rail, where an overnight run of a thousand games left a panel of
+  /// zeros (https://github.com/muchq/MoonBase/issues/1323); this rail creates
+  /// its instruments the same way.
+  ///
+  /// Declare the label sets whose values are known up front — outcomes,
+  /// error kinds, states. A label whose values come from client input or a
+  /// generated union has no series to declare, and declaring one per possible
+  /// value is how a metric becomes a cardinality problem.
+  ///
+  /// Idempotent, and harmless once events have arrived: adding zero to a
+  /// counter leaves its total alone.
+  ///
+  /// @param metric_name The metric name (e.g., "trace_requests_failed").
+  /// @param attributes The label set to declare (default: none).
+  virtual void DeclareCounter(const std::string& metric_name,
+                              const std::map<std::string, std::string>& attributes = {});
+
   /// @brief Records a histogram metric for latency/duration measurements.
   ///
   /// Use for timing operations: request latency, processing time, etc.

--- a/domains/platform/libs/futility/otel/metrics_declaration_test.cc
+++ b/domains/platform/libs/futility/otel/metrics_declaration_test.cc
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+
+#include "domains/platform/libs/futility/otel/capturing_metrics_recorder.h"
+#include "domains/platform/libs/futility/otel/metrics.h"
+
+// The zero baseline (#1323). Instruments here are created lazily on the first
+// RecordCounter, so without a declaration a counter's first exported sample is
+// its first event's value — and increase() has nothing earlier to measure it
+// against, which makes that event invisible for good. Declaring records a zero
+// so the series exists before anything happens.
+
+namespace futility::otel {
+namespace {
+
+TEST(MetricsDeclarationTest, DeclareCounterRecordsAZeroForTheSeries) {
+  CapturingMetricsRecorder metrics;
+  metrics.DeclareCounter("trace_requests_completed");
+
+  EXPECT_EQ(metrics.CounterTotal("trace_requests_completed"), 0);
+  // Presence, not just a zero read: CounterTotal sums an empty match to 0, so
+  // the assertion above passes just as happily against a recorder that
+  // declared nothing at all.
+  ASSERT_EQ(metrics.Entries().size(), 1U);
+  EXPECT_EQ(metrics.Entries()[0].name, "trace_requests_completed");
+  EXPECT_EQ(metrics.Entries()[0].value, 0);
+}
+
+TEST(MetricsDeclarationTest, DeclareCounterCarriesItsLabelSet) {
+  CapturingMetricsRecorder metrics;
+  metrics.DeclareCounter("trace_requests_failed", {{"error", "out_of_memory"}});
+
+  // The declared series is the labelled one, not a bare name beside it — a
+  // baseline under the wrong labels leaves the real series unbaselined.
+  EXPECT_EQ(metrics.CounterTotal("trace_requests_failed", {{"error", "out_of_memory"}}), 0);
+  ASSERT_EQ(metrics.Entries().size(), 1U);
+  EXPECT_EQ(metrics.Entries()[0].attributes,
+            (std::map<std::string, std::string>{{"error", "out_of_memory"}}));
+}
+
+TEST(MetricsDeclarationTest, DeclaringDoesNotDisturbLaterCounting) {
+  CapturingMetricsRecorder metrics;
+  metrics.DeclareCounter("trace_requests_total");
+  metrics.RecordCounter("trace_requests_total", 1, {});
+  metrics.RecordCounter("trace_requests_total", 1, {});
+
+  EXPECT_EQ(metrics.CounterTotal("trace_requests_total"), 2);
+}
+
+}  // namespace
+}  // namespace futility::otel

--- a/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
+++ b/domains/platform/libs/yodel/src/main/java/com/muchq/platform/yodel/CustomMetrics.java
@@ -195,6 +195,34 @@ public final class CustomMetrics {
         .record(value);
   }
 
+  /**
+   * Declares a distribution series ahead of its first observation, so it exports as an empty
+   * histogram — count 0, sum 0, every bucket 0 — from process start.
+   *
+   * <p>Same failure as {@link #defineCounter}, one level less obvious. {@link #defineDistribution}
+   * declares only the <em>bounds</em>; the series itself is still created by the first {@code
+   * record}, so a windowed mean of {@code rate(x_sum)/rate(x_count)} over that first observation
+   * divides a rate computed from one sample by another, and the first run's duration never appears
+   * on the chart it was instrumented for.
+   *
+   * <p>Takes the label set, which is why it cannot simply be folded into {@code
+   * defineDistribution}: bounds are per name, but a series is per name <em>and</em> labels, and
+   * declaring bounds for {@code index_run_duration_micros} says nothing about which outcomes it
+   * will be sliced by.
+   *
+   * <p>Idempotent, and never discards observations a series has already taken.
+   */
+  public void defineDistributionSeries(String name, Map<String, String> labels) {
+    distributions.computeIfAbsent(
+        series(name, labels),
+        s -> new Distribution(boundsByName.getOrDefault(name, DEFAULT_BOUNDS)));
+  }
+
+  /** Declares an unlabelled distribution series. See {@link #defineDistributionSeries}. */
+  public void defineDistributionSeries(String name) {
+    defineDistributionSeries(name, Map.of());
+  }
+
   /** Cumulative counter totals, ordered by name then labels so payloads are stable. */
   public List<CounterSnapshot> counterSnapshot() {
     List<CounterSnapshot> out = new ArrayList<>(counters.size());

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsEncodingTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsEncodingTest.java
@@ -63,6 +63,41 @@ public class CustomMetricsEncodingTest {
   }
 
   /**
+   * The zero baseline has to survive the wire, not just the registry. A declared-but-untouched
+   * counter is the whole point of {@link CustomMetrics#defineCounter} — if the encoder dropped it
+   * as uninteresting, or wrote a bare {@code 0} where the collector expects a string, the series
+   * would still not exist in Prometheus and the first real event would still be invisible.
+   */
+  @Test
+  public void aDeclaredButUntouchedCounterShipsAsAZeroPoint() throws Exception {
+    CustomMetrics custom = new CustomMetrics();
+    custom.defineCounter("index_runs", Map.of("outcome", "completed"));
+
+    JsonNode metric = customScope(encode(custom)).at("/metrics/0");
+    assertThat(metric.get("name").asText()).isEqualTo("index_runs");
+    assertThat(metric.at("/sum/dataPoints/0/asInt").isTextual()).isTrue();
+    assertThat(metric.at("/sum/dataPoints/0/asInt").asText()).isEqualTo("0");
+  }
+
+  /** Same for a declared distribution: an empty histogram, not an absent one. */
+  @Test
+  public void aDeclaredButUnobservedDistributionShipsAsAnEmptyHistogram() throws Exception {
+    CustomMetrics custom = new CustomMetrics();
+    custom.defineDistribution("index_run_duration_micros", new double[] {1, 10});
+    custom.defineDistributionSeries("index_run_duration_micros", Map.of("outcome", "completed"));
+
+    JsonNode metric = customScope(encode(custom)).at("/metrics/0");
+    assertThat(metric.get("name").asText()).isEqualTo("index_run_duration_micros");
+    JsonNode point = metric.at("/histogram/dataPoints/0");
+    assertThat(point.get("count").asText()).isEqualTo("0");
+    assertThat(point.get("sum").asDouble()).isZero();
+    // Buckets are still shaped by the declared bounds, so the first observation lands in the
+    // right one rather than reshaping the histogram mid-flight.
+    assertThat(point.get("explicitBounds")).hasSize(2);
+    assertThat(point.get("bucketCounts")).hasSize(3);
+  }
+
+  /**
    * One metric, many points — not many metrics sharing a name. The labels are dimensions of a
    * single series, and repeating the name instead is what makes a collector treat them as rivals.
    */

--- a/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
+++ b/domains/platform/libs/yodel/src/test/java/com/muchq/platform/yodel/CustomMetricsTest.java
@@ -415,4 +415,37 @@ public class CustomMetricsTest {
     assertThat(metrics.counterSnapshot()).hasSize(1);
     assertThat(metrics.counterSnapshot().get(0).labels()).containsEntry("outcome", "completed");
   }
+
+  /**
+   * Distributions have the counter's problem one level down: defineDistribution declares bounds,
+   * not a series, so the first observation still creates the series and a windowed mean over it
+   * divides a one-sample rate by a one-sample rate.
+   */
+  @Test
+  public void aDeclaredDistributionExportsEmptyBeforeAnyObservation() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.defineDistribution("index_run_duration_micros", new double[] {1, 10, 100});
+    metrics.defineDistributionSeries("index_run_duration_micros", Map.of("outcome", "completed"));
+
+    assertThat(metrics.isEmpty()).isFalse();
+    assertThat(metrics.distributionSnapshot()).hasSize(1);
+    CustomMetrics.DistributionSnapshot snapshot = metrics.distributionSnapshot().get(0);
+    assertThat(snapshot.count()).isZero();
+    assertThat(snapshot.sum()).isZero();
+    assertThat(snapshot.labels()).containsEntry("outcome", "completed");
+    assertThat(snapshot.bounds())
+        .as("a declared series must use the declared bounds, not the fallback")
+        .containsExactly(1, 10, 100);
+  }
+
+  /** Declaring does not discard what a series has already observed. */
+  @Test
+  public void redeclaringADistributionSeriesKeepsItsObservations() {
+    CustomMetrics metrics = new CustomMetrics();
+    metrics.record("index_games_per_month", 40);
+    metrics.defineDistributionSeries("index_games_per_month");
+
+    assertThat(metrics.distributionSnapshot().get(0).count()).isEqualTo(1L);
+    assertThat(metrics.distributionSnapshot().get(0).sum()).isEqualTo(40.0);
+  }
 }


### PR DESCRIPTION
Closes the three items #1323 left open when the one_d4 fix (#1322) landed.

## 1. The C++ rail has the same bug

Not a variant of it — the same one. `futility/otel` creates instruments lazily on the first `RecordCounter`, so a counter's first exported sample carries that event's value and `increase()` has nothing earlier to measure it against.

The deployment shows the shape rather than my inferring it: golf_hub's `session_starts` has existed since 08-03 with **no increase in it across seven days**, and `chat_message_count` appeared mid-week already carrying its first events.

`MetricsRecorder::DeclareCounter` records a **zero**, which is what actually materializes the series — creating the instrument alone registers no attribute set, so the SDK still exports nothing until a measurement arrives.

- **portrait** declares its five series in the `TracerService` constructor.
- **golf_hub** declares its eleven unlabelled counters when the handler is built.

`stream_commands{command}` and `stream_events{event}` are deliberately left out: their labels come from a generated union's case names rather than a list either file could state, and they fire continuously in any live session — the case where a missing first event costs least. Declaring one series per possible value is how a metric becomes a cardinality problem, which is the same line the Java rail already draws around motif names.

## 2. Distributions had the counter's problem one level down

`defineDistribution` declares **bounds**, not a series, so the first observation still created the series — and a windowed `rate(sum)/rate(count)` over that first run divides a one-sample rate by a one-sample rate. So `avg_run_seconds_1h` was blind to the first run for exactly the same reason the counters were.

`defineDistributionSeries` takes the label set, which is why it can't fold into `defineDistribution`: bounds are per name, but a series is per name **and** labels, and declaring bounds for `index_run_duration_micros` says nothing about which outcomes it will be sliced by. `IndexWorker` declares its two, `RUN_DURATION` once per outcome.

## 3. The encoder pin that was missing

A declared-but-untouched counter ships as `asInt: "0"` — not dropped as uninteresting, and not written as a bare number the collector would reject. A declared distribution ships as an empty histogram whose buckets already carry the declared shape, so the first observation lands in the right bucket instead of reshaping the histogram mid-flight.

## Tests

Every "declared at zero" assertion is paired with a **presence** assertion. `CounterTotal` and the Java `counter()` helper both sum an empty match to `0`, so the zero reads alone would pass against code that declared nothing — the assertion would have been vacuous in exactly the way this whole issue is about.

**Five mutations killed**: `DeclareCounter`'s record, golf_hub's `DeclareMetrics()` call, and each of the two distribution declarations. The distribution mutation initially **survived** and the test was strengthened until it didn't.

One process note: a `--test_filter` run reported PASSED before the test existed, because the filter matched nothing. I re-ran with `--test_output=all` to confirm the golf_hub test actually executes rather than trusting the green.

## Verification

21/21 across yodel, futility/otel, one_d4 workers, portrait and golf_hub; `scripts/format-all` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHNHh5jFLF4t6oFxUR1Fsg)_